### PR TITLE
Implement SIMD detection on macOS-gcc; complain if no SIMD detection

### DIFF
--- a/arch/simddetect.cpp
+++ b/arch/simddetect.cpp
@@ -26,7 +26,7 @@
 #endif // x86 target
 
 #if defined(X86_BUILD)
-# if defined(__linux__) || defined(__MINGW32__) || defined(__APPLE__)
+# if defined(__GNUC__) || defined(__clang__) || defined(__MINGW32__) || defined(__MINGW64__) 
 #  include <cpuid.h>
 # elif defined(_WIN32)
 #  include <intrin.h>
@@ -45,7 +45,7 @@ bool SIMDDetect::sse_available_;
 // any other available SIMD equipment.
 SIMDDetect::SIMDDetect() {
 #if defined(X86_BUILD)
-# if defined(__linux__) || defined(__MINGW32__) || defined(__APPLE__)
+# if defined(__GNUC__) || defined(__clang__) || defined(__MINGW32__) || defined(__MINGW64__) 
   unsigned int eax, ebx, ecx, edx;
   if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) != 0) {
     sse_available_ = (ecx & 0x00080000) != 0;
@@ -60,7 +60,7 @@ SIMDDetect::SIMDDetect() {
     avx_available_ = (cpuInfo[2] & 0x10000000) != 0;
   }
 # else
-#  error "I don't know how to test for SIMD on this platform"
+#  error "I don't know how to test for SIMD with this compiler"
 # endif
 #endif // X86_BUILD
 }

--- a/arch/simddetect.cpp
+++ b/arch/simddetect.cpp
@@ -26,7 +26,7 @@
 #endif // x86 target
 
 #if defined(X86_BUILD)
-# if defined(__GNUC__) || defined(__clang__) || defined(__MINGW32__) || defined(__MINGW64__) 
+# if defined(__GNUC__) || defined(__MINGW32__)
 #  include <cpuid.h>
 # elif defined(_WIN32)
 #  include <intrin.h>
@@ -43,9 +43,11 @@ bool SIMDDetect::sse_available_;
 // Constructor.
 // Tests the architecture in a system-dependent way to detect AVX, SSE and
 // any other available SIMD equipment.
+// __GNUC__ is also defined by compilers that include GNU extensions such as clang.
+// __MINGW32__ includes 64-bit mingw
 SIMDDetect::SIMDDetect() {
 #if defined(X86_BUILD)
-# if defined(__GNUC__) || defined(__clang__) || defined(__MINGW32__) || defined(__MINGW64__) 
+# if defined(__GNUC__) || defined(__MINGW32__)
   unsigned int eax, ebx, ecx, edx;
   if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) != 0) {
     sse_available_ = (ecx & 0x00080000) != 0;

--- a/arch/simddetect.cpp
+++ b/arch/simddetect.cpp
@@ -26,7 +26,7 @@
 #endif // x86 target
 
 #if defined(X86_BUILD)
-# if defined(__linux__) || defined(__MINGW32__)
+# if defined(__linux__) || defined(__MINGW32__) || defined(__APPLE__)
 #  include <cpuid.h>
 # elif defined(_WIN32)
 #  include <intrin.h>
@@ -45,7 +45,7 @@ bool SIMDDetect::sse_available_;
 // any other available SIMD equipment.
 SIMDDetect::SIMDDetect() {
 #if defined(X86_BUILD)
-# if defined(__linux__) || defined(__MINGW32__)
+# if defined(__linux__) || defined(__MINGW32__) || defined(__APPLE__)
   unsigned int eax, ebx, ecx, edx;
   if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) != 0) {
     sse_available_ = (ecx & 0x00080000) != 0;
@@ -59,6 +59,8 @@ SIMDDetect::SIMDDetect() {
     sse_available_ = (cpuInfo[2] & 0x00080000) != 0;
     avx_available_ = (cpuInfo[2] & 0x10000000) != 0;
   }
+# else
+#  error "I don't know how to test for SIMD on this platform"
 # endif
 #endif // X86_BUILD
 }


### PR DESCRIPTION
Verified that this compiles and runs on macOS El Capitan with homebrew gcc. I don't believe clang compiles at the moment so not sure if it works for that.

Also added an #error if SIMD checking is missing. Autotools already causes configure to fail if there is no SIMD implementation, so if Makefiles are generated something is wrong. 