### PR TITLE
Replace use of TLOG_FATAL() with tprintf() and exit(1)

### DIFF
--- a/training/text2image.cpp
+++ b/training/text2image.cpp
@@ -441,9 +441,10 @@ int main(int argc, char** argv) {
   if (!FLAGS_find_fonts && !FontUtils::IsAvailableFont(FLAGS_font.c_str())) {
     string pango_name;
     if (!FontUtils::IsAvailableFont(FLAGS_font.c_str(), &pango_name)) {
-      tprintf("Could not find font named %s. Pango suggested font %s\n",
+      tprintf("Could not find font named %s. Pango suggested font %s\n"
+              "Please correct --font arg.\n",
               FLAGS_font.c_str(), pango_name.c_str());
-      TLOG_FATAL("Please correct --font arg.");
+      exit(1);
     }
   }
 
@@ -487,7 +488,8 @@ int main(int argc, char** argv) {
     render.set_gravity_hint_strong(true);
     render.set_render_fullwidth_latin(true);
   } else {
-    TLOG_FATAL("Invalid writing mode : %s\n", FLAGS_writing_mode.c_str());
+    tprintf("Invalid writing mode: %s\n", FLAGS_writing_mode.c_str());
+    exit(1);
   }
 
   string src_utf8;
@@ -512,8 +514,9 @@ int main(int argc, char** argv) {
     UNICHARSET unicharset;
     if (FLAGS_render_ngrams && !FLAGS_unicharset_file.empty() &&
         !unicharset.load_from_file(FLAGS_unicharset_file.c_str())) {
-      TLOG_FATAL("Failed to load unicharset from file %s\n",
+      tprintf("Failed to load unicharset from file %s\n",
                  FLAGS_unicharset_file.c_str());
+      exit(1);
     }
 
     // If we are rendering ngrams that will be OCRed later, shuffle them so that


### PR DESCRIPTION
Asserts should not be used for missing or invalid input in the command
line! This leads to a bad UX.