### PR TITLE
text2image: Add linefeed to error message

### DIFF
--- a/training/text2image.cpp
+++ b/training/text2image.cpp
@@ -444,7 +444,7 @@ int main(int argc, char** argv) {
   if (!FLAGS_find_fonts && !FontUtils::IsAvailableFont(FLAGS_font.c_str())) {
     string pango_name;
     if (!FontUtils::IsAvailableFont(FLAGS_font.c_str(), &pango_name)) {
-      tprintf("Could not find font named %s.", FLAGS_font.c_str());
+      tprintf("Could not find font named %s.\n", FLAGS_font.c_str());
       if (!pango_name.empty()) { 
         tprintf("Pango suggested font %s.\n", pango_name.c_str());
       }


### PR DESCRIPTION
This changes the error message for a missing font from

  Could not find font named Times New Roman.Please correct --font arg.

(missing space after first sentence) to

  Could not find font named Times New Roman.
  Please correct --font arg.

Signed-off-by: Stefan Weil <sw@weilnetz.de>