### PR TITLE
Only generate dir for HOCR when needed - fixes #208

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -1379,14 +1379,14 @@ static void AddBaselineCoordsTohOCR(const PageIterator *it,
 }
 
 static void AddIdTohOCR(STRING* hocr_str, const std::string base, int num1, int num2) {
-  unsigned long bufsize = base.length() + 2 * kMaxIntSize;
-  char id_buffer[bufsize];
+  const unsigned long BUFSIZE = 64;
+  char id_buffer[BUFSIZE];
   if (num2 >= 0) {
-    snprintf(id_buffer, bufsize - 1, "%s_%d_%d", base.c_str(), num1, num2);
+    snprintf(id_buffer, BUFSIZE - 1, "%s_%d_%d", base.c_str(), num1, num2);
   } else {
-    snprintf(id_buffer, bufsize - 1, "%s_%d", base.c_str(), num1);
+    snprintf(id_buffer, BUFSIZE - 1, "%s_%d", base.c_str(), num1);
   }
-  id_buffer[bufsize - 1] = '\0';
+  id_buffer[BUFSIZE - 1] = '\0';
   *hocr_str += " id='";
   *hocr_str += id_buffer;
   *hocr_str += "'";


### PR DESCRIPTION
Takes advantage of inheritance and default of `dir="ltr"` to:
 - only generate paragraph `dir` attributes which are not `ltr`
 - only generate word `dir` attributes which don't match enclosing paragraph

Tested against LTR, RTL, and mixed direction files. Files for the latter two cases are in a separate PR
