### PR TITLE
Improve textonly_pdf parameter description

### DIFF
--- a/ccmain/tesseractclass.cpp
+++ b/ccmain/tesseractclass.cpp
@@ -389,7 +389,7 @@ Tesseract::Tesseract()
                   this->params()),
       BOOL_MEMBER(tessedit_create_pdf, false, "Write .pdf output file",
                   this->params()),
-      BOOL_MEMBER(textonly_pdf, false, "Invisible text only for PDF",
+      BOOL_MEMBER(textonly_pdf, false, "Create PDF with only one invisible text layer",
                   this->params()),
       STRING_MEMBER(unrecognised_char, "|",
                     "Output char for unidentified blobs", this->params()),

--- a/ccmain/tesseractclass.h
+++ b/ccmain/tesseractclass.h
@@ -1026,7 +1026,7 @@ class Tesseract : public Wordrec {
   BOOL_VAR_H(tessedit_create_hocr, false, "Write .html hOCR output file");
   BOOL_VAR_H(tessedit_create_tsv, false, "Write .tsv output file");
   BOOL_VAR_H(tessedit_create_pdf, false, "Write .pdf output file");
-  BOOL_VAR_H(textonly_pdf, false, "Invisible text only for PDF");
+  BOOL_VAR_H(textonly_pdf, false, "Create PDF with only one invisible text layer");
   STRING_VAR_H(unrecognised_char, "|",
                "Output char for unidentified blobs");
   INT_VAR_H(suspect_level, 99, "Suspect marker level");


### PR DESCRIPTION
I changed the parameter description because the older text was ambiguous.