### PR TITLE
Fix some issues reported by shellcheck (SC2004, SC2006)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,14 +38,14 @@ dist-hook:
 # Need to remove .svn directories from directories
 # added using EXTRA_DIST. $(distdir)/tessdata would in
 # theory suffice.
-	rm -rf `find $(distdir) -name .svn`
-	rm -rf `find $(distdir) -name .git`
-	rm -rf `find $(distdir) -name .deps`
-	rm -rf `find $(distdir) -name .libs`
-	rm -rf `find $(distdir) -name *.o`
-	rm -rf `find $(distdir) -name *.lo`
-	rm -rf `find $(distdir) -name *.la`
-	rm -rf `find $(distdir)/training -executable -type f`
+	rm -rf $(find $(distdir) -name .svn)
+	rm -rf $(find $(distdir) -name .git)
+	rm -rf $(find $(distdir) -name .deps)
+	rm -rf $(find $(distdir) -name .libs)
+	rm -rf $(find $(distdir) -name *.o)
+	rm -rf $(find $(distdir) -name *.lo)
+	rm -rf $(find $(distdir) -name *.la)
+	rm -rf $(find $(distdir)/training -executable -type f)
 	rm -rf $(distdir)/doc/html/*
 
 ScrollView.jar:

--- a/testing/reorgdata.sh
+++ b/testing/reorgdata.sh
@@ -36,11 +36,11 @@ do
 	mkdir -p $new
     	echo "Set $old -> $new"
 	#The pages file had - instead of _ so fix it and add the extension.
-	for page in `cat $old/PAGES`
+	for page in $(cat $old/PAGES)
 	do
     	    echo "${page%-*}_${page#*-}.$ext"
 	done >$new/pages
-	for f in `cat $new/pages`
+	for f in $(cat $new/pages)
 	do
     	    #Put a tif extension on the tif files.
 	    cp $old/${old}_B/$f $new/$f.tif

--- a/testing/runalltests.sh
+++ b/testing/runalltests.sh
@@ -81,30 +81,30 @@ do
 	# Count the errors on all the pages.
 	$bindir/counttestset.sh $imdir/$set/pages
 	# Get the old character word and nonstop word errors.
-	olderrs=`cat testing/reports/1995.$set.sum | cut -f3`
-	oldwerrs=`cat testing/reports/1995.$set.sum | cut -f6`
-	oldnswerrs=`cat testing/reports/1995.$set.sum | cut -f9`
+	olderrs=$(cat testing/reports/1995.$set.sum | cut -f3)
+	oldwerrs=$(cat testing/reports/1995.$set.sum | cut -f6)
+	oldnswerrs=$(cat testing/reports/1995.$set.sum | cut -f9)
 	# Get the new character word and nonstop word errors and accuracy.
-	cherrs=`head -4 testing/reports/$set.characc |tail -1 |cut -c1-9 |
-	    tr -d '[:blank:]'`
-	chacc=`head -5 testing/reports/$set.characc |tail -1 |cut -c1-9 |
-	    tr -d '[:blank:]'`
-	wderrs=`head -4 testing/reports/$set.wordacc |tail -1 |cut -c1-9 |
-	    tr -d '[:blank:]'`
-	wdacc=`head -5 testing/reports/$set.wordacc |tail -1 |cut -c1-9 |
-	    tr -d '[:blank:]'`
-	nswderrs=`grep Total testing/reports/$set.wordacc |head -2 |tail -1 |
-	    cut -c10-17 |tr -d '[:blank:]'`
-	nswdacc=`grep Total testing/reports/$set.wordacc |head -2 |tail -1 |
-	    cut -c19-26 |tr -d '[:blank:]'`
+	cherrs=$(head -4 testing/reports/$set.characc |tail -1 |cut -c1-9 |
+	    tr -d '[:blank:]')
+	chacc=$(head -5 testing/reports/$set.characc |tail -1 |cut -c1-9 |
+	    tr -d '[:blank:]')
+	wderrs=$(head -4 testing/reports/$set.wordacc |tail -1 |cut -c1-9 |
+	    tr -d '[:blank:]')
+	wdacc=$(head -5 testing/reports/$set.wordacc |tail -1 |cut -c1-9 |
+	    tr -d '[:blank:]')
+	nswderrs=$(grep Total testing/reports/$set.wordacc |head -2 |tail -1 |
+	    cut -c10-17 |tr -d '[:blank:]')
+	nswdacc=$(grep Total testing/reports/$set.wordacc |head -2 |tail -1 |
+	    cut -c19-26 |tr -d '[:blank:]')
 	# Compute the percent change.
-	chdelta=`deltapc $cherrs $olderrs`
-	wdelta=`deltapc $wderrs $oldwerrs`
-	nswdelta=`deltapc $nswderrs $oldnswerrs`
+	chdelta=$(deltapc $cherrs $olderrs)
+	wdelta=$(deltapc $wderrs $oldwerrs)
+	nswdelta=$(deltapc $nswderrs $oldnswerrs)
 	sumfile=$rdir/$vid.$set.sum
         if [ -r testing/reports/$set.times ]
         then
-          total_time=`timesum testing/reports/$set.times`
+          total_time=$(timesum testing/reports/$set.times)
           if [ -r testing/reports/prev/$set.times ]
           then
             paste testing/reports/prev/$set.times testing/reports/$set.times |
@@ -125,9 +125,9 @@ do
     fi
 done
 # Compute grand total percent change.
-chdelta=`deltapc $totalerrs $totalolderrs`
-wdelta=`deltapc $totalwerrs $totaloldwerrs`
-nswdelta=`deltapc $totalnswerrs $totaloldnswerrs `
+chdelta=$(deltapc $totalerrs $totalolderrs)
+wdelta=$(deltapc $totalwerrs $totaloldwerrs)
+nswdelta=$(deltapc $totalnswerrs $totaloldnswerrs)
 tfile=$rdir/$vid.total.sum
 echo "$vid	Total	$totalerrs	-	$chdelta%	$totalwerrs\
 	-	$wdelta%	$totalnswerrs	-	$nswdelta%" >$tfile

--- a/training/tesstrain.sh
+++ b/training/tesstrain.sh
@@ -45,7 +45,7 @@
 # appropriate --fonts_dir path.
 
 
-source `dirname $0`/tesstrain_utils.sh
+source "$(dirname $0)/tesstrain_utils.sh"
 
 ARGV=("$@")
 parse_flags
@@ -53,7 +53,7 @@ parse_flags
 mkdir -p ${TRAINING_DIR}
 tlog "\n=== Starting training for language '${LANG_CODE}'"
 
-source `dirname $0`/language-specific.sh
+source "$(dirname $0)/language-specific.sh"
 set_lang_specific_parameters ${LANG_CODE}
 
 initialize_fontconfig
@@ -61,7 +61,7 @@ initialize_fontconfig
 phase_I_generate_image 8
 phase_UP_generate_unicharset
 phase_D_generate_dawg
-if (( ${LINEDATA} )); then
+if ((LINEDATA)); then
   phase_E_extract_features "lstm.train" 8 "lstmf"
   make__lstmdata
 else

--- a/training/tesstrain_utils.sh
+++ b/training/tesstrain_utils.sh
@@ -26,7 +26,7 @@ OVERWRITE=0
 LINEDATA=0
 RUN_SHAPE_CLUSTERING=0
 EXTRACT_FONT_PROPERTIES=1
-WORKSPACE_DIR=`mktemp -d`
+WORKSPACE_DIR=$(mktemp -d)
 
 # Logging helper functions.
 tlog() {
@@ -42,7 +42,7 @@ err_exit() {
 # if the program file is not found.
 # Usage: run_command CMD ARG1 ARG2...
 run_command() {
-    local cmd=`which $1`
+    local cmd=$(which $1)
     if [[ -z ${cmd} ]]; then
         err_exit "$1 not found"
     fi
@@ -95,7 +95,7 @@ parse_flags() {
                 FONTS=""
                 while test $j -lt ${#ARGV[@]}; do
                     test -z "${ARGV[$j]}" && break
-                    test `echo ${ARGV[$j]} | cut -c -2` = "--" && break
+                    test $(echo ${ARGV[$j]} | cut -c -2) = "--" && break
                     FONTS[$fn]="${ARGV[$j]}"
                     fn=$((fn+1))
                     j=$((j+1))
@@ -105,7 +105,7 @@ parse_flags() {
                 exp=""
                 while test $j -lt ${#ARGV[@]}; do
                     test -z "${ARGV[$j]}" && break
-                    test `echo ${ARGV[$j]} | cut -c -2` = "--" && break
+                    test $(echo ${ARGV[$j]} | cut -c -2) = "--" && break
                     exp="$exp ${ARGV[$j]}"
                     j=$((j+1))
                 done
@@ -219,7 +219,7 @@ generate_font_image() {
         --text=${TRAINING_TEXT} ${TEXT2IMAGE_EXTRA_ARGS}
     check_file_readable ${outbase}.box ${outbase}.tif
 
-    if (( ${EXTRACT_FONT_PROPERTIES} )) &&
+    if ((EXTRACT_FONT_PROPERTIES)) &&
         [[ -r ${TRAIN_NGRAMS_FILE} ]]; then
         tlog "Extracting font properties of ${font}"
         run_command text2image ${common_args} --font="${font}" \
@@ -243,7 +243,7 @@ phase_I_generate_image() {
     CHAR_SPACING="0.0"
 
     for EXPOSURE in $EXPOSURES; do
-        if (( ${EXTRACT_FONT_PROPERTIES} )) && [[ -r ${BIGRAM_FREQS_FILE} ]]; then
+        if ((EXTRACT_FONT_PROPERTIES)) && [[ -r ${BIGRAM_FREQS_FILE} ]]; then
             # Parse .bigram_freqs file and compose a .train_ngrams file with text
             # for tesseract to recognize during training. Take only the ngrams whose
             # combined weight accounts for 95% of all the bigrams in the language.
@@ -424,7 +424,7 @@ phase_C_cluster_prototypes() {
 
 # Phase S : (S)hape clustering
 phase_S_cluster_shapes() {
-    if (( ! ${RUN_SHAPE_CLUSTERING} )); then
+    if ((! RUN_SHAPE_CLUSTERING)); then
         tlog "\n=== Shape Clustering disabled ==="
         return
     fi
@@ -557,7 +557,7 @@ make__traineddata() {
       mkdir -p ${OUTPUT_DIR}
   fi
   local destfile=${OUTPUT_DIR}/${LANG_CODE}.traineddata;
-  if [[ -f ${destfile} ]] && (( ! ${OVERWRITE} )); then
+  if [[ -f ${destfile} ]] && ((! OVERWRITE)); then
       err_exit "File ${destfile} exists and no --overwrite specified";
   fi
   tlog "Moving ${TRAINING_DIR}/${LANG_CODE}.traineddata to ${OUTPUT_DIR}"


### PR DESCRIPTION
Examples:

In training/tesstrain.sh line 64:
if (( ${LINEDATA} )); then
      ^-- SC2004: $/${} is unnecessary on arithmetic variables.

In training/tesstrain.sh line 56:
source `dirname $0`/language-specific.sh
       ^-- SC2006: Use $(..) instead of legacy `..`.

Signed-off-by: Stefan Weil <sw@weilnetz.de>