### PR TITLE
java: Improve build rules

### DIFF
--- a/java/Makefile.am
+++ b/java/Makefile.am
@@ -36,19 +36,20 @@ SCROLLVIEW_CLASSES = \
 	com/google/scrollview/ScrollView.class
 
 SCROLLVIEW_LIBS = \
-	$(srcdir)/piccolo2d-core-3.0.jar \
-	$(srcdir)/piccolo2d-extras-3.0.jar
+	piccolo2d-core-3.0.jar \
+	piccolo2d-extras-3.0.jar
 
-CLASSPATH = $(srcdir)/piccolo2d-core-3.0.jar:$(srcdir)/piccolo2d-extras-3.0.jar
+CLASSPATH = piccolo2d-core-3.0.jar:piccolo2d-extras-3.0.jar
 
 ScrollView.jar : $(SCROLLVIEW_CLASSES)
-	$(JAR) cfm $@ Manifest.txt com/google/scrollview/*.class \
+	$(JAR) cfm $@ $(srcdir)/Manifest.txt com/google/scrollview/*.class \
            com/google/scrollview/events/*.class com/google/scrollview/ui/*.class
 
-$(SCROLLVIEW_CLASSES) : $(SCROLLVIEW_FILES)
+$(SCROLLVIEW_CLASSES) : $(SCROLLVIEW_FILES) $(SCROLLVIEW_LIBS)
 	$(JAVAC) -encoding UTF8 -sourcepath $(srcdir) -classpath $(CLASSPATH) $(SCROLLVIEW_FILES) -d $(builddir)
 
-fetch-jars :
+.PHONY: fetch-jars
+fetch-jars $(SCROLLVIEW_LIBS):
 	curl -L http://search.maven.org/remotecontent?filepath=org/piccolo2d/piccolo2d-core/3.0/piccolo2d-core-3.0.jar > piccolo2d-core-3.0.jar
 	curl -L http://search.maven.org/remotecontent?filepath=org/piccolo2d/piccolo2d-extras/3.0/piccolo2d-extras-3.0.jar > piccolo2d-extras-3.0.jar
 
@@ -64,7 +65,7 @@ uninstall:
 endif
 
 clean :
-	rm -f ScrollView.jar *.class $(srcdir)/*.class
+	rm -f ScrollView.jar $(SCROLLVIEW_CLASSES)
 
 # all-am does nothing, to make the java part optional.
 all all-am install :


### PR DESCRIPTION
* Fix builds in subdirectories:
  * Add srcdir to Manifest.txt.
  * Remove srcdir from piccolo2d-core-3.0.jar and piccolo2d-extras-3.0.jar.

* Add dependency of SCROLLVIEW_CLASSES on SCROLLVIEW_LIBS.
  The SCROLLVIEW_LIBS are now automatically fetched when needed.

* Add .PHONY target for fetch-jars.

* Improve rule for clean target.

Signed-off-by: Stefan Weil <sw@weilnetz.de>