### PR TITLE
openmp: Fix OpenMP support

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -81,9 +81,7 @@ tesseract_LDADD = libtesseract.la
 
 tesseract_LDFLAGS = $(OPENCL_LDFLAGS)
 
-if OPENMP
-tesseract_LDADD += $(OPENMP_CFLAGS)
-endif
+tesseract_LDADD += $(OPENMP_CXXFLAGS)
 
 if T_WIN
 tesseract_LDADD += -lws2_32
@@ -92,4 +90,3 @@ endif
 if ADD_RT
 tesseract_LDADD += -lrt
 endif
-

--- a/ccmain/Makefile.am
+++ b/ccmain/Makefile.am
@@ -7,6 +7,7 @@ AM_CPPFLAGS += \
     -I$(top_srcdir)/textord -I$(top_srcdir)/opencl
 
 AM_CPPFLAGS += $(OPENCL_CPPFLAGS)
+AM_CPPFLAGS += $(OPENMP_CXXFLAGS)
 
 if VISIBILITY
 AM_CPPFLAGS += -DTESS_EXPORTS \

--- a/ccmain/par_control.cpp
+++ b/ccmain/par_control.cpp
@@ -18,9 +18,9 @@
 ///////////////////////////////////////////////////////////////////////
 
 #include "tesseractclass.h"
-#ifdef OPENMP
+#ifdef _OPENMP
 #include <omp.h>
-#endif  // OPENMP
+#endif // _OPENMP
 
 namespace tesseract {
 
@@ -53,7 +53,9 @@ void Tesseract::PrerecAllWordsPar(const GenericVector<WordData>& words) {
   }
   // Pre-classify all the blobs.
   if (tessedit_parallelize > 1) {
+#ifdef _OPENMP
     #pragma omp parallel for num_threads(10)
+#endif // _OPENMP
     for (int b = 0; b < blobs.size(); ++b) {
       *blobs[b].choices =
           blobs[b].tesseract->classify_blob(blobs[b].blob, "par", White, NULL);

--- a/configure.ac
+++ b/configure.ac
@@ -171,14 +171,7 @@ if test "$enable_embedded" = "yes"; then
 fi
 
 # check whether to build OpenMP support
-AM_CONDITIONAL([OPENMP], false)
 AC_OPENMP
-AS_IF([test "x$OPENMP_CFLAGS" != "x"],
-  [AM_CONDITIONAL([OPENMP], true)
-   AM_CPPFLAGS="$OPENMP_CXXFLAGS $AM_CPPFLAGS"
-   AC_DEFINE([OPENMP], [], [Defined when compiled with OpenMP support])]
-)
-
 
 # check whether to build opencl version
 AC_MSG_CHECKING([--enable-opencl argument])


### PR DESCRIPTION
* Add OPENMP_CXXFLAGS for ccmain.
* Replace OPENMP_CFLAGS by OPENMP_CXXFLAGS.
* Always use _OPENMP for conditional compilation.
* Remove OPENMP as there is already _OPENMP.
* Include omp.h conditionally.

Signed-off-by: Stefan Weil <sw@weilnetz.de>