### PR TITLE
openmp: Fix build with clang++ and compilers without OpenMP support

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -88,9 +88,7 @@ tesseract_LDADD = libtesseract.la
 
 tesseract_LDFLAGS = $(OPENCL_LDFLAGS)
 
-if OPENMP
 tesseract_LDADD += $(OPENMP_CFLAGS)
-endif
 
 if T_WIN
 tesseract_LDADD += -lws2_32
@@ -99,4 +97,3 @@ endif
 if ADD_RT
 tesseract_LDADD += -lrt
 endif
-

--- a/ccmain/Makefile.am
+++ b/ccmain/Makefile.am
@@ -8,6 +8,7 @@ AM_CPPFLAGS += \
     -I$(top_srcdir)/textord -I$(top_srcdir)/opencl
 
 AM_CPPFLAGS += $(OPENCL_CPPFLAGS)
+AM_CPPFLAGS += $(OPENMP_CXXFLAGS)
 
 if VISIBILITY
 AM_CPPFLAGS += -DTESS_EXPORTS \

--- a/ccmain/par_control.cpp
+++ b/ccmain/par_control.cpp
@@ -18,9 +18,9 @@
 ///////////////////////////////////////////////////////////////////////
 
 #include "tesseractclass.h"
-#ifdef OPENMP
+#ifdef _OPENMP
 #include <omp.h>
-#endif  // OPENMP
+#endif // _OPENMP
 
 namespace tesseract {
 
@@ -53,7 +53,9 @@ void Tesseract::PrerecAllWordsPar(const GenericVector<WordData>& words) {
   }
   // Pre-classify all the blobs.
   if (tessedit_parallelize > 1) {
+#ifdef _OPENMP
     #pragma omp parallel for num_threads(10)
+#endif // _OPENMP
     for (int b = 0; b < blobs.size(); ++b) {
       *blobs[b].choices =
           blobs[b].tesseract->classify_blob(blobs[b].blob, "par", White, NULL);

--- a/configure.ac
+++ b/configure.ac
@@ -171,14 +171,7 @@ if test "$enable_embedded" = "yes"; then
 fi
 
 # check whether to build OpenMP support
-AM_CONDITIONAL([OPENMP], false)
 AC_OPENMP
-AS_IF([test "x$OPENMP_CFLAGS" != "x"],
-  [AM_CONDITIONAL([OPENMP], true)
-   AM_CPPFLAGS="$OPENMP_CXXFLAGS $AM_CPPFLAGS"
-   AC_DEFINE([OPENMP], [], [Defined when compiled with OpenMP support])]
-)
-
 
 # check whether to build opencl version
 AC_MSG_CHECKING([--enable-opencl argument])

--- a/lstm/Makefile.am
+++ b/lstm/Makefile.am
@@ -4,7 +4,7 @@ AM_CPPFLAGS += \
     -I$(top_srcdir)/dict -I$(top_srcdir)/lstm
 AUTOMAKE_OPTIONS = subdir-objects
 SUBDIRS =
-AM_CXXFLAGS = -fopenmp
+AM_CXXFLAGS = $(OPENMP_CXXFLAGS)
 
 if !NO_TESSDATA_PREFIX
 AM_CXXFLAGS += -DTESSDATA_PREFIX=@datadir@/

--- a/lstm/lstm.cpp
+++ b/lstm/lstm.cpp
@@ -18,7 +18,7 @@
 
 #include "lstm.h"
 
-#ifndef ANDROID_BUILD
+#ifdef _OPENMP
 #include <omp.h>
 #endif
 #include <stdio.h>

--- a/lstm/parallel.cpp
+++ b/lstm/parallel.cpp
@@ -18,7 +18,9 @@
 
 #include "parallel.h"
 
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 #include "functions.h"  // For conditional undef of _OPENMP.
 #include "networkscratch.h"


### PR DESCRIPTION
Builds without support for OpenMP failed with the old code. Fix this:

* Add OPENMP_CXXFLAGS for ccmain.
* Replace unconditional -fopenmp by OPENMP_CXXFLAGS for lstm.
* Always use _OPENMP for conditional compilation.
* Remove OPENMP as there is already _OPENMP.
* Include omp.h conditionally.

Signed-off-by: Stefan Weil <sw@weilnetz.de>