### PR TITLE
Remove some unused constants

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -1740,7 +1740,6 @@ const int kBytesPerNumber = 5;
  * * kNumbersPerBlob plus the newline. Add to this the
  * original UTF8 characters, and one kMaxBytesPerLine for safety.
  */
-const int kBytesPerBlob = kNumbersPerBlob * (kBytesPerNumber + 1) + 1;
 const int kBytesPerBoxFileLine = (kBytesPerNumber + 1) * kNumbersPerBlob + 1;
 /** Max bytes in the decimal representation of inT64. */
 const int kBytesPer64BitNumber = 20;

--- a/ccmain/control.cpp
+++ b/ccmain/control.cpp
@@ -51,8 +51,6 @@
 #define MAX_XHEIGHT_DIFF  3
 
 const char* const kBackUpConfigFile = "tempconfigdata.config";
-// Multiple of x-height to make a repeated word have spaces in it.
-const double kRepcharGapThreshold = 0.5;
 // Min believable x-height for any text when refitting as a fraction of
 // original x-height
 const double kMinRefitXHeightFraction = 0.5;

--- a/ccmain/osdetect.cpp
+++ b/ccmain/osdetect.cpp
@@ -39,7 +39,6 @@ const int kMaxCharactersToTry = 5 * kMinCharactersToTry;
 const float kSizeRatioToReject = 2.0;
 const int kMinAcceptableBlobHeight = 10;
 
-const float kOrientationAcceptRatio = 1.3;
 const float kScriptAcceptRatio = 1.3;
 
 const float kHanRatioInKorean = 0.7;
@@ -61,8 +60,6 @@ const char* ScriptDetector::fraktur_script_ = "Fraktur";
 
 // Minimum believable resolution.
 const int kMinCredibleResolution = 70;
