### PR TITLE
configure: Enclose most macro arguments in []

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,16 +5,16 @@
 # ----------------------------------------
 # Initialization
 # ----------------------------------------
-AC_PREREQ(2.50)
+AC_PREREQ([2.50])
 AC_INIT([tesseract], [3.05.00dev], [https://github.com/tesseract-ocr/tesseract/issues])
-AC_PROG_CXX(g++ clang++)
+AC_PROG_CXX([g++ clang++])
 AC_LANG([C++])
 AC_LANG_COMPILER_REQUIRE
 CXXFLAGS=${CXXFLAGS:-""}
 AC_CONFIG_MACRO_DIR([m4])
-AC_CONFIG_AUX_DIR(config)
-AC_CONFIG_SRCDIR(api/tesseractmain.cpp)
-AC_PREFIX_DEFAULT(/usr/local)
+AC_CONFIG_AUX_DIR([config])
+AC_CONFIG_SRCDIR([api/tesseractmain.cpp])
+AC_PREFIX_DEFAULT([/usr/local])
 
 # Define date of package, etc. Could be useful in auto-generated
 # documentation.
@@ -24,20 +24,20 @@ PACKAGE_DATE="07/11"
 abs_top_srcdir=`AS_DIRNAME([$0])`
 gitrev="`git --git-dir=${abs_top_srcdir}/.git --work-tree=${abs_top_srcdir} describe --always --tags`"
 if test -n "${gitrev}" ; then
-	AC_REVISION("${gitrev}")
-	AC_DEFINE_UNQUOTED(GIT_REV,"${gitrev}", [Define to be the git revision])
+	AC_REVISION(["${gitrev}"])
+	AC_DEFINE_UNQUOTED([GIT_REV], ["${gitrev}"], [Define to be the git revision])
 	echo "Using git revision: ${gitrev}"
 fi
 
-AC_DEFINE_UNQUOTED(PACKAGE_NAME,["${PACKAGE_NAME}"],[Name of package])
-AC_DEFINE_UNQUOTED(PACKAGE_VERSION,["${PACKAGE_VERSION}"],[Version number])
-AC_DEFINE_UNQUOTED(PACKAGE_YEAR,"$PACKAGE_YEAR",[Official year for this release])
-AC_DEFINE_UNQUOTED(PACKAGE_DATE,"$PACKAGE_DATE",[Official date of release])
+AC_DEFINE_UNQUOTED([PACKAGE_NAME], ["${PACKAGE_NAME}"], [Name of package])
+AC_DEFINE_UNQUOTED([PACKAGE_VERSION], ["${PACKAGE_VERSION}"], [Version number])
+AC_DEFINE_UNQUOTED([PACKAGE_YEAR], ["$PACKAGE_YEAR"], [Official year for this release])
+AC_DEFINE_UNQUOTED([PACKAGE_DATE], ["$PACKAGE_DATE"], [Official date of release])
 
-AC_SUBST(PACKAGE_NAME)
-AC_SUBST(PACKAGE_VERSION)
-AC_SUBST(PACKAGE_YEAR)
-AC_SUBST(PACKAGE_DATE)
+AC_SUBST([PACKAGE_NAME])
+AC_SUBST([PACKAGE_VERSION])
+AC_SUBST([PACKAGE_YEAR])
+AC_SUBST([PACKAGE_DATE])
 
 GENERIC_LIBRARY_NAME=tesseract
 
@@ -49,17 +49,17 @@ GENERIC_MICRO_VERSION=0
 # API version (often = GENERIC_MAJOR_VERSION.GENERIC_MINOR_VERSION)
 GENERIC_API_VERSION=$GENERIC_MAJOR_VERSION.$GENERIC_MINOR_VERSION
 GENERIC_LIBRARY_VERSION=$GENERIC_MAJOR_VERSION:$GENERIC_MINOR_VERSION
-AC_SUBST(GENERIC_API_VERSION)
-AC_SUBST(GENERIC_MAJOR_VERSION)
+AC_SUBST([GENERIC_API_VERSION])
+AC_SUBST([GENERIC_MAJOR_VERSION])
 
-AC_SUBST(GENERIC_LIBRARY_VERSION)
+AC_SUBST([GENERIC_LIBRARY_VERSION])
 PACKAGE=$GENERIC_LIBRARY_NAME
-AC_SUBST(GENERIC_LIBRARY_NAME)
+AC_SUBST([GENERIC_LIBRARY_NAME])
 
 GENERIC_VERSION=$GENERIC_MAJOR_VERSION.$GENERIC_MINOR_VERSION.$GENERIC_MICRO_VERSION
 GENERIC_RELEASE=$GENERIC_MAJOR_VERSION.$GENERIC_MINOR_VERSION
-AC_SUBST(GENERIC_RELEASE)
-AC_SUBST(GENERIC_VERSION)
+AC_SUBST([GENERIC_RELEASE])
+AC_SUBST([GENERIC_VERSION])
 
 # ----------------------------------------
 # Automake configuration
@@ -67,14 +67,14 @@ AC_SUBST(GENERIC_VERSION)
 
 # Do not require README file (we use README.md)
 AM_INIT_AUTOMAKE([foreign])
-AC_CONFIG_HEADERS(config_auto.h:config/config.h.in)
+AC_CONFIG_HEADERS([config_auto.h:config/config.h.in])
 AM_MAINTAINER_MODE
 
 # default conditional
-AM_CONDITIONAL(T_WIN, false)
-AM_CONDITIONAL(MINGW, false)
-AM_CONDITIONAL(OSX, false)
-AM_CONDITIONAL(GRAPHICS_DISABLED, false)
+AM_CONDITIONAL([T_WIN], false)
+AM_CONDITIONAL([MINGW], false)
+AM_CONDITIONAL([OSX], false)
+AM_CONDITIONAL([GRAPHICS_DISABLED], false)
 
 OPENCL_INC="/opt/AMDAPP/include"
 OPENCL_LIBS="-lOpenCL"
@@ -86,115 +86,115 @@ OPENCL_LIBS="-lOpenCL"
 AC_CANONICAL_HOST
 case "${host_os}" in
     mingw*)
-        AC_DEFINE_UNQUOTED(MINGW,1,[This is a MinGW system])
-        AM_CONDITIONAL(T_WIN, true)
-        AM_CONDITIONAL(MINGW, true)
-        AM_CONDITIONAL(ADD_RT, false)
+        AC_DEFINE_UNQUOTED([MINGW], 1, [This is a MinGW system])
+        AM_CONDITIONAL([T_WIN], true)
+        AM_CONDITIONAL([MINGW], true)
+        AM_CONDITIONAL([ADD_RT], false)
         AC_SUBST([AM_LDFLAGS], ['-Wl,-no-undefined -Wl,--as-needed'])
         ;;
     cygwin*)
