### PR TITLE
opencl: Move declaration of MORPH_BC from .h to .cpp file

### DIFF
--- a/opencl/openclwrapper.cpp
+++ b/opencl/openclwrapper.cpp
@@ -47,6 +47,8 @@ ds_device OpenclDevice::selectedDevice;
 
 int OpenclDevice::isInited = 0;
 
+static l_int32 MORPH_BC = ASYMMETRIC_MORPH_BC;
+
 static const l_uint32 lmask32[] = {
     0x80000000, 0xc0000000, 0xe0000000, 0xf0000000,
     0xf8000000, 0xfc000000, 0xfe000000, 0xff000000,

--- a/opencl/openclwrapper.h
+++ b/opencl/openclwrapper.h
@@ -171,9 +171,6 @@ typedef struct _OpenCLEnv
 } OpenCLEnv;
 typedef int ( *cl_kernel_function )( void **userdata, KernelEnv *kenv );
 
-
-static l_int32 MORPH_BC = ASYMMETRIC_MORPH_BC;
-
 #define CHECK_OPENCL(status,name)    \
 if( status != CL_SUCCESS )    \
 {    \


### PR DESCRIPTION
It is only used locally in opencl/openclwrapper.cpp.

For all other files which include openclwrapper.h, the compiler
complained about an unused static variable:

opencl/openclwrapper.h:175:16: warning:
 ‘MORPH_BC’ defined but not used [-Wunused-variable]

Signed-off-by: Stefan Weil <sw@weilnetz.de>