### PR TITLE
Fix arguments for tprintf

### DIFF
--- a/textord/colpartition.cpp
+++ b/textord/colpartition.cpp
@@ -1182,7 +1182,7 @@ bool ColPartition::MarkAsLeaderIfMonospaced() {
         tprintf("No path\n");
       } else {
         tprintf("Total cost = %d vs allowed %d\n",
-                best_end->total_cost() < blob_count);
+                best_end->total_cost(), blob_count);
       }
     }
     delete [] projection;


### PR DESCRIPTION
The format string expects two int arguments.

Signed-off-by: Stefan Weil <sw@weilnetz.de>