-        AM_CONDITIONAL(ADD_RT, false)
-        AM_CONDITIONAL(T_WIN, true)
+        AM_CONDITIONAL([ADD_RT], false)
+        AM_CONDITIONAL([T_WIN], true)
         AC_SUBST([AM_LDFLAGS], ['-Wl,-no-undefined -Wl,--as-needed'])
         ;;
     solaris*)
         LIBS="-lsocket -lnsl -lrt -lxnet"
-        AM_CONDITIONAL(ADD_RT, true)
+        AM_CONDITIONAL([ADD_RT], true)
         ;;
     *darwin*)
         OPENCL_LIBS=""
         OPENCL_INC=""
-        AM_CONDITIONAL(ADD_RT, false)
+        AM_CONDITIONAL([ADD_RT], false)
         ;;
     powerpc-*-darwin*)
         OPENCL_LIBS=""
         ;;
     *)
         # default
-        AM_CONDITIONAL(ADD_RT, true)
+        AM_CONDITIONAL([ADD_RT], true)
         ;;
 esac
 
 includedir="${includedir}/tesseract"
 
-AC_ARG_WITH(extra-includes,
-            AC_HELP_STRING([--with-extra-includes=DIR],
-                       [Define an additional directory for include files]),
-        [ if test -d "$withval" ; then
-            CFLAGS="$CFLAGS -I$withval"
-          else
-            AC_MSG_ERROR([Cannot stat directory $withval])
-          fi ] )
+AC_ARG_WITH([extra-includes],
+            [AC_HELP_STRING([--with-extra-includes=DIR],
+                       [Define an additional directory for include files])],
+            [if test -d "$withval" ; then
+               CFLAGS="$CFLAGS -I$withval"
+             else
+               AC_MSG_ERROR([Cannot stat directory $withval])
+             fi])
 
