### PR TITLE
Document hocr_font_info in config

### DIFF
--- a/tessdata/configs/hocr
+++ b/tessdata/configs/hocr
@@ -1,2 +1,3 @@
 tessedit_create_hocr 1
 tessedit_pageseg_mode 1
+hocr_font_info 0


### PR DESCRIPTION
Tiny change to add the hocr_font_info config parameter to the hocr config file as a way of documenting its existence to interested parties. It is turned off, matching the default in the code.