### PR TITLE
Use shell quoting rather than pluses to separate font arguments in tesstrain.sh

### DIFF
--- a/training/tesstrain.sh
+++ b/training/tesstrain.sh
@@ -17,7 +17,7 @@
 # USAGE:
 #
 # tesstrain.sh
-#    --fontlist FONTS_STR       # A plus-separated list of fontnames to train on.
+#    --fontlist FONTS           # A list of fontnames to train on.
 #    --fonts_dir FONTS_PATH     # Path to font files.
 #    --lang LANG_CODE           # ISO 639 code.
 #    --langdata_dir DATADIR     # Path to tesseract/training/langdata directory.

--- a/training/tesstrain_utils.sh
+++ b/training/tesstrain_utils.sh
@@ -90,19 +90,21 @@ parse_flags() {
         case ${ARGV[$i]} in
             --)
                 break;;
-            --fontlist)   # Expect a plus-separated list of names
-                if [[ -z ${ARGV[$j]} ]] || [[ ${ARGV[$j]:0:2} == "--" ]]; then
-                    err_exit "Invalid value passed to --fontlist"
-                fi
-                local ofs=$IFS
-                IFS='+'
-                FONTS=( ${ARGV[$j]} )
-                IFS=$ofs
-                i=$j ;;
+            --fontlist)
+		fn=0
+		FONTS=""
+                while test $j -lt ${#ARGV[@]}; do
+                    test -z "${ARGV[$j]}" && break
+                    test `echo ${ARGV[$j]} | cut -c -2` = "--" && break
+                    FONTS[$fn]="${ARGV[$j]}"
+                    fn=$((fn+1))
+                    j=$((j+1))
+                done
+                i=$((j-1)) ;;
             --exposures)
                 exp=""
                 while test $j -lt ${#ARGV[@]}; do
-                    test -z ${ARGV[$j]} && break
+                    test -z "${ARGV[$j]}" && break
                     test `echo ${ARGV[$j]} | cut -c -2` = "--" && break
                     exp="$exp ${ARGV[$j]}"
                     j=$((j+1))


### PR DESCRIPTION
The way tesstrain.sh handled font names was really weird, using '+'
signs as a delimiter. However quoting arguments is a much more
straightforward, standard and sensible way to do things.

So whereas previously one would have used this:
  --fontlist Times New Roman + Arial Black
Now they should be specified like this:
  --fontlist "Times New Roman" "Arial Black"