-AC_ARG_WITH(extra-libraries,
-            AC_HELP_STRING([--with-extra-libraries=DIR],
-                       [Define an additional directory for library files]),
-        [ if test -d "$withval" ; then
-           LDFLAGS="$LDFLAGS -L$withval"
-          else
-            AC_MSG_ERROR([Cannot stat directory $withval])
-          fi ] )
+AC_ARG_WITH([extra-libraries],
+            [AC_HELP_STRING([--with-extra-libraries=DIR],
+                       [Define an additional directory for library files])],
+            [if test -d "$withval" ; then
+              LDFLAGS="$LDFLAGS -L$withval"
+             else
+               AC_MSG_ERROR([Cannot stat directory $withval])
+             fi])
 
-AC_MSG_CHECKING(--enable-graphics argument)
+AC_MSG_CHECKING([--enable-graphics argument])
 AC_ARG_ENABLE([graphics],
  [AC_HELP_STRING([--enable-graphics],[enable graphics (ScrollView) (default)])
 AC_HELP_STRING([--disable-graphics],[disable graphics (ScrollView)])],
     [enable_graphics=$enableval],
     [enable_graphics="yes"])
-AC_MSG_RESULT($enable_graphics)
+AC_MSG_RESULT([$enable_graphics])
 if test "$enable_graphics" = "no"; then
   AC_DEFINE([GRAPHICS_DISABLED], [], [Disable graphics])
-  AM_CONDITIONAL(GRAPHICS_DISABLED, true)
+  AM_CONDITIONAL([GRAPHICS_DISABLED], true)
 fi
 
 # Check if cube should be disabled
