### PR TITLE
Issue 1353: Patch for /training/tessopt.cpp

### DIFF
--- a/training/tessopt.cpp
+++ b/training/tessopt.cpp
@@ -57,3 +57,9 @@ const char *arglist                    //string of arg chars
   else
     return EOF;
 }
+
+void tessopt_reset()
+{
+  tessoptind = 0;
+  tessoptarg = 0;
+}


### PR DESCRIPTION
https://code.google.com/p/tesseract-ocr/issues/detail?id=1353

When training batch boxes and tifs this causes training to fail after 2nd iteration. The issue is that the tessopt iterator index is a global. The fix is to 1.) reset before each tessopt usage 2.) wrap the iterator state in a class/generator. Low priority, but useful if we want to generate a bunch of traineddatas in the same process or even multiple threads.

(http://web.archive.org/web/20150413012203/https://code.google.com/p/tesseract-ocr/issues/detail?id=1353)
