### PR TITLE
opencl: Remove unused function getNumDeviceWithEmptyScore

### DIFF
--- a/opencl/opencl_device_selection.h
+++ b/opencl/opencl_device_selection.h
@@ -578,19 +578,5 @@ cleanup:
   return status;
 }
 
-static ds_status getNumDeviceWithEmptyScore(ds_profile* profile,
-                                            unsigned int* num) {
-  unsigned int i;
-  if (profile == NULL || num==NULL)
-    return DS_MEMORY_ERROR;
-  *num=0;
-  for (i = 0; i < profile->numDevices; i++) {
-    if (profile->devices[i].score == NULL) {
-      (*num)++;
-    }
-  }
-  return DS_SUCCESS;
-}
-
 #endif
 #endif


### PR DESCRIPTION
This fixes compiler warnings.

Signed-off-by: Stefan Weil <sw@weilnetz.de>