### PR TITLE
Fix Cygwin compatibility – part III

### DIFF
--- a/training/pango_font_info.cpp
+++ b/training/pango_font_info.cpp
@@ -25,13 +25,13 @@
 #if (defined __MINGW32__) || (defined __CYGWIN__)
 // workaround for stdlib.h and putenv
 #undef __STRICT_ANSI__
-#endif
 
 #if (defined __MINGW32__)
 #include "strcasestr.h"
-#else
+#elif !defined(_GNU_SOURCE)
 // needed for strcasestr in string.h
 #define _GNU_SOURCE
+#endif
 #endif
 
 #include <stdlib.h>


### PR DESCRIPTION
Commit 65504c8cd2300b0dd7c9352e66d0a69a5918f340 misplaced the #endif.
The definition of _GNU_SOURCE is only needed for Cygwin.

Defining _GNU_SOURCE on Linux results in compiler warnings because this
macro is already defined by the compiler.

Fix this by moving the #endif to the right place. In addition the code
for Cygwin is made more robust: If a future Cygwin compiler defines
_GNU_SOURCE, too, the code will still work.

Signed-off-by: Stefan Weil <sw@weilnetz.de>