### PR TITLE
Fix a typo in tesseract(1) man page

### DIFF
--- a/doc/tesseract.1.asc
+++ b/doc/tesseract.1.asc
@@ -268,7 +268,7 @@ The engine was developed at Hewlett Packard Laboratories Bristol and at
 Hewlett Packard Co, Greeley Colorado between 1985 and 1994, with some more 
 changes made in 1996 to port to Windows, and some C\+\+izing in 1998. A 
 lot of the code was written in C, and then some more was written in C\+\+. 
-The C\++ code makes heavy use of a list system using macros. This predates
+The C\+\+ code makes heavy use of a list system using macros. This predates
 stl, was portable before stl, and is more efficient than stl lists, but has
 the big negative that if you do get a segmentation violation, it is hard to
 debug.


### PR DESCRIPTION
`C++` needs to escaped as `C\+\+` in the AsciiDoc source code.