### PR TITLE
Replace deliberate segv with raise(SIGABRT)

### DIFF
--- a/ccutil/errcode.cpp
+++ b/ccutil/errcode.cpp
@@ -21,9 +21,7 @@
 #include          <stdlib.h>
 #include          <stdarg.h>
 #include          <string.h>
-#ifdef __UNIX__
 #include          <signal.h>
-#endif
 #include          "tprintf.h"
 #include          "errcode.h"
 
@@ -74,7 +72,6 @@ const char *format, ...          // special message
   // %s is needed here so msg is printed correctly!
   fprintf(stderr, "%s", msg);
 
-  int* p = NULL;
   switch (action) {
     case DBG:
     case TESSLOG:
@@ -82,9 +79,7 @@ const char *format, ...          // special message
     case TESSEXIT:
       //err_exit();
     case ABORT:
-      // Create a deliberate segv as the stack trace is more useful that way.
-      if (!*p)
-        abort();
+      raise(SIGABRT);
     default:
       BADERRACTION.error ("error", ABORT, NULL);
   }


### PR DESCRIPTION
For front-ends to tesseract, the deliberate segfault [1] created when tesseract encounters a critical error is rather inconvenient, resp. makes it hard to keep the application alive ([2] works first time but fails to recover a second time). I'd like to propose replacing this with something from which applications can recover more easily, such as `raise(SIGABRT)`.

[1] https://github.com/tesseract-ocr/tesseract/blob/master/ccutil/errcode.cpp#L86
[2] https://github.com/manisandro/gImageReader/blob/0628f8c653169cb6bf53d51c6eb8921fcd5f66cb/gtk/src/Recognizer.cc#L171