### PR TITLE
Fix duplicate fclose

### DIFF
--- a/ccmain/recogtraining.cpp
+++ b/ccmain/recogtraining.cpp
@@ -84,7 +84,7 @@ void Tesseract::recog_training_segmented(const STRING &fname,
   const char *lastdot = strrchr(box_fname.string(), '.');
   if (lastdot != NULL) box_fname[lastdot - box_fname.string()] = '\0';
   box_fname += ".box";
-  // read_next_box() will close box_file
+  // ReadNextBox() will close box_file
   FILE *box_file = open_file(box_fname.string(), "r");
 
   PAGE_RES_IT page_res_it;
@@ -132,7 +132,6 @@ void Tesseract::recog_training_segmented(const STRING &fname,
     }
     page_res_it.forward();
   } while (keep_going);
-  fclose(box_file);
 
   // Set up scripts on all of the words that did not get sent to
   // ambigs_classify_and_output.  They all should have, but if all the


### PR DESCRIPTION
Coverity bug report: CID 1270401 (#1 of 1): Use after free

As the comment (which was also fixed) says, ReadNextBox() already
calls fclose(box_file), so don't call it a 2nd time.

Signed-off-by: Stefan Weil <sw@weilnetz.de>