### PR TITLE
Fix crash caused by undefined value of local variable

### DIFF
--- a/classify/adaptmatch.cpp
+++ b/classify/adaptmatch.cpp
@@ -818,14 +818,14 @@ int Classify::GetAdaptiveFeatures(TBLOB *Blob,
   classify_norm_method.set_value(baseline);
   Features = ExtractPicoFeatures(Blob);
 
+  *FloatFeatures = Features;
+
   NumFeatures = Features->NumFeatures;
   if (NumFeatures > UNLIKELY_NUM_FEAT) {
-    FreeFeatureSet(Features);
     return 0;
   }
 
   ComputeIntFeatures(Features, IntFeatures);
-  *FloatFeatures = Features;
 
   return NumFeatures;
 }                                /* GetAdaptiveFeatures */


### PR DESCRIPTION
Commit b1f03cb6975ee4bde6d8c9450ea55f111cc36ac1 added a call of function
FreeFeatureSet to fix a memory leak, but introduced a new bug because the
local variable FloatFeatures was not always assigned a value.

Now FloatFeatures is always assigned a value, and we only need a single
place where FreeFeatureSet is called.

Signed-off-by: Stefan Weil <sw@weilnetz.de>