### PR TITLE
When off_t is unavailable, define it as long long

### DIFF
--- a/ccutil/scanutils.cpp
+++ b/ccutil/scanutils.cpp
@@ -39,7 +39,7 @@
 
 // workaround for "'off_t' was not declared in this scope" with -std=c++11
 #if !defined(HAVE_OFF_T)
-typedef long off_t;
+typedef long long off_t;
 #endif  // off_t
 
 enum Flags {


### PR DESCRIPTION
It is currently defined as long if unavailable. This doesn't violate any
C specifications, but it's suboptimal because it can prevent >2 GB files
from being handled as expected. Because of this, some platforms always
make it 64-bit, and this is probably the best option.