### PR TITLE
Remove register attribute for local variables

### DIFF
--- a/ccstruct/polyaprx.cpp
+++ b/ccstruct/polyaprx.cpp
@@ -214,18 +214,18 @@ EDGEPT edgepts[]                 //output is array
 void fix2(                //polygonal approx
           EDGEPT *start,  /*loop to approimate */
           int area) {
-  register EDGEPT *edgept;       /*current point */
-  register EDGEPT *edgept1;
-  register EDGEPT *loopstart;    /*modified start of loop */
-  register EDGEPT *linestart;    /*start of line segment */
-  register int dir1, dir2;       /*directions of line */
-  register int sum1, sum2;       /*lengths in dir1,dir2 */
+  EDGEPT *edgept;                /*current point */
+  EDGEPT *edgept1;
+  EDGEPT *loopstart;             /*modified start of loop */
+  EDGEPT *linestart;             /*start of line segment */
+  int dir1, dir2;                /*directions of line */
+  int sum1, sum2;                /*lengths in dir1,dir2 */
   int stopped;                   /*completed flag */
   int fixed_count;               //no of fixed points
   int d01, d12, d23, gapmin;
   TPOINT d01vec, d12vec, d23vec;
-  register EDGEPT *edgefix, *startfix;
-  register EDGEPT *edgefix0, *edgefix1, *edgefix2, *edgefix3;
+  EDGEPT *edgefix, *startfix;
+  EDGEPT *edgefix0, *edgefix1, *edgefix2, *edgefix3;
 
   edgept = start;                /*start of loop */
   while (((edgept->flags[DIR] - edgept->prev->flags[DIR] + 1) & 7) < 3
@@ -400,10 +400,10 @@ EDGEPT *poly2(                  //second poly
               EDGEPT *startpt,  /*start of loop */
               int area          /*area of blob box */
              ) {
-  register EDGEPT *edgept;       /*current outline point */
+  EDGEPT *edgept;                /*current outline point */
   EDGEPT *loopstart;             /*starting point */
-  register EDGEPT *linestart;    /*start of line */
-  register int edgesum;          /*correction count */
+  EDGEPT *linestart;             /*start of line */
+  int edgesum;                   /*correction count */
 
   if (area < 1200)
     area = 1200;                 /*minimum value */
@@ -499,13 +499,13 @@ void cutline(                //recursive refine
              EDGEPT *last,
              int area        /*area of object */
             ) {
-  register EDGEPT *edge;         /*current edge */
+  EDGEPT *edge;                  /*current edge */
   TPOINT vecsum;                 /*vector sum */
   int vlen;                      /*approx length of vecsum */
   TPOINT vec;                    /*accumulated vector */
   EDGEPT *maxpoint;              /*worst point */
   int maxperp;                   /*max deviation */
-  register int perp;             /*perp distance */
+  int perp;                      /*perp distance */
   int ptcount;                   /*no of points */
   int squaresum;                 /*sum of perps */
 

--- a/ccstruct/quspline.cpp
+++ b/ccstruct/quspline.cpp
@@ -71,8 +71,8 @@ int xpts[],                      //points to fit
 int ypts[], int pointcount,      //no of pts
 int degree                       //fit required
 ) {
-  register int pointindex;       /*no along text line */
-  register int segment;          /*segment no */
+  int pointindex;                /*no along text line */
+  int segment;                   /*segment no */
   inT32 *ptcounts;               //no in each segment
   QLSQ qlsq;                     /*accumulator */
 
@@ -308,7 +308,7 @@ void QSPLINE::extrapolate(                  //linear extrapolation
                           int xmin,         //new left edge
                           int xmax          //new right edge
                          ) {
-  register int segment;          /*current segment of spline */
+  int segment;                   /*current segment of spline */
   int dest_segment;              //dest index
   int *xstarts;                  //new boundaries
   QUAD_COEFFS *quads;            //new ones

--- a/classify/intmatcher.cpp
+++ b/classify/intmatcher.cpp
@@ -778,10 +778,10 @@ int IntegerMatcher::UpdateTablesForFeature(
     const INT_FEATURE_STRUCT* Feature,
     ScratchEvidence *tables,
     int Debug) {
-  register uinT32 ConfigWord;
-  register uinT32 ProtoWord;
-  register uinT32 ProtoNum;
-  register uinT32 ActualProtoNum;
+  uinT32 ConfigWord;
+  uinT32 ProtoWord;
+  uinT32 ProtoNum;
+  uinT32 ActualProtoNum;
   uinT8 proto_byte;
   inT32 proto_word_offset;
   inT32 proto_offset;
@@ -795,14 +795,14 @@ int IntegerMatcher::UpdateTablesForFeature(
   uinT32 XFeatureAddress;
   uinT32 YFeatureAddress;
   uinT32 ThetaFeatureAddress;
-  register uinT8 *UINT8Pointer;
-  register int ProtoIndex;
+  uinT8 *UINT8Pointer;
+  int ProtoIndex;
   uinT8 Temp;
-  register int *IntPointer;
+  int *IntPointer;
   int ConfigNum;
-  register inT32 M3;
-  register inT32 A3;
-  register uinT32 A4;
+  inT32 M3;
+  inT32 A3;
+  uinT32 A4;
 
   tables->ClearFeatureEvidence(ClassTemplate);
 
@@ -1240,7 +1240,7 @@ float IntegerMatcher::ApplyCNCorrection(float rating, int blob_length,
  */
 void
 HeapSort (int n, register int ra[], register int rb[]) {
-  register int i, rra, rrb;
+  int i, rra, rrb;
   int l, j, ir;
 
   l = (n >> 1) + 1;

--- a/classify/intproto.cpp
+++ b/classify/intproto.cpp
@@ -297,7 +297,7 @@ int AddIntProto(INT_CLASS Class) {
   int ProtoSetId;
   PROTO_SET ProtoSet;
   INT_PROTO Proto;
-  register uinT32 *Word;
+  uinT32 *Word;
 
   if (Class->NumProtos >= MAX_NUM_PROTOS)
     return (NO_PROTO);
@@ -1256,8 +1256,8 @@ void DoFill(FILL_SPEC *FillSpec,
             register uinT32 ClassMask,
             register uinT32 ClassCount,
             register uinT32 WordIndex) {
-  register int X, Y, Angle;
-  register uinT32 OldWord;
+  int X, Y, Angle;
+  uinT32 OldWord;
 
   X = FillSpec->X;
   if (X < 0)

--- a/cutil/bitvec.h
+++ b/cutil/bitvec.h
@@ -32,7 +32,7 @@ typedef uinT32 *BIT_VECTOR;
 -----------------------------------------------------------------------------*/
 #define zero_all_bits(array,length) \
 {\
-    register int            index;                        /*temporary index*/\
+    int index;                        /*temporary index*/\
 \
 for (index=0;index<length;index++)\
     array[index]=0;                                        /*zero all bits*/\
@@ -40,7 +40,7 @@ for (index=0;index<length;index++)\
 
 #define set_all_bits(array,length) \
 {\
-    register int            index;                        /*temporary index*/\
+    int index;                        /*temporary index*/\
 \
 for (index=0;index<length;index++)\
     array[index]= ~0;                                    /*set all bits*/\
@@ -48,7 +48,7 @@ for (index=0;index<length;index++)\
 
 #define copy_all_bits(source,dest,length) \
 {\
-    register int            index;                        /*temporary index*/\
+    int index;                        /*temporary index*/\
 \
 for (index=0;index<length;index++)\
     dest[index]=source[index];                            /*copy all bits*/\

--- a/textord/oldbasel.cpp
+++ b/textord/oldbasel.cpp
@@ -121,7 +121,7 @@ void Textord::make_old_baselines(TO_BLOCK *block,   // block to do
 void Textord::correlate_lines(TO_BLOCK *block, float gradient) {
   TO_ROW **rows;                 //array of ptrs
   int rowcount;                  /*no of rows to do */
-  register int rowindex;         /*no of row */
+  int rowindex;                  /*no of row */
                                  //iterator
   TO_ROW_IT row_it = block->get_rows ();
 
@@ -164,8 +164,8 @@ void Textord::correlate_neighbours(TO_BLOCK *block,  // block rows are in.
                                    TO_ROW **rows,    // rows of block.
                                    int rowcount) {   // no of rows to do.
   TO_ROW *row;                   /*current row */
-  register int rowindex;         /*no of row */
-  register int otherrow;         /*second row */
+  int rowindex;                  /*no of row */
+  int otherrow;                  /*second row */
   int upperrow;                  /*row above to use */
   int lowerrow;                  /*row below to use */
   float biggest;
@@ -220,7 +220,7 @@ int Textord::correlate_with_stats(TO_ROW **rows,  // rows of block.
                                   int rowcount,   // no of rows to do.
                                   TO_BLOCK* block) {
   TO_ROW *row;                   /*current row */
-  register int rowindex;         /*no of row */
+  int rowindex;                  /*no of row */
   float lineheight;              /*mean x-height */
   float ascheight;               /*average ascenders */
   float minascheight;            /*min allowed ascheight */
@@ -447,7 +447,7 @@ int get_blob_coords(                    //get boxes
                    ) {
                                  //blobs
   BLOBNBOX_IT blob_it = row->blob_list ();
-  register int blobindex;        /*no along text line */
+  int blobindex;                 /*no along text line */
   int losscount;                 //lost blobs
   int maxlosscount;              //greatest lost blobs
                                  /*height stat collection */
@@ -719,7 +719,7 @@ QSPLINE * spline,                /*curve to fit to */
 float jumplimit,                 /*allowed delta change */
 float ydiffs[]                   /*diff from spline */
 ) {
-  register int blobindex;        /*no along text line */
+  int blobindex;                 /*no along text line */
   int bestpart;                  /*best new partition */
   int biggestpart;               /*part with most members */
   float diff;                    /*difference from line */
@@ -800,7 +800,7 @@ float jumplimit                  /*allowed delta change */
 ) {
   BOOL8 found_one;               //found a bestpart blob
   BOOL8 close_one;               //found was close enough
-  register int blobindex;        /*no along text line */
+  int blobindex;                 /*no along text line */
   int prevpart;                  //previous iteration
   int runlength;                 //no in this part
   float diff;                    /*difference from line */
@@ -909,7 +909,7 @@ int blobcount,                   /*no of blobs */
 QSPLINE * spline,                /*approximating spline */
 float ydiffs[]                   /*output */
 ) {
-  register int blobindex;        /*current blob */
+  int blobindex;                 /*current blob */
   int xcentre;                   /*xcoord */
   int lastx;                     /*last xcentre */
   float diffsum;                 /*sum of diffs */
@@ -963,7 +963,7 @@ float* drift,
 float* lastdelta,
 int *partcount                   /*no of partitions */
 ) {
-  register int partition;        /*partition no */
+  int partition;                 /*partition no */
   int bestpart;                  /*best new partition */
   float bestdelta;               /*best gap from a part */
   float delta;                   /*diff from part */
@@ -1028,7 +1028,7 @@ int *partcount                   /*no of partitions */
 //int                        blobcount;                    /*no of blobs*/
 //int                        bestpart;                     /*best partition*/
 //{
-//   register int            blobindex;                    /*no along text line*/
+//   int                     blobindex;                    /*no along text line*/
 //   int                     runlength;                    /*run of same partition*/
 //   int                     bestrun;                      /*biggest runlength*/
 //
@@ -1089,7 +1089,7 @@ int bestpart,                    /*best new partition */
 int xcoords[],                   /*points to work on */
 int ycoords[]                    /*points to work on */
 ) {
-  register int blobindex;        /*no along text line */
+  int blobindex;                 /*no along text line */
   int pointcount;                /*no of points */
 
   pointcount = 0;
@@ -1120,8 +1120,8 @@ int ycoords[],                   /*points to work on */
 int degree, int pointcount,      /*no of points */
 int xstarts[]                    //result
 ) {
-  register int ptindex;          /*no along text line */
-  register int segment;          /*partition no */
+  int ptindex;                   /*no along text line */
+  int segment;                   /*partition no */
   int lastmin, lastmax;          /*possible turn points */
   int turnpoints[SPLINESIZE];    /*good turning points */
   int turncount;                 /*no of turning points */
@@ -1245,7 +1245,7 @@ int xstarts[],                   //result
 int &segments                    //no of segments
 ) {
   BOOL8 doneany;                 //return value
-  register int segment;          /*partition no */
+  int segment;                   /*partition no */
   int startindex, centreindex, endindex;
   float leftcoord, rightcoord;
   int leftindex, rightindex;
@@ -1377,8 +1377,8 @@ int partsizes[],                 /*size of each part */
 int partcount,                   /*no of partitions */
 int bestpart                     /*biggest partition */
 ) {
-  register int blobindex;        /*index of blob */
-  register int partition;        /*current partition */
+  int blobindex;                 /*index of blob */
+  int partition;                 /*current partition */
   int xcentre;                   /*centre of blob */
   int poscount;                  /*count of best up step */
   int negcount;                  /*count of best down step */
@@ -1459,7 +1459,7 @@ int blobcount,                   /*blobs in blobcoords */
 QSPLINE * baseline,              /*established */
 float jumplimit                  /*min ascender height */
 ) {
-  register int blobindex;        /*current blob */
+  int blobindex;                 /*current blob */
                                  /*height statistics */
   STATS heightstat (0, MAXHEIGHT);
   int height;                    /*height of blob */
@@ -1469,7 +1469,7 @@ float jumplimit                  /*min ascender height */
   int asccount;                  /*no of ascenders */
   float xsum;                    /*xheight sum */
   int xcount;                    /*xheight count */
-  register float diff;           /*height difference */
+  float diff;                    /*height difference */
 
   if (blobcount > 1) {
     for (blobindex = 0; blobindex < blobcount; blobindex++) {

--- a/wordrec/gradechop.cpp
+++ b/wordrec/gradechop.cpp
@@ -49,8 +49,8 @@ namespace tesseract {
  *   100  =  "no way jay"
  **********************************************************************/
 PRIORITY Wordrec::grade_split_length(register SPLIT *split) {
-  register PRIORITY grade;
-  register float split_length;
+  PRIORITY grade;
+  float split_length;
 
   split_length =
       split->point1->WeightedDistance(*split->point2, chop_x_y_weight);
@@ -72,7 +72,7 @@ PRIORITY Wordrec::grade_split_length(register SPLIT *split) {
  *   100  =  "no way jay"
  **********************************************************************/
 PRIORITY Wordrec::grade_sharpness(register SPLIT *split) {
-  register PRIORITY grade;
+  PRIORITY grade;
 
   grade = point_priority (split->point1) + point_priority (split->point2);
 


### PR DESCRIPTION
This fixes clang compiler warnings like this one:

wordrec/gradechop.cpp:52:3: warning:
 'register' storage class specifier is deprecated [-Wdeprecated-register]

Signed-off-by: Stefan Weil <sw@weilnetz.de>