### PR TITLE
training: Update Makefile for current Mingw-w64

### DIFF
--- a/training/Makefile.am
+++ b/training/Makefile.am
@@ -11,14 +11,7 @@ AM_CPPFLAGS += \
 
 EXTRA_DIST = language-specific.sh tesstrain.sh tesstrain_utils.sh
 
-if MINGW
-# try static build
-#AM_LDFLAGS += -all-static
-#libic=-lsicuin -licudt -lsicuuc
-libicu=-licuin -licuuc
-else
 libicu=-licui18n -licuuc
-endif
 # TODO: training programs can not be linked to shared library created 
 # with -fvisibility 
 if VISIBILITY


### PR DESCRIPTION
Mingw-w64 no longer needs special linker options,
builds with those options fail.

Signed-off-by: Stefan Weil <sw@weilnetz.de>