### PR TITLE
Unicharset extractor problems with wchar

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -314,7 +314,7 @@ AC_SYS_LARGEFILE
 # Checks for typedefs, structures, and compiler characteristics.
 # ----------------------------------------
 
-AC_CHECK_TYPES(wchar_t)
+AC_CHECK_TYPES(wchar_t,,,[#include "wchar.h"])
 AC_CHECK_TYPES(long long int)
 AC_CHECK_TYPES(mbstate_t,,,[#include "wchar.h"])
 

--- a/training/unicharset_extractor.cpp
+++ b/training/unicharset_extractor.cpp
@@ -105,6 +105,11 @@ int main(int argc, char** argv) {
   // Print usage
   if (argc <= 1) {
     printf("Usage: %s [-D DIRECTORY] FILE...\n", argv[0]);
+#ifdef USING_WCTYPE
+    printf("Character properties using wctype is enabled\n");
+#else
+    printf("WARNING: Character properties using wctype is DISABLED\n");
+#endif
     exit(1);
 
   }


### PR DESCRIPTION
I found some issues with building unicharset_extractor under Fedora as it wouldn't detect wchar correctly.