### PR TITLE
Avoid unnecessary memory allocations

### DIFF
--- a/ccutil/genericvector.h
+++ b/ccutil/genericvector.h
@@ -37,9 +37,9 @@
 template <typename T>
 class GenericVector {
  public:
-  GenericVector() {
-    init(kDefaultVectorSize);
-  }
+  GenericVector() : size_used_(0), size_reserved_(0), data_(NULL),
+                    clear_cb_(NULL), compare_cb_(NULL) {}
+
   GenericVector(int size, T init_val) {
     init(size);
     init_to_size(size, init_val);

--- a/wordrec/language_model.cpp
+++ b/wordrec/language_model.cpp
@@ -796,7 +796,7 @@ LanguageModelDawgInfo *LanguageModel::GenerateDawgInfo(
     dawg_args_->permuter = NO_PERM;
   } else {
     if (parent_vse->dawg_info == NULL) return NULL;  // not a dict word path
-    dawg_args_->active_dawgs = parent_vse->dawg_info->active_dawgs;
+    dawg_args_->active_dawgs = &parent_vse->dawg_info->active_dawgs;
     dawg_args_->permuter = parent_vse->dawg_info->permuter;
   }
 
@@ -822,8 +822,8 @@ LanguageModelDawgInfo *LanguageModel::GenerateDawgInfo(
     int i;
     // Check a that the path terminated before the current character is a word.
     bool has_word_ending = false;
-    for (i = 0; i < parent_vse->dawg_info->active_dawgs->size(); ++i) {
-      const DawgPosition &pos = (*parent_vse->dawg_info->active_dawgs)[i];
+    for (i = 0; i < parent_vse->dawg_info->active_dawgs.size(); ++i) {
+      const DawgPosition &pos = parent_vse->dawg_info->active_dawgs[i];
       const Dawg *pdawg = pos.dawg_index < 0
           ? NULL : dict_->GetDawg(pos.dawg_index);
       if (pdawg == NULL || pos.back_to_punc) continue;;

--- a/wordrec/lm_state.h
+++ b/wordrec/lm_state.h
@@ -59,13 +59,9 @@ typedef unsigned char LanguageModelFlagsType;
 /// component. It stores the set of active dawgs in which the sequence of
 /// letters on a path can be found.
 struct LanguageModelDawgInfo {
-  LanguageModelDawgInfo(DawgPositionVector *a, PermuterType pt) : permuter(pt) {
-    active_dawgs = new DawgPositionVector(*a);
-  }
-  ~LanguageModelDawgInfo() {
-    delete active_dawgs;
-  }
-  DawgPositionVector *active_dawgs;
+  LanguageModelDawgInfo(const DawgPositionVector *a, PermuterType pt)
+    : active_dawgs(*a), permuter(pt) {}
+  DawgPositionVector active_dawgs;
   PermuterType permuter;
 };
 


### PR DESCRIPTION
These commits reduce the number of memory allocations (in my test cases by about 15%).

`GenericVector` should not prematurely allocate memory in the default constructor since quite a lot of vectors stay empty and there is no overhead in doing the allocation later.

Also, I don't see any reason to do the extra allocation in `LanguageModelDawgInfo`.
