### PR TITLE
Remove unneeded 'struct' from TessBaseAPI::GetHOCRText (issue #414)

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -1457,7 +1457,7 @@ char* TessBaseAPI::GetHOCRText(int page_number) {
  * GetHOCRText
  * STL removed from original patch submission and refactored by rays.
  */
-char* TessBaseAPI::GetHOCRText(struct ETEXT_DESC* monitor, int page_number) {
+char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
   if (tesseract_ == NULL ||
       (page_res_ == NULL && Recognize(monitor) < 0))
     return NULL;

--- a/api/baseapi.h
+++ b/api/baseapi.h
@@ -591,7 +591,7 @@ class TESS_API TessBaseAPI {
    * 	cancel the recognition
    * 	receive progress callbacks
    */
-  char* GetHOCRText(struct ETEXT_DESC* monitor, int page_number);
+  char* GetHOCRText(ETEXT_DESC* monitor, int page_number);
 
   /**
    * Make a HTML-formatted string with hOCR markup from the internal


### PR DESCRIPTION
It conflicts with a previous 'class' declaration for ETEXT_DESC:

include/tesseract/baseapi.h:594:21:
 Struct 'ETEXT_DESC' was previously declared as a class

Signed-off-by: Stefan Weil <sw@weilnetz.de>