### PR TITLE
[`autogen.sh`:]  Abstract the absolute path of `libtoolize` or `glibtoolize` away into `$LIBTOOLIZE`.  

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -46,6 +46,18 @@ if [ "$1" = "clean" ]; then
     find . -iname "Makefile.in" -type f -exec rm '{}' +
 fi
 
+# Prevent any errors that might result from failing to properly invoke `libtoolize` or `glibtoolize,` whichever 
+# is present on your system, from occurring by testing for its existence and capturing the absolute path to its 
+# location for caching purposes prior to using it later on in 'Step 2:'  
+if command -v libtoolize >/dev/null 2>&1; then
+  LIBTOOLIZE="$(command -v libtoolize)"
+elif command -v glibtoolize >/dev/null 2>&1; then
+  LIBTOOLIZE="$(command -v glibtoolize)"
+else
+  echo "Unable to find a valid copy of libtoolize in your PATH!"
+  bail_out
+fi
+
 # create m4 directory if it not exists
 if [ ! -d m4 ];  then
     mkdir m4
@@ -71,8 +83,8 @@ aclocal -I config || bail_out
 # --- Step 2:
 
 echo "Running libtoolize"
-libtoolize -f -c || glibtoolize -f -c || bail_out
-libtoolize --automake || glibtoolize --automake || bail_out
+$LIBTOOLIZE -f -c || bail_out
+$LIBTOOLIZE --automake || bail_out
 
 # --- Step 3: Generate config.h.in from:
 #             . configure.ac (look for AM_CONFIG_HEADER tag or AC_CONFIG_HEADER tag)

--- a/autogen.sh
+++ b/autogen.sh
@@ -83,7 +83,7 @@ aclocal -I config || bail_out
 
 # --- Step 2:
 
-echo "Running libtoolize"
+echo "Running $LIBTOOLIZE"
 $LIBTOOLIZE -f -c || bail_out
 $LIBTOOLIZE --automake || bail_out
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -46,9 +46,10 @@ if [ "$1" = "clean" ]; then
     find . -iname "Makefile.in" -type f -exec rm '{}' +
 fi
 
-# Prevent any errors that might result from failing to properly invoke `libtoolize` or `glibtoolize,` whichever 
-# is present on your system, from occurring by testing for its existence and capturing the absolute path to its 
-# location for caching purposes prior to using it later on in 'Step 2:'  
+# Prevent any errors that might result from failing to properly invoke 
+# `libtoolize` or `glibtoolize,` whichever is present on your system, 
+# from occurring by testing for its existence and capturing the absolute path to 
+# its location for caching purposes prior to using it later on in 'Step 2:'  
 if command -v libtoolize >/dev/null 2>&1; then
   LIBTOOLIZE="$(command -v libtoolize)"
 elif command -v glibtoolize >/dev/null 2>&1; then

--- a/autogen.sh
+++ b/autogen.sh
@@ -55,7 +55,7 @@ if command -v libtoolize >/dev/null 2>&1; then
 elif command -v glibtoolize >/dev/null 2>&1; then
   LIBTOOLIZE="$(command -v glibtoolize)"
 else
-  echo "Unable to find a valid copy of libtoolize in your PATH!"
+  echo "Unable to find a valid copy of libtoolize or glibtoolize in your PATH!"
   bail_out
 fi
 


### PR DESCRIPTION
Increase portability by insulating `autogen.sh` from platform variance.  

<hr />

Specifically, test for the existence of either `libtoolize` or `glibtoolize` and caching its location into a script variable prior to running the utility in order to prevent either utility's invocation from spawning error messages of the form './autogen.sh: line $LINE: $COMMAND: command not found' (with the $LINE and $COMMAND pseudo-variables replaced with content relevant to what line the command that spawned this error message was on within `autogen.sh` and what command's invocation was attempted at that point, of course.)  In particular, this takes into account macOS's wonky `libtool` semantics, which involve the following idiosyncrasies:  

* The version of `libtool` that Apple bundles within both Xcode and its separate associated 'Command-Line Developer Tools' package comes _without_ a copy of `libtoolize`.  
* macOS package managers like Homebrew and MacPorts typically install the GNU versions of `libtool` and `libtoolize` as `glibtool` and `glibtoolize`, respectively, when needed by another package as a dependency or otherwise requested by an end-user.  

The pre-existing code which was _supposed_ to handle this case was _not_ resilient with respect to errors finding either the system copy or the GNU variant of `libtoolize`, as it ran _both_ `libtoolize` and `glibtoolize`, in _that_ order, _without_ checking for the existence of _either_ utility!  (From the `man` page of the copy of `bash` included with macOS 'El Capitan' v10.11.6, which is reported to be `GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin15)` by `bash --version`:  

> ```
> …
>
> SHELL GRAMMAR
>
> …
>
>    Lists
>           A list is a sequence of one or more pipelines separated by one of the operators ;, &, &&, or ||,  and optionally terminated by one of ;, &, or <newline>.
>
>           Of  these  list  operators,  &&  and  || have equal precedence, followed by ; and &, which have equal precedence.
>
>           A sequence of one or more newlines may appear in a list instead of a semicolon to delimit commands.
>
>           If a command is terminated by the control operator &, the shell executes the  command  in  the  background in a subshell.  The shell does not wait for the command to finish, and the return status is 0.
>           Commands separated by a ; are executed sequentially; the shell waits for each command to terminate in turn.  The return status is the exit status of the last command executed.
>
>           The  control  operators  &&  and || denote AND lists and OR lists, respectively.  An AND list has the form
>
>                  command1 && command2
>
>           command2 is executed if, and only if, command1 returns an exit status of zero.
>
>           An OR list has the form
>
>                  command1 || command2
>
>           command2 is executed if and only if command1 returns a non-zero exit status.  The  return  status  of AND and OR lists is the exit status of the last command executed in the list.
>
> …
> ```

—&thinsp;_note_, however, that this text only implies that execution of the _second_ command in the `||` list can be short-circuited if the execution of the first command fails; that _first_ command is _always_ executed!)  

This root cause of this issue was initially clarified to me by the second half of [this comment](https://github.com/Homebrew/homebrew-core/issues/10380#issuecomment-283186646) on Homebrew/homebrew-core#10380 because it appeared as a red herring of a side effect during diagnosis of [that same issue](https://github.com/Homebrew/homebrew-core/issues/10380).  Per [this further comment](https://github.com/Homebrew/homebrew-core/issues/10380#issuecomment-283505099) on that issue, further corrections to `autogen.sh` may remain desired after the merger of this pull request into `master`.  This pull request should also be backported to at _least_ branch `3.05`.  