### PR TITLE
Check that pango's suggested font name is not an empty string

### DIFF
--- a/training/text2image.cpp
+++ b/training/text2image.cpp
@@ -441,9 +441,11 @@ int main(int argc, char** argv) {
   if (!FLAGS_find_fonts && !FontUtils::IsAvailableFont(FLAGS_font.c_str())) {
     string pango_name;
     if (!FontUtils::IsAvailableFont(FLAGS_font.c_str(), &pango_name)) {
-      tprintf("Could not find font named %s. Pango suggested font %s\n"
-              "Please correct --font arg.\n",
-              FLAGS_font.c_str(), pango_name.c_str());
+      tprintf("Could not find font named %s.", FLAGS_font.c_str());
+      if (!pango_name.empty()) { 
+        tprintf("Pango suggested font %s.\n", pango_name.c_str());
+      }
+      tprintf("Please correct --font arg.\n");
       exit(1);
     }
   }


### PR DESCRIPTION
On msys2 pango seems to always returns empty string for the suggested
font. It's a good idea to check that the string is not empty before
printing it - on all platforms.