### PR TITLE
Add TSV result renderer

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -1417,7 +1417,7 @@ static void AddBoxTohOCR(const ResultIterator *it,
   *hocr_str += "\">";
 }
 
-static void AddBoxTohOCRTSV(const PageIterator *it,
+static void AddBoxToTSV(const PageIterator *it,
                          PageIteratorLevel level,
                          STRING* hocr_str) {
   int left, top, right, bottom;
@@ -1615,57 +1615,31 @@ char* TessBaseAPI::GetHOCRText(struct ETEXT_DESC* monitor, int page_number) {
 }
 
 /**
- * Make a TSV-formatted string with hOCR markup from the internal
- * data structures.
+ * Make a TSV-formatted string from the internal data structures.
  * page_number is 0-based but will appear in the output as 1-based.
- * Image name/input_file_ can be set by SetInputName before calling
- * GetHOCRText
- * STL removed from original patch submission and refactored by rays.
  */
-char* TessBaseAPI::GetHOCRTSVText(int page_number) {
+char* TessBaseAPI::GetTSVText(int page_number) {
   if (tesseract_ == NULL ||
       (page_res_ == NULL && Recognize(NULL) < 0))
     return NULL;
 
   int lcnt = 1, bcnt = 1, pcnt = 1, wcnt = 1;
-  int page_id = page_number + 1;  // hOCR uses 1-based page numbers.
-  bool font_info = false;
-  GetBoolVariable("hocr_font_info", &font_info);
+  int page_id = page_number + 1;  // we use 1-based page numbers.
 
-  STRING hocr_str("");
-
-  if (input_file_ == NULL)
-      SetInputName(NULL);
-
-#ifdef _WIN32
-  // convert input name from ANSI encoding to utf-8
-  int str16_len = MultiByteToWideChar(CP_ACP, 0, input_file_->string(), -1,
-                                      NULL, NULL);
-  wchar_t *uni16_str = new WCHAR[str16_len];
-  str16_len = MultiByteToWideChar(CP_ACP, 0, input_file_->string(), -1,
-                                  uni16_str, str16_len);
-  int utf8_len = WideCharToMultiByte(CP_UTF8, 0, uni16_str, str16_len, NULL,
-                                     NULL, NULL, NULL);
-  char *utf8_str = new char[utf8_len];
-  WideCharToMultiByte(CP_UTF8, 0, uni16_str, str16_len, utf8_str,
-                      utf8_len, NULL, NULL);
-  *input_file_ = utf8_str;
-  delete[] uni16_str;
-  delete[] utf8_str;
-#endif
+  STRING tsv_str("");
 
   int page_num = page_id, block_num = 0, par_num = 0, line_num = 0, word_num = 0;
 
-  hocr_str.add_str_int("1\t", page_num);
-  hocr_str.add_str_int("\t", block_num);
-  hocr_str.add_str_int("\t", par_num);
-  hocr_str.add_str_int("\t", line_num);
-  hocr_str.add_str_int("\t", word_num);
-  hocr_str.add_str_int("\t", rect_left_);
-  hocr_str.add_str_int("\t", rect_top_);
-  hocr_str.add_str_int("\t", rect_width_);
-  hocr_str.add_str_int("\t", rect_height_);
-  hocr_str += "\t-1\t\n";
+  tsv_str.add_str_int("1\t", page_num); // level 1 - page
+  tsv_str.add_str_int("\t", block_num);
+  tsv_str.add_str_int("\t", par_num);
+  tsv_str.add_str_int("\t", line_num);
+  tsv_str.add_str_int("\t", word_num);
+  tsv_str.add_str_int("\t", rect_left_);
+  tsv_str.add_str_int("\t", rect_top_);
+  tsv_str.add_str_int("\t", rect_width_);
+  tsv_str.add_str_int("\t", rect_height_);
+  tsv_str += "\t-1\t\n";
 
   ResultIterator *res_it = GetIterator();
   while (!res_it->Empty(RIL_BLOCK)) {
@@ -1674,36 +1648,36 @@ char* TessBaseAPI::GetHOCRTSVText(int page_number) {
       continue;
     }
 
-    // Open any new block/paragraph/textline.
+    // Add rows for any new block/paragraph/textline.
     if (res_it->IsAtBeginningOf(RIL_BLOCK)) {
       block_num++, par_num = 0, line_num = 0, word_num = 0;
-      hocr_str.add_str_int("2\t", page_num);
-      hocr_str.add_str_int("\t", block_num);
-      hocr_str.add_str_int("\t", par_num);
-      hocr_str.add_str_int("\t", line_num);
-      hocr_str.add_str_int("\t", word_num);
-      AddBoxTohOCRTSV(res_it, RIL_BLOCK, &hocr_str);
-      hocr_str += "\t-1\t\n";
+      tsv_str.add_str_int("2\t", page_num); // level 2 - block
+      tsv_str.add_str_int("\t", block_num);
+      tsv_str.add_str_int("\t", par_num);
+      tsv_str.add_str_int("\t", line_num);
+      tsv_str.add_str_int("\t", word_num);
+      AddBoxToTSV(res_it, RIL_BLOCK, &tsv_str);
+      tsv_str += "\t-1\t\n"; // end of row for block
     }
     if (res_it->IsAtBeginningOf(RIL_PARA)) {
       par_num++, line_num = 0, word_num = 0;
-      hocr_str.add_str_int("3\t", page_num);
-      hocr_str.add_str_int("\t", block_num);
-      hocr_str.add_str_int("\t", par_num);
-      hocr_str.add_str_int("\t", line_num);
-      hocr_str.add_str_int("\t", word_num);
-      AddBoxTohOCRTSV(res_it, RIL_PARA, &hocr_str);
-      hocr_str += "\t-1\t\n";
+      tsv_str.add_str_int("3\t", page_num); // level 3 - paragraph
+      tsv_str.add_str_int("\t", block_num);
+      tsv_str.add_str_int("\t", par_num);
+      tsv_str.add_str_int("\t", line_num);
+      tsv_str.add_str_int("\t", word_num);
+      AddBoxToTSV(res_it, RIL_PARA, &tsv_str);
+      tsv_str += "\t-1\t\n"; // end of row for para
     }
     if (res_it->IsAtBeginningOf(RIL_TEXTLINE)) {
       line_num++, word_num = 0;
-      hocr_str.add_str_int("4\t", page_num);
-      hocr_str.add_str_int("\t", block_num);
-      hocr_str.add_str_int("\t", par_num);
-      hocr_str.add_str_int("\t", line_num);
-      hocr_str.add_str_int("\t", word_num);
-      AddBoxTohOCRTSV(res_it, RIL_TEXTLINE, &hocr_str);
-      hocr_str += "\t-1\t\n";
+      tsv_str.add_str_int("4\t", page_num); // level 4 - line
+      tsv_str.add_str_int("\t", block_num);
+      tsv_str.add_str_int("\t", par_num);
+      tsv_str.add_str_int("\t", line_num);
+      tsv_str.add_str_int("\t", word_num);
+      AddBoxToTSV(res_it, RIL_TEXTLINE, &tsv_str);
+      tsv_str += "\t-1\t\n"; // end of row for line
     }
 
     // Now, process the word...
@@ -1715,49 +1689,34 @@ char* TessBaseAPI::GetHOCRTSVText(int page_number) {
     font_name = res_it->WordFontAttributes(&bold, &italic, &underlined,
                                            &monospace, &serif, &smallcaps,
                                            &pointsize, &font_id);
-      word_num++;
-      hocr_str.add_str_int("5\t", page_num);
-      hocr_str.add_str_int("\t", block_num);
-      hocr_str.add_str_int("\t", par_num);
-      hocr_str.add_str_int("\t", line_num);
-      hocr_str.add_str_int("\t", word_num);
-      hocr_str.add_str_int("\t", left);
-      hocr_str.add_str_int("\t", top);
-      hocr_str.add_str_int("\t", right - left + 1);
-      hocr_str.add_str_int("\t", bottom - top + 1);
-      hocr_str.add_str_int("\t", res_it->Confidence(RIL_WORD));
-    bool last_word_in_line = res_it->IsAtFinalElement(RIL_TEXTLINE, RIL_WORD);
-    bool last_word_in_para = res_it->IsAtFinalElement(RIL_PARA, RIL_WORD);
-    bool last_word_in_block = res_it->IsAtFinalElement(RIL_BLOCK, RIL_WORD);
-    hocr_str += "\t";
+    word_num++;
+    tsv_str.add_str_int("5\t", page_num); // level 5 - word
+    tsv_str.add_str_int("\t", block_num);
+    tsv_str.add_str_int("\t", par_num);
+    tsv_str.add_str_int("\t", line_num);
+    tsv_str.add_str_int("\t", word_num);
+    tsv_str.add_str_int("\t", left);
+    tsv_str.add_str_int("\t", top);
+    tsv_str.add_str_int("\t", right - left + 1);
+    tsv_str.add_str_int("\t", bottom - top + 1);
+    tsv_str.add_str_int("\t", res_it->Confidence(RIL_WORD));
+    tsv_str += "\t";
+
+    // Increment counts if at end of block/paragraph/textline.
+    if (res_it->IsAtFinalElement(RIL_TEXTLINE, RIL_WORD)) lcnt++;
+    if (res_it->IsAtFinalElement(RIL_PARA, RIL_WORD)) pcnt++;
+    if (res_it->IsAtFinalElement(RIL_BLOCK, RIL_WORD)) bcnt++;
+
     do {
-      const char *grapheme = res_it->GetUTF8Text(RIL_SYMBOL);
-//      if (grapheme && grapheme[0] != 0) {
-//        if (grapheme[1] == 0) {
-//          hocr_str += HOcrEscape(grapheme);
-//        } else {
-          hocr_str += grapheme;
-//        }
-//      }
-      delete []grapheme;
+      tsv_str += res_it->GetUTF8Text(RIL_SYMBOL);
       res_it->Next(RIL_SYMBOL);
     } while (!res_it->Empty(RIL_BLOCK) && !res_it->IsAtBeginningOf(RIL_WORD));
-    hocr_str += "\n";
+    tsv_str += "\n"; // end of row
     wcnt++;
-    // Close any ending block/paragraph/textline.
-    if (last_word_in_line) {
-      lcnt++;
-    }
-    if (last_word_in_para) {
-      pcnt++;
-    }
-    if (last_word_in_block) {
-      bcnt++;
-    }
   }
 
-  char *ret = new char[hocr_str.length() + 1];
-  strcpy(ret, hocr_str.string());
+  char *ret = new char[tsv_str.length() + 1];
+  strcpy(ret, tsv_str.string());
   delete res_it;
   return ret;
 }

--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -1417,6 +1417,19 @@ static void AddBoxTohOCR(const ResultIterator *it,
   *hocr_str += "\">";
 }
 
+static void AddBoxTohOCRTSV(const PageIterator *it,
+                         PageIteratorLevel level,
+                         STRING* hocr_str) {
+  int left, top, right, bottom;
+  it->BoundingBox(level, &left, &top, &right, &bottom);
+  hocr_str->add_str_int("\t", left);
+  hocr_str->add_str_int("\t", top);
+  hocr_str->add_str_int("\t", right - left + 1);
+  hocr_str->add_str_int("\t", bottom - top + 1);
+}
+
+
+
 /**
  * Make a HTML-formatted string with hOCR markup from the internal
  * data structures.
@@ -1641,19 +1654,18 @@ char* TessBaseAPI::GetHOCRTSVText(int page_number) {
   delete[] utf8_str;
 #endif
 
-  hocr_str.add_str_int("  <div class='ocr_page' id='page_", page_id);
-  hocr_str += "' title='image \"";
-  if (input_file_) {
-    hocr_str += HOcrEscape(input_file_->string());
-  } else {
-    hocr_str += "unknown";
-  }
-  hocr_str.add_str_int("\"; bbox ", rect_left_);
-  hocr_str.add_str_int(" ", rect_top_);
-  hocr_str.add_str_int(" ", rect_width_);
-  hocr_str.add_str_int(" ", rect_height_);
-  hocr_str.add_str_int("; ppageno ", page_number);
-  hocr_str += "'>\n";
+  int page_num = page_id, block_num = 0, par_num = 0, line_num = 0, word_num = 0;
+
+  hocr_str.add_str_int("1\t", page_num);
+  hocr_str.add_str_int("\t", block_num);
+  hocr_str.add_str_int("\t", par_num);
+  hocr_str.add_str_int("\t", line_num);
+  hocr_str.add_str_int("\t", word_num);
+  hocr_str.add_str_int("\t", rect_left_);
+  hocr_str.add_str_int("\t", rect_top_);
+  hocr_str.add_str_int("\t", rect_width_);
+  hocr_str.add_str_int("\t", rect_height_);
+  hocr_str += "\t-1\t\n";
 
   ResultIterator *res_it = GetIterator();
   while (!res_it->Empty(RIL_BLOCK)) {
@@ -1664,31 +1676,37 @@ char* TessBaseAPI::GetHOCRTSVText(int page_number) {
 
     // Open any new block/paragraph/textline.
     if (res_it->IsAtBeginningOf(RIL_BLOCK)) {
-      hocr_str.add_str_int("   <div class='ocr_carea' id='block_", page_id);
-      hocr_str.add_str_int("_", bcnt);
-      AddBoxTohOCR(res_it, RIL_BLOCK, &hocr_str);
+      block_num++, par_num = 0, line_num = 0, word_num = 0;
+      hocr_str.add_str_int("2\t", page_num);
+      hocr_str.add_str_int("\t", block_num);
+      hocr_str.add_str_int("\t", par_num);
+      hocr_str.add_str_int("\t", line_num);
+      hocr_str.add_str_int("\t", word_num);
+      AddBoxTohOCRTSV(res_it, RIL_BLOCK, &hocr_str);
+      hocr_str += "\t-1\t\n";
     }
     if (res_it->IsAtBeginningOf(RIL_PARA)) {
-      if (res_it->ParagraphIsLtr()) {
-        hocr_str.add_str_int("\n    <p class='ocr_par' dir='ltr' id='par_",
-                             page_id);
-        hocr_str.add_str_int("_", pcnt);
-      } else {
-        hocr_str.add_str_int("\n    <p class='ocr_par' dir='rtl' id='par_",
-                             page_id);
-        hocr_str.add_str_int("_", pcnt);
-      }
-      AddBoxTohOCR(res_it, RIL_PARA, &hocr_str);
+      par_num++, line_num = 0, word_num = 0;
+      hocr_str.add_str_int("3\t", page_num);
+      hocr_str.add_str_int("\t", block_num);
+      hocr_str.add_str_int("\t", par_num);
+      hocr_str.add_str_int("\t", line_num);
+      hocr_str.add_str_int("\t", word_num);
+      AddBoxTohOCRTSV(res_it, RIL_PARA, &hocr_str);
+      hocr_str += "\t-1\t\n";
     }
     if (res_it->IsAtBeginningOf(RIL_TEXTLINE)) {
-      hocr_str.add_str_int("\n     <span class='ocr_line' id='line_", page_id);
-      hocr_str.add_str_int("_", lcnt);
-      AddBoxTohOCR(res_it, RIL_TEXTLINE, &hocr_str);
+      line_num++, word_num = 0;
+      hocr_str.add_str_int("4\t", page_num);
+      hocr_str.add_str_int("\t", block_num);
+      hocr_str.add_str_int("\t", par_num);
+      hocr_str.add_str_int("\t", line_num);
+      hocr_str.add_str_int("\t", word_num);
+      AddBoxTohOCRTSV(res_it, RIL_TEXTLINE, &hocr_str);
+      hocr_str += "\t-1\t\n";
     }
 
     // Now, process the word...
-    hocr_str.add_str_int("<span class='ocrx_word' id='word_", page_id);
-    hocr_str.add_str_int("_", wcnt);
     int left, top, right, bottom;
     bool bold, italic, underlined, monospace, serif, smallcaps;
     int pointsize, font_id;
@@ -1697,34 +1715,21 @@ char* TessBaseAPI::GetHOCRTSVText(int page_number) {
     font_name = res_it->WordFontAttributes(&bold, &italic, &underlined,
                                            &monospace, &serif, &smallcaps,
                                            &pointsize, &font_id);
-    hocr_str.add_str_int("' title='bbox ", left);
-    hocr_str.add_str_int(" ", top);
-    hocr_str.add_str_int(" ", right);
-    hocr_str.add_str_int(" ", bottom);
-    hocr_str.add_str_int("; x_wconf ", res_it->Confidence(RIL_WORD));
-    if (font_info) {
-      hocr_str += "; x_font ";
-      hocr_str += HOcrEscape(font_name);
-      hocr_str.add_str_int("; x_fsize ", pointsize);
-    }
-    hocr_str += "'";
-    if (res_it->WordRecognitionLanguage()) {
-      hocr_str += " lang='";
-      hocr_str += res_it->WordRecognitionLanguage();
-      hocr_str += "'";
-    }
-    switch (res_it->WordDirection()) {
-      case DIR_LEFT_TO_RIGHT: hocr_str += " dir='ltr'"; break;
-      case DIR_RIGHT_TO_LEFT: hocr_str += " dir='rtl'"; break;
-      default:  // Do nothing.
-        break;
-    }
-    hocr_str += ">";
+      word_num++;
+      hocr_str.add_str_int("5\t", page_num);
+      hocr_str.add_str_int("\t", block_num);
+      hocr_str.add_str_int("\t", par_num);
+      hocr_str.add_str_int("\t", line_num);
+      hocr_str.add_str_int("\t", word_num);
+      hocr_str.add_str_int("\t", left);
+      hocr_str.add_str_int("\t", top);
+      hocr_str.add_str_int("\t", right - left + 1);
+      hocr_str.add_str_int("\t", bottom - top + 1);
+      hocr_str.add_str_int("\t", res_it->Confidence(RIL_WORD));
     bool last_word_in_line = res_it->IsAtFinalElement(RIL_TEXTLINE, RIL_WORD);
     bool last_word_in_para = res_it->IsAtFinalElement(RIL_PARA, RIL_WORD);
     bool last_word_in_block = res_it->IsAtFinalElement(RIL_BLOCK, RIL_WORD);
-    if (bold) hocr_str += "<strong>";
-    if (italic) hocr_str += "<em>";
+    hocr_str += "\t";
     do {
       const char *grapheme = res_it->GetUTF8Text(RIL_SYMBOL);
       if (grapheme && grapheme[0] != 0) {
@@ -1737,25 +1742,19 @@ char* TessBaseAPI::GetHOCRTSVText(int page_number) {
       delete []grapheme;
       res_it->Next(RIL_SYMBOL);
     } while (!res_it->Empty(RIL_BLOCK) && !res_it->IsAtBeginningOf(RIL_WORD));
-    if (italic) hocr_str += "</em>";
-    if (bold) hocr_str += "</strong>";
-    hocr_str += "</span> ";
+    hocr_str += "\n";
     wcnt++;
     // Close any ending block/paragraph/textline.
     if (last_word_in_line) {
-      hocr_str += "\n     </span>";
       lcnt++;
     }
     if (last_word_in_para) {
-      hocr_str += "\n    </p>\n";
       pcnt++;
     }
     if (last_word_in_block) {
-      hocr_str += "   </div>\n";
       bcnt++;
     }
   }
-  hocr_str += "  </div>\n";
 
   char *ret = new char[hocr_str.length() + 1];
   strcpy(ret, hocr_str.string());

--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -1732,13 +1732,13 @@ char* TessBaseAPI::GetHOCRTSVText(int page_number) {
     hocr_str += "\t";
     do {
       const char *grapheme = res_it->GetUTF8Text(RIL_SYMBOL);
-      if (grapheme && grapheme[0] != 0) {
-        if (grapheme[1] == 0) {
-          hocr_str += HOcrEscape(grapheme);
-        } else {
+//      if (grapheme && grapheme[0] != 0) {
+//        if (grapheme[1] == 0) {
+//          hocr_str += HOcrEscape(grapheme);
+//        } else {
           hocr_str += grapheme;
-        }
-      }
+//        }
+//      }
       delete []grapheme;
       res_it->Next(RIL_SYMBOL);
     } while (!res_it->Empty(RIL_BLOCK) && !res_it->IsAtBeginningOf(RIL_WORD));

--- a/api/baseapi.h
+++ b/api/baseapi.h
@@ -603,12 +603,10 @@ class TESS_API TessBaseAPI {
   char* GetHOCRText(int page_number);
 
   /**
-   * Make a TSV-formatted string with hOCR markup from the internal
-   * data structures.
+   * Make a TSV-formatted string from the internal data structures.
    * page_number is 0-based but will appear in the output as 1-based.
    */
-  char* GetHOCRTSVText(int page_number);
-
+  char* GetTSVText(int page_number);
 
   /**
    * The recognized text is returned as a char* which is coded in the same

--- a/api/baseapi.h
+++ b/api/baseapi.h
@@ -603,6 +603,14 @@ class TESS_API TessBaseAPI {
   char* GetHOCRText(int page_number);
 
   /**
+   * Make a TSV-formatted string with hOCR markup from the internal
+   * data structures.
+   * page_number is 0-based but will appear in the output as 1-based.
+   */
+  char* GetHOCRTSVText(int page_number);
+
+
+  /**
    * The recognized text is returned as a char* which is coded in the same
    * format as a box file used in training. Returned string must be freed with
    * the delete [] operator.

--- a/api/renderer.cpp
+++ b/api/renderer.cpp
@@ -180,6 +180,61 @@ bool TessHOcrRenderer::AddImageHandler(TessBaseAPI* api) {
 }
 
 /**********************************************************************
+ * HOcr Text Renderer interface implementation
+ **********************************************************************/
+TessHOcrTsvRenderer::TessHOcrTsvRenderer(const char *outputbase)
+    : TessResultRenderer(outputbase, "hocr.tsv") {
+    font_info_ = false;
+}
+
+TessHOcrTsvRenderer::TessHOcrTsvRenderer(const char *outputbase, bool font_info)
+    : TessResultRenderer(outputbase, "hocr.tsv") {
+    font_info_ = font_info;
+}
+
+bool TessHOcrTsvRenderer::BeginDocumentHandler() {
+  AppendString(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n"
+        "    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n"
+        "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" "
+        "lang=\"en\">\n <head>\n  <title>\n");
+  AppendString(title());
+  AppendString(
+      "</title>\n"
+      "<meta http-equiv=\"Content-Type\" content=\"text/html;"
+      "charset=utf-8\" />\n"
+      "  <meta name='ocr-system' content='tesseract " TESSERACT_VERSION_STR
+              "' />\n"
+      "  <meta name='ocr-capabilities' content='ocr_page ocr_carea ocr_par"
+      " ocr_line ocrx_word");
+  if (font_info_)
+    AppendString(
+      " ocrp_lang ocrp_dir ocrp_font ocrp_fsize ocrp_wconf");
+  AppendString(
+      "'/>\n"
+      "</head>\n<body>\n");
+
+  return true;
+}
+
+bool TessHOcrTsvRenderer::EndDocumentHandler() {
+  AppendString(" </body>\n</html>\n");
+
+  return true;
+}
+
+bool TessHOcrTsvRenderer::AddImageHandler(TessBaseAPI* api) {
+  char* hocr = api->GetHOCRText(imagenum());
+  if (hocr == NULL) return false;
+
+  AppendString(hocr);
+  delete[] hocr;
+
+  return true;
+}
+
+/**********************************************************************
  * UNLV Text Renderer interface implementation
  **********************************************************************/
 TessUnlvRenderer::TessUnlvRenderer(const char *outputbase)

--- a/api/renderer.cpp
+++ b/api/renderer.cpp
@@ -182,31 +182,32 @@ bool TessHOcrRenderer::AddImageHandler(TessBaseAPI* api) {
 /**********************************************************************
  * HOcr Text Renderer interface implementation
  **********************************************************************/
-TessHOcrTsvRenderer::TessHOcrTsvRenderer(const char *outputbase)
-    : TessResultRenderer(outputbase, "hocr.tsv") {
+TessTsvRenderer::TessTsvRenderer(const char *outputbase)
+    : TessResultRenderer(outputbase, "tsv") {
     font_info_ = false;
 }
 
-TessHOcrTsvRenderer::TessHOcrTsvRenderer(const char *outputbase, bool font_info)
-    : TessResultRenderer(outputbase, "hocr.tsv") {
+TessTsvRenderer::TessTsvRenderer(const char *outputbase, bool font_info)
+    : TessResultRenderer(outputbase, "tsv") {
     font_info_ = font_info;
 }
 
-bool TessHOcrTsvRenderer::BeginDocumentHandler() {
+bool TessTsvRenderer::BeginDocumentHandler() {
+  // Output TSV column headings
   AppendString("level\tpage_num\tblock_num\tpar_num\tline_num\tword_num\tleft\ttop\twidth\theight\tconf\ttext\n");
   return true;
 }
 
-bool TessHOcrTsvRenderer::EndDocumentHandler() {
+bool TessTsvRenderer::EndDocumentHandler() {
   return true;
 }
 
-bool TessHOcrTsvRenderer::AddImageHandler(TessBaseAPI* api) {
-  char* hocrtsv = api->GetHOCRTSVText(imagenum());
-  if (hocrtsv == NULL) return false;
+bool TessTsvRenderer::AddImageHandler(TessBaseAPI* api) {
+  char* tsv = api->GetTSVText(imagenum());
+  if (tsv == NULL) return false;
 
-  AppendString(hocrtsv);
-  delete[] hocrtsv;
+  AppendString(tsv);
+  delete[] tsv;
 
   return true;
 }

--- a/api/renderer.cpp
+++ b/api/renderer.cpp
@@ -193,43 +193,20 @@ TessHOcrTsvRenderer::TessHOcrTsvRenderer(const char *outputbase, bool font_info)
 }
 
 bool TessHOcrTsvRenderer::BeginDocumentHandler() {
-  AppendString(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n"
-        "    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n"
-        "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" "
-        "lang=\"en\">\n <head>\n  <title>\n");
-  AppendString(title());
-  AppendString(
-      "</title>\n"
-      "<meta http-equiv=\"Content-Type\" content=\"text/html;"
-      "charset=utf-8\" />\n"
-      "  <meta name='ocr-system' content='tesseract " TESSERACT_VERSION_STR
-              "' />\n"
-      "  <meta name='ocr-capabilities' content='ocr_page ocr_carea ocr_par"
-      " ocr_line ocrx_word");
-  if (font_info_)
-    AppendString(
-      " ocrp_lang ocrp_dir ocrp_font ocrp_fsize ocrp_wconf");
-  AppendString(
-      "'/>\n"
-      "</head>\n<body>\n");
-
+  AppendString("level\tpage_num\tblock_num\tpar_num\tline_num\tword_num\tleft\ttop\twidth\theight\tconf\ttext\n");
   return true;
 }
 
 bool TessHOcrTsvRenderer::EndDocumentHandler() {
-  AppendString(" </body>\n</html>\n");
-
   return true;
 }
 
 bool TessHOcrTsvRenderer::AddImageHandler(TessBaseAPI* api) {
-  char* hocr = api->GetHOCRText(imagenum());
-  if (hocr == NULL) return false;
+  char* hocrtsv = api->GetHOCRTSVText(imagenum());
+  if (hocrtsv == NULL) return false;
 
-  AppendString(hocr);
-  delete[] hocr;
+  AppendString(hocrtsv);
+  delete[] hocrtsv;
 
   return true;
 }

--- a/api/renderer.h
+++ b/api/renderer.h
@@ -163,6 +163,23 @@ private:
 };
 
 /**
+ * Renders tesseract output into an hocr tsv string
+ */
+class TESS_API TessHOcrTsvRenderer : public TessResultRenderer {
+ public:
+  explicit TessHOcrTsvRenderer(const char *outputbase, bool font_info);
+  explicit TessHOcrTsvRenderer(const char *outputbase);
+
+protected:
+  virtual bool BeginDocumentHandler();
+  virtual bool AddImageHandler(TessBaseAPI* api);
+  virtual bool EndDocumentHandler();
+
+private:
+  bool font_info_;              // whether to print font information
+};
+
+/**
  * Renders tesseract output into searchable PDF
  */
 class TESS_API TessPDFRenderer : public TessResultRenderer {

--- a/api/renderer.h
+++ b/api/renderer.h
@@ -163,12 +163,12 @@ private:
 };
 
 /**
- * Renders tesseract output into an hocr tsv string
+ * Renders Tesseract output into a TSV string
  */
-class TESS_API TessHOcrTsvRenderer : public TessResultRenderer {
+class TESS_API TessTsvRenderer : public TessResultRenderer {
  public:
-  explicit TessHOcrTsvRenderer(const char *outputbase, bool font_info);
-  explicit TessHOcrTsvRenderer(const char *outputbase);
+  explicit TessTsvRenderer(const char *outputbase, bool font_info);
+  explicit TessTsvRenderer(const char *outputbase);
 
 protected:
   virtual bool BeginDocumentHandler();

--- a/api/tesseractmain.cpp
+++ b/api/tesseractmain.cpp
@@ -299,6 +299,14 @@ void PreloadRenderers(tesseract::TessBaseAPI* api,
                      new tesseract::TessHOcrRenderer(outputbase, font_info));
     }
 
+    api->GetBoolVariable("tessedit_create_hocrtsv", &b);
+    if (b) {
+      bool font_info;
+      api->GetBoolVariable("hocr_font_info", &font_info);
+      renderers->push_back(
+          new tesseract::TessHOcrTsvRenderer(outputbase, font_info));
+    }
+
     api->GetBoolVariable("tessedit_create_pdf", &b);
     if (b) {
       renderers->push_back(new tesseract::TessPDFRenderer(outputbase,
@@ -421,6 +429,8 @@ int main(int argc, char **argv) {
         (api.GetBoolVariable("tessedit_make_boxes_from_boxes", &b) && b);
 
   tesseract::PointerVector<tesseract::TessResultRenderer> renderers;
+
+
 
   if (in_training_mode) {
     renderers.push_back(NULL);

--- a/api/tesseractmain.cpp
+++ b/api/tesseractmain.cpp
@@ -299,12 +299,12 @@ void PreloadRenderers(tesseract::TessBaseAPI* api,
                      new tesseract::TessHOcrRenderer(outputbase, font_info));
     }
 
-    api->GetBoolVariable("tessedit_create_hocrtsv", &b);
+    api->GetBoolVariable("tessedit_create_tsv", &b);
     if (b) {
       bool font_info;
       api->GetBoolVariable("hocr_font_info", &font_info);
       renderers->push_back(
-          new tesseract::TessHOcrTsvRenderer(outputbase, font_info));
+          new tesseract::TessTsvRenderer(outputbase, font_info));
     }
 
     api->GetBoolVariable("tessedit_create_pdf", &b);

--- a/ccmain/tesseractclass.cpp
+++ b/ccmain/tesseractclass.cpp
@@ -385,6 +385,8 @@ Tesseract::Tesseract()
                   this->params()),
       BOOL_MEMBER(tessedit_create_hocr, false, "Write .html hOCR output file",
                   this->params()),
+      BOOL_MEMBER(tessedit_create_hocrtsv, false, "Write .hocr.tsv TSV output file",
+                  this->params()),
       BOOL_MEMBER(tessedit_create_pdf, false, "Write .pdf output file",
                   this->params()),
       STRING_MEMBER(unrecognised_char, "|",
@@ -509,6 +511,7 @@ Tesseract::Tesseract()
       STRING_MEMBER(page_separator, "\f",
                     "Page separator (default is form feed control character)",
                     this->params()),
+
 
       // The following parameters were deprecated and removed from their
       // original

--- a/ccmain/tesseractclass.cpp
+++ b/ccmain/tesseractclass.cpp
@@ -385,7 +385,7 @@ Tesseract::Tesseract()
                   this->params()),
       BOOL_MEMBER(tessedit_create_hocr, false, "Write .html hOCR output file",
                   this->params()),
-      BOOL_MEMBER(tessedit_create_hocrtsv, false, "Write .hocr.tsv TSV output file",
+      BOOL_MEMBER(tessedit_create_tsv, false, "Write .tsv output file",
                   this->params()),
       BOOL_MEMBER(tessedit_create_pdf, false, "Write .pdf output file",
                   this->params()),

--- a/ccmain/tesseractclass.h
+++ b/ccmain/tesseractclass.h
@@ -1003,7 +1003,7 @@ class Tesseract : public Wordrec {
   BOOL_VAR_H(tessedit_write_unlv, false, "Write .unlv output file");
   BOOL_VAR_H(tessedit_create_txt, false, "Write .txt output file");
   BOOL_VAR_H(tessedit_create_hocr, false, "Write .html hOCR output file");
-  BOOL_VAR_H(tessedit_create_hocrtsv, false, "Write .hocr.tsv hOCR-tsv output file");
+  BOOL_VAR_H(tessedit_create_tsv, false, "Write .tsv output file");
   BOOL_VAR_H(tessedit_create_pdf, false, "Write .pdf output file");
   STRING_VAR_H(unrecognised_char, "|",
                "Output char for unidentified blobs");

--- a/ccmain/tesseractclass.h
+++ b/ccmain/tesseractclass.h
@@ -1003,6 +1003,7 @@ class Tesseract : public Wordrec {
   BOOL_VAR_H(tessedit_write_unlv, false, "Write .unlv output file");
   BOOL_VAR_H(tessedit_create_txt, false, "Write .txt output file");
   BOOL_VAR_H(tessedit_create_hocr, false, "Write .html hOCR output file");
+  BOOL_VAR_H(tessedit_create_hocrtsv, false, "Write .hocr.tsv hOCR-tsv output file");
   BOOL_VAR_H(tessedit_create_pdf, false, "Write .pdf output file");
   STRING_VAR_H(unrecognised_char, "|",
                "Output char for unidentified blobs");

--- a/tessdata/configs/Makefile.am
+++ b/tessdata/configs/Makefile.am
@@ -1,3 +1,3 @@
 datadir = @datadir@/tessdata/configs
-data_DATA = inter makebox box.train unlv ambigs.train api_config kannada box.train.stderr quiet logfile digits hocr hocrtsv linebox pdf rebox strokewidth bigram txt
-EXTRA_DIST = inter makebox box.train unlv ambigs.train api_config kannada box.train.stderr quiet logfile digits hocr hocrtsv linebox pdf rebox strokewidth bigram txt
+data_DATA = inter makebox box.train unlv ambigs.train api_config kannada box.train.stderr quiet logfile digits hocr tsv linebox pdf rebox strokewidth bigram txt
+EXTRA_DIST = inter makebox box.train unlv ambigs.train api_config kannada box.train.stderr quiet logfile digits hocr tsv linebox pdf rebox strokewidth bigram txt

--- a/tessdata/configs/Makefile.am
+++ b/tessdata/configs/Makefile.am
@@ -1,3 +1,3 @@
 datadir = @datadir@/tessdata/configs
-data_DATA = inter makebox box.train unlv ambigs.train api_config kannada box.train.stderr quiet logfile digits hocr linebox pdf rebox strokewidth bigram txt
-EXTRA_DIST = inter makebox box.train unlv ambigs.train api_config kannada box.train.stderr quiet logfile digits hocr linebox pdf rebox strokewidth bigram txt
+data_DATA = inter makebox box.train unlv ambigs.train api_config kannada box.train.stderr quiet logfile digits hocr hocrtsv linebox pdf rebox strokewidth bigram txt
+EXTRA_DIST = inter makebox box.train unlv ambigs.train api_config kannada box.train.stderr quiet logfile digits hocr hocrtsv linebox pdf rebox strokewidth bigram txt

--- a/tessdata/configs/hocrtsv
+++ b/tessdata/configs/hocrtsv
@@ -1,0 +1,2 @@
+tessedit_create_hocr 1
+tessedit_pageseg_mode 1

--- a/tessdata/configs/hocrtsv
+++ b/tessdata/configs/hocrtsv
@@ -1,2 +1,0 @@
-tessedit_create_hocrtsv 1
-tessedit_pageseg_mode 1

--- a/tessdata/configs/hocrtsv
+++ b/tessdata/configs/hocrtsv
@@ -1,2 +1,2 @@
-tessedit_create_hocr 1
+tessedit_create_hocrtsv 1
 tessedit_pageseg_mode 1

--- a/tessdata/configs/tsv
+++ b/tessdata/configs/tsv
@@ -1,0 +1,2 @@
+tessedit_create_tsv 1
+tessedit_pageseg_mode 1


### PR DESCRIPTION
This is a cleaned up version of #18 which adds a tabular output format and which came from https://code.google.com/archive/p/email-hocr-tsv/.

The differences from #18 include:
- rebased to avoid merge commits both in the original repo and on the branch
- removed all references to hOCR since that's an internal implementation detail that has nothing to do with the functionality (it was created by cloning & hacking on the hOCR renderer)
- removed a bunch of dead code and made some other minor simplifications

Note that it does not include some of the information that was added to the hOCR output after it was created two years ago, such as writing direction, font attributes, etc. It's not clear to me how useful/necessary those are.