### PR TITLE
training: Remove unnecessary const qualifiers

### DIFF
--- a/training/pango_font_info.h
+++ b/training/pango_font_info.h
@@ -93,15 +93,15 @@ class PangoFontInfo {
   // Font Family name eg. "Arial"
   const string& family_name() const    { return family_name_; }
   // Size in points (1/72"), rounded to the nearest integer.
-  const int font_size() const          { return font_size_; }
-  const bool is_bold() const           { return is_bold_; }
-  const bool is_italic() const         { return is_italic_; }
-  const bool is_smallcaps() const      { return is_smallcaps_; }
-  const bool is_monospace() const      { return is_monospace_; }
-  const bool is_fraktur() const        { return is_fraktur_; }
-  const FontTypeEnum font_type() const { return font_type_; }
+  int font_size() const          { return font_size_; }
+  bool is_bold() const           { return is_bold_; }
+  bool is_italic() const         { return is_italic_; }
+  bool is_smallcaps() const      { return is_smallcaps_; }
+  bool is_monospace() const      { return is_monospace_; }
+  bool is_fraktur() const        { return is_fraktur_; }
+  FontTypeEnum font_type() const { return font_type_; }
 
-  const int resolution() const         { return resolution_; }
+  int resolution() const         { return resolution_; }
   void set_resolution(const int resolution) {
     resolution_ = resolution;
   }

--- a/training/stringrenderer.h
+++ b/training/stringrenderer.h
@@ -130,10 +130,10 @@ class StringRenderer {
   const PangoFontInfo& font() const {
     return font_;
   }
-  const int h_margin() const {
+  int h_margin() const {
     return h_margin_;
   }
-  const int v_margin() const {
+  int v_margin() const {
     return v_margin_;
   }
 


### PR DESCRIPTION
This fixes several gcc warnings:

warning:
 type qualifiers ignored on function return type [-Wignored-qualifiers]

Signed-off-by: Stefan Weil <sw@weilnetz.de>