### PR TITLE
Issue 1106: [PATCH] Fixed potential usage of uninitialized bool varia…

### DIFF
--- a/textord/tospace.cpp
+++ b/textord/tospace.cpp
@@ -932,6 +932,9 @@ ROW *Textord::make_prop_words(
   box_it.set_to_list (row->blob_list ());
   word_it.set_to_list (&words);
   bol = TRUE;
+  fuzzy_non = FALSE;
+  fuzzy_sp = FALSE;
+  blanks = 0;
   prev_blanks = 0;
   prev_fuzzy_sp = FALSE;
   prev_fuzzy_non = FALSE;


### PR DESCRIPTION
…ble in textord/tospace.cpp

https://code.google.com/p/tesseract-ocr/issues/detail?id=1106

Reported by ettl.martin78, Feb 11, 2014
Please review the attached patch. It fixes a potential usage of an uninitialized bool variable ('fuzzy_sp'). The fix simply initialized the variable by default to 'FALSE'. Before the fix, the value of 'fuzzy_sp' was not set, but used in the else-branch in line 1107:

```
      else {
        prev_blanks = blanks;
        prev_fuzzy_sp = fuzzy_sp;
        prev_fuzzy_non = fuzzy_non;
      }
```

Best regards and many thanks

Feb 11, 2014
#1 ettl.martin78

The updated patch fixes two more uninitialized variable usages in the same function.

Many thanks for reviewing.

(http://web.archive.org/web/20150509223835/https://code.google.com/p/tesseract-ocr/issues/detail?id=1106)
