### PR TITLE
Remove swap parameter and related code

### DIFF
--- a/ccmain/tessedit.cpp
+++ b/ccmain/tessedit.cpp
@@ -191,15 +191,11 @@ bool Tesseract::init_tesseract_lang_data(
 #ifndef ANDROID_BUILD
   if (tessedit_ocr_engine_mode == OEM_LSTM_ONLY ||
       tessedit_ocr_engine_mode == OEM_TESSERACT_LSTM_COMBINED) {
-    if (tessdata_manager.swap()) {
-      tprintf("Error: LSTM requested on big-endian hardware!!\n");
-      tprintf("Big-endian not yet supported! Loading tesseract.\n");
-      tessedit_ocr_engine_mode.set_value(OEM_TESSERACT_ONLY);
-    } else if (tessdata_manager.SeekToStart(TESSDATA_LSTM)) {
+    if (tessdata_manager.SeekToStart(TESSDATA_LSTM)) {
       lstm_recognizer_ = new LSTMRecognizer;
       TFile fp;
       fp.Open(tessdata_manager.GetDataFilePtr(), -1);
-      ASSERT_HOST(lstm_recognizer_->DeSerialize(tessdata_manager.swap(), &fp));
+      ASSERT_HOST(lstm_recognizer_->DeSerialize(&fp));
       if (lstm_use_matrix)
         lstm_recognizer_->LoadDictionary(tessdata_path.string(), language);
     } else {

--- a/ccstruct/fontinfo.cpp
+++ b/ccstruct/fontinfo.cpp
@@ -30,10 +30,9 @@ bool FontInfo::Serialize(FILE* fp) const {
   return true;
 }
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool FontInfo::DeSerialize(bool swap, FILE* fp) {
-  if (!read_info(fp, this, swap)) return false;
-  if (!read_spacing_info(fp, this, swap)) return false;
+bool FontInfo::DeSerialize(FILE* fp) {
+  if (!read_info(fp, this)) return false;
+  if (!read_spacing_info(fp, this)) return false;
   return true;
 }
 
@@ -50,10 +49,9 @@ bool FontInfoTable::Serialize(FILE* fp) const {
   return this->SerializeClasses(fp);
 }
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool FontInfoTable::DeSerialize(bool swap, FILE* fp) {
+bool FontInfoTable::DeSerialize(FILE* fp) {
   truncate(0);
-  return this->DeSerializeClasses(swap, fp);
+  return this->DeSerializeClasses(fp);
 }
 
 // Returns true if the given set of fonts includes one with the same
@@ -149,19 +147,15 @@ void FontSetDeleteCallback(FontSet fs) {
 
 /*---------------------------------------------------------------------------*/
 // Callbacks used by UnicityTable to read/write FontInfo/FontSet structures.
-bool read_info(FILE* f, FontInfo* fi, bool swap) {
+bool read_info(FILE* f, FontInfo* fi) {
   inT32 size;
   if (fread(&size, sizeof(size), 1, f) != 1) return false;
-  if (swap)
-    Reverse32(&size);
   char* font_name = new char[size + 1];
   fi->name = font_name;
   if (static_cast<int>(fread(font_name, sizeof(*font_name), size, f)) != size)
     return false;
   font_name[size] = '\0';
   if (fread(&fi->properties, sizeof(fi->properties), 1, f) != 1) return false;
-  if (swap)
-    Reverse32(&fi->properties);
   return true;
 }
 
@@ -174,10 +168,9 @@ bool write_info(FILE* f, const FontInfo& fi) {
   return true;
 }
 
-bool read_spacing_info(FILE *f, FontInfo* fi, bool swap) {
+bool read_spacing_info(FILE *f, FontInfo* fi) {
   inT32 vec_size, kern_size;
   if (fread(&vec_size, sizeof(vec_size), 1, f) != 1) return false;
-  if (swap) Reverse32(&vec_size);
   ASSERT_HOST(vec_size >= 0);
   if (vec_size == 0) return true;
   fi->init_spacing(vec_size);
@@ -189,17 +182,12 @@ bool read_spacing_info(FILE *f, FontInfo* fi, bool swap) {
       delete fs;
       return false;
     }
-    if (swap) {
-      ReverseN(&(fs->x_gap_before), sizeof(fs->x_gap_before));
-      ReverseN(&(fs->x_gap_after), sizeof(fs->x_gap_after));
-      Reverse32(&kern_size);
-    }
     if (kern_size < 0) {  // indication of a NULL entry in fi->spacing_vec
       delete fs;
       continue;
     }
-    if (kern_size > 0 && (!fs->kerned_unichar_ids.DeSerialize(swap, f) ||
-                          !fs->kerned_x_gaps.DeSerialize(swap, f))) {
+    if (kern_size > 0 && (!fs->kerned_unichar_ids.DeSerialize(f) ||
+                          !fs->kerned_x_gaps.DeSerialize(f))) {
       delete fs;
       return false;
     }
@@ -237,15 +225,11 @@ bool write_spacing_info(FILE* f, const FontInfo& fi) {
   return true;
 }
 
-bool read_set(FILE* f, FontSet* fs, bool swap) {
+bool read_set(FILE* f, FontSet* fs) {
   if (fread(&fs->size, sizeof(fs->size), 1, f) != 1) return false;
-  if (swap)
-    Reverse32(&fs->size);
   fs->configs = new int[fs->size];
   for (int i = 0; i < fs->size; ++i) {
     if (fread(&fs->configs[i], sizeof(fs->configs[i]), 1, f) != 1) return false;
-    if (swap)
-      Reverse32(&fs->configs[i]);
   }
   return true;
 }

--- a/ccstruct/fontinfo.h
+++ b/ccstruct/fontinfo.h
@@ -66,8 +66,7 @@ struct FontInfo {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   // Reserves unicharset_size spots in spacing_vec.
   void init_spacing(int unicharset_size) {
@@ -151,8 +150,7 @@ class FontInfoTable : public GenericVector<FontInfo> {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   // Returns true if the given set of fonts includes one with the same
   // properties as font_id.
@@ -177,11 +175,11 @@ void FontInfoDeleteCallback(FontInfo f);
 void FontSetDeleteCallback(FontSet fs);
 
 // Callbacks used by UnicityTable to read/write FontInfo/FontSet structures.
-bool read_info(FILE* f, FontInfo* fi, bool swap);
+bool read_info(FILE* f, FontInfo* fi);
 bool write_info(FILE* f, const FontInfo& fi);
-bool read_spacing_info(FILE *f, FontInfo* fi, bool swap);
+bool read_spacing_info(FILE *f, FontInfo* fi);
 bool write_spacing_info(FILE* f, const FontInfo& fi);
-bool read_set(FILE* f, FontSet* fs, bool swap);
+bool read_set(FILE* f, FontSet* fs);
 bool write_set(FILE* f, const FontSet& fs);
 
 }  // namespace tesseract.

--- a/ccstruct/imagedata.h
+++ b/ccstruct/imagedata.h
@@ -72,8 +72,7 @@ class WordFeature {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
  private:
   inT16 x_;
@@ -116,10 +115,9 @@ class ImageData {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, TFile* fp);
+  bool DeSerialize(TFile* fp);
   // As DeSerialize, but only seeks past the data - hence a static method.
-  static bool SkipDeSerialize(bool swap, tesseract::TFile* fp);
+  static bool SkipDeSerialize(tesseract::TFile* fp);
 
   // Other accessors.
   const STRING& imagefilename() const {

--- a/ccstruct/matrix.h
+++ b/ccstruct/matrix.h
@@ -151,29 +151,18 @@ class GENERIC_2D_ARRAY {
 
   // Reads from the given file. Returns false in case of error.
   // Only works with bitwise-serializeable types!
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp) {
-    if (!DeSerializeSize(swap, fp)) return false;
+  bool DeSerialize(FILE* fp) {
+    if (!DeSerializeSize(fp)) return false;
     if (fread(&empty_, sizeof(empty_), 1, fp) != 1) return false;
-    if (swap) ReverseN(&empty_, sizeof(empty_));
     int size = num_elements();
     if (fread(array_, sizeof(*array_), size, fp) != size) return false;
-    if (swap) {
-      for (int i = 0; i < size; ++i)
-        ReverseN(&array_[i], sizeof(array_[i]));
-    }
     return true;
   }
-  bool DeSerialize(bool swap, tesseract::TFile* fp) {
-    if (!DeSerializeSize(swap, fp)) return false;
+  bool DeSerialize(tesseract::TFile* fp) {
+    if (!DeSerializeSize(fp)) return false;
     if (fp->FRead(&empty_, sizeof(empty_), 1) != 1) return false;
-    if (swap) ReverseN(&empty_, sizeof(empty_));
     int size = num_elements();
     if (fp->FRead(array_, sizeof(*array_), size) != size) return false;
-    if (swap) {
-      for (int i = 0; i < size; ++i)
-        ReverseN(&array_[i], sizeof(array_[i]));
-    }
     return true;
   }
 
@@ -190,14 +179,13 @@ class GENERIC_2D_ARRAY {
   }
 
   // Reads from the given file. Returns false in case of error.
-  // Assumes a T::DeSerialize(bool swap, FILE*) function.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerializeClasses(bool swap, FILE* fp) {
-    if (!DeSerializeSize(swap, fp)) return false;
-    if (!empty_.DeSerialize(swap, fp)) return false;
+  // Assumes a T::DeSerialize(FILE*) function.
+  bool DeSerializeClasses(FILE* fp) {
+    if (!DeSerializeSize(fp)) return false;
+    if (!empty_.DeSerialize(fp)) return false;
     int size = num_elements();
     for (int i = 0; i < size; ++i) {
-      if (!array_[i].DeSerialize(swap, fp)) return false;
+      if (!array_[i].DeSerialize(fp)) return false;
     }
     return true;
   }
@@ -475,26 +463,17 @@ class GENERIC_2D_ARRAY {
     return true;
   }
   // Factored helper to deserialize the size.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerializeSize(bool swap, FILE* fp) {
+  bool DeSerializeSize(FILE* fp) {
     inT32 size1, size2;
     if (fread(&size1, sizeof(size1), 1, fp) != 1) return false;
     if (fread(&size2, sizeof(size2), 1, fp) != 1) return false;
-    if (swap) {
-      ReverseN(&size1, sizeof(size1));
-      ReverseN(&size2, sizeof(size2));
-    }
     Resize(size1, size2, empty_);
     return true;
   }
-  bool DeSerializeSize(bool swap, tesseract::TFile* fp) {
+  bool DeSerializeSize(tesseract::TFile* fp) {
     inT32 size1, size2;
     if (fp->FRead(&size1, sizeof(size1), 1) != 1) return false;
     if (fp->FRead(&size2, sizeof(size2), 1) != 1) return false;
-    if (swap) {
-      ReverseN(&size1, sizeof(size1));
-      ReverseN(&size2, sizeof(size2));
-    }
     Resize(size1, size2, empty_);
     return true;
   }

--- a/ccstruct/points.cpp
+++ b/ccstruct/points.cpp
@@ -66,14 +66,9 @@ bool ICOORD::Serialize(FILE* fp) const {
   return true;
 }
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool ICOORD::DeSerialize(bool swap, FILE* fp) {
+bool ICOORD::DeSerialize(FILE* fp) {
   if (fread(&xcoord, sizeof(xcoord), 1, fp) != 1) return false;
   if (fread(&ycoord, sizeof(ycoord), 1, fp) != 1) return false;
-  if (swap) {
-    ReverseN(&xcoord, sizeof(xcoord));
-    ReverseN(&ycoord, sizeof(ycoord));
-  }
   return true;
 }
 

--- a/ccstruct/points.h
+++ b/ccstruct/points.h
@@ -150,8 +150,7 @@ class ICOORD
     // Writes to the given file. Returns false in case of error.
     bool Serialize(FILE* fp) const;
     // Reads from the given file. Returns false in case of error.
-    // If swap is true, assumes a big/little-endian swap is needed.
-    bool DeSerialize(bool swap, FILE* fp);
+    bool DeSerialize(FILE* fp);
 
   protected:
     inT16 xcoord;                //< x value

--- a/ccstruct/points.h
+++ b/ccstruct/points.h
@@ -163,7 +163,7 @@ class DLLSYM ICOORDELT:public ELIST_LINK, public ICOORD
 {
   public:
     ///empty constructor
-    ICOORDELT() {  
+    ICOORDELT() {
     }
     ///constructor from ICOORD
     ICOORDELT (ICOORD icoord):ICOORD (icoord) {

--- a/ccstruct/rect.cpp
+++ b/ccstruct/rect.cpp
@@ -188,10 +188,9 @@ bool TBOX::Serialize(FILE* fp) const {
   return true;
 }
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool TBOX::DeSerialize(bool swap, FILE* fp) {
-  if (!bot_left.DeSerialize(swap, fp)) return false;
-  if (!top_right.DeSerialize(swap, fp)) return false;
+bool TBOX::DeSerialize(FILE* fp) {
+  if (!bot_left.DeSerialize(fp)) return false;
+  if (!top_right.DeSerialize(fp)) return false;
   return true;
 }
 

--- a/ccstruct/rect.h
+++ b/ccstruct/rect.h
@@ -289,8 +289,7 @@ class DLLSYM TBOX  {  // bounding box
     // Writes to the given file. Returns false in case of error.
     bool Serialize(FILE* fp) const;
     // Reads from the given file. Returns false in case of error.
-    // If swap is true, assumes a big/little-endian swap is needed.
-    bool DeSerialize(bool swap, FILE* fp);
+    bool DeSerialize(FILE* fp);
 
     friend TBOX& operator+=(TBOX&, const TBOX&);
     // in place union

--- a/ccutil/bitvector.cpp
+++ b/ccutil/bitvector.cpp
@@ -144,21 +144,13 @@ bool BitVector::Serialize(FILE* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool BitVector::DeSerialize(bool swap, FILE* fp) {
+bool BitVector::DeSerialize(FILE* fp) {
   uinT32 new_bit_size;
   if (fread(&new_bit_size, sizeof(new_bit_size), 1, fp) != 1) return false;
-  if (swap) {
-    ReverseN(&new_bit_size, sizeof(new_bit_size));
-  }
   Alloc(new_bit_size);
   int wordlen = WordLength();
   if (static_cast<int>(fread(array_, sizeof(*array_), wordlen, fp)) != wordlen)
       return false;
-  if (swap) {
-    for (int i = 0; i < wordlen; ++i)
-      ReverseN(&array_[i], sizeof(array_[i]));
-  }
   return true;
 }
 

--- a/ccutil/bitvector.h
+++ b/ccutil/bitvector.h
@@ -60,8 +60,7 @@ class BitVector {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   void SetAllFalse();
   void SetAllTrue();

--- a/ccutil/genericvector.h
+++ b/ccutil/genericvector.h
@@ -162,7 +162,7 @@ class GenericVector {
   // Returns false on error or if the callback returns false.
   // DEPRECATED. Use [De]Serialize[Classes] instead.
   bool write(FILE* f, TessResultCallback2<bool, FILE*, T const &>* cb) const;
-  bool read(FILE* f, TessResultCallback3<bool, FILE*, T*, bool>* cb, bool swap);
+  bool read(FILE* f, TessResultCallback2<bool, FILE*, T*>* cb);
   // Writes a vector of simple types to the given file. Assumes that bitwise
   // read/write of T will work. Returns false in case of error.
   // TODO(rays) Change all callers to use TFile and remove deprecated methods.
@@ -171,25 +171,23 @@ class GenericVector {
   // Reads a vector of simple types from the given file. Assumes that bitwise
   // read/write will work with ReverseN according to sizeof(T).
   // Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
-  bool DeSerialize(bool swap, tesseract::TFile* fp);
+  bool DeSerialize(FILE* fp);
+  bool DeSerialize(tesseract::TFile* fp);
   // Skips the deserialization of the vector.
-  static bool SkipDeSerialize(bool swap, tesseract::TFile* fp);
+  static bool SkipDeSerialize(tesseract::TFile* fp);
   // Writes a vector of classes to the given file. Assumes the existence of
   // bool T::Serialize(FILE* fp) const that returns false in case of error.
   // Returns false in case of error.
   bool SerializeClasses(FILE* fp) const;
   bool SerializeClasses(tesseract::TFile* fp) const;
   // Reads a vector of classes from the given file. Assumes the existence of
-  // bool T::Deserialize(bool swap, FILE* fp) that returns false in case of
+  // bool T::Deserialize(FILE* fp) that returns false in case of
   // error. Also needs T::T() and T::T(constT&), as init_to_size is used in
   // this function. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerializeClasses(bool swap, FILE* fp);
-  bool DeSerializeClasses(bool swap, tesseract::TFile* fp);
+  bool DeSerializeClasses(FILE* fp);
+  bool DeSerializeClasses(tesseract::TFile* fp);
   // Calls SkipDeSerialize on the elements of the vector.
-  static bool SkipDeSerializeClasses(bool swap, tesseract::TFile* fp);
+  static bool SkipDeSerializeClasses(tesseract::TFile* fp);
 
   // Allocates a new array of double the current_size, copies over the
   // information from data to the new location, deletes data and returns
@@ -540,13 +538,11 @@ class PointerVector : public GenericVector<T*> {
   // existence of bool T::DeSerialize(bool, Tfile*) const that returns false in
   // case of error. There is no Serialize for simple types, as you would have a
   // normal GenericVector of those.
-  // If swap is true, assumes a big/little-endian swap is needed.
   // Also needs T::T(), as new T is used in this function.
   // Returns false in case of error.
-  bool DeSerialize(bool swap, FILE* fp) {
+  bool DeSerialize(FILE* fp) {
     inT32 reserved;
     if (fread(&reserved, sizeof(reserved), 1, fp) != 1) return false;
-    if (swap) Reverse32(&reserved);
     GenericVector<T*>::reserve(reserved);
     truncate(0);
     for (int i = 0; i < reserved; ++i) {
@@ -555,7 +551,7 @@ class PointerVector : public GenericVector<T*> {
       T* item = NULL;
       if (non_null) {
         item = new T;
-        if (!item->DeSerialize(swap, fp)) {
+        if (!item->DeSerialize(fp)) {
           delete item;
           return false;
         }
@@ -567,13 +563,13 @@ class PointerVector : public GenericVector<T*> {
     }
     return true;
   }
-  bool DeSerialize(bool swap, TFile* fp) {
+  bool DeSerialize(TFile* fp) {
     inT32 reserved;
-    if (!DeSerializeSize(swap, fp, &reserved)) return false;
+    if (!DeSerializeSize(fp, &reserved)) return false;
     GenericVector<T*>::reserve(reserved);
     truncate(0);
     for (int i = 0; i < reserved; ++i) {
-      if (!DeSerializeElement(swap, fp)) return false;
+      if (!DeSerializeElement(fp)) return false;
     }
     return true;
   }
@@ -581,19 +577,18 @@ class PointerVector : public GenericVector<T*> {
   // retain the integrity of the stream, the caller must call some combination
   // of DeSerializeElement and DeSerializeSkip of the exact number returned in
   // *size, assuming a true return.
-  static bool DeSerializeSize(bool swap, TFile* fp, inT32* size) {
+  static bool DeSerializeSize(TFile* fp, inT32* size) {
     if (fp->FRead(size, sizeof(*size), 1) != 1) return false;
-    if (swap) Reverse32(size);
     return true;
   }
   // Reads and appends to the vector the next element of the serialization.
-  bool DeSerializeElement(bool swap, TFile* fp) {
+  bool DeSerializeElement(TFile* fp) {
     inT8 non_null;
     if (fp->FRead(&non_null, sizeof(non_null), 1) != 1) return false;
     T* item = NULL;
     if (non_null) {
       item = new T;
-      if (!item->DeSerialize(swap, fp)) {
+      if (!item->DeSerialize(fp)) {
         delete item;
         return false;
       }
@@ -605,11 +600,11 @@ class PointerVector : public GenericVector<T*> {
     return true;
   }
   // Skips the next element of the serialization.
-  static bool DeSerializeSkip(bool swap, TFile* fp) {
+  static bool DeSerializeSkip(TFile* fp) {
     inT8 non_null;
     if (fp->FRead(&non_null, sizeof(non_null), 1) != 1) return false;
     if (non_null) {
-      if (!T::SkipDeSerialize(swap, fp)) return false;
+      if (!T::SkipDeSerialize(fp)) return false;
     }
     return true;
   }
@@ -886,17 +881,14 @@ bool GenericVector<T>::write(
 
 template <typename T>
 bool GenericVector<T>::read(FILE* f,
-                            TessResultCallback3<bool, FILE*, T*, bool>* cb,
-                            bool swap) {
+                            TessResultCallback2<bool, FILE*, T*>* cb) {
   inT32 reserved;
   if (fread(&reserved, sizeof(reserved), 1, f) != 1) return false;
-  if (swap) Reverse32(&reserved);
   reserve(reserved);
   if (fread(&size_used_, sizeof(size_used_), 1, f) != 1) return false;
-  if (swap) Reverse32(&size_used_);
   if (cb != NULL) {
     for (int i = 0; i < size_used_; ++i) {
-      if (!cb->Run(f, data_ + i, swap)) {
+      if (!cb->Run(f, data_ + i)) {
         delete cb;
         return false;
       }
@@ -904,10 +896,6 @@ bool GenericVector<T>::read(FILE* f,
     delete cb;
   } else {
     if (fread(data_, sizeof(T), size_used_, f) != size_used_) return false;
-    if (swap) {
-      for (int i = 0; i < size_used_; ++i)
-        ReverseN(&data_[i], sizeof(T));
-    }
   }
   return true;
 }
@@ -930,40 +918,28 @@ bool GenericVector<T>::Serialize(tesseract::TFile* fp) const {
 // Reads a vector of simple types from the given file. Assumes that bitwise
 // read/write will work with ReverseN according to sizeof(T).
 // Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
 template <typename T>
-bool GenericVector<T>::DeSerialize(bool swap, FILE* fp) {
+bool GenericVector<T>::DeSerialize(FILE* fp) {
   inT32 reserved;
   if (fread(&reserved, sizeof(reserved), 1, fp) != 1) return false;
-  if (swap) Reverse32(&reserved);
   reserve(reserved);
   size_used_ = reserved;
   if (fread(data_, sizeof(T), size_used_, fp) != size_used_) return false;
-  if (swap) {
-    for (int i = 0; i < size_used_; ++i)
-      ReverseN(&data_[i], sizeof(data_[i]));
-  }
   return true;
 }
 template <typename T>
-bool GenericVector<T>::DeSerialize(bool swap, tesseract::TFile* fp) {
+bool GenericVector<T>::DeSerialize(tesseract::TFile* fp) {
   inT32 reserved;
   if (fp->FRead(&reserved, sizeof(reserved), 1) != 1) return false;
-  if (swap) Reverse32(&reserved);
   reserve(reserved);
   size_used_ = reserved;
   if (fp->FRead(data_, sizeof(T), size_used_) != size_used_) return false;
-  if (swap) {
-    for (int i = 0; i < size_used_; ++i)
-      ReverseN(&data_[i], sizeof(data_[i]));
-  }
   return true;
 }
 template <typename T>
-bool GenericVector<T>::SkipDeSerialize(bool swap, tesseract::TFile* fp) {
+bool GenericVector<T>::SkipDeSerialize(tesseract::TFile* fp) {
   inT32 reserved;
   if (fp->FRead(&reserved, sizeof(reserved), 1) != 1) return false;
-  if (swap) Reverse32(&reserved);
   return fp->FRead(NULL, sizeof(T), reserved) == reserved;
 }
 
@@ -988,41 +964,37 @@ bool GenericVector<T>::SerializeClasses(tesseract::TFile* fp) const {
 }
 
 // Reads a vector of classes from the given file. Assumes the existence of
-// bool T::Deserialize(bool swap, FILE* fp) that returns false in case of
+// bool T::Deserialize(FILE* fp) that returns false in case of
 // error. Also needs T::T() and T::T(constT&), as init_to_size is used in
 // this function. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
 template <typename T>
-bool GenericVector<T>::DeSerializeClasses(bool swap, FILE* fp) {
+bool GenericVector<T>::DeSerializeClasses(FILE* fp) {
   uinT32 reserved;
   if (fread(&reserved, sizeof(reserved), 1, fp) != 1) return false;
-  if (swap) Reverse32(&reserved);
   T empty;
   init_to_size(reserved, empty);
   for (int i = 0; i < reserved; ++i) {
-    if (!data_[i].DeSerialize(swap, fp)) return false;
+    if (!data_[i].DeSerialize(fp)) return false;
   }
   return true;
 }
 template <typename T>
-bool GenericVector<T>::DeSerializeClasses(bool swap, tesseract::TFile* fp) {
+bool GenericVector<T>::DeSerializeClasses(tesseract::TFile* fp) {
   uinT32 reserved;
   if (fp->FRead(&reserved, sizeof(reserved), 1) != 1) return false;
-  if (swap) Reverse32(&reserved);
   T empty;
   init_to_size(reserved, empty);
   for (int i = 0; i < reserved; ++i) {
-    if (!data_[i].DeSerialize(swap, fp)) return false;
+    if (!data_[i].DeSerialize(fp)) return false;
   }
   return true;
 }
 template <typename T>
-bool GenericVector<T>::SkipDeSerializeClasses(bool swap, tesseract::TFile* fp) {
+bool GenericVector<T>::SkipDeSerializeClasses(tesseract::TFile* fp) {
   uinT32 reserved;
   if (fp->FRead(&reserved, sizeof(reserved), 1) != 1) return false;
-  if (swap) Reverse32(&reserved);
   for (int i = 0; i < reserved; ++i) {
-    if (!T::SkipDeSerialize(swap, fp)) return false;
+    if (!T::SkipDeSerialize(fp)) return false;
   }
   return true;
 }

--- a/ccutil/indexmapbidi.cpp
+++ b/ccutil/indexmapbidi.cpp
@@ -48,14 +48,11 @@ bool IndexMap::Serialize(FILE* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool IndexMap::DeSerialize(bool swap, FILE* fp) {
+bool IndexMap::DeSerialize(FILE* fp) {
   inT32 sparse_size;
   if (fread(&sparse_size, sizeof(sparse_size), 1, fp) != 1) return false;
-  if (swap)
-    ReverseN(&sparse_size, sizeof(sparse_size));
   sparse_size_ = sparse_size;
-  if (!compact_map_.DeSerialize(swap, fp)) return false;
+  if (!compact_map_.DeSerialize(fp)) return false;
   return true;
 }
 
@@ -205,11 +202,10 @@ bool IndexMapBiDi::Serialize(FILE* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool IndexMapBiDi::DeSerialize(bool swap, FILE* fp) {
-  if (!IndexMap::DeSerialize(swap, fp)) return false;
+bool IndexMapBiDi::DeSerialize(FILE* fp) {
+  if (!IndexMap::DeSerialize(fp)) return false;
   GenericVector<inT32> remaining_pairs;
-  if (!remaining_pairs.DeSerialize(swap, fp)) return false;
+  if (!remaining_pairs.DeSerialize(fp)) return false;
   sparse_map_.init_to_size(sparse_size_, -1);
   for (int i = 0; i < compact_map_.size(); ++i) {
     sparse_map_[compact_map_[i]] = i;

--- a/ccutil/indexmapbidi.h
+++ b/ccutil/indexmapbidi.h
@@ -69,8 +69,7 @@ class IndexMap {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
  protected:
   // The sparse space covers integers in the range [0, sparse_size_-1].
@@ -149,8 +148,7 @@ class IndexMapBiDi : public IndexMap {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   // Bulk calls to SparseToCompact.
   // Maps the given array of sparse indices to an array of compact indices.

--- a/ccutil/strngs.cpp
+++ b/ccutil/strngs.cpp
@@ -159,33 +159,26 @@ bool STRING::Serialize(TFile* fp) const {
   return true;
 }
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool STRING::DeSerialize(bool swap, FILE* fp) {
+bool STRING::DeSerialize(FILE* fp) {
   inT32 len;
   if (fread(&len, sizeof(len), 1, fp) != 1) return false;
-  if (swap)
-    ReverseN(&len, sizeof(len));
   truncate_at(len);
   if (static_cast<int>(fread(GetCStr(), 1, len, fp)) != len) return false;
   return true;
 }
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool STRING::DeSerialize(bool swap, TFile* fp) {
+bool STRING::DeSerialize(TFile* fp) {
   inT32 len;
   if (fp->FRead(&len, sizeof(len), 1) != 1) return false;
-  if (swap)
-    ReverseN(&len, sizeof(len));
   truncate_at(len);
   if (fp->FRead(GetCStr(), 1, len) != len) return false;
   return true;
 }
 
 // As DeSerialize, but only seeks past the data - hence a static method.
-bool STRING::SkipDeSerialize(bool swap, tesseract::TFile* fp) {
+bool STRING::SkipDeSerialize(tesseract::TFile* fp) {
   inT32 len;
   if (fp->FRead(&len, sizeof(len), 1) != 1) return false;
-  if (swap) ReverseN(&len, sizeof(len));
   return fp->FRead(NULL, 1, len) == len;
 }
 

--- a/ccutil/strngs.h
+++ b/ccutil/strngs.h
@@ -53,15 +53,13 @@ class TESS_API STRING
     // Writes to the given file. Returns false in case of error.
     bool Serialize(FILE* fp) const;
     // Reads from the given file. Returns false in case of error.
-    // If swap is true, assumes a big/little-endian swap is needed.
-    bool DeSerialize(bool swap, FILE* fp);
+    bool DeSerialize(FILE* fp);
     // Writes to the given file. Returns false in case of error.
     bool Serialize(tesseract::TFile* fp) const;
     // Reads from the given file. Returns false in case of error.
-    // If swap is true, assumes a big/little-endian swap is needed.
-    bool DeSerialize(bool swap, tesseract::TFile* fp);
+    bool DeSerialize(tesseract::TFile* fp);
     // As DeSerialize, but only seeks past the data - hence a static method.
-    static bool SkipDeSerialize(bool swap, tesseract::TFile* fp);
+    static bool SkipDeSerialize(tesseract::TFile* fp);
 
     BOOL8 contains(const char c) const;
     inT32 length() const;

--- a/ccutil/tessdatamanager.cpp
+++ b/ccutil/tessdatamanager.cpp
@@ -45,22 +45,12 @@ bool TessdataManager::Init(const char *data_file_name, int debug_level) {
     return false;
   }
   fread(&actual_tessdata_num_entries_, sizeof(inT32), 1, data_file_);
-  swap_ = (actual_tessdata_num_entries_ > kMaxNumTessdataEntries);
-  if (swap_) {
-    ReverseN(&actual_tessdata_num_entries_,
-             sizeof(actual_tessdata_num_entries_));
-  }
   if (actual_tessdata_num_entries_ > TESSDATA_NUM_ENTRIES) {
     // For forward compatibility, truncate to the number we can handle.
     actual_tessdata_num_entries_ = TESSDATA_NUM_ENTRIES;
   }
   fread(offset_table_, sizeof(inT64),
         actual_tessdata_num_entries_, data_file_);
-  if (swap_) {
-    for (i = 0 ; i < actual_tessdata_num_entries_; ++i) {
-      ReverseN(&offset_table_[i], sizeof(offset_table_[i]));
-    }
-  }
   if (debug_level_) {
     tprintf("TessdataManager loaded %d types of tesseract data files.\n",
             actual_tessdata_num_entries_);

--- a/ccutil/tessdatamanager.h
+++ b/ccutil/tessdatamanager.h
@@ -217,9 +217,6 @@ class TessdataManager {
       data_file_ = NULL;
     }
   }
-  bool swap() const {
-    return swap_;
-  }
 
   /** Writes the number of entries and the given offset table to output_file.
    * Returns false on error.
@@ -315,8 +312,6 @@ class TessdataManager {
   STRING data_file_name_;  // name of the data file.
   FILE *data_file_;  ///< pointer to the data file.
   int debug_level_;
-  // True if the bytes need swapping.
-  bool swap_;
 };
 
 

--- a/ccutil/unicharcompress.cpp
+++ b/ccutil/unicharcompress.cpp
@@ -315,9 +315,8 @@ bool UnicharCompress::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool UnicharCompress::DeSerialize(bool swap, TFile* fp) {
-  if (!encoder_.DeSerializeClasses(swap, fp)) return false;
+bool UnicharCompress::DeSerialize(TFile* fp) {
+  if (!encoder_.DeSerializeClasses(fp)) return false;
   ComputeCodeRange();
   SetupDecoder();
   return true;

--- a/ccutil/unicharcompress.h
+++ b/ccutil/unicharcompress.h
@@ -68,18 +68,11 @@ class RecodedCharID {
     return true;
   }
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, TFile* fp) {
+  bool DeSerialize(TFile* fp) {
     if (fp->FRead(&self_normalized_, sizeof(self_normalized_), 1) != 1)
       return false;
     if (fp->FRead(&length_, sizeof(length_), 1) != 1) return false;
-    if (swap) ReverseN(&length_, sizeof(length_));
     if (fp->FRead(code_, sizeof(code_[0]), length_) != length_) return false;
-    if (swap) {
-      for (int i = 0; i < length_; ++i) {
-        ReverseN(&code_[i], sizeof(code_[i]));
-      }
-    }
     return true;
   }
   bool operator==(const RecodedCharID& other) const {
@@ -205,8 +198,7 @@ class UnicharCompress {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, TFile* fp);
+  bool DeSerialize(TFile* fp);
 
   // Returns a STRING containing a text file that describes the encoding thus:
   // <index>[,<index>]*<tab><UTF8-str><newline>

--- a/ccutil/unicity_table.h
+++ b/ccutil/unicity_table.h
@@ -86,8 +86,7 @@ class UnicityTable {
   /// once. The given callback will be deleted at the end.
   /// Returns false on read/write error.
   bool write(FILE* f, TessResultCallback2<bool, FILE*, T const &>* cb) const;
-  /// swap is used to switch the endianness.
-  bool read(FILE* f, TessResultCallback3<bool, FILE*, T*, bool>* cb, bool swap);
+  bool read(FILE* f, TessResultCallback2<bool, FILE*, T*>* cb);
 
  private:
   GenericVector<T> table_;
@@ -194,8 +193,8 @@ bool UnicityTable<T>::write(
 
 template <typename T>
 bool UnicityTable<T>::read(
-    FILE* f, TessResultCallback3<bool, FILE*, T*, bool>* cb, bool swap) {
-  return table_.read(f, cb, swap);
+    FILE* f, TessResultCallback2<bool, FILE*, T*>* cb) {
+  return table_.read(f, cb);
 }
 
 // This method clear the current object, then, does a shallow copy of

--- a/classify/adaptmatch.cpp
+++ b/classify/adaptmatch.cpp
@@ -541,8 +541,7 @@ void Classify::InitAdaptiveClassifier(bool load_pre_trained_templates) {
 
     if (tessdata_manager.SeekToStart(TESSDATA_SHAPE_TABLE)) {
       shape_table_ = new ShapeTable(unicharset);
-      if (!shape_table_->DeSerialize(tessdata_manager.swap(),
-                                     tessdata_manager.GetDataFilePtr())) {
+      if (!shape_table_->DeSerialize(tessdata_manager.GetDataFilePtr())) {
         tprintf("Error loading shape table!\n");
         delete shape_table_;
         shape_table_ = NULL;
@@ -553,7 +552,6 @@ void Classify::InitAdaptiveClassifier(bool load_pre_trained_templates) {
 
     ASSERT_HOST(tessdata_manager.SeekToStart(TESSDATA_PFFMTABLE));
     ReadNewCutoffs(tessdata_manager.GetDataFilePtr(),
-                   tessdata_manager.swap(),
                    tessdata_manager.GetEndOffset(TESSDATA_PFFMTABLE),
                    CharNormCutoffs);
     if (tessdata_manager.DebugLevel() > 0) tprintf("Loaded pffmtable\n");

--- a/classify/classify.h
+++ b/classify/classify.h
@@ -103,7 +103,7 @@ class Classify : public CCStruct {
                    const uinT8* normalization_factors,
                    const uinT16* expected_num_features,
                    GenericVector<CP_RESULT_STRUCT>* results);
-  void ReadNewCutoffs(FILE *CutoffFile, bool swap, inT64 end_offset,
+  void ReadNewCutoffs(FILE *CutoffFile, inT64 end_offset,
                       CLASS_CUTOFF_ARRAY Cutoffs);
   void PrintAdaptedTemplates(FILE *File, ADAPT_TEMPLATES Templates);
   void WriteAdaptedTemplates(FILE *File, ADAPT_TEMPLATES Templates);

--- a/classify/cutoffs.cpp
+++ b/classify/cutoffs.cpp
@@ -42,14 +42,13 @@ namespace tesseract {
  * array are set to an arbitrarily high cutoff value.
  * @param CutoffFile name of file containing cutoff definitions
  * @param Cutoffs array to put cutoffs into
- * @param swap
  * @param end_offset
  * @return none
  * @note Globals: none
  * @note Exceptions: none
  * @note History: Wed Feb 20 09:38:26 1991, DSJ, Created.
  */
-void Classify::ReadNewCutoffs(FILE *CutoffFile, bool swap, inT64 end_offset,
+void Classify::ReadNewCutoffs(FILE *CutoffFile, inT64 end_offset,
                               CLASS_CUTOFF_ARRAY Cutoffs) {
   char Class[UNICHAR_LEN + 1];
   CLASS_ID ClassId;
@@ -57,7 +56,7 @@ void Classify::ReadNewCutoffs(FILE *CutoffFile, bool swap, inT64 end_offset,
   int i;
 
   if (shape_table_ != NULL) {
-    if (!shapetable_cutoffs_.DeSerialize(swap, CutoffFile)) {
+    if (!shapetable_cutoffs_.DeSerialize(CutoffFile)) {
       tprintf("Error during read of shapetable pffmtable!\n");
     }
   }

--- a/classify/intfeaturespace.cpp
+++ b/classify/intfeaturespace.cpp
@@ -45,9 +45,8 @@ bool IntFeatureSpace::Serialize(FILE* fp) const {
 }
 
 // DeSerializes the feature space definition from the given file.
-// If swap is true, the data is big/little-endian swapped.
 // Returns false on error.
-bool IntFeatureSpace::DeSerialize(bool swap, FILE* fp) {
+bool IntFeatureSpace::DeSerialize(FILE* fp) {
   if (fread(&x_buckets_, sizeof(x_buckets_), 1, fp) != 1)
     return false;
   if (fread(&y_buckets_, sizeof(y_buckets_), 1, fp) != 1)

--- a/classify/intfeaturespace.h
+++ b/classify/intfeaturespace.h
@@ -48,9 +48,8 @@ class IntFeatureSpace {
   bool Serialize(FILE* fp) const;
 
   // DeSerializes the feature space definition from the given file.
-  // If swap is true, the data is big/little-endian swapped.
   // Returns false on error.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   // Returns the total size of the feature space.
   int Size() const {

--- a/classify/intproto.cpp
+++ b/classify/intproto.cpp
@@ -760,7 +760,6 @@ namespace tesseract {
  */
 INT_TEMPLATES Classify::ReadIntTemplates(FILE *File) {
   int i, j, w, x, y, z;
-  BOOL8 swap;
   int nread;
   int unicharset_size;
   int version_id = 0;
@@ -793,22 +792,12 @@ INT_TEMPLATES Classify::ReadIntTemplates(FILE *File) {
       fread(&Templates->NumClassPruners,
             sizeof(Templates->NumClassPruners), 1, File) != 1)
     cprintf("Bad read of inttemp!\n");
-  // Swap status is determined automatically.
-  swap = Templates->NumClassPruners < 0 ||
-    Templates->NumClassPruners > MAX_NUM_CLASS_PRUNERS;
-  if (swap) {
-    Reverse32(&Templates->NumClassPruners);
-    Reverse32(&Templates->NumClasses);
-    Reverse32(&unicharset_size);
-  }
   if (Templates->NumClasses < 0) {
     // This file has a version id!
     version_id = -Templates->NumClasses;
     if (fread(&Templates->NumClasses, sizeof(Templates->NumClasses),
               1, File) != 1)
       cprintf("Bad read of inttemp!\n");
-    if (swap)
-      Reverse32(&Templates->NumClasses);
   }
 
   if (version_id < 3) {
@@ -825,12 +814,6 @@ INT_TEMPLATES Classify::ReadIntTemplates(FILE *File) {
       if (fread(&ClassIdFor[i], sizeof(CLASS_ID), 1, File) != 1)
         cprintf("Bad read of inttemp!\n");
     }
-    if (swap) {
-      for (i = 0; i < Templates->NumClasses; i++)
-        Reverse16(&IndexFor[i]);
-      for (i = 0; i < Templates->NumClasses; i++)
-        Reverse32(&ClassIdFor[i]);
-    }
   }
 
   /* then read in the class pruners */
@@ -840,17 +823,6 @@ INT_TEMPLATES Classify::ReadIntTemplates(FILE *File) {
          fread(Pruner, 1, sizeof(CLASS_PRUNER_STRUCT),
                 File)) != sizeof(CLASS_PRUNER_STRUCT))
       cprintf("Bad read of inttemp!\n");
-    if (swap) {
-      for (x = 0; x < NUM_CP_BUCKETS; x++) {
-        for (y = 0; y < NUM_CP_BUCKETS; y++) {
-          for (z = 0; z < NUM_CP_BUCKETS; z++) {
-            for (w = 0; w < WERDS_PER_CP_VECTOR; w++) {
-              Reverse32(&Pruner->p[x][y][z][w]);
-            }
-          }
-        }
-      }
-    }
     if (version_id < 2) {
       TempClassPruner[i] = Pruner;
     } else {
@@ -931,21 +903,11 @@ INT_TEMPLATES Classify::ReadIntTemplates(FILE *File) {
         if (fread(&Class->ConfigLengths[j], sizeof(uinT16), 1, File) != 1)
           cprintf ("Bad read of inttemp!\n");
       }
-      if (swap) {
-        Reverse16(&Class->NumProtos);
-        for (j = 0; j < MaxNumConfigs; j++)
-          Reverse16(&Class->ConfigLengths[j]);
-      }
     } else {
       ASSERT_HOST(Class->NumConfigs < MaxNumConfigs);
       for (j = 0; j < Class->NumConfigs; ++j) {
         if (fread(&Class->ConfigLengths[j], sizeof(uinT16), 1, File) != 1)
           cprintf ("Bad read of inttemp!\n");
-      }
-      if (swap) {
-        Reverse16(&Class->NumProtos);
-        for (j = 0; j < MaxNumConfigs; j++)
-          Reverse16(&Class->ConfigLengths[j]);
       }
     }
     if (version_id < 2) {
@@ -994,23 +956,12 @@ INT_TEMPLATES Classify::ReadIntTemplates(FILE *File) {
                    File)) != sizeof(PROTO_SET_STRUCT))
           cprintf("Bad read of inttemp!\n");
       }
-      if (swap) {
-        for (x = 0; x < NUM_PP_PARAMS; x++)
-          for (y = 0; y < NUM_PP_BUCKETS; y++)
-            for (z = 0; z < WERDS_PER_PP_VECTOR; z++)
-              Reverse32(&ProtoSet->ProtoPruner[x][y][z]);
-        for (x = 0; x < PROTOS_PER_PROTO_SET; x++)
-          for (y = 0; y < WerdsPerConfigVec; y++)
-            Reverse32(&ProtoSet->Protos[x].Configs[y]);
-      }
       Class->ProtoSets[j] = ProtoSet;
     }
     if (version_id < 4)
       Class->font_set_id = -1;
     else {
       fread(&Class->font_set_id, sizeof(int), 1, File);
-      if (swap)
-        Reverse32(&Class->font_set_id);
     }
   }
 
@@ -1037,13 +988,12 @@ INT_TEMPLATES Classify::ReadIntTemplates(FILE *File) {
     }
   }
   if (version_id >= 4) {
-    this->fontinfo_table_.read(File, NewPermanentTessCallback(read_info), swap);
+    this->fontinfo_table_.read(File, NewPermanentTessCallback(read_info));
     if (version_id >= 5) {
       this->fontinfo_table_.read(File,
-                                 NewPermanentTessCallback(read_spacing_info),
-                                 swap);
+                                 NewPermanentTessCallback(read_spacing_info));
     }
-    this->fontset_table_.read(File, NewPermanentTessCallback(read_set), swap);
+    this->fontset_table_.read(File, NewPermanentTessCallback(read_set));
   }
 
   // Clean up.

--- a/classify/mastertrainer.cpp
+++ b/classify/mastertrainer.cpp
@@ -87,23 +87,19 @@ bool MasterTrainer::Serialize(FILE* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool MasterTrainer::DeSerialize(bool swap, FILE* fp) {
+bool MasterTrainer::DeSerialize(FILE* fp) {
   if (fread(&norm_mode_, sizeof(norm_mode_), 1, fp) != 1) return false;
-  if (swap) {
-    ReverseN(&norm_mode_, sizeof(norm_mode_));
-  }
   if (!unicharset_.load_from_file(fp)) return false;
   charsetsize_ = unicharset_.size();
-  if (!feature_space_.DeSerialize(swap, fp)) return false;
+  if (!feature_space_.DeSerialize(fp)) return false;
   feature_map_.Init(feature_space_);
-  if (!samples_.DeSerialize(swap, fp)) return false;
-  if (!junk_samples_.DeSerialize(swap, fp)) return false;
-  if (!verify_samples_.DeSerialize(swap, fp)) return false;
-  if (!master_shapes_.DeSerialize(swap, fp)) return false;
-  if (!flat_shapes_.DeSerialize(swap, fp)) return false;
-  if (!fontinfo_table_.DeSerialize(swap, fp)) return false;
-  if (!xheights_.DeSerialize(swap, fp)) return false;
+  if (!samples_.DeSerialize(fp)) return false;
+  if (!junk_samples_.DeSerialize(fp)) return false;
+  if (!verify_samples_.DeSerialize(fp)) return false;
+  if (!master_shapes_.DeSerialize(fp)) return false;
+  if (!flat_shapes_.DeSerialize(fp)) return false;
+  if (!fontinfo_table_.DeSerialize(fp)) return false;
+  if (!xheights_.DeSerialize(fp)) return false;
   return true;
 }
 

--- a/classify/mastertrainer.h
+++ b/classify/mastertrainer.h
@@ -75,8 +75,7 @@ class MasterTrainer {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   // Loads an initial unicharset, or sets one up if the file cannot be read.
   void LoadUnicharset(const char* filename);

--- a/classify/shapetable.cpp
+++ b/classify/shapetable.cpp
@@ -70,12 +70,9 @@ bool UnicharAndFonts::Serialize(FILE* fp) const {
   return true;
 }
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool UnicharAndFonts::DeSerialize(bool swap, FILE* fp) {
+bool UnicharAndFonts::DeSerialize(FILE* fp) {
   if (fread(&unichar_id, sizeof(unichar_id), 1, fp) != 1) return false;
-  if (swap)
-    ReverseN(&unichar_id, sizeof(unichar_id));
-  if (!font_ids.DeSerialize(swap, fp)) return false;
+  if (!font_ids.DeSerialize(fp)) return false;
   return true;
 }
 
@@ -95,13 +92,12 @@ bool Shape::Serialize(FILE* fp) const {
   return true;
 }
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool Shape::DeSerialize(bool swap, FILE* fp) {
+bool Shape::DeSerialize(FILE* fp) {
   uinT8 sorted;
   if (fread(&sorted, sizeof(sorted), 1, fp) != 1)
     return false;
   unichars_sorted_ = sorted != 0;
-  if (!unichars_.DeSerializeClasses(swap, fp)) return false;
+  if (!unichars_.DeSerializeClasses(fp)) return false;
   return true;
 }
 
@@ -252,9 +248,8 @@ bool ShapeTable::Serialize(FILE* fp) const {
   return true;
 }
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool ShapeTable::DeSerialize(bool swap, FILE* fp) {
-  if (!shape_table_.DeSerialize(swap, fp)) return false;
+bool ShapeTable::DeSerialize(FILE* fp) {
+  if (!shape_table_.DeSerialize(fp)) return false;
   num_fonts_ = 0;
   return true;
 }

--- a/classify/shapetable.h
+++ b/classify/shapetable.h
@@ -167,8 +167,7 @@ struct UnicharAndFonts {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   // Sort function to sort a pair of UnicharAndFonts by unichar_id.
   static int SortByUnicharId(const void* v1, const void* v2);
@@ -190,8 +189,7 @@ class Shape {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   int destination_index() const {
     return destination_index_;
@@ -271,8 +269,7 @@ class ShapeTable {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   // Accessors.
   int NumShapes() const {

--- a/classify/trainingsample.cpp
+++ b/classify/trainingsample.cpp
@@ -76,32 +76,24 @@ bool TrainingSample::Serialize(FILE* fp) const {
 }
 
 // Creates from the given file. Returns NULL in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-TrainingSample* TrainingSample::DeSerializeCreate(bool swap, FILE* fp) {
+TrainingSample* TrainingSample::DeSerializeCreate(FILE* fp) {
   TrainingSample* sample = new TrainingSample;
-  if (sample->DeSerialize(swap, fp)) return sample;
+  if (sample->DeSerialize(fp)) return sample;
   delete sample;
   return NULL;
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool TrainingSample::DeSerialize(bool swap, FILE* fp) {
+bool TrainingSample::DeSerialize(FILE* fp) {
   if (fread(&class_id_, sizeof(class_id_), 1, fp) != 1) return false;
   if (fread(&font_id_, sizeof(font_id_), 1, fp) != 1) return false;
   if (fread(&page_num_, sizeof(page_num_), 1, fp) != 1) return false;
-  if (!bounding_box_.DeSerialize(swap, fp)) return false;
+  if (!bounding_box_.DeSerialize(fp)) return false;
   if (fread(&num_features_, sizeof(num_features_), 1, fp) != 1) return false;
   if (fread(&num_micro_features_, sizeof(num_micro_features_), 1, fp) != 1)
     return false;
   if (fread(&outline_length_, sizeof(outline_length_), 1, fp) != 1)
     return false;
-  if (swap) {
-    ReverseN(&class_id_, sizeof(class_id_));
-    ReverseN(&num_features_, sizeof(num_features_));
-    ReverseN(&num_micro_features_, sizeof(num_micro_features_));
-    ReverseN(&outline_length_, sizeof(outline_length_));
-  }
   delete [] features_;
   features_ = new INT_FEATURE_STRUCT[num_features_];
   if (static_cast<int>(fread(features_, sizeof(*features_), num_features_, fp))

--- a/classify/trainingsample.h
+++ b/classify/trainingsample.h
@@ -83,11 +83,9 @@ class TrainingSample : public ELIST_LINK {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Creates from the given file. Returns NULL in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  static TrainingSample* DeSerializeCreate(bool swap, FILE* fp);
+  static TrainingSample* DeSerializeCreate(FILE* fp);
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   // Extracts the needed information from the CHAR_DESC_STRUCT.
   void ExtractCharDesc(int feature_type, int micro_type,

--- a/classify/trainingsampleset.cpp
+++ b/classify/trainingsampleset.cpp
@@ -51,19 +51,13 @@ bool TrainingSampleSet::FontClassInfo::Serialize(FILE* fp) const {
   return true;
 }
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool TrainingSampleSet::FontClassInfo::DeSerialize(bool swap, FILE* fp) {
+bool TrainingSampleSet::FontClassInfo::DeSerialize(FILE* fp) {
   if (fread(&num_raw_samples, sizeof(num_raw_samples), 1, fp) != 1)
     return false;
   if (fread(&canonical_sample, sizeof(canonical_sample), 1, fp) != 1)
     return false;
   if (fread(&canonical_dist, sizeof(canonical_dist), 1, fp) != 1) return false;
-  if (!samples.DeSerialize(swap, fp)) return false;
-  if (swap) {
-    ReverseN(&num_raw_samples, sizeof(num_raw_samples));
-    ReverseN(&canonical_sample, sizeof(canonical_sample));
-    ReverseN(&canonical_dist, sizeof(canonical_dist));
-  }
+  if (!samples.DeSerialize(fp)) return false;
   return true;
 }
 
@@ -90,12 +84,11 @@ bool TrainingSampleSet::Serialize(FILE* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool TrainingSampleSet::DeSerialize(bool swap, FILE* fp) {
-  if (!samples_.DeSerialize(swap, fp)) return false;
+bool TrainingSampleSet::DeSerialize(FILE* fp) {
+  if (!samples_.DeSerialize(fp)) return false;
   num_raw_samples_ = samples_.size();
   if (!unicharset_.load_from_file(fp)) return false;
-  if (!font_id_map_.DeSerialize(swap, fp)) return false;
+  if (!font_id_map_.DeSerialize(fp)) return false;
   delete font_class_array_;
   font_class_array_ = NULL;
   inT8 not_null;
@@ -103,7 +96,7 @@ bool TrainingSampleSet::DeSerialize(bool swap, FILE* fp) {
   if (not_null) {
     FontClassInfo empty;
     font_class_array_ = new GENERIC_2D_ARRAY<FontClassInfo >(1, 1 , empty);
-    if (!font_class_array_->DeSerializeClasses(swap, fp)) return false;
+    if (!font_class_array_->DeSerializeClasses(fp)) return false;
   }
   unicharset_size_ = unicharset_.size();
   return true;

--- a/classify/trainingsampleset.h
+++ b/classify/trainingsampleset.h
@@ -48,8 +48,7 @@ class TrainingSampleSet {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, FILE* fp);
+  bool DeSerialize(FILE* fp);
 
   // Accessors
   int num_samples() const {
@@ -234,8 +233,7 @@ class TrainingSampleSet {
     // Writes to the given file. Returns false in case of error.
     bool Serialize(FILE* fp) const;
     // Reads from the given file. Returns false in case of error.
-    // If swap is true, assumes a big/little-endian swap is needed.
-    bool DeSerialize(bool swap, FILE* fp);
+    bool DeSerialize(FILE* fp);
 
     // Number of raw samples.
     inT32 num_raw_samples;

--- a/dict/dawg.cpp
+++ b/dict/dawg.cpp
@@ -323,30 +323,20 @@ void SquishedDawg::read_squished_dawg(FILE *file,
   if (debug_level) tprintf("Reading squished dawg\n");
 
   // Read the magic number and if it does not match kDawgMagicNumber
-  // set swap to true to indicate that we need to switch endianness.
   inT16 magic;
   fread(&magic, sizeof(inT16), 1, file);
-  bool swap = (magic != kDawgMagicNumber);
+  ASSERT_HOST(magic == kDawgMagicNumber);
 
   int unicharset_size;
   fread(&unicharset_size, sizeof(inT32), 1, file);
   fread(&num_edges_, sizeof(inT32), 1, file);
 
-  if (swap) {
-    ReverseN(&unicharset_size, sizeof(unicharset_size));
-    ReverseN(&num_edges_, sizeof(num_edges_));
-  }
   ASSERT_HOST(num_edges_ > 0);  // DAWG should not be empty
   Dawg::init(type, lang, perm, unicharset_size, debug_level);
 
   edges_ = (EDGE_ARRAY) memalloc(sizeof(EDGE_RECORD) * num_edges_);
   fread(&edges_[0], sizeof(EDGE_RECORD), num_edges_, file);
   EDGE_REF edge;
-  if (swap) {
-    for (edge = 0; edge < num_edges_; ++edge) {
-      ReverseN(&edges_[edge], sizeof(edges_[edge]));
-    }
-  }
   if (debug_level > 2) {
     tprintf("type: %d lang: %s perm: %d unicharset_size: %d num_edges: %d\n",
             type_, lang_.string(), perm_, unicharset_size_, num_edges_);

--- a/lstm/convolve.cpp
+++ b/lstm/convolve.cpp
@@ -42,14 +42,9 @@ bool Convolve::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool Convolve::DeSerialize(bool swap, TFile* fp) {
+bool Convolve::DeSerialize(TFile* fp) {
   if (fp->FRead(&half_x_, sizeof(half_x_), 1) != 1) return false;
   if (fp->FRead(&half_y_, sizeof(half_y_), 1) != 1) return false;
-  if (swap) {
-    ReverseN(&half_x_, sizeof(half_x_));
-    ReverseN(&half_y_, sizeof(half_y_));
-  }
   no_ = ni_ * (2*half_x_ + 1) * (2*half_y_ + 1);
   return true;
 }

--- a/lstm/convolve.h
+++ b/lstm/convolve.h
@@ -47,8 +47,7 @@ class Convolve : public Network {
   // Writes to the given file. Returns false in case of error.
   virtual bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  virtual bool DeSerialize(bool swap, TFile* fp);
+  virtual bool DeSerialize(TFile* fp);
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.

--- a/lstm/fullyconnected.cpp
+++ b/lstm/fullyconnected.cpp
@@ -94,9 +94,8 @@ bool FullyConnected::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool FullyConnected::DeSerialize(bool swap, TFile* fp) {
-  if (!weights_.DeSerialize(IsTraining(), swap, fp)) return false;
+bool FullyConnected::DeSerialize(TFile* fp) {
+  if (!weights_.DeSerialize(IsTraining(), fp)) return false;
   return true;
 }
 

--- a/lstm/fullyconnected.h
+++ b/lstm/fullyconnected.h
@@ -78,8 +78,7 @@ class FullyConnected : public Network {
   // Writes to the given file. Returns false in case of error.
   virtual bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  virtual bool DeSerialize(bool swap, TFile* fp);
+  virtual bool DeSerialize(TFile* fp);
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.

--- a/lstm/input.cpp
+++ b/lstm/input.cpp
@@ -48,10 +48,8 @@ bool Input::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool Input::DeSerialize(bool swap, TFile* fp) {
+bool Input::DeSerialize(TFile* fp) {
   if (fp->FRead(&shape_, sizeof(shape_), 1) != 1) return false;
-  // TODO(rays) swaps!
   return true;
 }
 

--- a/lstm/input.h
+++ b/lstm/input.h
@@ -51,9 +51,8 @@ class Input : public Network {
   // Should be overridden by subclasses, but called by their Serialize.
   virtual bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
   // Should be overridden by subclasses, but NOT called by their DeSerialize.
-  virtual bool DeSerialize(bool swap, TFile* fp);
+  virtual bool DeSerialize(TFile* fp);
 
   // Returns an integer reduction factor that the network applies to the
   // time sequence. Assumes that any 2-d is already eliminated. Used for

--- a/lstm/lstm.cpp
+++ b/lstm/lstm.cpp
@@ -173,10 +173,8 @@ bool LSTM::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool LSTM::DeSerialize(bool swap, TFile* fp) {
+bool LSTM::DeSerialize(TFile* fp) {
   if (fp->FRead(&na_, sizeof(na_), 1) != 1) return false;
-  if (swap) ReverseN(&na_, sizeof(na_));
   if (type_ == NT_LSTM_SOFTMAX) {
     nf_ = no_;
   } else if (type_ == NT_LSTM_SOFTMAX_ENCODED) {
@@ -187,7 +185,7 @@ bool LSTM::DeSerialize(bool swap, TFile* fp) {
   is_2d_ = false;
   for (int w = 0; w < WT_COUNT; ++w) {
     if (w == GFS && !Is2D()) continue;
-    if (!gate_weights_[w].DeSerialize(IsTraining(), swap, fp)) return false;
+    if (!gate_weights_[w].DeSerialize(IsTraining(), fp)) return false;
     if (w == CI) {
       ns_ = gate_weights_[CI].NumOutputs();
       is_2d_ = na_ - nf_ == ni_ + 2 * ns_;
@@ -196,7 +194,7 @@ bool LSTM::DeSerialize(bool swap, TFile* fp) {
   delete softmax_;
   if (type_ == NT_LSTM_SOFTMAX || type_ == NT_LSTM_SOFTMAX_ENCODED) {
     softmax_ =
-        reinterpret_cast<FullyConnected*>(Network::CreateFromFile(swap, fp));
+        reinterpret_cast<FullyConnected*>(Network::CreateFromFile(fp));
     if (softmax_ == NULL) return false;
   } else {
     softmax_ = NULL;

--- a/lstm/lstm.h
+++ b/lstm/lstm.h
@@ -86,8 +86,7 @@ class LSTM : public Network {
   // Writes to the given file. Returns false in case of error.
   virtual bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  virtual bool DeSerialize(bool swap, TFile* fp);
+  virtual bool DeSerialize(TFile* fp);
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.

--- a/lstm/lstmrecognizer.cpp
+++ b/lstm/lstmrecognizer.cpp
@@ -88,13 +88,12 @@ bool LSTMRecognizer::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool LSTMRecognizer::DeSerialize(bool swap, TFile* fp) {
+bool LSTMRecognizer::DeSerialize(TFile* fp) {
   delete network_;
-  network_ = Network::CreateFromFile(swap, fp);
+  network_ = Network::CreateFromFile(fp);
   if (network_ == NULL) return false;
   if (!ccutil_.unicharset.load_from_file(fp, false)) return false;
-  if (!network_str_.DeSerialize(swap, fp)) return false;
+  if (!network_str_.DeSerialize(fp)) return false;
   if (fp->FRead(&training_flags_, sizeof(training_flags_), 1) != 1)
     return false;
   if (fp->FRead(&training_iteration_, sizeof(training_iteration_), 1) != 1)
@@ -106,7 +105,7 @@ bool LSTMRecognizer::DeSerialize(bool swap, TFile* fp) {
   if (fp->FRead(&learning_rate_, sizeof(learning_rate_), 1) != 1) return false;
   if (fp->FRead(&momentum_, sizeof(momentum_), 1) != 1) return false;
   if (IsRecoding()) {
-    if (!recoder_.DeSerialize(swap, fp)) return false;
+    if (!recoder_.DeSerialize(fp)) return false;
     RecodedCharID code;
     recoder_.EncodeUnichar(UNICHAR_SPACE, &code);
     if (code(0) != UNICHAR_SPACE) {
@@ -114,7 +113,6 @@ bool LSTMRecognizer::DeSerialize(bool swap, TFile* fp) {
       return false;
     }
   }
-  // TODO(rays) swaps!
   network_->SetRandomizer(&randomizer_);
   network_->CacheXScaleFactor(network_->XScaleFactor());
   return true;

--- a/lstm/lstmrecognizer.h
+++ b/lstm/lstmrecognizer.h
@@ -158,8 +158,7 @@ class LSTMRecognizer {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool swap, TFile* fp);
+  bool DeSerialize(TFile* fp);
   // Loads the dictionary if possible from the traineddata file.
   // Prints a warning message, and returns false but otherwise fails silently
   // and continues to work without it if loading fails.

--- a/lstm/lstmtrainer.cpp
+++ b/lstm/lstmtrainer.cpp
@@ -480,9 +480,8 @@ bool LSTMTrainer::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool LSTMTrainer::DeSerialize(bool swap, TFile* fp) {
-  if (!LSTMRecognizer::DeSerialize(swap, fp)) return false;
+bool LSTMTrainer::DeSerialize(TFile* fp) {
+  if (!LSTMRecognizer::DeSerialize(fp)) return false;
   if (fp->FRead(&learning_iteration_, sizeof(learning_iteration_), 1) != 1) {
     // Special case. If we successfully decoded the recognizer, but fail here
     // then it means we were just given a recognizer, so issue a warning and
@@ -500,7 +499,7 @@ bool LSTMTrainer::DeSerialize(bool swap, TFile* fp) {
                 sizeof(last_perfect_training_iteration_), 1) != 1)
     return false;
   for (int i = 0; i < ET_COUNT; ++i) {
-    if (!error_buffers_[i].DeSerialize(swap, fp)) return false;
+    if (!error_buffers_[i].DeSerialize(fp)) return false;
   }
   if (fp->FRead(&error_rates_, sizeof(error_rates_), 1) != 1) return false;
   if (fp->FRead(&training_stage_, sizeof(training_stage_), 1) != 1)
@@ -522,12 +521,12 @@ bool LSTMTrainer::DeSerialize(bool swap, TFile* fp) {
     return false;
   if (fp->FRead(&stall_iteration_, sizeof(stall_iteration_), 1) != 1)
     return false;
-  if (!best_model_data_.DeSerialize(swap, fp)) return false;
-  if (!worst_model_data_.DeSerialize(swap, fp)) return false;
-  if (amount != NO_BEST_TRAINER && !best_trainer_.DeSerialize(swap, fp))
+  if (!best_model_data_.DeSerialize(fp)) return false;
+  if (!worst_model_data_.DeSerialize(fp)) return false;
+  if (amount != NO_BEST_TRAINER && !best_trainer_.DeSerialize(fp))
     return false;
   GenericVector<char> sub_data;
-  if (!sub_data.DeSerialize(swap, fp)) return false;
+  if (!sub_data.DeSerialize(fp)) return false;
   delete sub_trainer_;
   if (sub_data.empty()) {
     sub_trainer_ = NULL;
@@ -535,8 +534,8 @@ bool LSTMTrainer::DeSerialize(bool swap, TFile* fp) {
     sub_trainer_ = new LSTMTrainer();
     if (!ReadTrainingDump(sub_data, sub_trainer_)) return false;
   }
-  if (!best_error_history_.DeSerialize(swap, fp)) return false;
-  if (!best_error_iterations_.DeSerialize(swap, fp)) return false;
+  if (!best_error_history_.DeSerialize(fp)) return false;
+  if (!best_error_iterations_.DeSerialize(fp)) return false;
   if (fp->FRead(&improvement_steps_, sizeof(improvement_steps_), 1) != 1)
     return false;
   return true;
@@ -925,7 +924,7 @@ bool LSTMTrainer::ReadTrainingDump(const GenericVector<char>& data,
 bool LSTMTrainer::ReadSizedTrainingDump(const char* data, int size) {
   TFile fp;
   fp.Open(data, size);
-  return DeSerialize(false, &fp);
+  return DeSerialize(&fp);
 }
 
 // Writes the recognizer to memory, so that it can be used for testing later.
@@ -943,7 +942,7 @@ LSTMRecognizer* LSTMTrainer::ReadRecognitionDump(
   TFile fp;
   fp.Open(&data[0], data.size());
   LSTMRecognizer* recognizer = new LSTMRecognizer;
-  ASSERT_HOST(recognizer->DeSerialize(false, &fp));
+  ASSERT_HOST(recognizer->DeSerialize(&fp));
   return recognizer;
 }
 

--- a/lstm/lstmtrainer.h
+++ b/lstm/lstmtrainer.h
@@ -215,8 +215,7 @@ class LSTMTrainer : public LSTMRecognizer {
   // Writes to the given file. Returns false in case of error.
   virtual bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  virtual bool DeSerialize(bool swap, TFile* fp);
+  virtual bool DeSerialize(TFile* fp);
 
   // De-serializes the saved best_trainer_ into sub_trainer_, and adjusts the
   // learning rates (by scaling reduction, or layer specific, according to

--- a/lstm/maxpool.cpp
+++ b/lstm/maxpool.cpp
@@ -31,9 +31,8 @@ Maxpool::~Maxpool() {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool Maxpool::DeSerialize(bool swap, TFile* fp) {
-  bool result = Reconfig::DeSerialize(swap, fp);
+bool Maxpool::DeSerialize(TFile* fp) {
+  bool result = Reconfig::DeSerialize(fp);
   no_ = ni_;
   return result;
 }

--- a/lstm/maxpool.h
+++ b/lstm/maxpool.h
@@ -40,8 +40,7 @@ class Maxpool : public Reconfig {
   }
 
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  virtual bool DeSerialize(bool swap, TFile* fp);
+  virtual bool DeSerialize(TFile* fp);
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.

--- a/lstm/network.cpp
+++ b/lstm/network.cpp
@@ -164,14 +164,13 @@ bool Network::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
 // Should be overridden by subclasses, but NOT called by their DeSerialize.
-bool Network::DeSerialize(bool swap, TFile* fp) {
+bool Network::DeSerialize(TFile* fp) {
   inT8 data = 0;
   if (fp->FRead(&data, sizeof(data), 1) != 1) return false;
   if (data == NT_NONE) {
     STRING type_name;
-    if (!type_name.DeSerialize(swap, fp)) return false;
+    if (!type_name.DeSerialize(fp)) return false;
     for (data = 0; data < NT_COUNT && type_name != kTypeNames[data]; ++data) {
     }
     if (data == NT_COUNT) {
@@ -188,23 +187,16 @@ bool Network::DeSerialize(bool swap, TFile* fp) {
   if (fp->FRead(&ni_, sizeof(ni_), 1) != 1) return false;
   if (fp->FRead(&no_, sizeof(no_), 1) != 1) return false;
   if (fp->FRead(&num_weights_, sizeof(num_weights_), 1) != 1) return false;
-  if (!name_.DeSerialize(swap, fp)) return false;
-  if (swap) {
-    ReverseN(&network_flags_, sizeof(network_flags_));
-    ReverseN(&ni_, sizeof(ni_));
-    ReverseN(&no_, sizeof(no_));
-    ReverseN(&num_weights_, sizeof(num_weights_));
-  }
+  if (!name_.DeSerialize(fp)) return false;
   return true;
 }
 
 // Reads from the given file. Returns NULL in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
 // Determines the type of the serialized class and calls its DeSerialize
 // on a new object of the appropriate type, which is returned.
-Network* Network::CreateFromFile(bool swap, TFile* fp) {
+Network* Network::CreateFromFile(TFile* fp) {
   Network stub;
-  if (!stub.DeSerialize(swap, fp)) return NULL;
+  if (!stub.DeSerialize(fp)) return NULL;
   Network* network = NULL;
   switch (stub.type_) {
     case NT_CONVOLVE:
@@ -269,7 +261,7 @@ Network* Network::CreateFromFile(bool swap, TFile* fp) {
   network->needs_to_backprop_ = stub.needs_to_backprop_;
   network->network_flags_ = stub.network_flags_;
   network->num_weights_ = stub.num_weights_;
-  if (!network->DeSerialize(swap, fp)) {
+  if (!network->DeSerialize(fp)) {
     delete network;
     return NULL;
   }

--- a/lstm/network.h
+++ b/lstm/network.h
@@ -208,9 +208,8 @@ class Network {
   // Should be overridden by subclasses, but called by their Serialize.
   virtual bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
   // Should be overridden by subclasses, but NOT called by their DeSerialize.
-  virtual bool DeSerialize(bool swap, TFile* fp);
+  virtual bool DeSerialize(TFile* fp);
 
   // Updates the weights using the given learning rate and momentum.
   // num_samples is the quotient to be used in the adagrad computation iff
@@ -223,10 +222,9 @@ class Network {
                                 double* changed) const {}
 
   // Reads from the given file. Returns NULL in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
   // Determines the type of the serialized class and calls its DeSerialize
   // on a new object of the appropriate type, which is returned.
-  static Network* CreateFromFile(bool swap, TFile* fp);
+  static Network* CreateFromFile(TFile* fp);
 
   // Runs forward propagation of activations on the input line.
   // Note that input and output are both 2-d arrays.

--- a/lstm/plumbing.cpp
+++ b/lstm/plumbing.cpp
@@ -187,19 +187,18 @@ bool Plumbing::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool Plumbing::DeSerialize(bool swap, TFile* fp) {
+bool Plumbing::DeSerialize(TFile* fp) {
   stack_.truncate(0);
   no_ = 0;  // We will be modifying this as we AddToStack.
   inT32 size;
   if (fp->FRead(&size, sizeof(size), 1) != 1) return false;
   for (int i = 0; i < size; ++i) {
-    Network* network = CreateFromFile(swap, fp);
+    Network* network = CreateFromFile(fp);
     if (network == NULL) return false;
     AddToStack(network);
   }
   if ((network_flags_ & NF_LAYER_SPECIFIC_LR) &&
-      !learning_rates_.DeSerialize(swap, fp)) {
+      !learning_rates_.DeSerialize(fp)) {
     return false;
   }
   return true;

--- a/lstm/plumbing.h
+++ b/lstm/plumbing.h
@@ -116,8 +116,7 @@ class Plumbing : public Network {
   // Writes to the given file. Returns false in case of error.
   virtual bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  virtual bool DeSerialize(bool swap, TFile* fp);
+  virtual bool DeSerialize(TFile* fp);
 
   // Updates the weights using the given learning rate and momentum.
   // num_samples is the quotient to be used in the adagrad computation iff

--- a/lstm/reconfig.cpp
+++ b/lstm/reconfig.cpp
@@ -59,14 +59,9 @@ bool Reconfig::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool Reconfig::DeSerialize(bool swap, TFile* fp) {
+bool Reconfig::DeSerialize(TFile* fp) {
   if (fp->FRead(&x_scale_, sizeof(x_scale_), 1) != 1) return false;
   if (fp->FRead(&y_scale_, sizeof(y_scale_), 1) != 1) return false;
-  if (swap) {
-    ReverseN(&x_scale_, sizeof(x_scale_));
-    ReverseN(&y_scale_, sizeof(y_scale_));
-  }
   no_ = ni_ * x_scale_ * y_scale_;
   return true;
 }

--- a/lstm/reconfig.h
+++ b/lstm/reconfig.h
@@ -57,8 +57,7 @@ class Reconfig : public Network {
   // Writes to the given file. Returns false in case of error.
   virtual bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  virtual bool DeSerialize(bool swap, TFile* fp);
+  virtual bool DeSerialize(TFile* fp);
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.

--- a/lstm/tfnetwork.cpp
+++ b/lstm/tfnetwork.cpp
@@ -53,11 +53,10 @@ bool TFNetwork::Serialize(TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
 // Should be overridden by subclasses, but NOT called by their DeSerialize.
-bool TFNetwork::DeSerialize(bool swap, TFile* fp) {
+bool TFNetwork::DeSerialize(TFile* fp) {
   GenericVector<char> data;
-  if (!data.DeSerialize(swap, fp)) return false;
+  if (!data.DeSerialize(fp)) return false;
   if (!model_proto_.ParseFromArray(&data[0], data.size())) {
     return false;
   }

--- a/lstm/tfnetwork.h
+++ b/lstm/tfnetwork.h
@@ -59,9 +59,8 @@ class TFNetwork : public Network {
   // Should be overridden by subclasses, but called by their Serialize.
   virtual bool Serialize(TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
   // Should be overridden by subclasses, but NOT called by their DeSerialize.
-  virtual bool DeSerialize(bool swap, TFile* fp);
+  virtual bool DeSerialize(TFile* fp);
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.

--- a/lstm/weightmatrix.cpp
+++ b/lstm/weightmatrix.cpp
@@ -121,22 +121,21 @@ bool WeightMatrix::Serialize(bool training, TFile* fp) const {
 }
 
 // Reads from the given file. Returns false in case of error.
-// If swap is true, assumes a big/little-endian swap is needed.
-bool WeightMatrix::DeSerialize(bool training, bool swap, TFile* fp) {
+bool WeightMatrix::DeSerialize(bool training, TFile* fp) {
   uinT8 mode = 0;
   if (fp->FRead(&mode, sizeof(mode), 1) != 1) return false;
   int_mode_ = (mode & kInt8Flag) != 0;
   use_ada_grad_ = (mode & kAdaGradFlag) != 0;
-  if ((mode & kDoubleFlag) == 0) return DeSerializeOld(training, swap, fp);
+  if ((mode & kDoubleFlag) == 0) return DeSerializeOld(training, fp);
   if (int_mode_) {
-    if (!wi_.DeSerialize(swap, fp)) return false;
-    if (!scales_.DeSerialize(swap, fp)) return false;
+    if (!wi_.DeSerialize(fp)) return false;
+    if (!scales_.DeSerialize(fp)) return false;
   } else {
-    if (!wf_.DeSerialize(swap, fp)) return false;
+    if (!wf_.DeSerialize(fp)) return false;
     if (training) {
       InitBackward(use_ada_grad_);
-      if (!updates_.DeSerialize(swap, fp)) return false;
-      if (use_ada_grad_ && !dw_sq_sum_.DeSerialize(swap, fp)) return false;
+      if (!updates_.DeSerialize(fp)) return false;
+      if (use_ada_grad_ && !dw_sq_sum_.DeSerialize(fp)) return false;
     }
   }
   return true;
@@ -144,24 +143,24 @@ bool WeightMatrix::DeSerialize(bool training, bool swap, TFile* fp) {
 
 // As DeSerialize, but reads an old (float) format WeightMatrix for
 // backward compatibility.
-bool WeightMatrix::DeSerializeOld(bool training, bool swap, TFile* fp) {
+bool WeightMatrix::DeSerializeOld(bool training, TFile* fp) {
   GENERIC_2D_ARRAY<float> float_array;
   if (int_mode_) {
-    if (!wi_.DeSerialize(swap, fp)) return false;
+    if (!wi_.DeSerialize(fp)) return false;
     GenericVector<float> old_scales;
-    if (!old_scales.DeSerialize(swap, fp)) return false;
+    if (!old_scales.DeSerialize(fp)) return false;
     scales_.init_to_size(old_scales.size(), 0.0);
     for (int i = 0; i < old_scales.size(); ++i) scales_[i] = old_scales[i];
   } else {
-    if (!float_array.DeSerialize(swap, fp)) return false;
+    if (!float_array.DeSerialize(fp)) return false;
     FloatToDouble(float_array, &wf_);
   }
   if (training) {
     InitBackward(use_ada_grad_);
-    if (!float_array.DeSerialize(swap, fp)) return false;
+    if (!float_array.DeSerialize(fp)) return false;
     FloatToDouble(float_array, &updates_);
     // Errs was only used in int training, which is now dead.
-    if (!float_array.DeSerialize(swap, fp)) return false;
+    if (!float_array.DeSerialize(fp)) return false;
   }
   return true;
 }

--- a/lstm/weightmatrix.h
+++ b/lstm/weightmatrix.h
@@ -97,11 +97,10 @@ class WeightMatrix {
   // Writes to the given file. Returns false in case of error.
   bool Serialize(bool training, TFile* fp) const;
   // Reads from the given file. Returns false in case of error.
-  // If swap is true, assumes a big/little-endian swap is needed.
-  bool DeSerialize(bool training, bool swap, TFile* fp);
+  bool DeSerialize(bool training, TFile* fp);
   // As DeSerialize, but reads an old (float) format WeightMatrix for
   // backward compatibility.
-  bool DeSerializeOld(bool training, bool swap, TFile* fp);
+  bool DeSerializeOld(bool training, TFile* fp);
 
   // Computes matrix.vector v = Wu.
   // u is of size W.dim2() - 1 and the output v is of size W.dim1().

--- a/training/commontraining.cpp
+++ b/training/commontraining.cpp
@@ -121,7 +121,7 @@ ShapeTable* LoadShapeTable(const STRING& file_prefix) {
   FILE* shape_fp = fopen(shape_table_file.string(), "rb");
   if (shape_fp != nullptr) {
     shape_table = new ShapeTable;
-    if (!shape_table->DeSerialize(false, shape_fp)) {
+    if (!shape_table->DeSerialize(shape_fp)) {
       delete shape_table;
       shape_table = nullptr;
       tprintf("Error: Failed to read shape table %s\n",
@@ -259,7 +259,7 @@ MasterTrainer* LoadTrainingData(int argc, const char* const * argv,
       tprintf("Can't read file %s to initialize master trainer\n",
               FLAGS_T.c_str());
     } else {
-      success = trainer->DeSerialize(false, fp);
+      success = trainer->DeSerialize(fp);
       fclose(fp);
     }
     if (!success) {


### PR DESCRIPTION
Remove all code for auto detection of endianness used in data files.
This prepares the switch to data files with fixed endianness.

Signed-off-by: Stefan Weil <sw@weilnetz.de>