-// Default resolution used if input is not believable.
-const int kDefaultResolution = 300;
 
 void OSResults::update_best_orientation() {
   float first = orientations[0];
@@ -167,7 +164,6 @@ void remove_nontext_regions(tesseract::Tesseract *tess, BLOCK_LIST *blocks,
   int vertical_y = 1;
   tesseract::TabVector_LIST v_lines;
   tesseract::TabVector_LIST h_lines;
-  const int kMinCredibleResolution = 70;
   int resolution = (kMinCredibleResolution > pixGetXRes(pix)) ?
       kMinCredibleResolution : pixGetXRes(pix);
 

--- a/ccmain/pagesegmain.cpp
+++ b/ccmain/pagesegmain.cpp
@@ -54,10 +54,6 @@
 
 namespace tesseract {
 
-/// Minimum believable resolution.
-const int kMinCredibleResolution = 70;
-/// Default resolution used if input in not believable.
-const int kDefaultResolution = 300;
 // Max erosions to perform in removing an enclosing circle.
 const int kMaxCircleErosions = 8;
 

--- a/classify/intfeaturemap.cpp
+++ b/classify/intfeaturemap.cpp
@@ -30,7 +30,6 @@
 namespace tesseract {
 
 const int kMaxOffsetDist = 32;
-const double kMinPCLengthIncrease = 1.0 / 1024;
 
 IntFeatureMap::IntFeatureMap()
   : mapping_changed_(true), compact_size_(0) {

--- a/textord/colfind.cpp
+++ b/textord/colfind.cpp
@@ -44,19 +44,12 @@
 
 namespace tesseract {
 
-// Minimum width (in pixels) to be considered when making columns.
-// TODO(rays) convert to inches, dependent on resolution.
-const int kMinColumnWidth = 100;
 // When assigning columns, the max number of misfit grid rows/ColPartitionSets
 // that can be ignored.
 const int kMaxIncompatibleColumnCount = 2;
-// Min fraction of ColPartition height to be overlapping for margin purposes.
-const double kMarginOverlapFraction = 0.25;
 // Max fraction of mean_column_gap_ for the gap between two partitions within a
 // column to allow them to merge.
 const double kHorizontalGapMergeFraction = 0.5;
-// Min fraction of grid size to not be considered likely noise.
-const double kMinNonNoiseFraction = 0.5;
 // Minimum gutter width as a fraction of gridsize
 const double kMinGutterWidthGrid = 0.5;
 // Max multiple of a partition's median size as a distance threshold for

--- a/textord/strokewidth.cpp
+++ b/textord/strokewidth.cpp
@@ -84,8 +84,6 @@ const double kMaxDiacriticDistanceRatio = 1.25;
 // Max x-gap between a diacritic and its base char as a fraction of the height
 // of the base char (allowing other blobs to fill the gap.)
 const double kMaxDiacriticGapToBaseCharHeight = 1.0;
-// Radius of a search for diacritics in grid units.
-const int kSearchRadius = 2;
 // Ratio between longest side of a line and longest side of a character.
 // (neighbor_min > blob_min * kLineTrapShortest &&
 //  neighbor_max < blob_max / kLineTrapLongest)
@@ -104,9 +102,6 @@ const int kLineResiduePadRatio = 3;
 const double kLineResidueSizeRatio = 1.75;
 // Aspect ratio filter for OSD.
 const float kSizeRatioToReject = 2.0;
-// Max number of normal blobs a large blob may overlap before it is rejected
-// and determined to be image
-const int kMaxLargeOverlaps = 3;
 // Expansion factor for search box for good neighbours.
 const double kNeighbourSearchFactor = 2.5;
 // Factor of increase of overlap when adding diacritics to make an image noisy.
@@ -114,8 +109,6 @@ const double kNoiseOverlapGrowthFactor = 4.0;
 // Fraction of the image size to add overlap when adding diacritics for an
 // image to qualify as noisy.
 const double kNoiseOverlapAreaFactor = 1.0 / 512;
-// Ratio of perimeter^2/area for a blob to be considered noise vs i dot.
-const double kShapePerimeterRatio = 3.0;
 
 StrokeWidth::StrokeWidth(int gridsize,
                          const ICOORD& bleft, const ICOORD& tright)

--- a/textord/tabfind.cpp
+++ b/textord/tabfind.cpp
@@ -45,8 +45,6 @@ const int kMinColumnWidth = 200;
 const double kMinFractionalLinesInColumn = 0.125;
 // Fraction of height used as alignment tolerance for aligned tabs.
 const double kAlignedFraction = 0.03125;
-// Minimum gutter width in absolute inch (multiplied by resolution)
-const double kMinGutterWidthAbsolute = 0.02;
 // Maximum gutter width (in absolute inch) that we care about
 const double kMaxGutterWidthAbsolute = 2.00;
 // Multiplier of gridsize for min gutter width of TT_MAYBE_RAGGED blobs.
@@ -54,27 +52,8 @@ const int kRaggedGutterMultiple = 5;
 // Min aspect ratio of tall objects to be considered a separator line.
 // (These will be ignored in searching the gutter for obstructions.)
 const double kLineFragmentAspectRatio = 10.0;
-// Multiplier of new y positions in running average for skew estimation.
-const double kSmoothFactor = 0.25;
-// Min coverage for a good baseline between vectors
-const double kMinBaselineCoverage = 0.5;
-// Minimum overlap fraction when scanning text lines for column widths.
-const double kCharVerticalOverlapFraction = 0.375;
-// Maximum horizontal gap allowed when scanning for column widths
-const double kMaxHorizontalGap = 3.0;
-// Maximum upper quartile error allowed on a baseline fit as a fraction
-// of height.
-const double kMaxBaselineError = 0.4375;
 // Min number of points to accept after evaluation.
 const int kMinEvaluatedTabs = 3;
-// Minimum aspect ratio of a textline to make a good textline blob with a
-// single blob.
-const int kMaxTextLineBlobRatio = 5;
-// Minimum aspect ratio of a textline to make a good textline blob with
-// multiple blobs. Target ratio varies according to number of blobs.
-const int kMinTextLineBlobRatio = 3;
-// Fraction of box area covered by image to make a blob image.
-const double kMinImageArea = 0.5;
 // Up to 30 degrees is allowed for rotations of diacritic blobs.
 // Keep this value slightly larger than kCosSmallAngle in blobbox.cpp
 // so that the assert there never fails.

--- a/textord/tablefind.cpp
+++ b/textord/tablefind.cpp
@@ -114,11 +114,6 @@ const int kLargeTableRowCount = 6;
 // Minimum number of rows in a table
 const int kMinRowsInTable = 3;
 
-// The number of "whitespace blobs" that should appear between the
-// ColPartition's bounding box and the column tab stops to the left/right
-// when looking for center justified tab stops.
-const double kRequiredFullJustifiedSpacing = 4.0;
-
 // The amount of padding (multiplied by global_median_xheight_ during use)
 // that is vertically added to the search adjacent leader search during
 // ColPartition marking.

--- a/textord/tordmain.cpp
+++ b/textord/tordmain.cpp
@@ -38,9 +38,6 @@
 
 #include "allheaders.h"
 
-// Gridsize for word grid when reassigning diacritics to words. Not critical.
-const int kWordGridSize = 50;
-
 #undef EXTERN
 #define EXTERN
 


### PR DESCRIPTION
This fixes several warnings from the clang compiler.

Signed-off-by: Stefan Weil <sw@weilnetz.de>
