### PR TITLE
strcasestr needed on Cygwin too

### DIFF
--- a/training/pango_font_info.cpp
+++ b/training/pango_font_info.cpp
@@ -22,11 +22,11 @@
 #include "config_auto.h"
 #endif
 
-#ifdef MINGW
+#if (defined MINGW) || (defined __CYGWIN__)
 // workaround for stdlib.h and putenv
 #undef __STRICT_ANSI__
 #include "strcasestr.h"
-#endif  // MINGW
+#endif  // MINGW/Cygwin
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
See: https://groups.google.com/d/msgid/tesseract-ocr/55B12C3C.3010908%40vol.at
```
pango_font_info.cpp:223:46: error: 'strcasestr' was not declared in this scope
   is_fraktur_ = (strcasestr(family, "Fraktur") != NULL);
```