### PR TITLE
Use portable data types

### DIFF
--- a/ccstruct/fontinfo.cpp
+++ b/ccstruct/fontinfo.cpp
@@ -241,7 +241,7 @@ bool read_set(FILE* f, FontSet* fs, bool swap) {
   if (fread(&fs->size, sizeof(fs->size), 1, f) != 1) return false;
   if (swap)
     Reverse32(&fs->size);
-  fs->configs = new int[fs->size];
+  fs->configs = new int32_t[fs->size];
   for (int i = 0; i < fs->size; ++i) {
     if (fread(&fs->configs[i], sizeof(fs->configs[i]), 1, f) != 1) return false;
     if (swap)

--- a/ccstruct/fontinfo.h
+++ b/ccstruct/fontinfo.h
@@ -135,8 +135,8 @@ struct FontInfo {
 // the FontInfo in the FontSet structure, it's better to share FontInfos among
 // FontSets (Classify::fontinfo_table_).
 struct FontSet {
-  int           size;
-  int*          configs;  // FontInfo ids
+  int32_t       size;
+  int32_t*      configs;  // FontInfo ids
 };
 
 // Class that adds a bit of functionality on top of GenericVector to

--- a/classify/adaptive.cpp
+++ b/classify/adaptive.cpp
@@ -311,8 +311,8 @@ void Classify::PrintAdaptedTemplates(FILE *File, ADAPT_TEMPLATES Templates) {
  * @note History: Tue Mar 19 14:11:01 1991, DSJ, Created.
  */
 ADAPT_CLASS ReadAdaptedClass(FILE *File) {
-  int NumTempProtos;
-  int NumConfigs;
+  int32_t NumTempProtos;
+  int32_t NumConfigs;
   int i;
   ADAPT_CLASS Class;
   TEMP_PROTO TempProto;
@@ -330,7 +330,7 @@ ADAPT_CLASS ReadAdaptedClass(FILE *File) {
     WordsInVectorOfSize (MAX_NUM_CONFIGS), File);
 
   /* then read in the list of temporary protos */
-  fread ((char *) &NumTempProtos, sizeof (int), 1, File);
+  fread (&NumTempProtos, sizeof(NumTempProtos), 1, File);
   Class->TempProtos = NIL_LIST;
   for (i = 0; i < NumTempProtos; i++) {
     TempProto =
@@ -341,7 +341,7 @@ ADAPT_CLASS ReadAdaptedClass(FILE *File) {
   }
 
   /* then read in the adapted configs */
-  fread ((char *) &NumConfigs, sizeof (int), 1, File);
+  fread (&NumConfigs, sizeof(NumConfigs), 1, File);
   for (i = 0; i < NumConfigs; i++)
     if (test_bit (Class->PermConfigs, i))
       Class->Config[i].Perm = ReadPermConfig (File);


### PR DESCRIPTION
Any variables which are read from a file must use a portable data type
with a well defined size.

Signed-off-by: Stefan Weil <sw@weilnetz.de>