### PR TITLE
stringrenderer: Fix compiler warning (-Wwrite-strings)

### DIFF
--- a/training/stringrenderer.h
+++ b/training/stringrenderer.h
@@ -90,7 +90,7 @@ class StringRenderer {
   void set_underline_style(const PangoUnderline style) {
     underline_style_ = style;
   }
-  void set_features(char *features) {
+  void set_features(const char *features) {
     free(features_);
     features_ = strdup(features);
   }


### PR DESCRIPTION
gcc reported this warning:

../training/stringrenderer.cpp:
 In member function ‘void tesseract::StringRenderer::SetLayoutProperties()’:
../training/stringrenderer.cpp:211:42: warning:
 ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
     set_features("liga, clig, dlig, hlig");
                                          ^
Signed-off-by: Stefan Weil <sw@weilnetz.de>