### PR TITLE
opencl: Add missing TIFF library for macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,7 +226,7 @@ case "${host_os}" in
       fi
       AM_CPPFLAGS="-DUSE_OPENCL $AM_CPPFLAGS"
       OPENCL_CPPFLAGS=""
-      OPENCL_LDFLAGS="-framework OpenCL"
+      OPENCL_LDFLAGS="-framework OpenCL -ltiff"
     fi
     ;;
   *)


### PR DESCRIPTION
The OpenCL code of Tesseract uses TIFF functions, but the TIFF library
was not added to the linker flags for macOS.

This fixes builds with OpenCL on Mac.

Signed-off-by: Stefan Weil <sw@weilnetz.de>