### PR TITLE
classify: Restore previous working state

### DIFF
--- a/classify/adaptmatch.cpp
+++ b/classify/adaptmatch.cpp
@@ -908,7 +908,8 @@ void Classify::AdaptToChar(TBLOB* Blob, CLASS_ID ClassId, int FontinfoId,
 
     NumFeatures = GetAdaptiveFeatures(Blob, IntFeatures, &FloatFeatures);
     if (NumFeatures <= 0) {
-      return;  // Features already freed by GetAdaptiveFeatures.
+      FreeFeatureSet(FloatFeatures);
+      return;
     }
 
     // Only match configs with the matching font.

--- a/classify/adaptmatch.cpp
+++ b/classify/adaptmatch.cpp
@@ -818,14 +818,14 @@ int Classify::GetAdaptiveFeatures(TBLOB *Blob,
   classify_norm_method.set_value(baseline);
   Features = ExtractPicoFeatures(Blob);
 
+  *FloatFeatures = Features;
+
   NumFeatures = Features->NumFeatures;
   if (NumFeatures > UNLIKELY_NUM_FEAT) {
-    FreeFeatureSet(Features);
     return 0;
   }
 
   ComputeIntFeatures(Features, IntFeatures);
-  *FloatFeatures = Features;
 
   return NumFeatures;
 }                                /* GetAdaptiveFeatures */


### PR DESCRIPTION
This restores classify/adaptmatch.cpp to commit 1e60a8d71c591ab9562983778d6ce2541b75abc0
(+ two deleted empty lines).

Signed-off-by: Stefan Weil <sw@weilnetz.de>