### PR TITLE
Add new C API for detecting orientation and script, remove old one (4.00)

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -1891,7 +1891,15 @@ char* TessBaseAPI::GetUNLVText() {
   return result;
 }
 
-bool TessBaseAPI::DetectOrientationScript(int& orient_deg, float& orient_conf, std::string& script, float& script_conf) {
+/**
+ * Detect the orientation of the input image and apparent script (alphabet).
+ * orient_deg is the detected clockwise rotation of the input image in degrees (0, 90, 180, 270)
+ * orient_conf is the confidence (15.0 is reasonably confident)
+ * script_name is an ASCII string, the name of the script, e.g. "Latin"
+ * script_conf is confidence level in the script
+ * Returns true on success and writes values to each parameter as an output
+ */
+bool TessBaseAPI::DetectOrientationScript(int* orient_deg, float* orient_conf, const char** script_name, float* script_conf) {
   OSResults osr;
 
   bool osd = DetectOS(&osr);
@@ -1901,15 +1909,21 @@ bool TessBaseAPI::DetectOrientationScript(int& orient_deg, float& orient_conf, s
 
   int orient_id = osr.best_result.orientation_id;
   int script_id = osr.get_best_script(orient_id);
-  orient_conf = osr.best_result.oconfidence;
-  script_conf = osr.best_result.sconfidence;
-  const char* script_name =
+  if (orient_conf)
+    *orient_conf = osr.best_result.oconfidence;
+  if (orient_deg)
+    *orient_deg = orient_id * 90; // convert quadrant to degrees
+
+  if (script_name) {
+    const char* script =
       osr.unicharset->get_script_from_script_id(script_id);
 
-  // clockwise orientation of the input image, in degrees
-  orient_deg = orient_id * 90;
+    *script_name = script;
+  }
 
-  script = script_name;
+  if (script_conf)
+    *script_conf = osr.best_result.sconfidence;
+  
   return true;
 }
 
@@ -1921,10 +1935,10 @@ bool TessBaseAPI::DetectOrientationScript(int& orient_deg, float& orient_conf, s
 char* TessBaseAPI::GetOsdText(int page_number) {
   int orient_deg;
   float orient_conf;
-  std::string script_name;
+  const char* script_name;
   float script_conf;
 
-  if (!DetectOrientationScript(orient_deg, orient_conf, script_name, script_conf))
+  if (!DetectOrientationScript(&orient_deg, &orient_conf, &script_name, &script_conf))
     return NULL;
 
   // clockwise rotation needed to make the page upright
@@ -1939,7 +1953,7 @@ char* TessBaseAPI::GetOsdText(int page_number) {
            "Orientation confidence: %.2f\n"
            "Script: %s\n"
            "Script confidence: %.2f\n",
-           page_number, orient_deg, rotate, orient_conf, script_name.c_str(),
+           page_number, orient_deg, rotate, orient_conf, script_name,
            script_conf);
 
   return osd_buf;

--- a/api/baseapi.h
+++ b/api/baseapi.h
@@ -26,6 +26,7 @@
                                             (patch))
 
 #include <stdio.h>
+#include <string>
 // To avoid collision with other typenames include the ABSOLUTE MINIMUM
 // complexity of includes here. Use forward declarations wherever possible
 // and hide includes of complex types in baseapi.cpp.
@@ -617,6 +618,15 @@ class TESS_API TessBaseAPI {
    * and must be freed with the delete [] operator.
    */
   char* GetUNLVText();
+
+  /**
+   * Detect the orientation of the input image and apparent script (alphabet).
+   * orient_deg is the detected clockwise rotation of the input image
+   * orient_conf is the confidence (15.0 is reasonable)
+   * script is an ASCII string, the name of the script, e.g. "Latin"
+   * script_conf is confidence level in the script
+   */
+  bool DetectOrientationScript(int& orient_deg, float& orient_conf, std::string& script, float& script_conf);
 
   /**
    * The recognized text is returned as a char* which is coded

--- a/api/baseapi.h
+++ b/api/baseapi.h
@@ -26,7 +26,6 @@
                                             (patch))
 
 #include <stdio.h>
-#include <string>
 // To avoid collision with other typenames include the ABSOLUTE MINIMUM
 // complexity of includes here. Use forward declarations wherever possible
 // and hide includes of complex types in baseapi.cpp.
@@ -621,12 +620,13 @@ class TESS_API TessBaseAPI {
 
   /**
    * Detect the orientation of the input image and apparent script (alphabet).
-   * orient_deg is the detected clockwise rotation of the input image
-   * orient_conf is the confidence (15.0 is reasonable)
-   * script is an ASCII string, the name of the script, e.g. "Latin"
+   * orient_deg is the detected clockwise rotation of the input image in degrees (0, 90, 180, 270)
+   * orient_conf is the confidence (15.0 is reasonably confident)
+   * script_name is an ASCII string, the name of the script, e.g. "Latin"
    * script_conf is confidence level in the script
+   * Returns true on success and writes values to each parameter as an output
    */
-  bool DetectOrientationScript(int& orient_deg, float& orient_conf, std::string& script, float& script_conf);
+  bool DetectOrientationScript(int* orient_deg, float* orient_conf, const char** script_name, float* script_conf);
 
   /**
    * The recognized text is returned as a char* which is coded

--- a/api/capi.cpp
+++ b/api/capi.cpp
@@ -541,32 +541,12 @@ TESS_API BOOL TESS_CALL TessBaseAPIDetectOS(TessBaseAPI* handle, OSResults* resu
     return FALSE; // Unsafe ABI, return FALSE always
 }
 
-TESS_API BOOL TESS_CALL TessBaseAPIDetectOrientationScript(TessBaseAPI* handle, char** best_script_name,
-                                                            int* best_orientation_deg, float* script_confidence,
-                                                            float* orientation_confidence)
+TESS_API BOOL TESS_CALL TessBaseAPIDetectOrientationScript(TessBaseAPI* handle,
+                                                            int* orient_deg, float* orient_conf, const char** script_name, float* script_conf)
 {
-    int orient_deg;
-    float orient_conf;
-    std::string script_name;
-    float script_conf;
-    BOOL success;
-
+    bool success;
     success = handle->DetectOrientationScript(orient_deg, orient_conf, script_name, script_conf);
-    if (!success)
-        return FALSE;
-    if (best_script_name) {
-        *best_script_name = new char [script_name.length() + 1];
-        strcpy(*best_script_name, script_name.c_str());
-    }
-
-    if (best_orientation_deg)
-        *best_orientation_deg = orient_deg;
-    if (script_confidence)
-        *script_confidence = script_conf;
-    if (orientation_confidence)
-        *orientation_confidence = orient_conf;
-
-    return TRUE;
+    return (BOOL)success;
 }
 
 

--- a/api/capi.cpp
+++ b/api/capi.cpp
@@ -538,8 +538,37 @@ TESS_API void TESS_CALL TessBaseAPISetProbabilityInContextFunc(TessBaseAPI* hand
 
 TESS_API BOOL TESS_CALL TessBaseAPIDetectOS(TessBaseAPI* handle, OSResults* results)
 {
-    return handle->DetectOS(results) ? TRUE : FALSE;
+    return FALSE; // Unsafe ABI, return FALSE always
 }
+
+TESS_API BOOL TESS_CALL TessBaseAPIDetectOrientationScript(TessBaseAPI* handle, char** best_script_name,
+                                                            int* best_orientation_deg, float* script_confidence,
+                                                            float* orientation_confidence)
+{
+    int orient_deg;
+    float orient_conf;
+    std::string script_name;
+    float script_conf;
+    BOOL success;
+
+    success = handle->DetectOrientationScript(orient_deg, orient_conf, script_name, script_conf);
+    if (!success)
+        return FALSE;
+    if (best_script_name) {
+        *best_script_name = new char [script_name.length() + 1];
+        strcpy(*best_script_name, script_name.c_str());
+    }
+
+    if (best_orientation_deg)
+        *best_orientation_deg = orient_deg;
+    if (script_confidence)
+        *script_confidence = script_conf;
+    if (orientation_confidence)
+        *orientation_confidence = orient_conf;
+
+    return TRUE;
+}
+
 
 TESS_API void TESS_CALL TessBaseAPIGetFeaturesForBlob(TessBaseAPI* handle, TBLOB* blob, INT_FEATURE_STRUCT* int_features,
                                                             int* num_features, int* FeatureOutlineIndex)

--- a/api/capi.h
+++ b/api/capi.h
@@ -285,7 +285,14 @@ TESS_API void  TESS_CALL TessBaseAPIClearPersistentCache(TessBaseAPI* handle);
 TESS_API void  TESS_CALL TessBaseAPISetProbabilityInContextFunc(TessBaseAPI* handle, TessProbabilityInContextFunc f);
 
 TESS_API void  TESS_CALL TessBaseAPISetFillLatticeFunc(TessBaseAPI* handle, TessFillLatticeFunc f);
+
+// Deprecated, no longer working
 TESS_API BOOL  TESS_CALL TessBaseAPIDetectOS(TessBaseAPI* handle, OSResults* results);
+
+// Call TessDeleteText(*best_script_name) to free memory allocated by this function
+TESS_API BOOL  TESS_CALL TessBaseAPIDetectOrientationScript(TessBaseAPI* handle, char** best_script_name,
+                                                            int* best_orientation_deg, float* script_confidence,
+                                                            float* orientation_confidence);
 
 TESS_API void  TESS_CALL TessBaseAPIGetFeaturesForBlob(TessBaseAPI* handle, TBLOB* blob, INT_FEATURE_STRUCT* int_features,
                                                        int* num_features, int* FeatureOutlineIndex);

--- a/api/capi.h
+++ b/api/capi.h
@@ -287,9 +287,8 @@ TESS_API void  TESS_CALL TessBaseAPISetProbabilityInContextFunc(TessBaseAPI* han
 TESS_API void  TESS_CALL TessBaseAPISetFillLatticeFunc(TessBaseAPI* handle, TessFillLatticeFunc f);
 
 // Call TessDeleteText(*best_script_name) to free memory allocated by this function
-TESS_API BOOL  TESS_CALL TessBaseAPIDetectOrientationScript(TessBaseAPI* handle, char** best_script_name,
-                                                            int* best_orientation_deg, float* script_confidence,
-                                                            float* orientation_confidence);
+TESS_API BOOL  TESS_CALL TessBaseAPIDetectOrientationScript(TessBaseAPI* handle,
+                                                            int* orient_deg, float* orient_conf, const char **script_name, float* script_conf);
 
 TESS_API void  TESS_CALL TessBaseAPIGetFeaturesForBlob(TessBaseAPI* handle, TBLOB* blob, INT_FEATURE_STRUCT* int_features,
                                                        int* num_features, int* FeatureOutlineIndex);

--- a/api/capi.h
+++ b/api/capi.h
@@ -286,9 +286,6 @@ TESS_API void  TESS_CALL TessBaseAPISetProbabilityInContextFunc(TessBaseAPI* han
 
 TESS_API void  TESS_CALL TessBaseAPISetFillLatticeFunc(TessBaseAPI* handle, TessFillLatticeFunc f);
 
-// Deprecated, no longer working
-TESS_API BOOL  TESS_CALL TessBaseAPIDetectOS(TessBaseAPI* handle, OSResults* results);
-
 // Call TessDeleteText(*best_script_name) to free memory allocated by this function
 TESS_API BOOL  TESS_CALL TessBaseAPIDetectOrientationScript(TessBaseAPI* handle, char** best_script_name,
                                                             int* best_orientation_deg, float* script_confidence,


### PR DESCRIPTION
I suggest for 4.00 removing the old API entirely because it's not really usable without a lot of fiddling, and at a major version jump there are probably other API changes anyway, not that I'd know.

For 3.x I suggest cherrypicking the first commit to add the new change and leaving DetectOS() intact but making it return FALSE instead of risk corrupting memory in the caller if there is disagreement about the OSResults results structure. Personally I think it's better to gently break the caller in this case without breaking their compilation, but opinions may differ so I am leaving 3.x untouched.