### PR TITLE
Fix other instance of VS2015 compiler problem

### DIFF
--- a/viewer/svutil.h
+++ b/viewer/svutil.h
@@ -27,7 +27,9 @@
 #ifdef _WIN32
 #ifndef __GNUC__
 #include <windows.h>
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 #if (_MSC_VER <= 1400)
 #define vsnprintf _vsnprintf
 #endif


### PR DESCRIPTION
As with 0c492cb, in VC14 snprintf function is provided in standard library there triggering error. "snprintf Do not define snprintf as a macro. Macro definition of snprintf conflicts with Standard Library function declaration"