### PR TITLE
Get --enable-opencl to compile (but not work)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ training/wordlist2dawg
 *.cube.*
 *.tesseract_cube.*
 *.traineddata
+
+# OpenCL
+tesseract_opencl_profile_devices.dat
+kernel*.bin
+

--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -6,9 +6,9 @@ AM_CPPFLAGS += -DLOCALEDIR=\"$(localedir)\"\
     -I$(top_srcdir)/classify -I$(top_srcdir)/ccmain \
     -I$(top_srcdir)/wordrec -I$(top_srcdir)/cutil \
     -I$(top_srcdir)/opencl
-if USE_OPENCL
-AM_CPPFLAGS += -I$(OPENCL_HDR_PATH)
-endif
+
+AM_CPPFLAGS += $(OPENCL_CPPFLAGS)
+
 if VISIBILITY
 AM_CPPFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
 endif
@@ -78,9 +78,9 @@ endif
 
 tesseract_LDADD = libtesseract.la
 
-if USE_OPENCL
-tesseract_LDADD += $(OPENCL_LIB)
-endif
+
+tesseract_LDFLAGS = $(OPENCL_LDFLAGS)
+
 if OPENMP
 tesseract_LDADD += $(OPENMP_CFLAGS)
 endif

--- a/ccmain/Makefile.am
+++ b/ccmain/Makefile.am
@@ -5,9 +5,9 @@ AM_CPPFLAGS += \
     -I$(top_srcdir)/classify  -I$(top_srcdir)/dict \
     -I$(top_srcdir)/wordrec -I$(top_srcdir)/cutil \
     -I$(top_srcdir)/textord -I$(top_srcdir)/opencl
-if USE_OPENCL
-AM_CPPFLAGS += -I$(OPENCL_HDR_PATH)
-endif
+
+AM_CPPFLAGS += $(OPENCL_CPPFLAGS)
+
 if VISIBILITY
 AM_CPPFLAGS += -DTESS_EXPORTS \
     -fvisibility=hidden -fvisibility-inlines-hidden

--- a/ccstruct/Makefile.am
+++ b/ccstruct/Makefile.am
@@ -2,9 +2,7 @@ AM_CPPFLAGS += \
     -I$(top_srcdir)/ccutil -I$(top_srcdir)/cutil \
     -I$(top_srcdir)/viewer \
     -I$(top_srcdir)/opencl
-if USE_OPENCL
-AM_CPPFLAGS += -I$(OPENCL_HDR_PATH)
-endif
+AM_CPPFLAGS += $(OPENCL_CPPFLAGS)
     
 if VISIBILITY
 AM_CPPFLAGS += -DTESS_EXPORTS \

--- a/configure.ac
+++ b/configure.ac
@@ -219,10 +219,12 @@ case "${host_os}" in
     if test $my_cv_framework_OpenCL = yes; then
        have_opencl_lib=true
     fi
+    AC_SUBST(OPENCL_OSX, [yes])
     ;;
   *)
     # default
     AC_CHECK_LIB(OpenCL, clGetPlatformIDs, have_opencl_lib=true, have_opencl_lib=false)
+    AC_SUBST(OPENCL_OSX, [no])
     ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ case "${host_os}" in
         AM_CONDITIONAL(ADD_RT, true)
         ;;
     *darwin*)
-        OPENCL_LIBS="-framework OpenCL"
+        OPENCL_LIBS=""
         OPENCL_INC=""
         AM_CONDITIONAL(ADD_RT, false)
         ;;
@@ -212,6 +212,8 @@ m4_define([MY_CHECK_FRAMEWORK],
 )
 
 have_opencl_lib=false
+OPENCL_CPPFLAGS=''
+OPENCL_LDFLAGS=''
 case "${host_os}" in
   *darwin* | *-macos10*)
     echo "checking for OpenCL framework"
@@ -219,30 +221,32 @@ case "${host_os}" in
     if test $my_cv_framework_OpenCL = yes; then
        have_opencl_lib=true
     fi
-    AC_SUBST(OPENCL_OSX, [yes])
+    AC_SUBST([AM_CPPFLAGS], [-DUSE_OPENCL])
+    OPENCL_CPPFLAGS=""
+    OPENCL_LDFLAGS="-framework OpenCL"
     ;;
   *)
     # default
     AC_CHECK_LIB(OpenCL, clGetPlatformIDs, have_opencl_lib=true, have_opencl_lib=false)
-    AC_SUBST(OPENCL_OSX, [no])
+    if test "$enable_opencl" = "yes"; then
+        if !($have_opencl); then
+            AC_MSG_ERROR(Required OpenCL headers not found!)
+        fi
+        if !($have_opencl_lib); then
+            AC_MSG_ERROR(Required OpenCL library not found!)
+        fi
+        if !($have_tiff); then
+            AC_MSG_ERROR(Required TIFF headers not found! Try to install libtiff-dev?? package.)
+        fi
+        AC_SUBST([AM_CPPFLAGS], [-DUSE_OPENCL])
+        OPENCL_CPPFLAGS="-I${OPENCL_INC}"
+        OPENCL_LDFLAGS="-l${OPENCL_LIBS}"
+    fi
     ;;
 esac
