### PR TITLE
free clusterer fixed a memory leak. TODO: free protolists referenced in normprotolist

### DIFF
--- a/training/cntraining.cpp
+++ b/training/cntraining.cpp
@@ -192,6 +192,8 @@ int main(int  argc, char* argv[])
     }
     Config.MinSamples = SavedMinSamples;
     AddToNormProtosList(&NormProtoList, ProtoList, CharSample->Label);
+    if(pCharList->next)
+      FreeClusterer(Clusterer);
   }
   FreeTrainingSamples(CharList);
   if (Clusterer == NULL) { // To avoid a SIGSEGV
@@ -200,7 +202,8 @@ int main(int  argc, char* argv[])
   }
   WriteNormProtos(FLAGS_D.c_str(), NormProtoList, Clusterer);
   FreeNormProtoList(NormProtoList);
-  FreeProtoList(&ProtoList);
+  FreeProtoList(&ProtoList);  // TODO: also delete the other ProtoLists in Norm-
+                              // ProtoList without causing a heap corruption
   FreeClusterer(Clusterer);
   printf ("\n");
   return 0;

--- a/training/commontraining.cpp
+++ b/training/commontraining.cpp
@@ -825,7 +825,7 @@ CLASS_STRUCT* SetUpForFloat2Int(const UNICHARSET& unicharset,
 
   // 	printf("Float2Int ...\n");
 
-  CLASS_STRUCT* float_classes = new CLASS_STRUCT[unicharset.size()];
+  CLASS_STRUCT* float_classes = MakeClassStructs(unicharset.size());
   iterate(LabeledClassList)
   {
     UnicityTableEqEq<int>   font_set;

--- a/training/commontraining.cpp
+++ b/training/commontraining.cpp
@@ -770,6 +770,39 @@ void FreeLabeledClassList (
 
 }	/* FreeLabeledClassList */
 
+  
+/* Returns an array which can be used for any purpose as a CLASS_STRUCT would. 
+Must be deleted after usage, prototypes and configurations must also be deleted
+if owner owns the ptrs.. */
+CLASS_STRUCT* MakeClassStructs(unsigned int size)
+{
+  CLASS_STRUCT* float_classes = new CLASS_STRUCT[size];
+  for (unsigned int i = 0; i < size; ++i) {
+    float_classes[i].Prototypes = NULL;
+    float_classes[i].Configurations = NULL;
+  }
+  return float_classes;
+}
+
+void FreeClassStructs(CLASS_STRUCT* classes, unsigned int size)
+{
+  // if size is not specified then try to figure it out
+  if(size == 0 && classes) 
+    size = (sizeof(classes)/sizeof(classes[0]));
+  if(size == 0 || !classes) 
+    return;
+
+    // free the prototypes and configurations first, 
+    // then delete classes array
+  for (unsigned int i = 0; i < size; ++i) {
+    free(classes[i].Prototypes); 
+    free(classes[i].Configurations); 
+    classes[i].Prototypes = NULL;
+    classes[i].Configurations = NULL;
+  }
+  delete[] classes;
+}
+
 /** SetUpForFloat2Int **************************************************/
 CLASS_STRUCT* SetUpForFloat2Int(const UNICHARSET& unicharset,
                                 LIST LabeledClassList) {

--- a/training/commontraining.cpp
+++ b/training/commontraining.cpp
@@ -794,11 +794,16 @@ void FreeClassStructs(CLASS_STRUCT* classes, unsigned int size)
 
     // free the prototypes and configurations first, 
     // then delete classes array
+  CLASS_TYPE curClass;
   for (unsigned int i = 0; i < size; ++i) {
-    free(classes[i].Prototypes); 
-    free(classes[i].Configurations); 
-    classes[i].Prototypes = NULL;
-    classes[i].Configurations = NULL;
+    curClass = &classes[i];
+    for(unsigned int configIdx = 0; configIdx < curClass->NumConfigs; ++configIdx) {
+      free(curClass->Configurations[configIdx]); // see setupforfloat2int for "NewConfig.."
+    }
+    free(curClass->Prototypes); 
+    free(curClass->Configurations); 
+    curClass->Prototypes = NULL;
+    curClass->Configurations = NULL;
   }
   delete[] classes;
 }

--- a/training/commontraining.h
+++ b/training/commontraining.h
@@ -146,6 +146,13 @@ MERGE_CLASS NewLabeledClass(
 void FreeTrainingSamples(
     LIST        CharList);
 
+// helper for creating and initializing the CLASS_STRUCTs 
+CLASS_STRUCT* MakeClassStructs(unsigned int size);
+
+// Frees the Prototypes and Configrations and then Frees the classes[]
+// size specifies the number of CLASS_STRUCT elements to delete
+void FreeClassStructs(CLASS_STRUCT* classes, unsigned int size = 0);
+
 CLASS_STRUCT* SetUpForFloat2Int(const UNICHARSET& unicharset,
                                 LIST LabeledClassList);
 

--- a/training/mftraining.cpp
+++ b/training/mftraining.cpp
@@ -309,7 +309,7 @@ int main (int argc, char **argv) {
                                     *shape_table, float_classes,
                                     inttemp_file.string(),
                                     pffmtable_file.string());
-  delete [] float_classes;
+  FreeClassStructs(float_classes, unicharset->size());
   FreeLabeledClassList(mf_classes);
   delete trainer;
   delete shape_table;


### PR DESCRIPTION
cntraining clusterer's are deleted, the last one is saved and used during final write, it seems. However there are still leaks with the protolists.. we still store the old protolists in the NormProtoList. This needs to be fixed somehow. 

mftraining memory leaks are fixed.
