### PR TITLE
doc: Remove unsupported font name

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -2135,7 +2135,7 @@ DOT_NUM_THREADS        = 0
 # The default value is: Helvetica.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTNAME           = FreeSans
+DOT_FONTNAME           =
 
 # The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
 # dot graphs.


### PR DESCRIPTION
Fix this warning from doxygen:

    warning: doxygen no longer ships with the FreeSans font.
    You may want to clear or change DOT_FONTNAME.
    Otherwise you run the risk that the wrong font is being used for dot generated graphs.

Signed-off-by: Stefan Weil <sw@weilnetz.de>