### PR TITLE
Compatibility with Leptonica 1.73

### DIFF
--- a/opencl/openclwrapper.cpp
+++ b/opencl/openclwrapper.cpp
@@ -19,6 +19,22 @@
 #include <stdio.h>
 #include <mach/mach_time.h>
 #endif
+
+/*
+    Convenience macro to test the version of Leptonica.
+*/
+#if defined(LIBLEPT_MAJOR_VERSION) && defined(LIBLEPT_MINOR_VERSION)
+#   define TESSERACT_LIBLEPT_PREREQ(maj, min) \
+        ((LIBLEPT_MAJOR_VERSION) > (maj) || ((LIBLEPT_MAJOR_VERSION) == (maj) && (LIBLEPT_MINOR_VERSION) >= (min)))
+#else
+#   define TESSERACT_LIBLEPT_PREREQ(maj, min) 0
+#endif
+
+#if TESSERACT_LIBLEPT_PREREQ(1,73)
+#   define CALLOC LEPT_CALLOC
+#   define FREE LEPT_FREE
+#endif
+
 #ifdef USE_OPENCL
 
 #include "opencl_device_selection.h"


### PR DESCRIPTION
CALLOC and FREE were renamed to LEPT_*

The alternative to using the TESSERACT_LIBLEPT_PREREQ macro introduced in this pull request, to define CALLOC and FREE to their new names, would be to depend on Leptonica >=1.73 and use the LEPT_* variants in Tesseract's code directly.

I opted for this pull request's approach for better backward compatibility.

See-Also: https://bugs.gentoo.org/show_bug.cgi?id=573382