### PR TITLE
Fix TSV bounding box width/hight calculation (addition to #358)

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -1704,8 +1704,8 @@ char* TessBaseAPI::GetTSVText(int page_number) {
     tsv_str.add_str_int("\t", word_num);
     tsv_str.add_str_int("\t", left);
     tsv_str.add_str_int("\t", top);
-    tsv_str.add_str_int("\t", right - left + 1);
-    tsv_str.add_str_int("\t", bottom - top + 1);
+    tsv_str.add_str_int("\t", right - left);
+    tsv_str.add_str_int("\t", bottom - top);
     tsv_str.add_str_int("\t", res_it->Confidence(RIL_WORD));
     tsv_str += "\t";
 


### PR DESCRIPTION
This occurrence should have been included in commit 29d971e
but was overlooked by error. I apologize for my lapse.