### PR TITLE
vs2010: Fix implementation of strcasestr

### DIFF
--- a/vs2010/port/strcasestr.cpp
+++ b/vs2010/port/strcasestr.cpp
@@ -49,9 +49,14 @@ char *strcasestr(const char *haystack, const char *needle) {
      return NULL;
 
    length_needle = strlen(needle);
-   length_haystack = strlen(haystack) - length_needle + 1;
+   length_haystack = strlen(haystack);
 
-   for (i = 0; i < length_haystack; i++)
+   if (length_haystack < length_needle)
+     return NULL;
+
+   length_haystack -= length_needle;
+
+   for (i = 0; i <= length_haystack; i++)
      {
         size_t j;
 


### PR DESCRIPTION
A haystack which is shorter than the needle resulted in negative value
for length_haystack which was forced to a very large unsigned value.

The resulting buffer overflow while reading the haystack would crash
text2image when it was called with a short font name.

Signed-off-by: Stefan Weil <sw@weilnetz.de>