### PR TITLE
Remove extra semicolons after member function definitions

### DIFF
--- a/api/baseapi.h
+++ b/api/baseapi.h
@@ -849,7 +849,7 @@ class TESS_API TessBaseAPI {
 
   TESS_LOCAL const PAGE_RES* GetPageRes() const {
     return page_res_;
-  };
+  }
   /* @} */
 
 

--- a/ccstruct/params_training_featdef.h
+++ b/ccstruct/params_training_featdef.h
@@ -126,7 +126,7 @@ typedef GenericVector<ParamsTrainingHypothesis> ParamsTrainingHypothesisList;
 // explored on PASS1, PASS2, fix xheight pass, etc).
 class ParamsTrainingBundle {
  public:
-  ParamsTrainingBundle() {};
+  ParamsTrainingBundle() {}
   // Starts a new hypothesis list.
   // Should be called at the beginning of a new run of the segmentation search.
   void StartHypothesisList() {

--- a/ccutil/bits16.h
+++ b/ccutil/bits16.h
@@ -37,12 +37,12 @@ class DLLSYM BITS16
     void turn_on_bit(                  // flip specified bit
                      uinT8 bit_num) {  // bit to flip 0..7
       val = val | 01 << bit_num;
-    };
+    }
 
     void turn_off_bit(                  // flip specified bit
                       uinT8 bit_num) {  // bit to flip 0..7
       val = val & ~(01 << bit_num);
-    };
+    }
 
     void set_bit(                // flip specified bit
                  uinT8 bit_num,  // bit to flip 0..7
@@ -51,11 +51,11 @@ class DLLSYM BITS16
         val = val | 01 << bit_num;
       else
         val = val & ~(01 << bit_num);
-    };
+    }
 
     BOOL8 bit(                        // access bit
               uinT8 bit_num) const {  // bit to access
       return (val >> bit_num) & 01;
-    };
+    }
 };
 #endif

--- a/ccutil/strngs.h
+++ b/ccutil/strngs.h
@@ -149,11 +149,11 @@ class TESS_API STRING
     // returns the string data part of storage
     inline char* GetCStr() {
       return ((char *)data_) + sizeof(STRING_HEADER);
-    };
+    }
 
     inline const char* GetCStr() const {
       return ((const char *)data_) + sizeof(STRING_HEADER);
-    };
+    }
     inline bool InvariantOk() const {
 #if STRING_IS_PROTECTED
       return (GetHeader()->used_ == 0) ?

--- a/cube/beam_search.h
+++ b/cube/beam_search.h
@@ -80,7 +80,7 @@ class BeamSearch {
   // best-cost path before the alternates list is sorted.
   inline int BestPresortedNodeIndex() const {
     return best_presorted_node_idx_;
-  };
+  }
 
  private:
   // Maximum reasonable segmentation point count

--- a/dict/dawg.h
+++ b/dict/dawg.h
@@ -128,7 +128,7 @@ class Dawg {
   inline const STRING &lang() const { return lang_; }
   inline PermuterType permuter() const { return perm_; }
 
-  virtual ~Dawg() {};
+  virtual ~Dawg() {}
 
   /// Returns true if the given word is in the Dawg.
   bool word_in_dawg(const WERD_CHOICE &word) const;

--- a/textord/blkocc.h
+++ b/textord/blkocc.h
@@ -53,7 +53,7 @@ class REGION_OCC:public ELIST_LINK
     inT16 region_type;           //Type of crossing
 
     REGION_OCC() {
-    };                           //constructor used
+    }                            //constructor used
     //only in COPIER etc
     REGION_OCC(  //constructor
                float min,


### PR DESCRIPTION
clang++ report:
api/baseapi.h:852:4: warning:
 extra ';' after member function definition [-Wextra-semi]
[...]

Signed-off-by: Stefan Weil <sw@weilnetz.de>