### PR TITLE
doc: Fix use of MAINTAINER_MODE

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,16 +1,16 @@
+if MAINTAINER_MODE
+
 asciidoc=asciidoc -d manpage
 
 man_MANS = cntraining.1  combine_tessdata.1  mftraining.1  tesseract.1 \
 	unicharset_extractor.1  wordlist2dawg.1 unicharambigs.5 \
 	unicharset.5 ambiguous_words.1 shapeclustering.1 dawg2wordlist.1
 
-if MAINTAINER_MODE
-
 EXTRA_DIST = $(man_MANS) Doxyfile
 
 %: %.asc
 	$(asciidoc) -o $@ $<
 
-endif # MAINTAINER_MODE
-
 MAINTAINERCLEANFILES = $(man_MANS) Doxyfile
+
+endif # MAINTAINER_MODE


### PR DESCRIPTION
It must also include man_MANS – otherwise make tries to build the
man pages also in non maintainer mode without having a rule for that.

This fixes commit 2794410c9b5095f1b6607f68584b1fe5b7a32f7c.

Signed-off-by: Stefan Weil <sw@weilnetz.de>