### PR TITLE
Simplify build and run of ScrollView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ training/wordlist2dawg
 *.o
 *.Plo
 *.a
+*.class
+*.jar
 
 # tessdata
 *.cube.*

--- a/java/Makefile.am
+++ b/java/Makefile.am
@@ -42,18 +42,22 @@ SCROLLVIEW_LIBS = \
 CLASSPATH = $(srcdir)/piccolo2d-core-3.0.jar:$(srcdir)/piccolo2d-extras-3.0.jar
 
 ScrollView.jar : $(SCROLLVIEW_CLASSES)
-	$(JAR) cf $@ com/google/scrollview/*.class \
+	$(JAR) cfm $@ Manifest.txt com/google/scrollview/*.class \
            com/google/scrollview/events/*.class com/google/scrollview/ui/*.class
 
 $(SCROLLVIEW_CLASSES) : $(SCROLLVIEW_FILES)
 	$(JAVAC) -encoding UTF8 -sourcepath $(srcdir) -classpath $(CLASSPATH) $(SCROLLVIEW_FILES) -d $(builddir)
+
+fetch-jars :
+	curl -L http://search.maven.org/remotecontent?filepath=org/piccolo2d/piccolo2d-core/3.0/piccolo2d-core-3.0.jar > piccolo2d-core-3.0.jar
+	curl -L http://search.maven.org/remotecontent?filepath=org/piccolo2d/piccolo2d-extras/3.0/piccolo2d-extras-3.0.jar > piccolo2d-extras-3.0.jar
 
 .PHONY: install-jars
 install-jars : ScrollView.jar
 	@if [ ! -d  $(scrollview_path) ]; then mkdir -p $(scrollview_path); fi;
 	$(INSTALL) -m 644 $(SCROLLVIEW_LIBS) $(scrollview_path);
 	$(INSTALL) -m 644 ScrollView.jar $(scrollview_path);
-	@echo "Don't forget to set eviroment variable SCROLLVIEW_PATH to $(scrollview_path)";
+	@echo "Don't forget to set enviroment variable SCROLLVIEW_PATH to $(scrollview_path)";
 
 uninstall:
 	rm -f $(scrollview_path)/*.jar

--- a/java/Manifest.txt
+++ b/java/Manifest.txt
@@ -1,0 +1,2 @@
+Main-Class: com/google/scrollview/ScrollView
+Class-Path: ScrollView.jar piccolo2d-core-3.0.jar piccolo2d-extras-3.0.jar

--- a/viewer/svutil.cpp
+++ b/viewer/svutil.cpp
@@ -127,7 +127,7 @@ SVSemaphore::SVSemaphore() {
   semaphore_ = CreateSemaphore(0, 0, 10, 0);
 #elif defined(__APPLE__)
   char name[50];
-  snprintf(name, sizeof(name), "%d", random());
+  snprintf(name, sizeof(name), "%ld", random());
   sem_unlink(name);
   semaphore_ = sem_open(name, O_CREAT , S_IWUSR, 0);
   if (semaphore_ == SEM_FAILED) {
@@ -296,14 +296,11 @@ static std::string ScrollViewCommand(std::string scrollview_path) {
   // this unnecessary.
   // Also the path has to be separated by ; on windows and : otherwise.
 #ifdef _WIN32
-  const char* cmd_template = "-Djava.library.path=%s -cp %s/ScrollView.jar;"
-      "%s/piccolo2d-core-3.0.jar:%s/piccolo2d-extras-3.0.jar"
-      " com.google.scrollview.ScrollView";
+  const char* cmd_template = "-Djava.library.path=%s -jar %s/ScrollView.jar";
+
 #else
   const char* cmd_template = "-c \"trap 'kill %%1' 0 1 2 ; java "
-      "-Xms1024m -Xmx2048m -Djava.library.path=%s -cp %s/ScrollView.jar:"
-      "%s/piccolo2d-core-3.0.jar:%s/piccolo2d-extras-3.0.jar"
-      " com.google.scrollview.ScrollView"
+      "-Xms1024m -Xmx2048m -jar %s/ScrollView.jar"
       " & wait\"";
 #endif
   int cmdlen = strlen(cmd_template) + 4*strlen(scrollview_path.c_str()) + 1;
@@ -374,7 +371,7 @@ static int GetAddrInfo(const char* hostname, int port,
                        struct addrinfo** address) {
 #if defined(__linux__)
   char port_str[40];
-  snprintf(port_str, 40, "%d", port);
+  snprintf(port_str, 40, "%ld", port);
   return getaddrinfo(hostname, port_str, NULL, address);
 #else
   return GetAddrInfoNonLinux(hostname, port, address);


### PR DESCRIPTION
This patch makes it easier to build and run ScrollView.

- add a Makefile target, fetch-jars, to fetch dependencies so they don't have to be copied by hand
- add a Manifest to the jar so dependencies don't need to be specified on the command line
- ignore .class and .jar files for Git