### PR TITLE
Add ULL to constants which overflow 32 bits

### DIFF
--- a/ccutil/helpers.h
+++ b/ccutil/helpers.h
@@ -61,8 +61,8 @@ class TRand {
  private:
   // Steps the generator to the next value.
   void Iterate() {
-    seed_ *= 6364136223846793005;
-    seed_ += 1442695040888963407;
+    seed_ *= 6364136223846793005ULL;
+    seed_ += 1442695040888963407ULL;
   }
 
   // The current value of the seed.


### PR DESCRIPTION
This patch fixes the problem reported here on the mailing list:

https://groups.google.com/forum/#!topic/tesseract-ocr/HbjEPm4CiiQ