### PR TITLE
opencl: Fix mismatched new[] / free

### DIFF
--- a/opencl/openclwrapper.cpp
+++ b/opencl/openclwrapper.cpp
@@ -375,7 +375,7 @@ int OpenclDevice::ReleaseOpenclEnv( GPUEnv *gpuInfo )
     }
     isInited = 0;
     gpuInfo->mnIsUserCreated = 0;
-    free( gpuInfo->mpArryDevsID );
+    delete[] gpuInfo->mpArryDevsID;
     return 1;
 }
 int OpenclDevice::BinaryGenerated( const char * clFileName, FILE ** fhandle )


### PR DESCRIPTION
valgrind report: Mismatched free() / delete / delete []

gpuInfo->mpArryDevsID is created by "new cl_device_id[1]",
so it must be destroyed by delete[].

Signed-off-by: Stefan Weil <sw@weilnetz.de>