### PR TITLE
win32: Show TIFF warnings on console

### DIFF
--- a/api/tesseractmain.cpp
+++ b/api/tesseractmain.cpp
@@ -33,6 +33,23 @@
 #include "openclwrapper.h"
 #include "osdetect.h"
 
+#if defined(_WIN32)
+
+#include <tiffio.h>
+#include <windows.h>
+
+static void Win32WarningHandler(const char* module, const char* fmt,
+                                va_list ap) {
+    if (module != NULL) {
+        fprintf(stderr, "%s: ", module);
+    }
+    fprintf(stderr, "Warning, ");
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, ".\n");
+}
+
+#endif /* _WIN32 */
+
 void PrintVersionInfo() {
     char *versionStrP;
 
@@ -351,6 +368,11 @@ int main(int argc, char **argv) {
   GenericVector<STRING> vars_vec, vars_values;
   int arg_i = 1;
   tesseract::PageSegMode pagesegmode = tesseract::PSM_AUTO;
+
+#if defined(_WIN32)
+  /* Show libtiff warnings on console (not in GUI). */
+  TIFFSetWarningHandler(Win32WarningHandler);
+#endif /* _WIN32 */
 
   ParseArgs(argc, argv,
           &lang, &image, &outputbase, &datapath,

--- a/api/tesseractmain.cpp
+++ b/api/tesseractmain.cpp
@@ -33,7 +33,7 @@
 #include "openclwrapper.h"
 #include "osdetect.h"
 
-#if defined(_WIN32)
+#if defined(HAVE_TIFFIO_H) && defined(_WIN32)
 
 #include <tiffio.h>
 #include <windows.h>
@@ -48,7 +48,7 @@ static void Win32WarningHandler(const char* module, const char* fmt,
     fprintf(stderr, ".\n");
 }
 
-#endif /* _WIN32 */
+#endif /* HAVE_TIFFIO_H &&  _WIN32 */
 
 void PrintVersionInfo() {
     char *versionStrP;
@@ -369,10 +369,10 @@ int main(int argc, char **argv) {
   int arg_i = 1;
   tesseract::PageSegMode pagesegmode = tesseract::PSM_AUTO;
 
-#if defined(_WIN32)
+#if defined(HAVE_TIFFIO_H) && defined(_WIN32)
   /* Show libtiff warnings on console (not in GUI). */
   TIFFSetWarningHandler(Win32WarningHandler);
-#endif /* _WIN32 */
+#endif /* HAVE_TIFFIO_H &&  _WIN32 */
 
   ParseArgs(argc, argv,
           &lang, &image, &outputbase, &datapath,


### PR DESCRIPTION
Showing them in a window (default) is not acceptable for a console
application like Tesseract which must be able to work in batch mode.

Signed-off-by: Stefan Weil <sw@weilnetz.de>