### PR TITLE
Initialize output parameters of word_char_quality() to zero before early exit

### DIFF
--- a/ccmain/docqual.cpp
+++ b/ccmain/docqual.cpp
@@ -99,8 +99,11 @@ void Tesseract::word_char_quality(WERD_RES *word,
                                   inT16 *match_count,
                                   inT16 *accepted_match_count) {
   if (word->bln_boxes == NULL ||
-      word->rebuild_word == NULL || word->rebuild_word->blobs.empty())
+    word->rebuild_word == NULL || word->rebuild_word->blobs.empty()) {
+    *match_count = 0;
+    *accepted_match_count = 0;
     return;
+  }
 
   DocQualCallbacks cb(word);
   word->bln_boxes->ProcessMatchedBlobs(


### PR DESCRIPTION
In one of our test-cases valgrind complained about a jump-condition based on an un-initialized value:

==9451== Conditional jump or move depends on uninitialised value(s)
==9451==    at 0x35CEEC31F7: tesseract::Tesseract::quality_based_rejection(PAGE_RES_IT&, unsigned char) (in /usr/lib64/libtesseract.so.3.0.3)
==9451==    by 0x35CEEB6370: tesseract::Tesseract::rejection_passes(PAGE_RES*, ETEXT_DESC*, TBOX const*, char const*) (in /usr/lib64/libtesseract.so.3.0.3)
==9451==    by 0x35CEEBB0D0: tesseract::Tesseract::recog_all_words(PAGE_RES*, ETEXT_DESC*, TBOX const*, char const*, int) (in /usr/lib64/libtesseract.so.3.0.3)
==9451==    by 0x35CEEA905A: tesseract::TessBaseAPI::Recognize(ETEXT_DESC*) (in /usr/lib64/libtesseract.so.3.0.3)
==9451==    by 0x35CEEA9B2B: tesseract::TessBaseAPI::GetUTF8Text() (in /usr/lib64/libtesseract.so.3.0.3)
==9451==    by 0x418970: main (ValgrindTest.cpp:382)
==9451== 

The reason is that sometimes word_char_quality() exits early without initializing its output parameters, however the callers expect the output-parameters to be written. Instead of initializing all the parameters for all callers, I chose to set output-parameters at early-exist directly.