### PR TITLE
add DAWG_TYPE_HFST, used by OCRicola

### DIFF
--- a/dict/dawg.h
+++ b/dict/dawg.h
@@ -73,7 +73,7 @@ enum DawgType {
   DAWG_TYPE_WORD,
   DAWG_TYPE_NUMBER,
   DAWG_TYPE_PATTERN,
-
+  DAWG_TYPE_HFST, // used by OCRicola
   DAWG_TYPE_COUNT  // number of enum entries
 };
 


### PR DESCRIPTION
OCRicola (https://sourceforge.net/projects/ocricola/) is a fork of Tesseract that includes support for wordlists created with HFST (http://hfst.sourceforge.net/). The University of Helsinki (where OCRicola and HFST are developed) have language packs using this support; the University of Tromsø may also.
