### PR TITLE
Fix indentation after conditional [-Wmisleading-indentation]

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -985,8 +985,8 @@ bool TessBaseAPI::ProcessPagesMultipageTiff(const l_uint8 *data,
   for (; ; ++page) {
     if (tessedit_page_number >= 0)
       page = tessedit_page_number;
-      pix = (data) ? pixReadMemFromMultipageTiff(data, size, &offset)
-                   : pixReadFromMultipageTiff(filename, &offset);
+    pix = (data) ? pixReadMemFromMultipageTiff(data, size, &offset)
+                 : pixReadFromMultipageTiff(filename, &offset);
     if (pix == NULL) break;
     tprintf("Page %d\n", page + 1);
     char page_str[kMaxIntSize];


### PR DESCRIPTION
The indentation is wrong since commit
fd0683f9e03934bbdf7fbebb4d21d64c37b68bc0 and results in a gcc warning:

api/baseapi.cpp: In member function 'bool tesseract::TessBaseAPI::ProcessPagesMultipageTiff(const l_uint8*, size_t, const char*, const char*, int, tesseract::TessResultRenderer*, int)':
api/baseapi.cpp:986:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if (tessedit_page_number >= 0)
     ^~
api/baseapi.cpp:988:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
       pix = (data) ? pixReadMemFromMultipageTiff(data, size, &offset)
       ^~~

Signed-off-by: Stefan Weil <sw@weilnetz.de>