### PR TITLE
[4.00] Fix #786 OpenCL linkage fails on macOS

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -46,7 +46,7 @@ endif
 libtesseract_api_la_SOURCES = baseapi.cpp capi.cpp renderer.cpp pdfrenderer.cpp
 
 lib_LTLIBRARIES += libtesseract.la
-libtesseract_la_LDFLAGS = $(LEPTONICA_LIBS)
+libtesseract_la_LDFLAGS = $(LEPTONICA_LIBS) $(OPENCL_LDFLAGS)
 libtesseract_la_SOURCES =
 # Dummy C++ source to cause C++ linking.
 # see http://www.gnu.org/s/hello/manual/automake/Libtool-Convenience-Libraries.html#Libtool-Convenience-Libraries


### PR DESCRIPTION
This change is needed to link Tesseract 4.00 with OpenCL on macOS.