### PR TITLE
tlog: Remove unused macro TLOG_FATAL

### DIFF
--- a/training/tlog.h
+++ b/training/tlog.h
@@ -38,12 +38,4 @@ DECLARE_INT_PARAM_FLAG(tlog_level);
 
 #define TLOG_IS_ON(level) (FLAGS_tlog_level >= level)
 
-#define TLOG_FATAL(msg, ...)                                              \
-  {                                                                     \
-    tprintf(msg);                                                       \
-    ASSERT_FAILED.error("", ABORT, "in file %s, line %d",               \
-                        __FILE__, __LINE__);                            \
-  }
-
-
 #endif  // TESSERACT_TRAINING_TLOG_H_


### PR DESCRIPTION
The implementation was also wrong because it did not use __VA_ARGS__.

Signed-off-by: Stefan Weil <sw@weilnetz.de>