### PR TITLE
Move AVX / SSE messages to function PrintVersionInfo (crash fix)

### DIFF
--- a/api/tesseractmain.cpp
+++ b/api/tesseractmain.cpp
@@ -28,6 +28,7 @@
 #include "baseapi.h"
 #include "basedir.h"
 #include "renderer.h"
+#include "simddetect.h"
 #include "strngs.h"
 #include "tprintf.h"
 #include "openclwrapper.h"
@@ -90,6 +91,10 @@ void PrintVersionInfo() {
       }
     }
 #endif
+  if (SIMDDetect::IsAVXAvailable())
+    printf(" Found AVX\n");
+  if (SIMDDetect::IsSSEAvailable())
+    printf(" Found SSE\n");
 }
 
 void PrintUsage(const char* program) {

--- a/arch/simddetect.cpp
+++ b/arch/simddetect.cpp
@@ -60,7 +60,5 @@ SIMDDetect::SIMDDetect() {
     avx_available_ = (cpuInfo[2] & 0x10000000) != 0;
   }
 # endif
-  if (avx_available_) tprintf("Found AVX\n");
-  if (sse_available_) tprintf("Found SSE\n");
 #endif // X86_BUILD
 }


### PR DESCRIPTION
This information is not needed for normal runs, so it is sufficient
to show it on request (like versions and OpenCL information).

This also fixes a crash caused by undefined order of global constructors:

When the global variable SIMDDetect::detector is initialized before the
global variable debug_file, the first tprintf call in simddetect.cpp
crashes because of a NULL pointer in debug_file. This was only seen when
running with a shared library (libtesseract.so).

Signed-off-by: Stefan Weil <sw@weilnetz.de>