### PR TITLE
Remove checks for this == NULL

### DIFF
--- a/ccstruct/split.cpp
+++ b/ccstruct/split.cpp
@@ -225,10 +225,8 @@ void remove_edgept(EDGEPT *point) {
  * Shows the coordinates of both points in a split.
  **********************************************************************/
 void SPLIT::Print() const {
-  if (this != NULL) {
-    tprintf("(%d,%d)--(%d,%d)", point1->pos.x, point1->pos.y, point2->pos.x,
-            point2->pos.y);
-  }
+  tprintf("(%d,%d)--(%d,%d)", point1->pos.x, point1->pos.y, point2->pos.x,
+          point2->pos.y);
 }
 
 #ifndef GRAPHICS_DISABLED

--- a/ccutil/clst.cpp
+++ b/ccutil/clst.cpp
@@ -43,11 +43,6 @@ void (*zapper) (void *)) {       //ptr to zapper functn
   CLIST_LINK *ptr;
   CLIST_LINK *next;
 
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST::internal_deep_clear", ABORT, NULL);
-  #endif
-
   if (!empty ()) {
     ptr = last->next;            //set to first
     last->next = NULL;           //break circle
@@ -74,11 +69,6 @@ void (*zapper) (void *)) {       //ptr to zapper functn
 void CLIST::shallow_clear() {  //destroy all links
   CLIST_LINK *ptr;
   CLIST_LINK *next;
-
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST::shallow_clear", ABORT, NULL);
-  #endif
 
   if (!empty ()) {
     ptr = last->next;            //set to first
@@ -111,11 +101,6 @@ void CLIST::assign_to_sublist(                           //to this list
   const ERRCODE LIST_NOT_EMPTY =
     "Destination list must be empty before extracting a sublist";
 
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST::assign_to_sublist", ABORT, NULL);
-  #endif
-
   if (!empty ())
     LIST_NOT_EMPTY.error ("CLIST.assign_to_sublist", ABORT, NULL);
 
@@ -132,11 +117,6 @@ void CLIST::assign_to_sublist(                           //to this list
 inT32 CLIST::length() const {  //count elements
   CLIST_ITERATOR it(const_cast<CLIST*>(this));
   inT32 count = 0;
-
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST::length", ABORT, NULL);
-  #endif
 
   for (it.mark_cycle_pt(); !it.cycled_list(); it.forward())
     count++;
@@ -159,11 +139,6 @@ const void *, const void *)) {
   void **base;                   //ptr array to sort
   void **current;
   inT32 i;
-
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST::sort", ABORT, NULL);
-  #endif
 
   /* Allocate an array of pointers, one per list element */
   count = length ();
@@ -272,8 +247,6 @@ void CLIST::set_subtract(int comparator(const void*, const void*),
 
 void *CLIST_ITERATOR::forward() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::forward", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::forward", ABORT, NULL);
   #endif
@@ -317,8 +290,6 @@ void *CLIST_ITERATOR::data_relative(                //get data + or - ...
   CLIST_LINK *ptr;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::data_relative", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::data_relative", ABORT, NULL);
   if (list->empty ())
@@ -352,8 +323,6 @@ void *CLIST_ITERATOR::data_relative(                //get data + or - ...
 
 void *CLIST_ITERATOR::move_to_last() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::move_to_last", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::move_to_last", ABORT, NULL);
   #endif
@@ -386,8 +355,6 @@ void CLIST_ITERATOR::exchange(                             //positions of 2 link
   CLIST_LINK *old_current;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::exchange", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::exchange", ABORT, NULL);
   if (!other_it)
@@ -490,8 +457,6 @@ CLIST_LINK *CLIST_ITERATOR::extract_sublist(                             //from 
   const ERRCODE DONT_EXTRACT_DELETED =
     "Can't extract a sublist marked by deleted points";
 
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::extract_sublist", ABORT, NULL);
   if (!other_it)
     BAD_PARAMETER.error ("CLIST_ITERATOR::extract_sublist", ABORT,
       "other_it NULL");

--- a/ccutil/clst.h
+++ b/ccutil/clst.h
@@ -255,8 +255,6 @@ class DLLSYM CLIST_ITERATOR
 inline void CLIST_ITERATOR::set_to_list(  //change list
                                         CLIST *list_to_iterate) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::set_to_list", ABORT, NULL);
   if (!list_to_iterate)
     BAD_PARAMETER.error ("CLIST_ITERATOR::set_to_list", ABORT,
       "list_to_iterate is NULL");
@@ -296,8 +294,6 @@ inline void CLIST_ITERATOR::add_after_then_move(  // element to add
   CLIST_LINK *new_element;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::add_after_then_move", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::add_after_then_move", ABORT, NULL);
   if (!new_data)
@@ -346,8 +342,6 @@ inline void CLIST_ITERATOR::add_after_stay_put(  // element to add
   CLIST_LINK *new_element;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::add_after_stay_put", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::add_after_stay_put", ABORT, NULL);
   if (!new_data)
@@ -399,8 +393,6 @@ inline void CLIST_ITERATOR::add_before_then_move(  // element to add
   CLIST_LINK *new_element;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::add_before_then_move", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::add_before_then_move", ABORT, NULL);
   if (!new_data)
@@ -446,8 +438,6 @@ inline void CLIST_ITERATOR::add_before_stay_put(  // element to add
   CLIST_LINK *new_element;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::add_before_stay_put", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::add_before_stay_put", ABORT, NULL);
   if (!new_data)
@@ -491,8 +481,6 @@ inline void CLIST_ITERATOR::add_before_stay_put(  // element to add
 
 inline void CLIST_ITERATOR::add_list_after(CLIST *list_to_add) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::add_list_after", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::add_list_after", ABORT, NULL);
   if (!list_to_add)
@@ -541,8 +529,6 @@ inline void CLIST_ITERATOR::add_list_after(CLIST *list_to_add) {
 
 inline void CLIST_ITERATOR::add_list_before(CLIST *list_to_add) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::add_list_before", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::add_list_before", ABORT, NULL);
   if (!list_to_add)
@@ -591,8 +577,6 @@ inline void *CLIST_ITERATOR::extract() {
   void *extracted_data;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::extract", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::extract", ABORT, NULL);
   if (!current)                  //list empty or
@@ -632,8 +616,6 @@ inline void *CLIST_ITERATOR::extract() {
 
 inline void *CLIST_ITERATOR::move_to_first() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::move_to_first", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::move_to_first", ABORT, NULL);
   #endif
@@ -658,8 +640,6 @@ inline void *CLIST_ITERATOR::move_to_first() {
 
 inline void CLIST_ITERATOR::mark_cycle_pt() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::mark_cycle_pt", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::mark_cycle_pt", ABORT, NULL);
   #endif
@@ -681,8 +661,6 @@ inline void CLIST_ITERATOR::mark_cycle_pt() {
 
 inline BOOL8 CLIST_ITERATOR::at_first() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::at_first", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::at_first", ABORT, NULL);
   #endif
@@ -703,8 +681,6 @@ inline BOOL8 CLIST_ITERATOR::at_first() {
 
 inline BOOL8 CLIST_ITERATOR::at_last() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::at_last", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::at_last", ABORT, NULL);
   #endif
@@ -725,8 +701,6 @@ inline BOOL8 CLIST_ITERATOR::at_last() {
 
 inline BOOL8 CLIST_ITERATOR::cycled_list() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::cycled_list", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::cycled_list", ABORT, NULL);
   #endif
@@ -745,8 +719,6 @@ inline BOOL8 CLIST_ITERATOR::cycled_list() {
 
 inline inT32 CLIST_ITERATOR::length() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::length", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::length", ABORT, NULL);
   #endif
@@ -767,8 +739,6 @@ CLIST_ITERATOR::sort (           //sort elements
 int comparator (                 //comparison routine
 const void *, const void *)) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::sort", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::sort", ABORT, NULL);
   #endif
@@ -793,8 +763,6 @@ inline void CLIST_ITERATOR::add_to_end(  // element to add
   CLIST_LINK *new_element;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("CLIST_ITERATOR::add_to_end", ABORT, NULL);
   if (!list)
     NO_LIST.error ("CLIST_ITERATOR::add_to_end", ABORT, NULL);
   if (!new_data)

--- a/ccutil/elst.cpp
+++ b/ccutil/elst.cpp
@@ -44,11 +44,6 @@ void (*zapper) (ELIST_LINK *)) {
   ELIST_LINK *ptr;
   ELIST_LINK *next;
 
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST::internal_clear", ABORT, NULL);
-  #endif
-
   if (!empty ()) {
     ptr = last->next;            //set to first
     last->next = NULL;           //break circle
@@ -80,11 +75,6 @@ void ELIST::assign_to_sublist(                           //to this list
   const ERRCODE LIST_NOT_EMPTY =
     "Destination list must be empty before extracting a sublist";
 
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST::assign_to_sublist", ABORT, NULL);
-  #endif
-
   if (!empty ())
     LIST_NOT_EMPTY.error ("ELIST.assign_to_sublist", ABORT, NULL);
 
@@ -101,11 +91,6 @@ void ELIST::assign_to_sublist(                           //to this list
 inT32 ELIST::length() const {  // count elements
   ELIST_ITERATOR it(const_cast<ELIST*>(this));
   inT32 count = 0;
-
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST::length", ABORT, NULL);
-  #endif
 
   for (it.mark_cycle_pt (); !it.cycled_list (); it.forward ())
     count++;
@@ -130,11 +115,6 @@ const void *, const void *)) {
   ELIST_LINK **base;             //ptr array to sort
   ELIST_LINK **current;
   inT32 i;
-
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST::sort", ABORT, NULL);
-  #endif
 
   /* Allocate an array of pointers, one per list element */
   count = length ();
@@ -215,8 +195,6 @@ ELIST_LINK *ELIST::add_sorted_and_find(
 
 ELIST_LINK *ELIST_ITERATOR::forward() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::forward", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::forward", ABORT, NULL);
   #endif
@@ -260,8 +238,6 @@ ELIST_LINK *ELIST_ITERATOR::data_relative(                //get data + or - ...
   ELIST_LINK *ptr;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::data_relative", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::data_relative", ABORT, NULL);
   if (list->empty ())
@@ -295,8 +271,6 @@ ELIST_LINK *ELIST_ITERATOR::data_relative(                //get data + or - ...
 
 ELIST_LINK *ELIST_ITERATOR::move_to_last() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::move_to_last", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::move_to_last", ABORT, NULL);
   #endif
@@ -326,8 +300,6 @@ void ELIST_ITERATOR::exchange(                             //positions of 2 link
   ELIST_LINK *old_current;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::exchange", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::exchange", ABORT, NULL);
   if (!other_it)
@@ -432,8 +404,6 @@ ELIST_LINK *ELIST_ITERATOR::extract_sublist(                             //from 
   ELIST_LINK *end_of_new_list;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::extract_sublist", ABORT, NULL);
   if (!other_it)
     BAD_PARAMETER.error ("ELIST_ITERATOR::extract_sublist", ABORT,
       "other_it NULL");

--- a/ccutil/elst.h
+++ b/ccutil/elst.h
@@ -297,8 +297,6 @@ class DLLSYM ELIST_ITERATOR
 inline void ELIST_ITERATOR::set_to_list(  //change list
                                         ELIST *list_to_iterate) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::set_to_list", ABORT, NULL);
   if (!list_to_iterate)
     BAD_PARAMETER.error ("ELIST_ITERATOR::set_to_list", ABORT,
       "list_to_iterate is NULL");
@@ -336,8 +334,6 @@ inline ELIST_ITERATOR::ELIST_ITERATOR(ELIST *list_to_iterate) {
 inline void ELIST_ITERATOR::add_after_then_move(  // element to add
                                                 ELIST_LINK *new_element) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::add_after_then_move", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::add_after_then_move", ABORT, NULL);
   if (!new_element)
@@ -383,8 +379,6 @@ inline void ELIST_ITERATOR::add_after_then_move(  // element to add
 inline void ELIST_ITERATOR::add_after_stay_put(  // element to add
                                                ELIST_LINK *new_element) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::add_after_stay_put", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::add_after_stay_put", ABORT, NULL);
   if (!new_element)
@@ -433,8 +427,6 @@ inline void ELIST_ITERATOR::add_after_stay_put(  // element to add
 inline void ELIST_ITERATOR::add_before_then_move(  // element to add
                                                  ELIST_LINK *new_element) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::add_before_then_move", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::add_before_then_move", ABORT, NULL);
   if (!new_element)
@@ -477,8 +469,6 @@ inline void ELIST_ITERATOR::add_before_then_move(  // element to add
 inline void ELIST_ITERATOR::add_before_stay_put(  // element to add
                                                 ELIST_LINK *new_element) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::add_before_stay_put", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::add_before_stay_put", ABORT, NULL);
   if (!new_element)
@@ -521,8 +511,6 @@ inline void ELIST_ITERATOR::add_before_stay_put(  // element to add
 
 inline void ELIST_ITERATOR::add_list_after(ELIST *list_to_add) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::add_list_after", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::add_list_after", ABORT, NULL);
   if (!list_to_add)
@@ -571,8 +559,6 @@ inline void ELIST_ITERATOR::add_list_after(ELIST *list_to_add) {
 
 inline void ELIST_ITERATOR::add_list_before(ELIST *list_to_add) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::add_list_before", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::add_list_before", ABORT, NULL);
   if (!list_to_add)
@@ -621,8 +607,6 @@ inline ELIST_LINK *ELIST_ITERATOR::extract() {
   ELIST_LINK *extracted_link;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::extract", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::extract", ABORT, NULL);
   if (!current)                  //list empty or
@@ -662,8 +646,6 @@ inline ELIST_LINK *ELIST_ITERATOR::extract() {
 
 inline ELIST_LINK *ELIST_ITERATOR::move_to_first() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::move_to_first", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::move_to_first", ABORT, NULL);
   #endif
@@ -688,8 +670,6 @@ inline ELIST_LINK *ELIST_ITERATOR::move_to_first() {
 
 inline void ELIST_ITERATOR::mark_cycle_pt() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::mark_cycle_pt", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::mark_cycle_pt", ABORT, NULL);
   #endif
@@ -711,8 +691,6 @@ inline void ELIST_ITERATOR::mark_cycle_pt() {
 
 inline bool ELIST_ITERATOR::at_first() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::at_first", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::at_first", ABORT, NULL);
   #endif
@@ -733,8 +711,6 @@ inline bool ELIST_ITERATOR::at_first() {
 
 inline bool ELIST_ITERATOR::at_last() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::at_last", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::at_last", ABORT, NULL);
   #endif
@@ -755,8 +731,6 @@ inline bool ELIST_ITERATOR::at_last() {
 
 inline bool ELIST_ITERATOR::cycled_list() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::cycled_list", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::cycled_list", ABORT, NULL);
   #endif
@@ -775,8 +749,6 @@ inline bool ELIST_ITERATOR::cycled_list() {
 
 inline inT32 ELIST_ITERATOR::length() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::length", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::length", ABORT, NULL);
   #endif
@@ -797,8 +769,6 @@ ELIST_ITERATOR::sort (           //sort elements
 int comparator (                 //comparison routine
 const void *, const void *)) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::sort", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::sort", ABORT, NULL);
   #endif
@@ -821,8 +791,6 @@ const void *, const void *)) {
 inline void ELIST_ITERATOR::add_to_end(  // element to add
                                        ELIST_LINK *new_element) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST_ITERATOR::add_to_end", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST_ITERATOR::add_to_end", ABORT, NULL);
   if (!new_element)

--- a/ccutil/elst2.cpp
+++ b/ccutil/elst2.cpp
@@ -45,11 +45,6 @@ void (*zapper) (ELIST2_LINK *)) {
   ELIST2_LINK *ptr;
   ELIST2_LINK *next;
 
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2::internal_clear", ABORT, NULL);
-  #endif
-
   if (!empty ()) {
     ptr = last->next;            //set to first
     last->next = NULL;           //break circle
@@ -81,11 +76,6 @@ void ELIST2::assign_to_sublist(                            //to this list
   const ERRCODE LIST_NOT_EMPTY =
     "Destination list must be empty before extracting a sublist";
 
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2::assign_to_sublist", ABORT, NULL);
-  #endif
-
   if (!empty ())
     LIST_NOT_EMPTY.error ("ELIST2.assign_to_sublist", ABORT, NULL);
 
@@ -102,11 +92,6 @@ void ELIST2::assign_to_sublist(                            //to this list
 inT32 ELIST2::length() const {  // count elements
   ELIST2_ITERATOR it(const_cast<ELIST2*>(this));
   inT32 count = 0;
-
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2::length", ABORT, NULL);
-  #endif
 
   for (it.mark_cycle_pt (); !it.cycled_list (); it.forward ())
     count++;
@@ -131,11 +116,6 @@ const void *, const void *)) {
   ELIST2_LINK **base;            //ptr array to sort
   ELIST2_LINK **current;
   inT32 i;
-
-  #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2::sort", ABORT, NULL);
-  #endif
 
   /* Allocate an array of pointers, one per list element */
   count = length ();
@@ -208,8 +188,6 @@ void ELIST2::add_sorted(int comparator(const void*, const void*),
 
 ELIST2_LINK *ELIST2_ITERATOR::forward() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::forward", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::forward", ABORT, NULL);
   #endif
@@ -250,8 +228,6 @@ ELIST2_LINK *ELIST2_ITERATOR::forward() {
 
 ELIST2_LINK *ELIST2_ITERATOR::backward() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::backward", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::backward", ABORT, NULL);
   #endif
@@ -294,8 +270,6 @@ ELIST2_LINK *ELIST2_ITERATOR::data_relative(                //get data + or - ..
   ELIST2_LINK *ptr;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::data_relative", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::data_relative", ABORT, NULL);
   if (list->empty ())
@@ -334,8 +308,6 @@ void ELIST2_ITERATOR::exchange(                              //positions of 2 li
   ELIST2_LINK *old_current;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::exchange", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::exchange", ABORT, NULL);
   if (!other_it)
@@ -452,8 +424,6 @@ ELIST2_LINK *ELIST2_ITERATOR::extract_sublist(                              //fr
   ELIST2_LINK *end_of_new_list;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::extract_sublist", ABORT, NULL);
   if (!other_it)
     BAD_PARAMETER.error ("ELIST2_ITERATOR::extract_sublist", ABORT,
       "other_it NULL");

--- a/ccutil/elst2.h
+++ b/ccutil/elst2.h
@@ -264,8 +264,6 @@ class DLLSYM ELIST2_ITERATOR
 inline void ELIST2_ITERATOR::set_to_list(  //change list
                                          ELIST2 *list_to_iterate) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::set_to_list", ABORT, NULL);
   if (!list_to_iterate)
     BAD_PARAMETER.error ("ELIST2_ITERATOR::set_to_list", ABORT,
       "list_to_iterate is NULL");
@@ -303,8 +301,6 @@ inline ELIST2_ITERATOR::ELIST2_ITERATOR(ELIST2 *list_to_iterate) {
 inline void ELIST2_ITERATOR::add_after_then_move(  // element to add
                                                  ELIST2_LINK *new_element) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::add_after_then_move", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::add_after_then_move", ABORT, NULL);
   if (!new_element)
@@ -354,8 +350,6 @@ inline void ELIST2_ITERATOR::add_after_then_move(  // element to add
 inline void ELIST2_ITERATOR::add_after_stay_put(  // element to add
                                                 ELIST2_LINK *new_element) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::add_after_stay_put", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::add_after_stay_put", ABORT, NULL);
   if (!new_element)
@@ -408,8 +402,6 @@ inline void ELIST2_ITERATOR::add_after_stay_put(  // element to add
 inline void ELIST2_ITERATOR::add_before_then_move(  // element to add
                                                   ELIST2_LINK *new_element) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::add_before_then_move", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::add_before_then_move", ABORT, NULL);
   if (!new_element)
@@ -457,8 +449,6 @@ inline void ELIST2_ITERATOR::add_before_then_move(  // element to add
 inline void ELIST2_ITERATOR::add_before_stay_put(  // element to add
                                                  ELIST2_LINK *new_element) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::add_before_stay_put", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::add_before_stay_put", ABORT, NULL);
   if (!new_element)
@@ -506,8 +496,6 @@ inline void ELIST2_ITERATOR::add_before_stay_put(  // element to add
 
 inline void ELIST2_ITERATOR::add_list_after(ELIST2 *list_to_add) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::add_list_after", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::add_list_after", ABORT, NULL);
   if (!list_to_add)
@@ -560,8 +548,6 @@ inline void ELIST2_ITERATOR::add_list_after(ELIST2 *list_to_add) {
 
 inline void ELIST2_ITERATOR::add_list_before(ELIST2 *list_to_add) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::add_list_before", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::add_list_before", ABORT, NULL);
   if (!list_to_add)
@@ -614,8 +600,6 @@ inline ELIST2_LINK *ELIST2_ITERATOR::extract() {
   ELIST2_LINK *extracted_link;
 
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::extract", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::extract", ABORT, NULL);
   if (!current)                  //list empty or
@@ -657,8 +641,6 @@ inline ELIST2_LINK *ELIST2_ITERATOR::extract() {
 
 inline ELIST2_LINK *ELIST2_ITERATOR::move_to_first() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::move_to_first", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::move_to_first", ABORT, NULL);
   #endif
@@ -679,8 +661,6 @@ inline ELIST2_LINK *ELIST2_ITERATOR::move_to_first() {
 
 inline ELIST2_LINK *ELIST2_ITERATOR::move_to_last() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::move_to_last", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::move_to_last", ABORT, NULL);
   #endif
@@ -705,8 +685,6 @@ inline ELIST2_LINK *ELIST2_ITERATOR::move_to_last() {
 
 inline void ELIST2_ITERATOR::mark_cycle_pt() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::mark_cycle_pt", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::mark_cycle_pt", ABORT, NULL);
   #endif
@@ -728,8 +706,6 @@ inline void ELIST2_ITERATOR::mark_cycle_pt() {
 
 inline BOOL8 ELIST2_ITERATOR::at_first() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::at_first", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::at_first", ABORT, NULL);
   #endif
@@ -750,8 +726,6 @@ inline BOOL8 ELIST2_ITERATOR::at_first() {
 
 inline BOOL8 ELIST2_ITERATOR::at_last() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::at_last", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::at_last", ABORT, NULL);
   #endif
@@ -772,8 +746,6 @@ inline BOOL8 ELIST2_ITERATOR::at_last() {
 
 inline BOOL8 ELIST2_ITERATOR::cycled_list() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::cycled_list", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::cycled_list", ABORT, NULL);
   #endif
@@ -792,8 +764,6 @@ inline BOOL8 ELIST2_ITERATOR::cycled_list() {
 
 inline inT32 ELIST2_ITERATOR::length() {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::length", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::length", ABORT, NULL);
   #endif
@@ -814,8 +784,6 @@ ELIST2_ITERATOR::sort (          //sort elements
 int comparator (                 //comparison routine
 const void *, const void *)) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::sort", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::sort", ABORT, NULL);
   #endif
@@ -838,8 +806,6 @@ const void *, const void *)) {
 inline void ELIST2_ITERATOR::add_to_end(  // element to add
                                         ELIST2_LINK *new_element) {
   #ifndef NDEBUG
-  if (!this)
-    NULL_OBJECT.error ("ELIST2_ITERATOR::add_to_end", ABORT, NULL);
   if (!list)
     NO_LIST.error ("ELIST2_ITERATOR::add_to_end", ABORT, NULL);
   if (!new_element)

--- a/textord/tabvector.cpp
+++ b/textord/tabvector.cpp
@@ -523,16 +523,12 @@ const char* kAlignmentNames[] = {
 
 // Print basic information about this tab vector.
 void TabVector::Print(const char* prefix) {
-  if (this == NULL) {
-    tprintf("%s <null>\n", prefix);
-  } else {
-    tprintf("%s %s (%d,%d)->(%d,%d) w=%d s=%d, sort key=%d, boxes=%d,"
-            " partners=%d\n",
-            prefix, kAlignmentNames[alignment_],
-            startpt_.x(), startpt_.y(), endpt_.x(), endpt_.y(),
-            mean_width_, percent_score_, sort_key_,
-            boxes_.length(), partners_.length());
-  }
+  tprintf("%s %s (%d,%d)->(%d,%d) w=%d s=%d, sort key=%d, boxes=%d,"
+          " partners=%d\n",
+          prefix, kAlignmentNames[alignment_],
+          startpt_.x(), startpt_.y(), endpt_.x(), endpt_.y(),
+          mean_width_, percent_score_, sort_key_,
+          boxes_.length(), partners_.length());
 }
 
 // Print basic information about this tab vector and every box in it.


### PR DESCRIPTION
This fixes warnings from clang.

Signed-off-by: Stefan Weil <sw@weilnetz.de>