### PR TITLE
ccstruct: Fix Leptonica data type

### DIFF
--- a/ccstruct/debugpixa.h
+++ b/ccstruct/debugpixa.h
@@ -44,7 +44,7 @@ class DebugPixa {
   // The collection of images to put in the PDF.
   Pixa* pixa_;
   // The fonts used to draw text captions.
-  L_Bmf* fonts_;
+  L_BMF* fonts_;
 };
 
 }  // namespace tesseract


### PR DESCRIPTION
L_Bmf works for C++ code, but the common form is L_BMF, so use that.

Signed-off-by: Stefan Weil <sw@weilnetz.de>