### PR TITLE
/usr/share/fonts is the wrong path on Mac

### DIFF
--- a/training/tesstrain_utils.sh
+++ b/training/tesstrain_utils.sh
@@ -20,7 +20,11 @@ FONTS=(
     "Arial" \
     "Times New Roman," \
 )
-FONTS_DIR="/usr/share/fonts/truetype/"
+if [ "$(uname)" == "Darwin" ];then
+    FONTS_DIR="/Library/Fonts/"
+else
+    FONTS_DIR="/usr/share/fonts/truetype/"
+fi
 OUTPUT_DIR="/tmp/tesstrain/tessdata"
 OVERWRITE=0
 RUN_SHAPE_CLUSTERING=0


### PR DESCRIPTION
There are three paths on OS X: 
/Library/Fonts/
/System/Library/Fonts/
and
/Users/`whoami`/Library/Fonts

Setting the font path is probably unavoidable on Mac, but at least we can use a default path that exists.