### PR TITLE
Fix page range in log message

### DIFF
--- a/ccstruct/imagedata.cpp
+++ b/ccstruct/imagedata.cpp
@@ -552,7 +552,7 @@ bool DocumentData::ReCachePages() {
     pages_.truncate(0);
   } else {
     tprintf("Loaded %d/%d pages (%d-%d) of document %s\n", pages_.size(),
-            loaded_pages, pages_offset_, pages_offset_ + pages_.size(),
+            loaded_pages, pages_offset_ + 1, pages_offset_ + pages_.size(),
             document_name_.string());
   }
   set_total_pages(loaded_pages);


### PR DESCRIPTION
The internal range is 0...(n-1), but for users a page range 1...n is
more natural. Showing a range 0...n is wrong because it would imply
n+1 pages.

Change printed text from

    Loaded 72/72 pages (0-72) of document ...

to

    Loaded 72/72 pages (1-72) of document ...

Signed-off-by: Stefan Weil <sw@weilnetz.de>