### PR TITLE
Replace alloc_struct, free_struct

### DIFF
--- a/ccstruct/rejctmap.cpp
+++ b/ccstruct/rejctmap.cpp
@@ -265,9 +265,9 @@ void REJ::full_print(FILE *fp) {
 }
 
 
-//The REJMAP class has been hacked to use alloc_struct instead of new [].
+//The REJMAP class has been hacked to use malloc instead of new [].
 //This is to reduce memory fragmentation only as it is rather kludgy.
-// alloc_struct by-passes the call to the constructor of REJ on each
+// malloc by-passes the call to the constructor of REJ on each
 // array element. Although the constructor is empty, the BITS16 members
 // do have a constructor which sets all the flags to 0. The memset
 // replaces this functionality.
@@ -281,7 +281,7 @@ REJMAP::REJMAP(  //classwise copy
   len = source.length ();
 
   if (len > 0) {
-    ptr = (REJ *) alloc_struct (len * sizeof (REJ), "REJ");
+    ptr = (REJ *) malloc(len * sizeof (REJ));
     to = ptr;
     for (i = 0; i < len; i++) {
       *to = *from;
@@ -317,12 +317,10 @@ const REJMAP & source            //from this
 
 void REJMAP::initialise(  //Redefine map
                         inT16 length) {
-  if (ptr != NULL)
-    free_struct (ptr, len * sizeof (REJ), "REJ");
+  free(ptr);
   len = length;
   if (len > 0)
-    ptr = (REJ *) memset (alloc_struct (len * sizeof (REJ), "REJ"),
-      0, len * sizeof (REJ));
+    ptr = (REJ *) calloc(len, sizeof(REJ));
   else
     ptr = NULL;
 }
@@ -374,8 +372,7 @@ void REJMAP::remove_pos(           //Cut out an element
 
   len--;
   if (len > 0)
-    new_ptr = (REJ *) memset (alloc_struct (len * sizeof (REJ), "REJ"),
-      0, len * sizeof (REJ));
+    new_ptr = (REJ *) malloc(len * sizeof(REJ));
   else
     new_ptr = NULL;
 
@@ -386,7 +383,7 @@ void REJMAP::remove_pos(           //Cut out an element
     new_ptr[pos] = ptr[pos + 1]; //copy post pos
 
                                  //delete old map
-  free_struct (ptr, (len + 1) * sizeof (REJ), "REJ");
+  free(ptr);
   ptr = new_ptr;
 }
 

--- a/ccstruct/rejctmap.h
+++ b/ccstruct/rejctmap.h
@@ -219,8 +219,7 @@ class REJMAP
       const REJMAP & source);    //from this
 
     ~REJMAP () {                 //destructor
-      if (ptr != NULL)
-        free_struct (ptr, len * sizeof (REJ), "REJ");
+      free(ptr);
     }
 
     void initialise(  //Redefine map

--- a/ccutil/memry.cpp
+++ b/ccutil/memry.cpp
@@ -36,14 +36,6 @@ void free_string(char *string) {
   free(string);
 }
 
-void* alloc_struct(inT32 count, const char *) {
-  return malloc(count);
-}
-
-void free_struct(void *deadstruct, inT32, const char *) {
-  free(deadstruct);
-}
-
 void *alloc_mem(inT32 count) {
   return malloc(static_cast<size_t>(count));
 }

--- a/ccutil/memry.h
+++ b/ccutil/memry.h
@@ -27,10 +27,6 @@
 extern char *alloc_string(inT32 count);
 // free a string.
 extern void free_string(char *string);
-// allocate memory
-extern void *alloc_struct(inT32 count, const char *name = NULL);
-// free a structure.
-extern void free_struct(void *deadstruct, inT32, const char *name = NULL);
 // get some memory
 extern void *alloc_mem(inT32 count);
 // get some memory initialized to 0.

--- a/classify/adaptive.cpp
+++ b/classify/adaptive.cpp
@@ -84,7 +84,7 @@ void FreeTempConfig(TEMP_CONFIG Config) {
 
   destroy_nodes (Config->ContextsSeen, memfree);
   FreeBitVector (Config->Protos);
-  free_struct (Config, sizeof (TEMP_CONFIG_STRUCT), "TEMP_CONFIG_STRUCT");
+  free(Config);
 
 }                                /* FreeTempConfig */
 
@@ -92,13 +92,13 @@ void FreeTempConfig(TEMP_CONFIG Config) {
 void FreeTempProto(void *arg) {
   PROTO proto = (PROTO) arg;
 
-  free_struct (proto, sizeof (TEMP_PROTO_STRUCT), "TEMP_PROTO_STRUCT");
+  free(proto);
 }
 
 void FreePermConfig(PERM_CONFIG Config) {
   assert(Config != NULL);
   delete [] Config->Ambigs;
-  free_struct(Config, sizeof(PERM_CONFIG_STRUCT), "PERM_CONFIG_STRUCT");
+  free(Config);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -223,12 +223,9 @@ void free_adapted_templates(ADAPT_TEMPLATES templates) {
  * @note History: Thu Mar 14 13:28:21 1991, DSJ, Created.
  */
 TEMP_CONFIG NewTempConfig(int MaxProtoId, int FontinfoId) {
-  TEMP_CONFIG Config;
   int NumProtos = MaxProtoId + 1;
 
-  Config =
-    (TEMP_CONFIG) alloc_struct (sizeof (TEMP_CONFIG_STRUCT),
-    "TEMP_CONFIG_STRUCT");
+  TEMP_CONFIG Config = (TEMP_CONFIG) malloc(sizeof(TEMP_CONFIG_STRUCT));
   Config->Protos = NewBitVector (NumProtos);
 
   Config->NumTimesSeen = 1;
@@ -254,8 +251,7 @@ TEMP_CONFIG NewTempConfig(int MaxProtoId, int FontinfoId) {
  * @note History: Thu Mar 14 13:31:31 1991, DSJ, Created.
  */
 TEMP_PROTO NewTempProto() {
-  return ((TEMP_PROTO)
-    alloc_struct (sizeof (TEMP_PROTO_STRUCT), "TEMP_PROTO_STRUCT"));
+  return (TEMP_PROTO) malloc(sizeof(TEMP_PROTO_STRUCT));
 }                                /* NewTempProto */
 
 
@@ -317,7 +313,6 @@ ADAPT_CLASS ReadAdaptedClass(TFile *fp) {
   int NumConfigs;
   int i;
   ADAPT_CLASS Class;
-  TEMP_PROTO TempProto;
 
   /* first read high level adapted class structure */
   Class = (ADAPT_CLASS) Emalloc (sizeof (ADAPT_CLASS_STRUCT));
@@ -335,9 +330,7 @@ ADAPT_CLASS ReadAdaptedClass(TFile *fp) {
   fp->FRead(&NumTempProtos, sizeof(int), 1);
   Class->TempProtos = NIL_LIST;
   for (i = 0; i < NumTempProtos; i++) {
-    TempProto =
-      (TEMP_PROTO) alloc_struct (sizeof (TEMP_PROTO_STRUCT),
-      "TEMP_PROTO_STRUCT");
+    TEMP_PROTO TempProto = (TEMP_PROTO) malloc(sizeof(TEMP_PROTO_STRUCT));
     fp->FRead(TempProto, sizeof(TEMP_PROTO_STRUCT), 1);
     Class->TempProtos = push_last (Class->TempProtos, TempProto);
   }
@@ -402,8 +395,7 @@ ADAPT_TEMPLATES Classify::ReadAdaptedTemplates(TFile *fp) {
  * @note History: Tue Mar 19 14:25:26 1991, DSJ, Created.
  */
 PERM_CONFIG ReadPermConfig(TFile *fp) {
-  PERM_CONFIG Config = (PERM_CONFIG) alloc_struct(sizeof(PERM_CONFIG_STRUCT),
-                                                  "PERM_CONFIG_STRUCT");
+  PERM_CONFIG Config = (PERM_CONFIG) malloc(sizeof(PERM_CONFIG_STRUCT));
   uinT8 NumAmbigs;
   fp->FRead(&NumAmbigs, sizeof(uinT8), 1);
   Config->Ambigs = new UNICHAR_ID[NumAmbigs + 1];
@@ -429,11 +421,7 @@ PERM_CONFIG ReadPermConfig(TFile *fp) {
  * @note History: Tue Mar 19 14:29:59 1991, DSJ, Created.
  */
 TEMP_CONFIG ReadTempConfig(TFile *fp) {
-  TEMP_CONFIG Config;
-
-  Config =
-    (TEMP_CONFIG) alloc_struct (sizeof (TEMP_CONFIG_STRUCT),
-    "TEMP_CONFIG_STRUCT");
+  TEMP_CONFIG Config = (TEMP_CONFIG) malloc(sizeof(TEMP_CONFIG_STRUCT));
   fp->FRead(Config, sizeof(TEMP_CONFIG_STRUCT), 1);
 
   Config->Protos = NewBitVector (Config->ProtoVectorSize * BITSINLONG);

--- a/classify/adaptmatch.cpp
+++ b/classify/adaptmatch.cpp
@@ -1980,8 +1980,7 @@ void Classify::MakePermanent(ADAPT_TEMPLATES Templates,
 
   // Initialize permanent config.
   Ambigs = GetAmbiguities(Blob, ClassId);
-  PERM_CONFIG Perm = (PERM_CONFIG) alloc_struct(sizeof(PERM_CONFIG_STRUCT),
-                                                "PERM_CONFIG_STRUCT");
+  PERM_CONFIG Perm = (PERM_CONFIG) malloc(sizeof(PERM_CONFIG_STRUCT));
   Perm->Ambigs = Ambigs;
   Perm->FontinfoId = Config->FontinfoId;
 

--- a/classify/mfoutline.cpp
+++ b/classify/mfoutline.cpp
@@ -160,7 +160,7 @@ void FreeMFOutline(void *arg) {  //MFOUTLINE                             Outline
   Start = list_rest (Outline);
   set_rest(Outline, NIL_LIST);
   while (Start != NULL) {
-    free_struct (first_node (Start), sizeof (MFEDGEPT), "MFEDGEPT");
+    free(first_node(Start));
     Start = pop (Start);
   }
 
@@ -219,7 +219,7 @@ void MarkDirectionChanges(MFOUTLINE Outline) {
 /*---------------------------------------------------------------------------*/
 /** Return a new edge point for a micro-feature outline. */
 MFEDGEPT *NewEdgePoint() {
-  return ((MFEDGEPT *) alloc_struct(sizeof(MFEDGEPT), "MFEDGEPT"));
+  return (MFEDGEPT *) malloc(sizeof(MFEDGEPT));
 }
 
 

--- a/classify/ocrfeatures.cpp
+++ b/classify/ocrfeatures.cpp
@@ -58,12 +58,7 @@ BOOL8 AddFeature(FEATURE_SET FeatureSet, FEATURE Feature) {
  * @note History: Mon May 21 13:33:27 1990, DSJ, Created.
  */
 void FreeFeature(FEATURE Feature) {
-  if (Feature) {
-    free_struct (Feature, sizeof (FEATURE_STRUCT)
-      + sizeof (FLOAT32) * (Feature->Type->NumParams - 1),
-      "sizeof(FEATURE_STRUCT)+sizeof(FLOAT32)*(NumParamsIn(Feature)-1)");
-  }
-
+  free(Feature);
 }                                /* FreeFeature */
 
 /**
@@ -94,10 +89,9 @@ void FreeFeatureSet(FEATURE_SET FeatureSet) {
 FEATURE NewFeature(const FEATURE_DESC_STRUCT* FeatureDesc) {
   FEATURE Feature;
 
-  Feature = (FEATURE) alloc_struct (sizeof (FEATURE_STRUCT) +
+  Feature = (FEATURE) malloc(sizeof(FEATURE_STRUCT) +
     (FeatureDesc->NumParams - 1) *
-    sizeof (FLOAT32),
-    "sizeof(FEATURE_STRUCT)+sizeof(FLOAT32)*(NumParamsIn(Feature)-1)");
+    sizeof (FLOAT32));
   Feature->Type = FeatureDesc;
   return (Feature);
 


### PR DESCRIPTION
Both functions simply call malloc, free.

Remove also unneeded null pointer checks and use calloc where possible.

Signed-off-by: Stefan Weil <sw@weilnetz.de>