### PR TITLE
Issue 1316: The traineddata file must be closed after it was opened

### DIFF
--- a/dict/dawg_cache.cpp
+++ b/dict/dawg_cache.cpp
@@ -60,7 +60,10 @@ Dawg *DawgLoader::Load() {
   if (!data_loader.Init(data_file_name_, dawg_debug_level_)) {
     return NULL;
   }
-  if (!data_loader.SeekToStart(tessdata_dawg_type_)) return NULL;
+  if (!data_loader.SeekToStart(tessdata_dawg_type_)) {
+    data_loader.End(); /// Must close the file
+    return NULL;
+  }
   FILE *fp = data_loader.GetDataFilePtr();
   DawgType dawg_type;
   PermuterType perm_type;

--- a/dict/dawg_cache.cpp
+++ b/dict/dawg_cache.cpp
@@ -61,7 +61,7 @@ Dawg *DawgLoader::Load() {
     return NULL;
   }
   if (!data_loader.SeekToStart(tessdata_dawg_type_)) {
-    data_loader.End(); /// Must close the file
+    data_loader.End();
     return NULL;
   }
   FILE *fp = data_loader.GetDataFilePtr();


### PR DESCRIPTION
Migrating from https://code.google.com/p/tesseract-ocr/issues/detail?id=1316