### PR TITLE
cube: Simplify delete operations

### DIFF
--- a/ccmain/cube_reco_context.cpp
+++ b/ccmain/cube_reco_context.cpp
@@ -55,40 +55,26 @@ CubeRecoContext::CubeRecoContext(Tesseract *tess_obj) {
 }
 
 CubeRecoContext::~CubeRecoContext() {
-  if (char_classifier_ != NULL) {
-    delete char_classifier_;
-    char_classifier_ = NULL;
-  }
+  delete char_classifier_;
+  char_classifier_ = NULL;
 
-  if (word_size_model_ != NULL) {
-    delete word_size_model_;
-    word_size_model_ = NULL;
-  }
+  delete word_size_model_;
+  word_size_model_ = NULL;
 
-  if (char_set_ != NULL) {
-    delete char_set_;
-    char_set_ = NULL;
-  }
+  delete char_set_;
+  char_set_ = NULL;
 
-  if (char_bigrams_ != NULL) {
-    delete char_bigrams_;
-    char_bigrams_ = NULL;
-  }
+  delete char_bigrams_;
+  char_bigrams_ = NULL;
 
-  if (word_unigrams_ != NULL) {
-    delete word_unigrams_;
-    word_unigrams_ = NULL;
-  }
+  delete word_unigrams_;
+  word_unigrams_ = NULL;
 
-  if (lang_mod_ != NULL) {
-    delete lang_mod_;
-    lang_mod_ = NULL;
-  }
+  delete lang_mod_;
+  lang_mod_ = NULL;
 
-  if (params_ != NULL) {
-    delete params_;
-    params_ = NULL;
-  }
+  delete params_;
+  params_ = NULL;
 }
 
 /**

--- a/cube/beam_search.cpp
+++ b/cube/beam_search.cpp
@@ -36,8 +36,7 @@ BeamSearch::BeamSearch(CubeRecoContext *cntxt, bool word_mode) {
 void BeamSearch::Cleanup() {
   if (col_ != NULL) {
     for (int col = 0; col < col_cnt_; col++) {
-      if (col_[col])
-        delete col_[col];
+      delete col_[col];
     }
     delete []col_;
   }
@@ -356,8 +355,7 @@ CharSamp **BeamSearch::BackTrack(SearchObject *srch_obj, SearchNode *srch_node,
     return NULL;
 
   if (str32) {
-    if (*str32)
-      delete [](*str32);  // clear existing value
+    delete [](*str32);  // clear existing value
     *str32 = srch_node->PathString();
     if (!*str32)
       return NULL;

--- a/cube/bmp_8.cpp
+++ b/cube/bmp_8.cpp
@@ -48,18 +48,14 @@ Bmp8::~Bmp8() {
 // free buffer
 void Bmp8::FreeBmpBuffer(unsigned char **buff) {
   if (buff != NULL) {
-    if (buff[0] != NULL) {
-      delete []buff[0];
-    }
+    delete []buff[0];
     delete []buff;
   }
 }
 
 void Bmp8::FreeBmpBuffer(unsigned int **buff) {
   if (buff != NULL) {
-    if (buff[0] != NULL) {
-      delete []buff[0];
-    }
+    delete []buff[0];
     delete []buff;
   }
 }
@@ -77,7 +73,6 @@ unsigned char **Bmp8::CreateBmpBuffer(unsigned char init_val) {
 
   buff = (unsigned char **) new unsigned char *[hgt_ * sizeof(*buff)];
   if (!buff) {
-    delete []buff;
     return NULL;
   }
 
@@ -85,6 +80,7 @@ unsigned char **Bmp8::CreateBmpBuffer(unsigned char init_val) {
   buff[0] = (unsigned char *)
       new unsigned char[stride_ * hgt_ * sizeof(*buff[0])];
   if (!buff[0]) {
+    delete []buff;
     return NULL;
   }
 
@@ -105,13 +101,13 @@ unsigned int ** Bmp8::CreateBmpBuffer(int wid, int hgt,
   // compute stride (align on 4 byte boundries)
   buff = (unsigned int **) new unsigned int *[hgt * sizeof(*buff)];
   if (!buff) {
-    delete []buff;
     return NULL;
   }
 
   // alloc and init memory for buffer and line buffer
   buff[0] = (unsigned int *) new unsigned int[wid * hgt * sizeof(*buff[0])];
   if (!buff[0]) {
+    delete []buff;
     return NULL;
   }
 

--- a/cube/classifier_base.h
+++ b/cube/classifier_base.h
@@ -49,21 +49,15 @@ class CharClassifier {
   virtual ~CharClassifier() {
     if (fold_sets_  != NULL) {
       for (int fold_set = 0; fold_set < fold_set_cnt_; fold_set++) {
-        if (fold_sets_[fold_set] != NULL) {
-          delete []fold_sets_[fold_set];
-        }
+        delete []fold_sets_[fold_set];
       }
       delete []fold_sets_;
       fold_sets_ = NULL;
     }
-    if (fold_set_len_ != NULL) {
-      delete []fold_set_len_;
-      fold_set_len_ = NULL;
-    }
-    if (feat_extract_ != NULL) {
-      delete feat_extract_;
-      feat_extract_ = NULL;
-    }
+    delete []fold_set_len_;
+    fold_set_len_ = NULL;
+    delete feat_extract_;
+    feat_extract_ = NULL;
   }
 
   // pure virtual functions that need to be implemented by any inheriting class

--- a/cube/cube_object.cpp
+++ b/cube/cube_object.cpp
@@ -54,47 +54,33 @@ void CubeObject::Init() {
 
 // Cleanup function
 void CubeObject::Cleanup() {
-  if (alt_list_ != NULL) {
-    delete alt_list_;
-    alt_list_ = NULL;
-  }
+  delete alt_list_;
+  alt_list_ = NULL;
 
-  if (deslanted_alt_list_ != NULL) {
-    delete deslanted_alt_list_;
-    deslanted_alt_list_ = NULL;
-  }
+  delete deslanted_alt_list_;
+  deslanted_alt_list_ = NULL;
 }
 
 CubeObject::~CubeObject() {
-  if (char_samp_ != NULL && own_char_samp_ == true) {
+  if (own_char_samp_ == true) {
     delete char_samp_;
     char_samp_ = NULL;
   }
 
-  if (srch_obj_ != NULL) {
-    delete srch_obj_;
-    srch_obj_ = NULL;
-  }
+  delete srch_obj_;
+  srch_obj_ = NULL;
 
-  if (deslanted_srch_obj_ != NULL) {
-    delete deslanted_srch_obj_;
-    deslanted_srch_obj_ = NULL;
-  }
+  delete deslanted_srch_obj_;
+  deslanted_srch_obj_ = NULL;
 
-  if (beam_obj_ != NULL) {
-    delete beam_obj_;
-    beam_obj_ = NULL;
-  }
+  delete beam_obj_;
+  beam_obj_ = NULL;
 
-  if (deslanted_beam_obj_ != NULL) {
-    delete deslanted_beam_obj_;
-    deslanted_beam_obj_ = NULL;
-  }
+  delete deslanted_beam_obj_;
+  deslanted_beam_obj_ = NULL;
 
-  if (deslanted_char_samp_ != NULL) {
-    delete deslanted_char_samp_;
-    deslanted_char_samp_ = NULL;
-  }
+  delete deslanted_char_samp_;
+  deslanted_char_samp_ = NULL;
 
   Cleanup();
 }


### PR DESCRIPTION
It is not necessary to check for null pointers.

Remove also unneeded delete operations and add missing delete operations
in cube/bmp_8.cpp.

Simplify also a conditional statement in cube/cube_object.cpp.

Signed-off-by: Stefan Weil <sw@weilnetz.de>