### PR TITLE
Add TessBaseApi::GetTessDataDir

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -413,6 +413,11 @@ void TessBaseAPI::GetAvailableLanguagesAsVector(
   }
 }
 
+const STRING& TessBaseAPI::GetTessDataDir() const
+{
+  return tesseract_->datadir;
+}
+
 /**
  * Init only the lang model component of Tesseract. The only functions
  * that work after this init are SetVariable and IsValidWord.

--- a/api/baseapi.h
+++ b/api/baseapi.h
@@ -263,6 +263,11 @@ class TESS_API TessBaseAPI {
   void GetAvailableLanguagesAsVector(GenericVector<STRING>* langs) const;
 
   /**
+    * Returns the location of the directory with language files and config files.
+    */
+  const STRING& GetTessDataDir() const;
+
+  /**
    * Init only the lang model component of Tesseract. The only functions
    * that work after this init are SetVariable and IsValidWord.
    * WARNING: temporary! This function will be removed from here and placed


### PR DESCRIPTION
Trivial patch to expose the used tessdata_prefix in the public API.