### PR TITLE
ccutil: Fix and simplify implementation of variadic macro

### DIFF
--- a/ccutil/errcode.h
+++ b/ccutil/errcode.h
@@ -87,21 +87,12 @@ const ERRCODE ASSERT_FAILED = "Assert failed";
                         __FILE__, __LINE__);                            \
   }
 
-#ifdef _MSC_VER
-#define ASSERT_HOST_MSG(x, msg, ...) if (!(x))                            \
+#define ASSERT_HOST_MSG(x, ...) if (!(x))                               \
   {                                                                     \
-    tprintf(msg);                                                       \
+    tprintf(__VA_ARGS__);                                               \
     ASSERT_FAILED.error(#x, ABORT, "in file %s, line %d",               \
                         __FILE__, __LINE__);                            \
   }
-#else
-#define ASSERT_HOST_MSG(x, msg...) if (!(x))                            \
-  {                                                                     \
-    tprintf(msg);                                                       \
-    ASSERT_FAILED.error(#x, ABORT, "in file %s, line %d",               \
-                        __FILE__, __LINE__);                            \
-  }
-#endif
 
 void signal_exit(int signal_code);
 


### PR DESCRIPTION
The implementation for MS C did not pass the variable arguments to
tprintf.

The standard is supported since C99 / C++11, so one implementation
is sufficient.

Signed-off-by: Stefan Weil <sw@weilnetz.de>