### PR TITLE
Fix Travis build error (error when getting cmake)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 install:
   - if [[ $OSX ]]; then brew install icu4c pango; brew link --force gettext; fi
   - if [[ $OSX ]]; then export ICU_ROOT=/usr/local/opt/icu4c ; fi
-  - wget http://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.sh
+  - wget --no-check-certificate https://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.sh
   - sudo sh cmake-3.3.1-Linux-x86_64.sh --skip-license --prefix=/usr
   - wget -O leptonica.zip https://github.com/egorpugin/leptonica/archive/master.zip
   - unzip leptonica.zip -d .


### PR DESCRIPTION
This command fails currently:

wget http://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.sh

Obviously cmake.org now redirects to https connections, so we have to
fix the URL.

Signed-off-by: Stefan Weil <sw@weilnetz.de>