### PR TITLE
autogen.sh: fix a bashism

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -27,7 +27,7 @@
 #
 # All the rest is auto-generated.
 
-if [ "$1" == "clean" ]; then
+if [ "$1" = "clean" ]; then
     echo "Cleaning..."
     rm configure aclocal.m4
     rm m4/*


### PR DESCRIPTION
Use `[ "$foo" = "bar" ]` instead of `[ "$foo" == "bar" ]`.
The latter is a bashism.