-
-if test "$enable_opencl" = "yes"; then
-    if !($have_opencl); then
-        AC_MSG_ERROR(Required OpenCL headers not found!)
-    fi
-    if !($have_opencl_lib); then
-        AC_MSG_ERROR(Required OpenCL library not found!)
-    fi
-    if !($have_tiff); then
-        AC_MSG_ERROR(Required TIFF headers not found! Try to install libtiff-dev?? package.)
-    fi
-    AC_SUBST([AM_CPPFLAGS], [-DUSE_OPENCL])
-    AC_SUBST([OPENCL_HDR_PATH],[$OPENCL_INC])
-    AC_SUBST([OPENCL_LIB],[$OPENCL_LIBS])
-fi
 AM_CONDITIONAL([USE_OPENCL], [test "$enable_opencl" = "yes"])
+AC_SUBST(OPENCL_CPPFLAGS)
+AC_SUBST(OPENCL_LDFLAGS)
 
 # check whether to build tesseract with -fvisibility=hidden -fvisibility-inlines-hidden
 # http://gcc.gnu.org/wiki/Visibility

--- a/configure.ac
+++ b/configure.ac
@@ -221,9 +221,14 @@ case "${host_os}" in
     if test $my_cv_framework_OpenCL = yes; then
        have_opencl_lib=true
     fi
-    AC_SUBST([AM_CPPFLAGS], [-DUSE_OPENCL])
-    OPENCL_CPPFLAGS=""
-    OPENCL_LDFLAGS="-framework OpenCL"
+    if test "$enable_opencl" = "yes"; then
+      if !($have_opencl_lib); then
+        AC_MSG_ERROR(Required OpenCL library not found!)
+      fi
+      AC_SUBST([AM_CPPFLAGS], [-DUSE_OPENCL])
+      OPENCL_CPPFLAGS=""
+      OPENCL_LDFLAGS="-framework OpenCL"
+    fi
     ;;
   *)
     # default

--- a/opencl/Makefile.am
+++ b/opencl/Makefile.am
@@ -1,11 +1,4 @@
-AM_CPPFLAGS += -I$(top_srcdir)/ccutil -I$(top_srcdir)/ccstruct -I$(top_srcdir)/ccmain 
-if USE_OPENCL
-	if OPENCL_OSX
-		AM_CFLAGS += -framework OpenCL
-	else
-		AM_CPPFLAGS += -I$(OPENCL_HDR_PATH)
-	endif
-endif
+AM_CPPFLAGS += -I$(top_srcdir)/ccutil -I$(top_srcdir)/ccstruct -I$(top_srcdir)/ccmain $(OPENCL_CFLAGS)
 noinst_HEADERS = \
     openclwrapper.h oclkernels.h opencl_device_selection.h 
 
@@ -13,17 +6,10 @@ if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_opencl.la
 else
 lib_LTLIBRARIES = libtesseract_opencl.la
-libtesseract_opencl_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
+libtesseract_opencl_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION) $(OPENCL_LDFLAGS)
 libtesseract_opencl_la_LIBADD = \
     ../ccutil/libtesseract_ccutil.la \
     ../viewer/libtesseract_viewer.la
-if USE_OPENCL
-	if OPENCL_OSX
-		libtesseract_opencl_la_LDFLAGS += -framework OpenCL
-	else
-		libtesseract_opencl_la_LDFLAGS += $(OPENCL_LIB)
-	endif
-endif
 endif
 
 libtesseract_opencl_la_SOURCES = \

--- a/opencl/Makefile.am
+++ b/opencl/Makefile.am
@@ -1,6 +1,10 @@
 AM_CPPFLAGS += -I$(top_srcdir)/ccutil -I$(top_srcdir)/ccstruct -I$(top_srcdir)/ccmain 
 if USE_OPENCL
-AM_CPPFLAGS += -I$(OPENCL_HDR_PATH)
+	if OPENCL_OSX
+		AM_CFLAGS += -framework OpenCL
+	else
+		AM_CPPFLAGS += -I$(OPENCL_HDR_PATH)
+	endif
 endif
 noinst_HEADERS = \
     openclwrapper.h oclkernels.h opencl_device_selection.h 
@@ -14,7 +18,11 @@ libtesseract_opencl_la_LIBADD = \
     ../ccutil/libtesseract_ccutil.la \
     ../viewer/libtesseract_viewer.la
 if USE_OPENCL
-libtesseract_opencl_la_LDFLAGS += $(OPENCL_LIB)
+	if OPENCL_OSX
+		libtesseract_opencl_la_LDFLAGS += -framework OpenCL
+	else
+		libtesseract_opencl_la_LDFLAGS += $(OPENCL_LIB)
+	endif
 endif
 endif
 

