### PR TITLE
Type mismatch on 64bit platforms

### DIFF
--- a/ccutil/genericvector.h
+++ b/ccutil/genericvector.h
@@ -361,7 +361,7 @@ inline bool LoadDataFromFile(const STRING& filename,
   size_t size = ftell(fp);
   fseek(fp, 0, SEEK_SET);
   // Pad with a 0, just in case we treat the result as a string.
-  data->init_to_size(size + 1, 0);
+  data->init_to_size((int)size + 1, 0);
   bool result = fread(&(*data)[0], 1, size, fp) == size;
   fclose(fp);
   return result;

--- a/ccutil/helpers.h
+++ b/ccutil/helpers.h
@@ -73,7 +73,7 @@ class TRand {
 
 // Remove newline (if any) at the end of the string.
 inline void chomp_string(char *str) {
-  int last_index = strlen(str) - 1;
+  int last_index = (int)strlen(str) - 1;
   while (last_index >= 0 &&
          (str[last_index] == '\n' || str[last_index] == '\r')) {
     str[last_index--] = '\0';


### PR DESCRIPTION
While building tesseract with clang for 64 bit architecture there are following warnings:

    helpers.h:33:32: Implicit conversion loses integer precision: 'unsigned long' to 'int'
    genericvector.h:338:27: Implicit conversion loses integer precision: 'unsigned long' to 'int'

This patch does explicit type casting and eliminates those warnings on 64bit platforms.