### PR TITLE
Enable all ligatures available in a font for text2image rendering

### DIFF
--- a/training/stringrenderer.cpp
+++ b/training/stringrenderer.cpp
@@ -206,12 +206,14 @@ void StringRenderer::SetLayoutProperties() {
     spacing_attr->end_index = static_cast<guint>(-1);
     pango_attr_list_change(attr_list, spacing_attr);
   }
+#if (PANGO_VERSION_MAJOR == 1 && PANGO_VERSION_MINOR >= 38)
   if (add_ligatures_) {
     set_features("liga, clig, dlig, hlig");
     PangoAttribute* feature_attr =
       pango_attr_font_features_new(features_);
     pango_attr_list_change(attr_list, feature_attr);
   }
+#endif
   pango_layout_set_attributes(layout_, attr_list);
   pango_attr_list_unref(attr_list);
   // Adjust line spacing

--- a/training/stringrenderer.cpp
+++ b/training/stringrenderer.cpp
@@ -120,6 +120,7 @@ StringRenderer::StringRenderer(const string& font_desc, int page_width,
       box_padding_(0),
       total_chars_(0),
       font_index_(0),
+      features_(NULL),
       last_offset_(0) {
   pen_color_[0] = 0.0;
   pen_color_[1] = 0.0;
@@ -149,6 +150,7 @@ void StringRenderer::set_underline_continuation_prob(const double frac) {
 }
 
 StringRenderer::~StringRenderer() {
+  free(features_);
   ClearBoxes();
   FreePangoCairo();
 }
@@ -203,6 +205,12 @@ void StringRenderer::SetLayoutProperties() {
     spacing_attr->start_index = 0;
     spacing_attr->end_index = static_cast<guint>(-1);
     pango_attr_list_change(attr_list, spacing_attr);
+  }
+  if (add_ligatures_) {
+    set_features("liga, clig, dlig, hlig");
+    PangoAttribute* feature_attr =
+      pango_attr_font_features_new(features_);
+    pango_attr_list_change(attr_list, feature_attr);
   }
   pango_layout_set_attributes(layout_, attr_list);
   pango_attr_list_unref(attr_list);

--- a/training/stringrenderer.h
+++ b/training/stringrenderer.h
@@ -90,6 +90,10 @@ class StringRenderer {
   void set_underline_style(const PangoUnderline style) {
     underline_style_ = style;
   }
+  void set_features(char *features) {
+    free(features_);
+    features_ = strdup(features);
+  }
   void set_page(int page) {
     page_ = page;
   }
@@ -185,6 +189,7 @@ class StringRenderer {
   double underline_start_prob_;
   double underline_continuation_prob_;
   PangoUnderline underline_style_;
+  char *features_;
   // Text filtering options
   bool drop_uncovered_chars_;
   bool strip_unrenderable_words_;


### PR DESCRIPTION
This enables all OpenType ligatures for a specific font, where
available. Specifically, it explicitly enables the OpenType
features liga (standard ligatures), hlig (historical ligatures),
clig (contextual ligatures), and dlig (discretionary ligatures).

This feature requires Pango 1.38 or newer.