### PR TITLE
add option "make training-uninstall"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ training/wordlist2dawg
 *.patch
 
 # ignore compilation files
+build/*
 */.deps/*
 */.libs/*
 *.lo

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,9 +4,12 @@ ACLOCAL_AMFLAGS = -I m4
 if ENABLE_TRAINING
 TRAINING_SUBDIR = training
 training:
+	$(MAKE)
 	@cd "$(top_builddir)/training" && $(MAKE)
 training-install:
 	@cd "$(top_builddir)/training" && $(MAKE) install
+training-uninstall:
+	@cd "$(top_builddir)/training" && $(MAKE) uninstall
 clean-local:
 	@cd "$(top_builddir)/training" && $(MAKE) clean
 else


### PR DESCRIPTION
This is a missing commit from Tesseract 3.04.