### PR TITLE
openmp: Fix OpenMP support

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -88,7 +88,7 @@ tesseract_LDADD = libtesseract.la
 
 tesseract_LDFLAGS = $(OPENCL_LDFLAGS)
 
-tesseract_LDADD += $(OPENMP_CFLAGS)
+tesseract_LDADD += $(OPENMP_CXXFLAGS)
 
 if T_WIN
 tesseract_LDADD += -lws2_32


### PR DESCRIPTION
Replace OPENMP_CFLAGS by OPENMP_CXXFLAGS.
This completes commit 6140be6a5575e9159e3678adf4ee9e673b3ff2cc.

Signed-off-by: Stefan Weil <sw@weilnetz.de>