### PR TITLE
Fix of add_str_double

### DIFF
--- a/ccutil/strngs.cpp
+++ b/ccutil/strngs.cpp
@@ -32,8 +32,8 @@ using tesseract::TFile;
 // possible length of an int (in 64 bits), being -<20 digits>.
 const int kMaxIntSize = 22;
 // Size of buffer needed to host the decimal representation of the maximum
-// possible length of a %.8g being -0.12345678e+999<nul> = 15.
-const int kMaxDoubleSize = 15;
+// possible length of a %.8g being -1.2345678e+999<nul> = 16.
+const int kMaxDoubleSize = 16;
 
 /**********************************************************************
  * STRING_HEADER provides metadata about the allocated buffer,


### PR DESCRIPTION
Location: file `ccutil/strngs.cpp`, method `STRING::add_str_double`

Because of a wrong value for `kMaxDoubleSize`, some small values are truncated by one byte.
Example: `-4.0382147e-006` has 16 bytes including the terminating null byte. But `kMaxDoubleSize` has value 15 and the number is truncated to `-4.0382147e-00`. As result, the number becomes way too large by a factor of 10<sup>6</sup>! (I had found such wrong values in `.tr` files inside the parameters for feature `mf`.)

Also the description for `kMaxDoubleSize` is wrong. The largest length for a formatted number with `%.8g` is `-1.2345678e-999<nul>`. The precision of format specifier `g` specifies the maximum number of significant digits. The length including the terminating null byte is 16 (eight digits, two signs, decimal marker, `e`, three exponent digits, null byte).