### PR TITLE
Fix incompatibility with some C++11 implementations

### DIFF
--- a/ccstruct/matrix.h
+++ b/ccstruct/matrix.h
@@ -30,7 +30,7 @@
 
 class BLOB_CHOICE_LIST;
 
-#define NOT_CLASSIFIED reinterpret_cast<BLOB_CHOICE_LIST*>(NULL)
+#define NOT_CLASSIFIED reinterpret_cast<BLOB_CHOICE_LIST*>(0)
 
 // A generic class to hold a 2-D matrix with entries of type T, but can also
 // act as a base class for other implementations, such as a triangular or


### PR DESCRIPTION
I've ran into this issue with `reinterpret_cast` while trying to compile Tesseract 3.04.01 on FreeBSD. The proposed change fixes this by no longer using `NULL`.

_Background:_

Since C++11, the null pointer constant `NULL` may be defined as either `0` or `nullptr` (see http://en.cppreference.com/w/cpp/types/NULL). It seems on most systems (like Mac OS X and Linux) it is still defined as `0` when using `-std=c++11`. However, this is not the case on my FreeBSD system (10.2-RELEASE), where it being defined as `nullptr` causes the `reinterpret_cast` to be rejected:

```
./matrix.h:292:63: error: reinterpret_cast from 'nullptr_t' to 'BLOB_CHOICE_LIST *' is not allowed
    : BandTriMatrix<BLOB_CHOICE_LIST *>(dimension, bandwidth, NOT_CLASSIFIED) {}
                                                              ^~~~~~~~~~~~~~
./matrix.h:33:24: note: expanded from macro 'NOT_CLASSIFIED'
#define NOT_CLASSIFIED reinterpret_cast<BLOB_CHOICE_LIST*>(NULL)
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

See http://en.cppreference.com/w/cpp/language/reinterpret_cast:

> 9) The null pointer value of any pointer type can be converted to any other pointer type, resulting in the null pointer value of that type. Note that the null pointer constant nullptr or any other value of type std::nullptr_t cannot be converted to a pointer with reinterpret_cast: implicit conversion or static_cast should be used for this purpose.