### PR TITLE
libicui18n is only called libicuin on mingw, not cygwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,7 @@ AM_MAINTAINER_MODE
 
 # default conditional
 AM_CONDITIONAL(T_WIN, false)
+AM_CONDITIONAL(MINGW, false)
 AM_CONDITIONAL(OSX, false)
 AM_CONDITIONAL(GRAPHICS_DISABLED, false)
 
@@ -83,6 +84,7 @@ case "${host_os}" in
     mingw32*)
         AC_DEFINE_UNQUOTED(MINGW,1,[This is a MinGW system])
         AM_CONDITIONAL(T_WIN, true)
+        AM_CONDITIONAL(MINGW, true)
         AM_CONDITIONAL(ADD_RT, false)
         AC_SUBST([AM_LDFLAGS], ['-Wl,-no-undefined -Wl,--as-needed'])
         ;;

--- a/training/Makefile.am
+++ b/training/Makefile.am
@@ -10,7 +10,7 @@ AM_CPPFLAGS += \
 
 EXTRA_DIST = language-specific.sh tesstrain.sh tesstrain_utils.sh
 
-if T_WIN
+if MINGW
 # try static build
 #AM_LDFLAGS += -all-static
 #libic=-lsicuin -licudt -lsicuuc


### PR DESCRIPTION
For the next part of #61 - again, I have no way of testing this.