### PR TITLE
ccmain: Remove unused private class member

### DIFF
--- a/ccmain/osdetect.h
+++ b/ccmain/osdetect.h
@@ -87,7 +87,6 @@ class OrientationDetector {
   int get_orientation();
  private:
   OSResults* osr_;
-  tesseract::Tesseract* tess_;
   const GenericVector<int>* allowed_scripts_;
 };
 


### PR DESCRIPTION
This fixes a warning from clang.

Signed-off-by: Stefan Weil <sw@weilnetz.de>