### PR TITLE
Issue 1139: Patch fixing text2image's --only_extract_font_properties mode to print variant kerning spacing

### DIFF
--- a/training/text2image.cpp
+++ b/training/text2image.cpp
@@ -203,12 +203,12 @@ static string StringReplace(const string& in,
 // Renders the bigrams and calls FontInfo::GetSpacingProperties() to
 // obtain spacing information. Produces the output .fontinfo file with a line
 // per unichar of the form:
-// unichar space_before space_after kerned1 kerned_space1 kerned2 ...
+// unichar space_before space_after kerned_number kerned1 kerned_space1 kerned2 ...
 // Fox example, if unichar "A" has spacing of 0 pixels before and -1 pixels
 // after, is kerned with "V" resulting in spacing of "AV" to be -7 and kerned
 // with "T", such that "AT" has spacing of -5, the entry/line for unichar "A"
 // in .fontinfo file will be:
-// A 0 -1 T -5 V -7
+// A 0 -1 2 T -5 V -7
 void ExtractFontProperties(const string &utf8_text,
                            StringRenderer *render,
                            const string &output_base) {
@@ -274,8 +274,8 @@ void ExtractFontProperties(const string &utf8_text,
         spacing_map_it1 = spacing_map.find(ch1);
         ++ok_count;
       }
-      if (ok_count == 2 && xgap != (spacing_map_it0->second.x_gap_after +
-                                    spacing_map_it1->second.x_gap_before)) {
+      if (xgap != (spacing_map_it0->second.x_gap_after +
+                   spacing_map_it1->second.x_gap_before)) {
         spacing_map_it0->second.kerned_x_gaps[ch1] = xgap;
       }
     }


### PR DESCRIPTION
https://code.google.com/p/tesseract-ocr/issues/detail?id=1139

Reported by nick.white@durham.ac.uk, Apr 8, 2014
The ok_count == 2 part of the test always failed, which prevented the kerning variations from ever being printed. As far as I can tell
it wasn't doing anything useful, but my C++ is (still) rusty, so
some light checking would be wise.

The patch also updates the function description to be in line with the current output.

Apr 24, 2014
#1 theraysmith

This could significantly change results after training.
Going to apply this change in a carefully controlled environment.

Apr 25, 2014
#2 nick.white@durham.ac.uk

This patch did make the example in the comments (A+V) output as expected, but it doesn't seem to have affected the fact that no kerning variations are printed for any ancient greek digrams. I'm not sure why, whether it's the ancient greek font, or there is something still not right about the code.

(http://web.archive.org/web/20150510031850/https://code.google.com/p/tesseract-ocr/issues/detail?id=1139)
