### PR TITLE
Fix compiler warnings for copy constructors

### DIFF
--- a/ccstruct/pageres.h
+++ b/ccstruct/pageres.h
@@ -327,7 +327,7 @@ class WERD_RES : public ELIST_LINK {
   }
   // Deep copies everything except the ratings MATRIX.
   // To get that use deep_copy below.
-  WERD_RES(const WERD_RES &source) {
+  WERD_RES(const WERD_RES &source) : ELIST_LINK(source) {
     InitPointers();
     *this = source;            // see operator=
   }

--- a/ccstruct/ratngs.cpp
+++ b/ccstruct/ratngs.cpp
@@ -112,7 +112,7 @@ BLOB_CHOICE::BLOB_CHOICE(UNICHAR_ID src_unichar_id, // character id
  *
  * Constructor to build a BLOB_CHOICE from another BLOB_CHOICE.
  */
-BLOB_CHOICE::BLOB_CHOICE(const BLOB_CHOICE &other) {
+BLOB_CHOICE::BLOB_CHOICE(const BLOB_CHOICE &other) : ELIST_LINK(other) {
   unichar_id_ = other.unichar_id();
   rating_ = other.rating();
   certainty_ = other.certainty();

--- a/ccstruct/ratngs.h
+++ b/ccstruct/ratngs.h
@@ -288,7 +288,7 @@ class WERD_CHOICE : public ELIST_LINK {
                src_certainty, src_permuter);
   }
   WERD_CHOICE(const char *src_string, const UNICHARSET &unicharset);
-  WERD_CHOICE(const WERD_CHOICE &word) : unicharset_(word.unicharset_) {
+  WERD_CHOICE(const WERD_CHOICE &word) : ELIST_LINK(word), unicharset_(word.unicharset_) {
     this->init(word.length());
     this->operator=(word);
   }

--- a/ccutil/genericvector.h
+++ b/ccutil/genericvector.h
@@ -432,7 +432,7 @@ class PointerVector : public GenericVector<T*> {
   }
   // Copy must be deep, as the pointers will be automatically deleted on
   // destruction.
-  PointerVector(const PointerVector& other) {
+  PointerVector(const PointerVector& other) : GenericVector<T*>(other) {
     this->init(other.size());
     this->operator+=(other);
   }


### PR DESCRIPTION
gcc reports these warnings with -Wextra:

ccstruct/pageres.h:330:3: warning:
 base class 'class ELIST_LINK' should be explicitly initialized
 in the copy constructor [-Wextra]
ccstruct/ratngs.cpp:115:1: warning:
 base class 'class ELIST_LINK' should be explicitly initialized
 in the copy constructor [-Wextra]
ccstruct/ratngs.h:291:3: warning:
 base class 'class ELIST_LINK' should be explicitly initialized
 in the copy constructor [-Wextra]
ccutil/genericvector.h:435:3: warning:
 base class 'class GenericVector<WERD_RES*>' should be explicitly initialized
 in the copy constructor [-Wextra]

Signed-off-by: Stefan Weil <sw@weilnetz.de>