### PR TITLE
Update Makefile.am (add 'lstm.train')

### DIFF
--- a/tessdata/configs/Makefile.am
+++ b/tessdata/configs/Makefile.am
@@ -1,3 +1,3 @@
 datadir = @datadir@/tessdata/configs
-data_DATA = inter makebox box.train unlv ambigs.train api_config kannada box.train.stderr quiet logfile digits hocr tsv linebox pdf rebox strokewidth bigram txt
-EXTRA_DIST = inter makebox box.train unlv ambigs.train api_config kannada box.train.stderr quiet logfile digits hocr tsv linebox pdf rebox strokewidth bigram txt
+data_DATA = inter makebox box.train unlv ambigs.train lstm.train api_config kannada box.train.stderr quiet logfile digits hocr tsv linebox pdf rebox strokewidth bigram txt
+EXTRA_DIST = inter makebox box.train unlv ambigs.train lstm.train api_config kannada box.train.stderr quiet logfile digits hocr tsv linebox pdf rebox strokewidth bigram txt


### PR DESCRIPTION
The  'lstm.train' config file doesn't install when `make install`. So, add entry for  'lstm.train'.