### PR TITLE
Update and improve configuration for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,41 @@
+# Travis CI configuration for Tesseract
+
 language: cpp
+
+dist: trusty
+
+env:
+  - LEPT_VER=1.74.1
 
 notifications:
   email: false
 
-sudo: required
+sudo: false
 
 os:
   - linux
   - osx
 
-#branches:
-  #only:
-    #- master
-
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
+    #- ubuntu-toolchain-r-test
     packages:
-    - gcc-4.8
-    - g++-4.8
+    #- g++-6
+
+cache:
+  directories:
+  - leptonica-$LEPT_VER
 
 before_install:
   - if [[ $TRAVIS_OS_NAME == linux   ]]; then LINUX=true; fi
   - if [[ $TRAVIS_OS_NAME == osx     ]]; then OSX=true; fi
 
-  #- if [[ $OSX ]]; then brew update; fi
-
-  - export LEPT_VER=1.74.1
-
 install:
-  #- if [[ $OSX ]]; then brew install icu4c pango; brew link --force gettext; fi
-  #- if [[ $OSX ]]; then export ICU_ROOT=/usr/local/opt/icu4c ; fi
-  - if [[ $LINUX ]]; then wget https://www.cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.sh; fi
-  - if [[ $LINUX ]]; then sudo sh cmake-3.7.2-Linux-x86_64.sh --skip-license --prefix=/usr; fi
-  - wget -O leptonica.zip https://github.com/DanBloomberg/leptonica/archive/$LEPT_VER.zip
-  - unzip leptonica.zip -d .
-  - cmake -Hleptonica-$LEPT_VER -Bleptonica-$LEPT_VER/build
-  - make -C leptonica-$LEPT_VER/build
-  - if [[ $LINUX && "$CXX" = "g++" ]]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  #- if [[ $LINUX && "$CXX" = "g++" ]]; then export CXX="g++-6" CC="gcc-6"; fi
+  - if test ! -d leptonica-$LEPT_VER/src; then curl -Ls https://github.com/DanBloomberg/leptonica/archive/$LEPT_VER.tar.gz | tar -xz; fi
+  - if test ! -d leptonica-$LEPT_VER/build/src; then cmake -Hleptonica-$LEPT_VER -Bleptonica-$LEPT_VER/build; fi
+  - if test ! -e leptonica-$LEPT_VER/build/src/libleptonica.so; then make -C leptonica-$LEPT_VER/build; fi
 
 script:
   - mkdir build


### PR DESCRIPTION
* Use container based Ubuntu trusty. This provides a newer gcc version
  by default. CI jobs should now start faster.

* Add caching. Leptonica is now only built once for each platform.

* Get Leptonica tar instead of zip file. It's smaller,
  and there is no need to store it on disk.

Signed-off-by: Stefan Weil <sw@weilnetz.de>