### PR TITLE
Purely informational, as Zdenko wants to merge parts of this

### DIFF
--- a/api/baseapi.h
+++ b/api/baseapi.h
@@ -521,8 +521,20 @@ class TESS_API TessBaseAPI {
    * Make a HTML-formatted string with hOCR markup from the internal
    * data structures.
    * page_number is 0-based but will appear in the output as 1-based.
+   * monitor can be used to
+   * 	cancel the regocnition
+   * 	receive progress callbacks
+   */
+  char* GetHOCRText(struct ETEXT_DESC* monitor, int page_number);
+
+  /**
+   * Make a HTML-formatted string with hOCR markup from the internal
+   * data structures.
+   * page_number is 0-based but will appear in the output as 1-based.
    */
   char* GetHOCRText(int page_number);
+
+
   /**
    * The recognized text is returned as a char* which is coded in the same
    * format as a box file used in training. Returned string must be freed with

--- a/api/capi.cpp
+++ b/api/capi.cpp
@@ -319,7 +319,7 @@ TESS_API char* TESS_CALL TessBaseAPIGetUTF8Text(TessBaseAPI* handle)
 
 TESS_API char* TESS_CALL TessBaseAPIGetHOCRText(TessBaseAPI* handle, int page_number)
 {
-    return handle->GetHOCRText(page_number);
+    return handle->GetHOCRText(NULL,page_number);
 }
 
 TESS_API char* TESS_CALL TessBaseAPIGetBoxText(TessBaseAPI* handle, int page_number)

--- a/ccmain/control.cpp
+++ b/ccmain/control.cpp
@@ -243,7 +243,11 @@ bool Tesseract::recog_all_words(PAGE_RES* page_res,
       word_index++;
       if (monitor != NULL) {
         monitor->ocr_alive = TRUE;
-        monitor->progress = 30 + 50 * word_index / stats_.word_count;
+        monitor->progress = 70 * word_index / stats_.word_count;
+        if (monitor->progress_callback!=NULL){
+        	TBOX box = page_res_it.word()->word->bounding_box();
+        	(*monitor->progress_callback)(monitor->progress,box.left(), box.right(), box.top(), box.bottom());
+        }
         if (monitor->deadline_exceeded() ||
             (monitor->cancel != NULL && (*monitor->cancel)(monitor->cancel_this,
                                                            stats_.dict_words)))
@@ -316,7 +320,10 @@ bool Tesseract::recog_all_words(PAGE_RES* page_res,
     word_index++;
     if (monitor != NULL) {
       monitor->ocr_alive = TRUE;
-      monitor->progress = 80 + 10 * word_index / stats_.word_count;
+      monitor->progress = 70 + 30 * word_index / stats_.word_count;
+      if (monitor->progress_callback!=NULL){
+          	  (*monitor->progress_callback)(monitor->progress,0,0,0,0);
+      }
       if (monitor->deadline_exceeded() ||
           (monitor->cancel != NULL && (*monitor->cancel)(monitor->cancel_this,
                                                          stats_.dict_words)))

--- a/ccmain/ltrresultiterator.cpp
+++ b/ccmain/ltrresultiterator.cpp
@@ -161,6 +161,14 @@ float LTRResultIterator::Confidence(PageIteratorLevel level) const {
   return 0.0f;
 }
 
+void LTRResultIterator::RowAttributes(	float* row_height,
+										float* descenders,
+										float* ascenders) const{
+	  *row_height = it_->row()->row->x_height() + it_->row()->row->ascenders() - it_->row()->row->descenders();
+	  *descenders = it_->row()->row->descenders();
+	  *ascenders = it_->row()->row->ascenders();
+}
+
 // Returns the font attributes of the current word. If iterating at a higher
 // level object than words, eg textlines, then this will return the
 // attributes of the first word in that textline.

--- a/ccmain/ltrresultiterator.h
+++ b/ccmain/ltrresultiterator.h
@@ -110,6 +110,8 @@ class TESS_API LTRResultIterator : public PageIterator {
                                  int* pointsize,
                                  int* font_id) const;
 
+  void RowAttributes(float* row_height, float* descenders, float* ascenders) const;
+
   // Return the name of the language used to recognize this word.
   // On error, NULL.  Do not delete this pointer.
   const char* WordRecognitionLanguage() const;

--- a/ccutil/ocrclass.h
+++ b/ccutil/ocrclass.h
@@ -101,6 +101,7 @@ typedef struct {                  /*single character */
  * the OCR engine is storing its output to shared memory.
  * During progress, all the buffer info is -1.
  * Progress starts at 0 and increases to 100 during OCR. No other constraint.
+ * Additionally the progress callback contains the bounding box of the word that is currently being processed
  * Every progress callback, the OCR engine must set ocr_alive to 1.
  * The HP side will set ocr_alive to 0. Repeated failure to reset
  * to 1 indicates that the OCR engine is dead.
@@ -108,6 +109,7 @@ typedef struct {                  /*single character */
  * user words found. If it returns true then operation is cancelled.
  **********************************************************************/
 typedef bool (*CANCEL_FUNC)(void* cancel_this, int words);
+typedef bool (*PROGRESS_FUNC)(int progress, int left, int right, int top, int bottom );
 
 class ETEXT_DESC {             // output header
  public:
@@ -117,6 +119,7 @@ class ETEXT_DESC {             // output header
   volatile inT8 ocr_alive;     // ocr sets to 1, HP 0
   inT8 err_code;               // for errcode use
   CANCEL_FUNC cancel;          // returns true to cancel
+  PROGRESS_FUNC progress_callback;/*called whenever progress increases*/
   void* cancel_this;           // this or other data for cancel
   struct timeval end_time;     // time to stop. expected to be set only by call
                                // to set_deadline_msecs()

--- a/tessdata/Makefile.am
+++ b/tessdata/Makefile.am
@@ -1,4 +1,4 @@
-datadir = @datadir@/tessdata
+dir = @datadir@/tessdata
 
 SUBDIRS = configs tessconfigs
 


### PR DESCRIPTION
changes:

   - extended ETEXT_DESC with PROGRESS_FUNC field. So users of the api can
   register a callback function to get notified of progress percentage as well
   as word bounding boxes.
      - (Most people i have shown my app really liked how it highlighted
      the current word when doing the ocr)
   - changed the percentage progress values to start with 0% instead of 30%
   - added row attributes to hocr output so that i can make more straight
   lines when creating the pdf files