### PR TITLE
Backports for GRAPHICS_DISABLED build/libtiff underlinking

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -81,6 +81,8 @@ tesseract_LDADD = libtesseract.la
 
 tesseract_LDFLAGS = $(OPENCL_LDFLAGS)
 
+tesseract_LDADD += -ltiff
+
 if T_WIN
 tesseract_LDADD += -lws2_32
 libtesseract_la_LDFLAGS += -no-undefined -Wl,--as-needed -lws2_32

--- a/viewer/svutil.cpp
+++ b/viewer/svutil.cpp
@@ -83,6 +83,27 @@ void SVMutex::Unlock() {
 #endif
 }
 
+// Create new thread.
+void SVSync::StartThread(void *(*func)(void*), void* arg) {
+#ifdef _WIN32
+  LPTHREAD_START_ROUTINE f = (LPTHREAD_START_ROUTINE) func;
+  DWORD threadid;
+  HANDLE newthread = CreateThread(
+  NULL,          // default security attributes
+  0,             // use default stack size
+  f,             // thread function
+  arg,           // argument to thread function
+  0,             // use default creation flags
+  &threadid);    // returns the thread identifier
+#else
+  pthread_t helper;
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+  pthread_create(&helper, &attr, func, arg);
+#endif
+}
+
 #ifndef GRAPHICS_DISABLED
 
 const int kMaxMsgSize = 4096;
@@ -183,29 +204,6 @@ void SVSemaphore::Wait() {
   sem_wait(semaphore_);
 #else
   sem_wait(&semaphore_);
-#endif
-}
-
-
-// Create new thread.
-
-void SVSync::StartThread(void *(*func)(void*), void* arg) {
-#ifdef _WIN32
-  LPTHREAD_START_ROUTINE f = (LPTHREAD_START_ROUTINE) func;
-  DWORD threadid;
-  HANDLE newthread = CreateThread(
-  NULL,          // default security attributes
-  0,             // use default stack size
-  f,             // thread function
-  arg,           // argument to thread function
-  0,             // use default creation flags
-  &threadid);    // returns the thread identifier
-#else
-  pthread_t helper;
-  pthread_attr_t attr;
-  pthread_attr_init(&attr);
-  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-  pthread_create(&helper, &attr, func, arg);
 #endif
 }
 


### PR DESCRIPTION
SVSync::StartThread() is used in api/ , backporting the GRAPHICS_DISABLED fix
Backport api/ libtfiff missing dependency for win32 platform