### PR TITLE
if data_ is not null (has been used), destroy it before alloc - *may* fix gcode issue 1390

### DIFF
--- a/ccutil/strngs.cpp
+++ b/ccutil/strngs.cpp
@@ -52,6 +52,9 @@ const int kMaxDoubleSize = 15;
 const int kMinCapacity = 16;
 
 char* STRING::AllocData(int used, int capacity) {
+  if (data_ != NULL) {
+    DiscardData();
+  }
   data_ = (STRING_HEADER *)alloc_string(capacity + sizeof(STRING_HEADER));
 
   // header is the metadata for this memory block


### PR DESCRIPTION
I can't coax valgrind into installing, though, so I can't confirm

https://code.google.com/p/tesseract-ocr/issues/detail?id=1390