### PR TITLE
opencl: Add tiff library needed by openclwrapper

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,7 @@ AM_CONDITIONAL([OSX], false)
 AM_CONDITIONAL([GRAPHICS_DISABLED], false)
 
 OPENCL_INC="/opt/AMDAPP/include"
-OPENCL_LIBS="-lOpenCL"
+OPENCL_LIBS="-lOpenCL -ltiff"
 #############################
 #
 # Platform specific setup


### PR DESCRIPTION
openclwrapper calls function TIFFReadRGBAImageOriented which is provided
by libtiff, so add that library to OPENCL_LIBS.

This fixes a linker error (unresolved symbol) when opencl is enabled.

Signed-off-by: Stefan Weil <sw@weilnetz.de>