### PR TITLE
fileio: Replace assert with tprintf() and exit(1)

### DIFF
--- a/training/fileio.cpp
+++ b/training/fileio.cpp
@@ -80,12 +80,6 @@ bool File::ReadFileToString(const string& filename, string* out) {
   return in.CloseFile();
 }
 
-void File::ReadFileToStringOrDie(const string& filename, string* out) {
-  ASSERT_HOST_MSG(ReadFileToString(filename, out),
-                  "Failed to read file: %s\n", filename.c_str());
-}
-
-
 string File::JoinPath(const string& prefix, const string& suffix) {
   return (!prefix.size() || prefix[prefix.size() - 1] == '/') ?
       prefix + suffix : prefix + "/" + suffix;

--- a/training/fileio.h
+++ b/training/fileio.h
@@ -42,7 +42,6 @@ class File {
   // Return true if the file 'filename' is readable.
   static bool Readable(const string& filename);
 
-  static void ReadFileToStringOrDie(const string& filename, string* out);
   static bool ReadFileToString(const string& filename, string* out);
 
   // Helper methods

--- a/training/text2image.cpp
+++ b/training/text2image.cpp
@@ -499,7 +499,10 @@ int main(int argc, char** argv) {
 
   string src_utf8;
   // This c_str is NOT redundant!
-  File::ReadFileToStringOrDie(FLAGS_text.c_str(), &src_utf8);
+  if (!File::ReadFileToString(FLAGS_text.c_str(), &src_utf8)) {
+    tprintf("Failed to read file: %s\n", FLAGS_text.c_str());
+    exit(1);
+  }
 
   // Remove the unicode mark if present.
   if (strncmp(src_utf8.c_str(), "\xef\xbb\xbf", 3) == 0) {


### PR DESCRIPTION
Assertions are good for programming errors, but not for wrong user input.

The new code no longer needs File::ReadFileToStringOrDie, so remove that
method.

Signed-off-by: Stefan Weil <sw@weilnetz.de>