-AC_MSG_CHECKING(whether to disable cube)
+AC_MSG_CHECKING([whether to disable cube])
 AC_ARG_ENABLE([cube],
   [AC_HELP_STRING([--disable-cube], [don't build cube support (experimental)])],
     [disable_cube="yes"], [disable_cube="no"])
-AC_MSG_RESULT($disable_cube)
+AC_MSG_RESULT([$disable_cube])
 AM_CONDITIONAL([NO_CUBE_BUILD], [test "$disable_cube" = "yes"])
 if test "$disable_cube" = "yes"; then
   AC_SUBST([AM_CPPFLAGS], [-DNO_CUBE_BUILD])
 fi
 
 # check whether to build embedded version
-AC_MSG_CHECKING(--enable-embedded argument)
+AC_MSG_CHECKING([--enable-embedded argument])
 AC_ARG_ENABLE([embedded],
     [  --enable-embedded       enable embedded build (default=no)],
     [enable_embedded=$enableval],
     [enable_embedded="no"])
-AC_MSG_RESULT($enable_embedded)
+AC_MSG_RESULT([$enable_embedded])
 AM_CONDITIONAL([EMBEDDED], [test "$enable_embedded" = "yes"])
 if test "$enable_embedded" = "yes"; then
   AC_SUBST([AM_CPPFLAGS], [-DEMBEDDED])
 fi
 
 # check whether to build OpenMP support
-AM_CONDITIONAL(OPENMP, false)
+AM_CONDITIONAL([OPENMP], false)
 AC_OPENMP
 AS_IF([test "x$OPENMP_CFLAGS" != "x"],
-  AM_CONDITIONAL([OPENMP], true)
-  AC_SUBST(AM_CPPFLAGS,"$OPENMP_CXXFLAGS")
-  AC_DEFINE([OPENMP], [], [Defined when compiled with OpenMP support])
+  [AM_CONDITIONAL([OPENMP], true)
+   AC_SUBST([AM_CPPFLAGS], ["$OPENMP_CXXFLAGS"])
+   AC_DEFINE([OPENMP], [], [Defined when compiled with OpenMP support])]
 )
 
 
 # check whether to build opencl version
-AC_MSG_CHECKING(--enable-opencl argument)
+AC_MSG_CHECKING([--enable-opencl argument])
 AC_ARG_ENABLE([opencl],
     [  --enable-opencl         enable opencl build (default=no)],
     [enable_opencl=$enableval],
     [enable_opencl="no"])
-AC_MSG_RESULT($enable_opencl)
+AC_MSG_RESULT([$enable_opencl])
 # check for opencl header
 have_opencl=false
-AC_CHECK_HEADERS(CL/cl.h, have_opencl=true, [
+AC_CHECK_HEADERS([CL/cl.h], [have_opencl=true], [
     AC_CHECK_HEADERS(OpenCL/cl.h, have_opencl=true, have_opencl=false)
 ])
 
 have_tiff=false
-AC_CHECK_HEADERS(tiffio.h, have_tiff=true, have_tiff=false)
+AC_CHECK_HEADERS([tiffio.h], [have_tiff=true], [have_tiff=false])
 
 # https://lists.apple.com/archives/unix-porting/2009/Jan/msg00026.html
 m4_define([MY_CHECK_FRAMEWORK],
@@ -207,10 +207,10 @@ m4_define([MY_CHECK_FRAMEWORK],
      LIBS="$save_LIBS"
     ])
    if test "$my_cv_framework_$1"="yes"; then
-       AC_DEFINE(AS_TR_CPP([HAVE_FRAMEWORK_$1]),1,
+     AC_DEFINE(AS_TR_CPP([HAVE_FRAMEWORK_$1]), 1,
             [Define if you have the  $1 framework])
-   AS_TR_CPP([FRAMEWORK_$1])="-framework $1"
-   AC_SUBST(AS_TR_CPP([FRAMEWORK_$1]))
+     AS_TR_CPP([FRAMEWORK_$1])="-framework $1"
+     AC_SUBST(AS_TR_CPP([FRAMEWORK_$1]))
    fi]
 )
 
@@ -226,7 +226,7 @@ case "${host_os}" in
     fi
     if test "$enable_opencl" = "yes"; then
       if !($have_opencl_lib); then
-        AC_MSG_ERROR(Required OpenCL library not found!)
+        AC_MSG_ERROR([Required OpenCL library not found!])
       fi
       AC_SUBST([AM_CPPFLAGS], [-DUSE_OPENCL])
       OPENCL_CPPFLAGS=""
@@ -235,16 +235,17 @@ case "${host_os}" in
     ;;
   *)
     # default
-    AC_CHECK_LIB(OpenCL, clGetPlatformIDs, have_opencl_lib=true, have_opencl_lib=false)
+    AC_CHECK_LIB([OpenCL], [clGetPlatformIDs],
+                 [have_opencl_lib=true], [have_opencl_lib=false])
     if test "$enable_opencl" = "yes"; then
         if !($have_opencl); then
-            AC_MSG_ERROR(Required OpenCL headers not found!)
+            AC_MSG_ERROR([Required OpenCL headers not found!])
         fi
         if !($have_opencl_lib); then
-            AC_MSG_ERROR(Required OpenCL library not found!)
+            AC_MSG_ERROR([Required OpenCL library not found!])
         fi
         if !($have_tiff); then
-            AC_MSG_ERROR(Required TIFF headers not found! Try to install libtiff-dev?? package.)
+            AC_MSG_ERROR([Required TIFF headers not found! Try to install libtiff-dev?? package.])
         fi
         AC_SUBST([AM_CPPFLAGS], [-DUSE_OPENCL])
         OPENCL_CPPFLAGS="-I${OPENCL_INC}"
@@ -253,46 +254,46 @@ case "${host_os}" in
     ;;
 esac
 AM_CONDITIONAL([USE_OPENCL], [test "$enable_opencl" = "yes"])
-AC_SUBST(OPENCL_CPPFLAGS)
-AC_SUBST(OPENCL_LDFLAGS)
+AC_SUBST([OPENCL_CPPFLAGS])
+AC_SUBST([OPENCL_LDFLAGS])
 
 # check whether to build tesseract with -fvisibility=hidden -fvisibility-inlines-hidden
 # http://gcc.gnu.org/wiki/Visibility
 # http://groups.google.com/group/tesseract-dev/browse_thread/thread/976645ae98189127
-AC_MSG_CHECKING(--enable-visibility argument)
+AC_MSG_CHECKING([--enable-visibility argument])
 AC_ARG_ENABLE([visibility],
     [AC_HELP_STRING([--enable-visibility],[enable experimental build with fvisibility (default=no)])],
     [enable_visibility=$enableval],
     [enable_visibility="no"])
-AC_MSG_RESULT($enable_visibility)
+AC_MSG_RESULT([$enable_visibility])
 AM_CONDITIONAL([VISIBILITY], [test "$enable_visibility" = "yes"])
 
 # check whether to build multiple libraries
-AC_MSG_CHECKING(--enable-multiple-libraries argument)
+AC_MSG_CHECKING([--enable-multiple-libraries argument])
 AC_ARG_ENABLE([multiple-libraries],
     [AC_HELP_STRING([--enable-multiple-libraries],[enable multiple libraries (default=no)])],
     [enable_mlibs=$enableval],
     [enable_mlibs="no"])
-AC_MSG_RESULT($enable_mlibs)
+AC_MSG_RESULT([$enable_mlibs])
 AM_CONDITIONAL([USING_MULTIPLELIBS], [test "$enable_mlibs" = "yes"])
 
 # Check if tessdata-prefix is disabled
-AC_MSG_CHECKING(whether to use tessdata-prefix)
-AC_ARG_ENABLE(tessdata-prefix,
+AC_MSG_CHECKING([whether to use tessdata-prefix])
+AC_ARG_ENABLE([tessdata-prefix],
     [AC_HELP_STRING([--disable-tessdata-prefix],
             [don't set TESSDATA-PREFIX during compile])],
     [tessdata_prefix="no"], [tessdata_prefix="yes"])
-AC_MSG_RESULT($tessdata_prefix)
+AC_MSG_RESULT([$tessdata_prefix])
 AM_CONDITIONAL([NO_TESSDATA_PREFIX], [test "$tessdata_prefix" = "no"])
 
 # Check whether enable debuging
-AC_MSG_CHECKING(whether to enable debugging)
+AC_MSG_CHECKING([whether to enable debugging])
 AC_ARG_ENABLE([debug],
     [AC_HELP_STRING([--enable-debug],
         [turn on debugging (default=no)])],
     [debug=$enableval],
     [debug="no"])
-AC_MSG_RESULT($debug)
+AC_MSG_RESULT([$debug])
 if test x"$debug" = x"yes"; then
     AM_CXXFLAGS="$AM_CXXFLAGS -g -Wall -Wno-uninitialized -O0 -DDEBUG"
     AM_CPPFLAGS="$AM_CPPFLAGS -g -Wall -Wno-uninitialized -O0 -DDEBUG"
@@ -361,7 +362,7 @@ dnl turn on c++11
 dnl ********************
 
 OLD_CXXFLAGS=$CXXFLAGS
-AC_MSG_CHECKING(whether compiler supports C++11)
+AC_MSG_CHECKING([whether compiler supports C++11])
 CXXFLAGS="$CXXFLAGS -std=c++11"
 snprintfworks=no
 AC_COMPILE_IFELSE(
@@ -379,14 +380,14 @@ AC_COMPILE_IFELSE(
      AC_MSG_RESULT(no)
      has_cpp11=no
    ])
-AC_CHECK_FUNCS(snprintf,, [snprintfworks=yes])
+AC_CHECK_FUNCS([snprintf],, [snprintfworks=yes])
 CXXFLAGS="$OLD_CXXFLAGS"
 
 # ----------------------------------------
 # Check for libraries
 # ----------------------------------------
 
-AC_SEARCH_LIBS(sem_init,pthread rt)
+AC_SEARCH_LIBS([sem_init], [pthread rt])
 
 
 # ----------------------------------------
@@ -396,8 +397,8 @@ AC_SEARCH_LIBS(sem_init,pthread rt)
 AC_HEADER_STDC
 AC_HEADER_TIME
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS(sys/ipc.h sys/shm.h)
-AC_CHECK_HEADERS(limits.h malloc.h)
+AC_CHECK_HEADERS([sys/ipc.h sys/shm.h])
+AC_CHECK_HEADERS([limits.h malloc.h])
 # Enable use of system-defined bool type if available:
 AC_HEADER_STDBOOL
 
@@ -411,18 +412,18 @@ AC_CHECK_FUNCS([getline])
 # Checks for typedefs, structures, and compiler characteristics.
 # ----------------------------------------
 
-AC_CHECK_TYPES(wchar_t,,,[#include "wchar.h"])
-AC_CHECK_TYPES(long long int)
-AC_CHECK_TYPES(off_t,,,[#include "sys/types.h"])
-AC_CHECK_TYPES(mbstate_t,,,[#include "wchar.h"])
+AC_CHECK_TYPES([wchar_t],,, [#include "wchar.h"])
+AC_CHECK_TYPES([long long int])
+AC_CHECK_TYPES([off_t],,, [#include "sys/types.h"])
+AC_CHECK_TYPES([mbstate_t],,, [#include "wchar.h"])
 
 # ----------------------------------------
 # Test auxiliary packages
 # ----------------------------------------
 
 # Check location of leptonica/liblept headers.
-AC_MSG_CHECKING(for leptonica)
-AC_ARG_VAR(LIBLEPT_HEADERSDIR,[Leptonica headers directory])
+AC_MSG_CHECKING([for leptonica])
+AC_ARG_VAR([LIBLEPT_HEADERSDIR], [Leptonica headers directory])
 
 have_lept=no
 if test "$LIBLEPT_HEADERSDIR" = "" ; then
@@ -441,7 +442,8 @@ done
 
 if test "$have_lept" = yes ; then
   AC_MSG_RESULT(yes)
-  AC_CHECK_LIB(lept,l_generateCIDataForPdf,[], AC_MSG_ERROR([leptonica library with pdf support (>= 1.71) is missing]))
+  AC_CHECK_LIB([lept], [l_generateCIDataForPdf], [],
+               [AC_MSG_ERROR([leptonica library with pdf support (>= 1.71) is missing])])
 else
   AC_MSG_ERROR([leptonica not found])
 fi
@@ -457,33 +459,33 @@ int i = 0;
     [AC_MSG_RESULT(yes)],
     [AC_MSG_FAILURE([leptonica 1.71 or higher is required])])
 
-AM_CONDITIONAL(ENABLE_TRAINING, true)
+AM_CONDITIONAL([ENABLE_TRAINING], true)
 
 # Check location of icu headers
 have_icu=false
-AC_CHECK_HEADERS(unicode/uchar.h, have_icu=true, have_icu=false)
+AC_CHECK_HEADERS([unicode/uchar.h], [have_icu=true], [have_icu=false])
 if !($have_icu); then
-        AC_MSG_WARN(Training tools WILL NOT be built because of missing icu library.)
-        AC_MSG_WARN(Try to install libicu-devel package.)
-        AM_CONDITIONAL(ENABLE_TRAINING, false)
+        AC_MSG_WARN([Training tools WILL NOT be built because of missing icu library.])
+        AC_MSG_WARN([Try to install libicu-devel package.])
+        AM_CONDITIONAL([ENABLE_TRAINING], false)
 fi
 
 # Check location of pango headers
-PKG_CHECK_MODULES(pango, pango, have_pango=true, have_pango=false)
+PKG_CHECK_MODULES([pango], [pango], [have_pango=true], [have_pango=false])
 if !($have_pango); then
-        AC_MSG_WARN(Training tools WILL NOT be built because of missing pango library.)
-        AC_MSG_WARN(Try to install libpango1.0-dev package.)
-        AM_CONDITIONAL(ENABLE_TRAINING, false)
+        AC_MSG_WARN([Training tools WILL NOT be built because of missing pango library.])
+        AC_MSG_WARN([Try to install libpango1.0-dev package.])
+        AM_CONDITIONAL([ENABLE_TRAINING], false)
 else
       CPPFLAGS="$CPPFLAGS $pango_CFLAGS"
 fi
 
 # Check location of cairo headers
-PKG_CHECK_MODULES(cairo, cairo, have_cairo=true, have_cairo=false)
+PKG_CHECK_MODULES([cairo], [cairo], [have_cairo=true], [have_cairo=false])
 if !($have_cairo); then
-        AC_MSG_WARN(Training tools WILL NOT be built because of missing cairo library.)
-        AC_MSG_WARN(Try to install libcairo-dev?? package.)
-        AM_CONDITIONAL(ENABLE_TRAINING, false)
+        AC_MSG_WARN([Training tools WILL NOT be built because of missing cairo library.])
+        AC_MSG_WARN([Try to install libcairo-dev?? package.])
+        AM_CONDITIONAL([ENABLE_TRAINING], false)
 else
       CPPFLAGS="$CPPFLAGS $cairo_CFLAGS"
 fi
@@ -508,8 +510,8 @@ if test "x$has_cpp11" = "xyes"; then
       ;;
   esac
 else
-  AC_MSG_WARN(Training tools WILL NOT be built because of missing c++11 support.)
-  AM_CONDITIONAL(ENABLE_TRAINING, false)
+  AC_MSG_WARN([Training tools WILL NOT be built because of missing c++11 support.])
+  AM_CONDITIONAL([ENABLE_TRAINING], false)
 fi
 
 # ----------------------------------------
@@ -518,31 +520,31 @@ fi
 
 # Output files
 AC_CONFIG_FILES([Makefile tesseract.pc])
-AC_CONFIG_FILES(api/Makefile)
-AC_CONFIG_FILES(ccmain/Makefile)
-AC_CONFIG_FILES(opencl/Makefile)
-AC_CONFIG_FILES(ccstruct/Makefile)
-AC_CONFIG_FILES(ccutil/Makefile)
-AC_CONFIG_FILES(classify/Makefile)
-AC_CONFIG_FILES(cube/Makefile)
-AC_CONFIG_FILES(cutil/Makefile)
-AC_CONFIG_FILES(dict/Makefile)
-AC_CONFIG_FILES(neural_networks/runtime/Makefile)
-AC_CONFIG_FILES(textord/Makefile)
-AC_CONFIG_FILES(viewer/Makefile)
-AC_CONFIG_FILES(wordrec/Makefile)
-AC_CONFIG_FILES(tessdata/Makefile)
-AC_CONFIG_FILES(tessdata/configs/Makefile)
-AC_CONFIG_FILES(tessdata/tessconfigs/Makefile)
-AC_CONFIG_FILES(testing/Makefile)
-AC_CONFIG_FILES(java/Makefile)
-AC_CONFIG_FILES(java/com/Makefile)
-AC_CONFIG_FILES(java/com/google/Makefile)
-AC_CONFIG_FILES(java/com/google/scrollview/Makefile)
-AC_CONFIG_FILES(java/com/google/scrollview/events/Makefile)
-AC_CONFIG_FILES(java/com/google/scrollview/ui/Makefile)
-AC_CONFIG_FILES(doc/Makefile)
-AM_COND_IF([ENABLE_TRAINING], AC_CONFIG_FILES(training/Makefile))
+AC_CONFIG_FILES([api/Makefile])
+AC_CONFIG_FILES([ccmain/Makefile])
+AC_CONFIG_FILES([opencl/Makefile])
+AC_CONFIG_FILES([ccstruct/Makefile])
+AC_CONFIG_FILES([ccutil/Makefile])
+AC_CONFIG_FILES([classify/Makefile])
+AC_CONFIG_FILES([cube/Makefile])
+AC_CONFIG_FILES([cutil/Makefile])
+AC_CONFIG_FILES([dict/Makefile])
+AC_CONFIG_FILES([neural_networks/runtime/Makefile])
+AC_CONFIG_FILES([textord/Makefile])
+AC_CONFIG_FILES([viewer/Makefile])
+AC_CONFIG_FILES([wordrec/Makefile])
+AC_CONFIG_FILES([tessdata/Makefile])
+AC_CONFIG_FILES([tessdata/configs/Makefile])
+AC_CONFIG_FILES([tessdata/tessconfigs/Makefile])
+AC_CONFIG_FILES([testing/Makefile])
+AC_CONFIG_FILES([java/Makefile])
+AC_CONFIG_FILES([java/com/Makefile])
+AC_CONFIG_FILES([java/com/google/Makefile])
+AC_CONFIG_FILES([java/com/google/scrollview/Makefile])
+AC_CONFIG_FILES([java/com/google/scrollview/events/Makefile])
+AC_CONFIG_FILES([java/com/google/scrollview/ui/Makefile])
+AC_CONFIG_FILES([doc/Makefile])
+AM_COND_IF([ENABLE_TRAINING], [AC_CONFIG_FILES(training/Makefile)])
 AC_OUTPUT
 
 # Final message
@@ -557,17 +559,16 @@ echo "$ sudo make install"
 # echo "$ sudo make install-langs"
 
 AM_COND_IF([ENABLE_TRAINING],
-  echo ""
-  echo "Training tools can be build and installed (after building of $PACKAGE_NAME) with:"
-  echo ""
-  echo "$ make training"
-  echo "$ sudo make training-install"
-  echo ""
-,
-  echo ""
-  echo "You can not build training tools because of missing dependency."
-  echo "Check configure output for details."
-  echo ""
+  [echo ""
+   echo "Training tools can be build and installed (after building of $PACKAGE_NAME) with:"
+   echo ""
+   echo "$ make training"
+   echo "$ sudo make training-install"
+   echo ""],
+  [echo ""
+   echo "You can not build training tools because of missing dependency."
+   echo "Check configure output for details."
+   echo ""]
 )
 
 # ----------------------------------------


### PR DESCRIPTION
This is not strictly necessary, but recommended in the GNU autoconf manual.
No [] was added to arguments like true or false.

Signed-off-by: Stefan Weil <sw@weilnetz.de>