### PR TITLE
[3.05] Fix #786 OpenCL linkage on macOS

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -45,7 +45,7 @@ endif
 libtesseract_api_la_SOURCES = baseapi.cpp capi.cpp renderer.cpp pdfrenderer.cpp
 
 lib_LTLIBRARIES += libtesseract.la
-libtesseract_la_LDFLAGS = 
+libtesseract_la_LDFLAGS = $(OPENCL_LDFLAGS)
 libtesseract_la_SOURCES =
 # Dummy C++ source to cause C++ linking.
 # see http://www.gnu.org/s/hello/manual/automake/Libtool-Convenience-Libraries.html#Libtool-Convenience-Libraries

--- a/configure.ac
+++ b/configure.ac
@@ -220,7 +220,7 @@ case "${host_os}" in
       fi
       AM_CPPFLAGS="-DUSE_OPENCL $AM_CPPFLAGS"
       OPENCL_CPPFLAGS=""
-      OPENCL_LDFLAGS="-framework OpenCL"
+      OPENCL_LDFLAGS="-framework OpenCL -ltiff"
     fi
     ;;
   *)


### PR DESCRIPTION
This includes and builds on @stweil 's patch to fix linkage on macOS.

~~@zdenop This includes PR #809, so if you accept this you can close PR #809.~~ Let's see if @stweil wants to cherrypick this and added other 3.05 changes.