### PR TITLE
Fix incorrect use of delete[] in TessDeleteResultRenderer 

### DIFF
--- a/api/capi.cpp
+++ b/api/capi.cpp
@@ -64,7 +64,7 @@ TESS_API TessResultRenderer* TESS_CALL TessBoxTextRendererCreate(const char* out
 
 TESS_API void TESS_CALL TessDeleteResultRenderer(TessResultRenderer* renderer)
 {
-    delete [] renderer;
+    delete renderer;
 }
 
 TESS_API void TESS_CALL TessResultRendererInsert(TessResultRenderer* renderer, TessResultRenderer* next)


### PR DESCRIPTION
Make TessDeleteResultRenderer use delete, not delete[]. Handles should be deleted with delete and all other handles are deleted with delete.