### PR TITLE
If there is no explicit renderer(s), default to TessTextRenderer

### DIFF
--- a/api/tesseractmain.cpp
+++ b/api/tesseractmain.cpp
@@ -323,7 +323,7 @@ void PreloadRenderers(tesseract::TessBaseAPI* api,
           (api->GetBoolVariable("tessedit_make_boxes_from_boxes", &b) && b);
 
     api->GetBoolVariable("tessedit_create_txt", &b);
-    if (b || (renderers->empty() && !disable_text_renderer) {
+    if (b || (renderers->empty() && !disable_text_renderer)) {
       renderers->push_back(new tesseract::TessTextRenderer(outputbase));
     }
   }

--- a/ccmain/tesseractclass.cpp
+++ b/ccmain/tesseractclass.cpp
@@ -381,7 +381,7 @@ Tesseract::Tesseract()
                   this->params()),
       BOOL_MEMBER(tessedit_write_unlv, false, "Write .unlv output file",
                   this->params()),
-      BOOL_MEMBER(tessedit_create_txt, true, "Write .txt output file",
+      BOOL_MEMBER(tessedit_create_txt, false, "Write .txt output file",
                   this->params()),
       BOOL_MEMBER(tessedit_create_hocr, false, "Write .html hOCR output file",
                   this->params()),

--- a/ccmain/tesseractclass.h
+++ b/ccmain/tesseractclass.h
@@ -1001,7 +1001,7 @@ class Tesseract : public Wordrec {
   BOOL_VAR_H(tessedit_write_rep_codes, false,
              "Write repetition char code");
   BOOL_VAR_H(tessedit_write_unlv, false, "Write .unlv output file");
-  BOOL_VAR_H(tessedit_create_txt, true, "Write .txt output file");
+  BOOL_VAR_H(tessedit_create_txt, false, "Write .txt output file");
   BOOL_VAR_H(tessedit_create_hocr, false, "Write .html hOCR output file");
   BOOL_VAR_H(tessedit_create_pdf, false, "Write .pdf output file");
   STRING_VAR_H(unrecognised_char, "|",

--- a/tessdata/configs/hocr
+++ b/tessdata/configs/hocr
@@ -1,3 +1,2 @@
-tessedit_create_txt 0
 tessedit_create_hocr 1
 tessedit_pageseg_mode 1

--- a/tessdata/configs/makebox
+++ b/tessdata/configs/makebox
@@ -1,2 +1,1 @@
-tessedit_create_txt 0
 tessedit_create_boxfile 1

--- a/tessdata/configs/pdf
+++ b/tessdata/configs/pdf
@@ -1,3 +1,2 @@
-tessedit_create_txt 0
 tessedit_create_pdf 1
 tessedit_pageseg_mode 1

--- a/tessdata/configs/txt
+++ b/tessdata/configs/txt
@@ -1,0 +1,3 @@
+# This config file should be used with other cofig files which creates renderers.
+# usage example: tesseract eurotext.tif eurotext txt hocr pdf
+tessedit_create_txt 1

--- a/tessdata/configs/unlv
+++ b/tessdata/configs/unlv
@@ -1,3 +1,2 @@
-tessedit_create_txt 0
 tessedit_write_unlv 1
 tessedit_pageseg_mode 6


### PR DESCRIPTION
Revert fd429c32, 43834da7, 05de195e.

See #49, #59.

The code in this commit solves the issue in a more elegant way, IMHO.

Now you can use:
  * `tesseract eurotext.tif eurotext txt pdf`
  * `tesseract eurotext.tif eurotext txt hocr`
  * `tesseract eurotext.tif eurotext txt hocr pdf`

NOTE:
  With `tesseract eurotext.tif eurotext`
  or `tesseract eurotext.tif eurotext txt`
  the psm will be set to '3', but...
  With `tesseract eurotext.tif eurotext txt pdf`
  or `tesseract eurotext.tif eurotext txt hocr`
  the psm will be set to '1'.