### PR TITLE
Fix VC14 (VS2015) compile issue with snprintf

### DIFF
--- a/ccutil/platform.h
+++ b/ccutil/platform.h
@@ -29,7 +29,9 @@
 #endif  /* __GNUC__ */
 #define SIGNED
 #if defined(_MSC_VER)
+#if (_MSC_VER < 1900)
 #define snprintf _snprintf
+#endif
 #if (_MSC_VER <= 1400)
 #define vsnprintf _vsnprintf
 #endif /* (_MSC_VER <= 1400) */


### PR DESCRIPTION
In VC14 _snprintf_ function is provided in standard library therefore triggering error: _"Do not define snprintf as a macro. Macro definition of snprintf conflicts with Standard Library function declaration"_.

Added preprocessor directive to skip defining snprintf if compiling with VC14.

Signed-off-by: Jaka Konda <jaka.konda@outlook.com>