### PR TITLE
Fix TSV bounding box width/hight calculation

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -1431,8 +1431,8 @@ static void AddBoxToTSV(const PageIterator *it,
   it->BoundingBox(level, &left, &top, &right, &bottom);
   hocr_str->add_str_int("\t", left);
   hocr_str->add_str_int("\t", top);
-  hocr_str->add_str_int("\t", right - left + 1);
-  hocr_str->add_str_int("\t", bottom - top + 1);
+  hocr_str->add_str_int("\t", right - left);
+  hocr_str->add_str_int("\t", bottom - top);
 }
 
 

--- a/api/renderer.cpp
+++ b/api/renderer.cpp
@@ -196,7 +196,7 @@ bool TessHOcrRenderer::AddImageHandler(TessBaseAPI* api) {
 }
 
 /**********************************************************************
- * HOcr Text Renderer interface implementation
+ * TSV Text Renderer interface implementation
  **********************************************************************/
 TessTsvRenderer::TessTsvRenderer(const char *outputbase)
     : TessResultRenderer(outputbase, "tsv") {


### PR DESCRIPTION
In Tesseract's coordinate system, width is just right - left, [cf. slide 2]
(github.com/tesseract-ocr/docs/blob/master/das_tutorial2016/2ArchitectureAndDataStructures.pdf).

You can verify the bug by running `tesseract A.png - -c tessedit_create_tsv=1 -psm 10` with this image ![test image](https://cloud.githubusercontent.com/assets/19879328/16364527/8fe92dba-3be9-11e6-81fb-893596c14e90.png). It yields a word bbox of 18x21 for this 17x20 pixel image:

level|page_num|block_num|par_num|line_num|word_num|left|top|width|height|conf|text
-----|--------|---------|-------|--------|--------|----|---|-----|------|----|----
1|1|0|0|0|0|0|0|17|20|-1|
2|1|1|0|0|0|0|0|18|21|-1|
3|1|1|1|0|0|0|0|18|21|-1|
4|1|1|1|1|0|0|0|18|21|-1|
5|1|1|1|1|1|0|0|18|21|95|A



