### PR TITLE
Update README link to point to the wiki

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Note that this is a text-only and possibly out-of-date version of the 
 wiki ReadMe, which is located at:
 
-  https://github.com/tesseract-ocr/tesseract/blob/master/README
+  https://github.com/tesseract-ocr/tesseract/wiki
 
 Introduction
 ============


### PR DESCRIPTION
The current link points to the README file in master branch, rather than the wiki that the intro text implies it should be pointing to.