### PR TITLE
Remove conditional definition of off_t

### DIFF
--- a/ccutil/scanutils.cpp
+++ b/ccutil/scanutils.cpp
@@ -37,11 +37,6 @@
 #include "scanutils.h"
 #include "tprintf.h"
 
-// workaround for "'off_t' was not declared in this scope" with -std=c++11
-#if !defined(HAVE_OFF_T)
-typedef long off_t;
-#endif  // off_t
-
 enum Flags {
   FL_SPLAT  = 0x01,   // Drop the value, do not assign
   FL_INV    = 0x02,   // Character-set with inverse


### PR DESCRIPTION
As pointed out by Stefan Weil, conditionally defining off_t using a
macro isn't a valid approach. off_t does not have a fixed size and is
used in ABI definitions (e.g. syscalls), so silently guessing its size
risks breaking the build. Additionally, all sane and modern platforms
will have off_t.