--- a/opencl/openclwrapper.cpp
+++ b/opencl/openclwrapper.cpp
@@ -60,7 +60,7 @@ KernelEnv rEnv;
 // substitute invalid characters in device name with _
 void legalizeFileName( char *fileName) {
     //printf("fileName: %s\n", fileName);
-    char *invalidChars = "/\?:*\"><| "; // space is valid but can cause headaches
+    const char* invalidChars = "/\?:*\"><| "; // space is valid but can cause headaches
     // for each invalid char
     for (int i = 0; i < strlen(invalidChars); i++) {
         char invalidStr[4];
@@ -2408,9 +2408,9 @@ PERF_COUNT_START("HistogramRectOCL")
     int requestedOccupancy = 10;
     int numWorkGroups = numCUs * requestedOccupancy;
     int numThreads = block_size*numWorkGroups;
-    size_t local_work_size[] = {block_size};
-    size_t global_work_size[] = {numThreads};
-    size_t red_global_work_size[] = {block_size*kHistogramSize*bytes_per_pixel};
+    size_t local_work_size[] = {static_cast<size_t>(block_size)};
+    size_t global_work_size[] = {static_cast<size_t>(numThreads)};
+    size_t red_global_work_size[] = {static_cast<size_t>(block_size*kHistogramSize*bytes_per_pixel)};
 
     /* map histogramAllChannels as write only */
     int numBins = kHistogramSize*bytes_per_pixel*numWorkGroups;
@@ -3398,8 +3398,8 @@ PERF_COUNT_SUB("pix setup")
     int block_size = 256;
     int numWorkGroups = ((h*w+block_size-1) / block_size );
     int numThreads = block_size*numWorkGroups;
-    size_t local_work_size[] = {block_size};
-    size_t global_work_size[] = {numThreads};
+    size_t local_work_size[] = {static_cast<size_t>(block_size)};
+    size_t global_work_size[] = {static_cast<size_t>(numThreads)};
     //printf("Enqueueing %i threads for %i output pixels\n", numThreads, w*h);
 
     /* compile kernel */

--- a/textord/Makefile.am
+++ b/textord/Makefile.am
@@ -5,9 +5,8 @@ AM_CPPFLAGS += \
     -I$(top_srcdir)/ccmain -I$(top_srcdir)/wordrec -I$(top_srcdir)/api \
     -I$(top_srcdir)/cutil -I$(top_srcdir)/classify -I$(top_srcdir)/dict \
     -I$(top_srcdir)/opencl
-if USE_OPENCL
-AM_CPPFLAGS += -I$(OPENCL_HDR_PATH)
-endif
+
+AM_CPPFLAGS += $(OPENCL_CPPFLAGS)
         
 if VISIBILITY
 AM_CPPFLAGS += -DTESS_EXPORTS \

--- a/training/Makefile.am
+++ b/training/Makefile.am
@@ -298,16 +298,14 @@ noinst_HEADERS += ../vs2010/port/strcasestr.h
 libtesseract_training_la_SOURCES += ../vs2010/port/strcasestr.cpp
 endif
 
-if USE_OPENCL
-ambiguous_words_LDADD += $(OPENCL_LIB)
-classifier_tester_LDADD += $(OPENCL_LIB)
-cntraining_LDADD += $(OPENCL_LIB)
-combine_tessdata_LDADD += $(OPENCL_LIB)
-dawg2wordlist_LDADD += $(OPENCL_LIB)
-mftraining_LDADD += $(OPENCL_LIB)
-set_unicharset_properties_LDADD += $(OPENCL_LIB)
-shapeclustering_LDADD += $(OPENCL_LIB)
-text2image_LDADD += $(OPENCL_LIB)
-unicharset_extractor_LDADD += $(OPENCL_LIB)
-wordlist2dawg_LDADD += $(OPENCL_LIB)
-endif
+ambiguous_words_LDFLAGS = $(OPENCL_LDFLAGS)
+classifier_tester_LDFLAGS = $(OPENCL_LDFLAGS)
+cntraining_LDFLAGS = $(OPENCL_LDFLAGS)
+combine_tessdata_LDFLAGS = $(OPENCL_LDFLAGS)
+dawg2wordlist_LDFLAGS = $(OPENCL_LDFLAGS)
+mftraining_LDFLAGS = $(OPENCL_LDFLAGS)
+set_unicharset_properties_LDFLAGS = $(OPENCL_LDFLAGS)
+shapeclustering_LDFLAGS = $(OPENCL_LDFLAGS)
+text2image_LDFLAGS = $(OPENCL_LDFLAGS)
+unicharset_extractor_LDFLAGS = $(OPENCL_LDFLAGS)
+wordlist2dawg_LDFLAGS = $(OPENCL_LDFLAGS)


### PR DESCRIPTION
I had to redo how flags were handled for OpenCL, and in the process I quite likely broke something on the *nix side. I think the template I've set up is more in line with autotools best practices (https://stackoverflow.com/questions/20230827/how-to-set-include-paths-with-autotools) and should be flexible enough to fix.

Unfortunately, with these changes OS X/OpenCL compiles, but the output of the binary is garbage, as opposed to crashing. :(