### PR TITLE
[3.05] Fix YAML parse error in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ platform:
 configuration:
   - Release  
   
- # for curl
- install:
-   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+# for curl
+install:
+  - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 
 before_build:
   - if %platform%==Win32 set generator=Visual Studio 15 2017


### PR DESCRIPTION
All of the appveyor build checks are failing for 3.05 on a parse error.