### PR TITLE
Reviewed uses of reinterpret_cast

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -165,7 +165,7 @@ size_t TessBaseAPI::getOpenCLDevice(void **data) {
 #if USE_DEVICE_SELECTION
   ds_device device = OpenclDevice::getDeviceSelection();
   if (device.type == DS_DEVICE_OPENCL_DEVICE) {
-    *data = reinterpret_cast<void*>(new cl_device_id);
+    *data = new cl_device_id;
     memcpy(*data, &device.oclDeviceID, sizeof(cl_device_id));
     return sizeof(cl_device_id);
   }

--- a/ccmain/equationdetect.cpp
+++ b/ccmain/equationdetect.cpp
@@ -56,24 +56,24 @@ namespace tesseract {
 // Utility ColParition sort functions.
 ///////////////////////////////////////////////////////////////////////////
 static int SortCPByTopReverse(const void* p1, const void* p2) {
-  const ColPartition* cp1 = *reinterpret_cast<ColPartition* const*>(p1);
-  const ColPartition* cp2 = *reinterpret_cast<ColPartition* const*>(p2);
+  const ColPartition* cp1 = *static_cast<ColPartition* const*>(p1);
+  const ColPartition* cp2 = *static_cast<ColPartition* const*>(p2);
   ASSERT_HOST(cp1 != NULL && cp2 != NULL);
   const TBOX &box1(cp1->bounding_box()), &box2(cp2->bounding_box());
   return box2.top() - box1.top();
 }
 
 static int SortCPByBottom(const void* p1, const void* p2) {
-  const ColPartition* cp1 = *reinterpret_cast<ColPartition* const*>(p1);
-  const ColPartition* cp2 = *reinterpret_cast<ColPartition* const*>(p2);
+  const ColPartition* cp1 = *static_cast<ColPartition* const*>(p1);
+  const ColPartition* cp2 = *static_cast<ColPartition* const*>(p2);
   ASSERT_HOST(cp1 != NULL && cp2 != NULL);
   const TBOX &box1(cp1->bounding_box()), &box2(cp2->bounding_box());
   return box1.bottom() - box2.bottom();
 }
 
 static int SortCPByHeight(const void* p1, const void* p2) {
-  const ColPartition* cp1 = *reinterpret_cast<ColPartition* const*>(p1);
-  const ColPartition* cp2 = *reinterpret_cast<ColPartition* const*>(p2);
+  const ColPartition* cp1 = *static_cast<ColPartition* const*>(p1);
+  const ColPartition* cp2 = *static_cast<ColPartition* const*>(p2);
   ASSERT_HOST(cp1 != NULL && cp2 != NULL);
   const TBOX &box1(cp1->bounding_box()), &box2(cp2->bounding_box());
   return box1.height() - box2.height();

--- a/ccmain/paramsd.cpp
+++ b/ccmain/paramsd.cpp
@@ -184,9 +184,9 @@ void ParamsEditor::GetPrefixes(const char* s, STRING* level_one,
 // Compare two VC objects by their name.
 int ParamContent::Compare(const void* v1, const void* v2) {
   const ParamContent* one =
-    *reinterpret_cast<const ParamContent* const *>(v1);
+    *static_cast<const ParamContent* const *>(v1);
   const ParamContent* two =
-    *reinterpret_cast<const ParamContent* const *>(v2);
+    *static_cast<const ParamContent* const *>(v2);
   return strcmp(one->GetName(), two->GetName());
 }
 

--- a/ccmain/thresholder.cpp
+++ b/ccmain/thresholder.cpp
@@ -312,7 +312,7 @@ void ImageThresholder::ThresholdRectToPix(Pix* src_pix,
       bool white_result = true;
       for (int ch = 0; ch < num_channels; ++ch) {
         int pixel = GET_DATA_BYTE(const_cast<void*>(
-                                  reinterpret_cast<const void *>(linedata)),
+                                  static_cast<const void *>(linedata)),
                                   (x + rect_left_) * num_channels + ch);
         if (hi_values[ch] >= 0 &&
             (pixel > thresholds[ch]) == (hi_values[ch] == 0)) {

--- a/ccstruct/coutln.cpp
+++ b/ccstruct/coutln.cpp
@@ -94,7 +94,7 @@ inT16 length                     //length of loop
   pos = startpt;
   stepcount = length;            // No. of steps.
   ASSERT_HOST(length >= 0);
-  steps = reinterpret_cast<uinT8*>(alloc_mem(step_mem()));  // Get memory.
+  steps = static_cast<uinT8*>(alloc_mem(step_mem()));  // Get memory.
   memset(steps, 0, step_mem());
 
   lastdir = new_steps[length - 1];
@@ -655,23 +655,23 @@ static void ComputeGradient(const l_uint32* data, int wpl,
   int pix_x_y =
       x < width && y < height
           ? GET_DATA_BYTE(
-                const_cast<void*>(reinterpret_cast<const void*>(line)), x)
+                const_cast<void*>(static_cast<const void*>(line)), x)
           : 255;
   int pix_x_prevy =
       x < width && y > 0
           ? GET_DATA_BYTE(
-                const_cast<void*>(reinterpret_cast<const void*>(line - wpl)), x)
+                const_cast<void*>(static_cast<const void*>(line - wpl)), x)
           : 255;
   int pix_prevx_prevy =
       x > 0 && y > 0
           ? GET_DATA_BYTE(
-                const_cast<void*>(reinterpret_cast<void const*>(line - wpl)),
+                const_cast<void*>(static_cast<void const*>(line - wpl)),
                 x - 1)
           : 255;
   int pix_prevx_y =
       x > 0 && y < height
           ? GET_DATA_BYTE(
-                const_cast<void*>(reinterpret_cast<const void*>(line)), x - 1)
+                const_cast<void*>(static_cast<const void*>(line)), x - 1)
           : 255;
   gradient->set_x(pix_x_y + pix_x_prevy - (pix_prevx_y + pix_prevx_prevy));
   gradient->set_y(pix_x_prevy + pix_prevx_prevy - (pix_x_y + pix_prevx_y));
@@ -689,9 +689,9 @@ static bool EvaluateVerticalDiff(const l_uint32* data, int wpl, int diff_sign,
     return false;
   const l_uint32* line = data + y * wpl;
   int pixel1 = GET_DATA_BYTE(
-      const_cast<void*>(reinterpret_cast<const void*>(line - wpl)), x);
+      const_cast<void*>(static_cast<const void*>(line - wpl)), x);
   int pixel2 =
-      GET_DATA_BYTE(const_cast<void*>(reinterpret_cast<const void*>(line)), x);
+      GET_DATA_BYTE(const_cast<void*>(static_cast<const void*>(line)), x);
   int diff = (pixel2 - pixel1) * diff_sign;
   if (diff > *best_diff) {
     *best_diff = diff;
@@ -712,9 +712,9 @@ static bool EvaluateHorizontalDiff(const l_uint32* line, int diff_sign,
   if (x <= 0 || x >= width)
     return false;
   int pixel1 = GET_DATA_BYTE(
-      const_cast<void*>(reinterpret_cast<const void*>(line)), x - 1);
+      const_cast<void*>(static_cast<const void*>(line)), x - 1);
   int pixel2 =
-      GET_DATA_BYTE(const_cast<void*>(reinterpret_cast<const void*>(line)), x);
+      GET_DATA_BYTE(const_cast<void*>(static_cast<const void*>(line)), x);
   int diff = (pixel2 - pixel1) * diff_sign;
   if (diff > *best_diff) {
     *best_diff = diff;

--- a/ccstruct/imagedata.cpp
+++ b/ccstruct/imagedata.cpp
@@ -112,8 +112,8 @@ void FloatWordFeature::FromWordFeatures(
 // Sort function to sort first by x-bucket, then by y.
 /* static */
 int FloatWordFeature::SortByXBucket(const void* v1, const void* v2) {
-  const FloatWordFeature* f1 = reinterpret_cast<const FloatWordFeature*>(v1);
-  const FloatWordFeature* f2 = reinterpret_cast<const FloatWordFeature*>(v2);
+  const FloatWordFeature* f1 = static_cast<const FloatWordFeature*>(v1);
+  const FloatWordFeature* f2 = static_cast<const FloatWordFeature*>(v2);
   int x_diff = f1->x_bucket - f2->x_bucket;
   if (x_diff == 0) return f1->y - f2->y;
   return x_diff;
@@ -367,7 +367,7 @@ bool ImageData::AddBoxes(const char* box_text) {
 
 // Thread function to call ReCachePages.
 void* ReCachePagesFunc(void* data) {
-  DocumentData* document_data = reinterpret_cast<DocumentData*>(data);
+  DocumentData* document_data = static_cast<DocumentData*>(data);
   document_data->ReCachePages();
   return NULL;
 }

--- a/ccstruct/matrix.h
+++ b/ccstruct/matrix.h
@@ -38,7 +38,7 @@
 class BLOB_CHOICE;
 class BLOB_CHOICE_LIST;
 
-#define NOT_CLASSIFIED reinterpret_cast<BLOB_CHOICE_LIST*>(0)
+#define NOT_CLASSIFIED static_cast<BLOB_CHOICE_LIST*>(0)
 
 // A generic class to hold a 2-D matrix with entries of type T, but can also
 // act as a base class for other implementations, such as a triangular or

--- a/ccstruct/otsuthr.cpp
+++ b/ccstruct/otsuthr.cpp
@@ -162,7 +162,7 @@ void HistogramRect(Pix* src_pix, int channel,
     const l_uint32* linedata = srcdata + y * src_wpl;
     for (int x = 0; x < width; ++x) {
       int pixel = GET_DATA_BYTE(const_cast<void*>(
-          reinterpret_cast<const void *>(linedata)),
+          static_cast<const void *>(linedata)),
           (x + left) * num_channels + channel);
       ++histogram[pixel];
     }

--- a/ccstruct/ratngs.h
+++ b/ccstruct/ratngs.h
@@ -191,9 +191,9 @@ class BLOB_CHOICE: public ELIST_LINK
     // Sort function for sorting BLOB_CHOICEs in increasing order of rating.
     static int SortByRating(const void *p1, const void *p2) {
       const BLOB_CHOICE *bc1 =
-          *reinterpret_cast<const BLOB_CHOICE * const *>(p1);
+          *static_cast<const BLOB_CHOICE * const *>(p1);
       const BLOB_CHOICE *bc2 =
-          *reinterpret_cast<const BLOB_CHOICE * const *>(p2);
+          *static_cast<const BLOB_CHOICE * const *>(p2);
       return (bc1->rating_ < bc2->rating_) ? -1 : 1;
     }
 

--- a/ccstruct/statistc.cpp
+++ b/ccstruct/statistc.cpp
@@ -772,8 +772,8 @@ void swap_entries(void *array,   // array of entries
   char *ptr2;
   size_t count;                  // of bytes
 
-  ptr1 = reinterpret_cast<char*>(array) + index1 * size;
-  ptr2 = reinterpret_cast<char*>(array) + index2 * size;
+  ptr1 = static_cast<char*>(array) + index1 * size;
+  ptr2 = static_cast<char*>(array) + index2 * size;
   for (count = 0; count < size; count++) {
     tmp = *ptr1;
     *ptr1++ = *ptr2;

--- a/ccstruct/stepblob.h
+++ b/ccstruct/stepblob.h
@@ -117,8 +117,8 @@ class C_BLOB:public ELIST_LINK
     }
 
     static int SortByXMiddle(const void *v1, const void *v2) {
-      const C_BLOB* blob1 = *reinterpret_cast<const C_BLOB* const *>(v1);
-      const C_BLOB* blob2 = *reinterpret_cast<const C_BLOB* const *>(v2);
+      const C_BLOB* blob1 = *static_cast<const C_BLOB* const *>(v1);
+      const C_BLOB* blob2 = *static_cast<const C_BLOB* const *>(v2);
       return blob1->bounding_box().x_middle() -
              blob2->bounding_box().x_middle();
     }

--- a/ccutil/ambigs.h
+++ b/ccutil/ambigs.h
@@ -121,9 +121,9 @@ class AmbigSpec : public ELIST_LINK {
   // in a a sorted AmbigSpec_LIST: [9 1 3], [9 3 4], [9 8], [9, 8 1].
   static int compare_ambig_specs(const void *spec1, const void *spec2) {
     const AmbigSpec *s1 =
-      *reinterpret_cast<const AmbigSpec * const *>(spec1);
+      *static_cast<const AmbigSpec * const *>(spec1);
     const AmbigSpec *s2 =
-      *reinterpret_cast<const AmbigSpec * const *>(spec2);
+      *static_cast<const AmbigSpec * const *>(spec2);
     int result = UnicharIdArrayUtils::compare(s1->wrong_ngram, s2->wrong_ngram);
     if (result != 0) return result;
     return UnicharIdArrayUtils::compare(s1->correct_fragments,

--- a/ccutil/genericvector.h
+++ b/ccutil/genericvector.h
@@ -421,8 +421,8 @@ int sort_cmp(const void* t1, const void* t2) {
 // return > 0 if t1 > t2
 template <typename T>
 int sort_ptr_cmp(const void* t1, const void* t2) {
-  const T* a = *reinterpret_cast<T * const *>(t1);
-  const T* b = *reinterpret_cast<T * const *>(t2);
+  const T* a = *static_cast<T * const *>(t1);
+  const T* b = *static_cast<T * const *>(t2);
   if (*a < *b) {
     return -1;
   } else if (*b < *a) {

--- a/ccutil/helpers.h
+++ b/ccutil/helpers.h
@@ -182,7 +182,7 @@ inline int IntCastRounded(double x) {
 
 // Reverse the order of bytes in a n byte quantity for big/little-endian switch.
 inline void ReverseN(void* ptr, int num_bytes) {
-  char *cptr = reinterpret_cast<char *>(ptr);
+  char *cptr = static_cast<char *>(ptr);
   int halfsize = num_bytes / 2;
   for (int i = 0; i < halfsize; ++i) {
     char tmp = cptr[i];

--- a/ccutil/serialis.cpp
+++ b/ccutil/serialis.cpp
@@ -97,7 +97,7 @@ char* TFile::FGets(char* buffer, int buffer_size) {
 int TFile::FReadEndian(void* buffer, int size, int count) {
   int num_read = FRead(buffer, size, count);
   if (swap_) {
-    char* char_buffer = reinterpret_cast<char*>(buffer);
+    char* char_buffer = static_cast<char*>(buffer);
     for (int i = 0; i < num_read; ++i, char_buffer += size) {
       ReverseN(char_buffer, size);
     }
@@ -109,7 +109,7 @@ int TFile::FRead(void* buffer, int size, int count) {
   ASSERT_HOST(!is_writing_);
   int required_size = size * count;
   if (required_size <= 0) return 0;
-  char* char_buffer = reinterpret_cast<char*>(buffer);
+  char* char_buffer = static_cast<char*>(buffer);
   if (data_->size() - offset_ < required_size)
     required_size = data_->size() - offset_;
   if (required_size > 0 && char_buffer != NULL)
@@ -150,7 +150,7 @@ int TFile::FWrite(const void* buffer, int size, int count) {
   ASSERT_HOST(is_writing_);
   int total = size * count;
   if (total <= 0) return 0;
-  const char* buf = reinterpret_cast<const char*>(buffer);
+  const char* buf = static_cast<const char*>(buffer);
   // This isn't very efficient, but memory is so fast compared to disk
   // that it is relatively unimportant, and very simple.
   for (int i = 0; i < total; ++i)

--- a/ccutil/sorthelper.h
+++ b/ccutil/sorthelper.h
@@ -42,14 +42,14 @@ class SortHelper {
   };
   // qsort function to sort by decreasing count.
   static int SortPairsByCount(const void* v1, const void* v2) {
-    const SortPair<T>* p1 = reinterpret_cast<const SortPair<T>*>(v1);
-    const SortPair<T>* p2 = reinterpret_cast<const SortPair<T>*>(v2);
+    const SortPair<T>* p1 = static_cast<const SortPair<T>*>(v1);
+    const SortPair<T>* p2 = static_cast<const SortPair<T>*>(v2);
     return p2->count - p1->count;
   }
   // qsort function to sort by decreasing value.
   static int SortPairsByValue(const void* v1, const void* v2) {
-    const SortPair<T>* p1 = reinterpret_cast<const SortPair<T>*>(v1);
-    const SortPair<T>* p2 = reinterpret_cast<const SortPair<T>*>(v2);
+    const SortPair<T>* p1 = static_cast<const SortPair<T>*>(v1);
+    const SortPair<T>* p2 = static_cast<const SortPair<T>*>(v2);
     if (p2->value - p1->value < 0) return -1;
     if (p2->value - p1->value > 0) return 1;
     return 0;

--- a/classify/adaptmatch.cpp
+++ b/classify/adaptmatch.cpp
@@ -2242,7 +2242,7 @@ void Classify::ShowBestMatchFor(int shape_id,
   tprintf("Static Shape ID: %d\n", shape_id);
   ShowMatchDisplay();
   im_.Match(ClassForClassId(PreTrainedTemplates, shape_id),
-            AllProtosOn, reinterpret_cast<BIT_VECTOR>(&config_mask),
+            AllProtosOn, &config_mask, // TODO: or reinterpret_cast<BIT_VECTOR>(&config_mask) anyway?
             num_features, features, &cn_result,
             classify_adapt_feature_threshold,
             matcher_debug_flags,

--- a/classify/cluster.cpp
+++ b/classify/cluster.cpp
@@ -1123,9 +1123,9 @@ PROTOTYPE *TestEllipticalProto(CLUSTERER *Clusterer,
   if (TotalDims < N + 1 || TotalDims < 2)
     return NULL;
   const int kMatrixSize = N * N * sizeof(FLOAT32);
-  FLOAT32* Covariance = reinterpret_cast<FLOAT32 *>(Emalloc(kMatrixSize));
-  FLOAT32* Inverse = reinterpret_cast<FLOAT32 *>(Emalloc(kMatrixSize));
-  FLOAT32* Delta = reinterpret_cast<FLOAT32*>(Emalloc(N * sizeof(FLOAT32)));
+  FLOAT32* Covariance = static_cast<FLOAT32 *>(Emalloc(kMatrixSize));
+  FLOAT32* Inverse = static_cast<FLOAT32 *>(Emalloc(kMatrixSize));
+  FLOAT32* Delta = static_cast<FLOAT32*>(Emalloc(N * sizeof(FLOAT32)));
   // Compute a new covariance matrix that only uses essential features.
   for (int i = 0; i < N; ++i) {
     int row_offset = i * N;
@@ -1749,13 +1749,13 @@ BUCKETS *MakeBuckets(DISTRIBUTION Distribution,
   BOOL8 Symmetrical;
 
   // allocate memory needed for data structure
-  Buckets = reinterpret_cast<BUCKETS*>(Emalloc(sizeof(BUCKETS)));
+  Buckets = static_cast<BUCKETS*>(Emalloc(sizeof(BUCKETS)));
   Buckets->NumberOfBuckets = OptimumNumberOfBuckets(SampleCount);
   Buckets->SampleCount = SampleCount;
   Buckets->Confidence = Confidence;
-  Buckets->Count = reinterpret_cast<uinT32*>(
+  Buckets->Count = static_cast<uinT32*>(
       Emalloc(Buckets->NumberOfBuckets * sizeof(uinT32)));
-  Buckets->ExpectedCount = reinterpret_cast<FLOAT32*>(
+  Buckets->ExpectedCount = static_cast<FLOAT32*>(
       Emalloc(Buckets->NumberOfBuckets * sizeof(FLOAT32)));
 
   // initialize simple fields

--- a/classify/clusttool.cpp
+++ b/classify/clusttool.cpp
@@ -227,7 +227,7 @@ FLOAT32 *ReadNFloats(TFile *fp, uinT16 N, FLOAT32 Buffer[]) {
   bool needs_free = false;
 
   if (Buffer == NULL) {
-    Buffer = reinterpret_cast<FLOAT32*>(Emalloc(N * sizeof(FLOAT32)));
+    Buffer = static_cast<FLOAT32*>(Emalloc(N * sizeof(FLOAT32)));
     needs_free = true;
   }
 

--- a/classify/shapetable.cpp
+++ b/classify/shapetable.cpp
@@ -79,8 +79,8 @@ bool UnicharAndFonts::DeSerialize(TFile* fp) {
 
 // Sort function to sort a pair of UnicharAndFonts by unichar_id.
 int UnicharAndFonts::SortByUnicharId(const void* v1, const void* v2) {
-  const UnicharAndFonts* p1 = reinterpret_cast<const UnicharAndFonts*>(v1);
-  const UnicharAndFonts* p2 = reinterpret_cast<const UnicharAndFonts*>(v2);
+  const UnicharAndFonts* p1 = static_cast<const UnicharAndFonts*>(v1);
+  const UnicharAndFonts* p2 = static_cast<const UnicharAndFonts*>(v2);
   return p1->unichar_id - p2->unichar_id;
 }
 

--- a/classify/shapetable.h
+++ b/classify/shapetable.h
@@ -54,8 +54,8 @@ struct UnicharRating {
 
   // Sort function to sort ratings appropriately by descending rating.
   static int SortDescendingRating(const void* t1, const void* t2) {
-    const UnicharRating* a = reinterpret_cast<const UnicharRating *>(t1);
-    const UnicharRating* b = reinterpret_cast<const UnicharRating *>(t2);
+    const UnicharRating* a = static_cast<const UnicharRating *>(t1);
+    const UnicharRating* b = static_cast<const UnicharRating *>(t2);
     if (a->rating > b->rating) {
       return -1;
     } else if (a->rating < b->rating) {
@@ -100,8 +100,8 @@ struct ShapeRating {
 
   // Sort function to sort ratings appropriately by descending rating.
   static int SortDescendingRating(const void* t1, const void* t2) {
-    const ShapeRating* a = reinterpret_cast<const ShapeRating *>(t1);
-    const ShapeRating* b = reinterpret_cast<const ShapeRating *>(t2);
+    const ShapeRating* a = static_cast<const ShapeRating *>(t1);
+    const ShapeRating* b = static_cast<const ShapeRating *>(t2);
     if (a->rating > b->rating) {
       return -1;
     } else if (a->rating < b->rating) {

--- a/dict/dict.cpp
+++ b/dict/dict.cpp
@@ -370,7 +370,7 @@ void Dict::End() {
 int Dict::def_letter_is_okay(void* void_dawg_args,
                              UNICHAR_ID unichar_id,
                              bool word_end) const {
-  DawgArgs *dawg_args = reinterpret_cast<DawgArgs*>(void_dawg_args);
+  DawgArgs *dawg_args = static_cast<DawgArgs*>(void_dawg_args);
 
   if (dawg_debug_level >= 3) {
     tprintf("def_letter_is_okay: current unichar=%s word_end=%d"

--- a/dict/permdawg.cpp
+++ b/dict/permdawg.cpp
@@ -53,7 +53,7 @@ void Dict::go_deeper_dawg_fxn(
     int char_choice_index, const CHAR_FRAGMENT_INFO *prev_char_frag_info,
     bool word_ending, WERD_CHOICE *word, float certainties[], float *limit,
     WERD_CHOICE *best_choice, int *attempts_left, void *void_more_args) {
-  DawgArgs *more_args = reinterpret_cast<DawgArgs*>(void_more_args);
+  DawgArgs *more_args = static_cast<DawgArgs*>(void_more_args);
   word_ending = (char_choice_index == char_choices.size()-1);
   int word_index = word->length() - 1;
   if (best_choice->rating() < *limit) return;

--- a/dict/trie.cpp
+++ b/dict/trie.cpp
@@ -281,8 +281,8 @@ NODE_REF Trie::new_dawg_node() {
 
 // Sort function to sort words by decreasing order of length.
 static int sort_strings_by_dec_length(const void* v1, const void* v2) {
-  const STRING* s1 = reinterpret_cast<const STRING*>(v1);
-  const STRING* s2 = reinterpret_cast<const STRING*>(v2);
+  const STRING* s1 = static_cast<const STRING*>(v1);
+  const STRING* s2 = static_cast<const STRING*>(v2);
   return s2->length() - s1->length();
 }
 

--- a/lstm/fullyconnected.cpp
+++ b/lstm/fullyconnected.cpp
@@ -291,7 +291,7 @@ void FullyConnected::Update(float learning_rate, float momentum,
 void FullyConnected::CountAlternators(const Network& other, double* same,
                                       double* changed) const {
   ASSERT_HOST(other.type() == type_);
-  const FullyConnected* fc = reinterpret_cast<const FullyConnected*>(&other);
+  const FullyConnected* fc = static_cast<const FullyConnected*>(&other);
   weights_.CountAlternators(fc->weights_, same, changed);
 }
 

--- a/lstm/lstm.cpp
+++ b/lstm/lstm.cpp
@@ -198,7 +198,7 @@ bool LSTM::DeSerialize(TFile* fp) {
   }
   delete softmax_;
   if (type_ == NT_LSTM_SOFTMAX || type_ == NT_LSTM_SOFTMAX_ENCODED) {
-    softmax_ = reinterpret_cast<FullyConnected*>(Network::CreateFromFile(fp));
+    softmax_ = static_cast<FullyConnected*>(Network::CreateFromFile(fp));
     if (softmax_ == nullptr) return false;
   } else {
     softmax_ = nullptr;
@@ -651,7 +651,7 @@ void LSTM::Update(float learning_rate, float momentum, int num_samples) {
 void LSTM::CountAlternators(const Network& other, double* same,
                             double* changed) const {
   ASSERT_HOST(other.type() == type_);
-  const LSTM* lstm = reinterpret_cast<const LSTM*>(&other);
+  const LSTM* lstm = static_cast<const LSTM*>(&other);
   for (int w = 0; w < WT_COUNT; ++w) {
     if (w == GFS && !Is2D()) continue;
     gate_weights_[w].CountAlternators(lstm->gate_weights_[w], same, changed);

--- a/lstm/lstmrecognizer.h
+++ b/lstm/lstmrecognizer.h
@@ -95,7 +95,7 @@ class LSTMRecognizer {
   // to access a specific layer.
   GenericVector<STRING> EnumerateLayers() const {
     ASSERT_HOST(network_ != NULL && network_->type() == NT_SERIES);
-    Series* series = reinterpret_cast<Series*>(network_);
+    Series* series = static_cast<Series*>(network_);
     GenericVector<STRING> layers;
     series->EnumerateLayers(NULL, &layers);
     return layers;
@@ -104,7 +104,7 @@ class LSTMRecognizer {
   Network* GetLayer(const STRING& id) const {
     ASSERT_HOST(network_ != NULL && network_->type() == NT_SERIES);
     ASSERT_HOST(id.length() > 1 && id[0] == ':');
-    Series* series = reinterpret_cast<Series*>(network_);
+    Series* series = static_cast<Series*>(network_);
     return series->GetLayer(&id[1]);
   }
   // Returns the learning rate of the layer from its id.
@@ -112,7 +112,7 @@ class LSTMRecognizer {
     ASSERT_HOST(network_ != NULL && network_->type() == NT_SERIES);
     if (network_->TestFlag(NF_LAYER_SPECIFIC_LR)) {
       ASSERT_HOST(id.length() > 1 && id[0] == ':');
-      Series* series = reinterpret_cast<Series*>(network_);
+      Series* series = static_cast<Series*>(network_);
       return series->LayerLearningRate(&id[1]);
     } else {
       return learning_rate_;
@@ -133,7 +133,7 @@ class LSTMRecognizer {
   void ScaleLayerLearningRate(const STRING& id, double factor) {
     ASSERT_HOST(network_ != NULL && network_->type() == NT_SERIES);
     ASSERT_HOST(id.length() > 1 && id[0] == ':');
-    Series* series = reinterpret_cast<Series*>(network_);
+    Series* series = static_cast<Series*>(network_);
     series->ScaleLayerLearningRate(&id[1], factor);
   }
 

--- a/lstm/networkbuilder.cpp
+++ b/lstm/networkbuilder.cpp
@@ -52,7 +52,7 @@ bool NetworkBuilder::InitNetwork(int num_outputs, STRING network_spec,
   if (append_index >= 0) {
     // Split the current network after the given append_index.
     ASSERT_HOST(*network != NULL && (*network)->type() == NT_SERIES);
-    Series* series = reinterpret_cast<Series*>(*network);
+    Series* series = static_cast<Series*>(*network);
     Series* top_series = NULL;
     series->SplitAt(append_index, &bottom_series, &top_series);
     if (bottom_series == NULL || top_series == NULL) {

--- a/lstm/plumbing.cpp
+++ b/lstm/plumbing.cpp
@@ -136,7 +136,7 @@ void Plumbing::EnumerateLayers(const STRING* prefix,
     if (prefix) layer_name = *prefix;
     layer_name.add_str_int(":", i);
     if (stack_[i]->IsPlumbingType()) {
-      Plumbing* plumbing = reinterpret_cast<Plumbing*>(stack_[i]);
+      Plumbing* plumbing = static_cast<Plumbing*>(stack_[i]);
       plumbing->EnumerateLayers(&layer_name, layers);
     } else {
       layers->push_back(layer_name);
@@ -150,7 +150,7 @@ Network* Plumbing::GetLayer(const char* id) const {
   int index = strtol(id, &next_id, 10);
   if (index < 0 || index >= stack_.size()) return NULL;
   if (stack_[index]->IsPlumbingType()) {
-    Plumbing* plumbing = reinterpret_cast<Plumbing*>(stack_[index]);
+    Plumbing* plumbing = static_cast<Plumbing*>(stack_[index]);
     ASSERT_HOST(*next_id == ':');
     return plumbing->GetLayer(next_id + 1);
   }
@@ -163,7 +163,7 @@ float* Plumbing::LayerLearningRatePtr(const char* id) const {
   int index = strtol(id, &next_id, 10);
   if (index < 0 || index >= stack_.size()) return NULL;
   if (stack_[index]->IsPlumbingType()) {
-    Plumbing* plumbing = reinterpret_cast<Plumbing*>(stack_[index]);
+    Plumbing* plumbing = static_cast<Plumbing*>(stack_[index]);
     ASSERT_HOST(*next_id == ':');
     return plumbing->LayerLearningRatePtr(next_id + 1);
   }
@@ -227,7 +227,7 @@ void Plumbing::Update(float learning_rate, float momentum, int num_samples) {
 void Plumbing::CountAlternators(const Network& other, double* same,
                                 double* changed) const {
   ASSERT_HOST(other.type() == type_);
-  const Plumbing* plumbing = reinterpret_cast<const Plumbing*>(&other);
+  const Plumbing* plumbing = static_cast<const Plumbing*>(&other);
   ASSERT_HOST(plumbing->stack_.size() == stack_.size());
   for (int i = 0; i < stack_.size(); ++i)
     stack_[i]->CountAlternators(*plumbing->stack_[i], same, changed);

--- a/lstm/series.cpp
+++ b/lstm/series.cpp
@@ -157,7 +157,7 @@ void Series::SplitAt(int last_start, Series** start, Series** end) {
   for (int s = 0; s <= last_start; ++s) {
     if (s + 1 == stack_.size() && stack_[s]->type() == NT_SOFTMAX) {
       // Change the softmax to a tanh.
-      FullyConnected* fc = reinterpret_cast<FullyConnected*>(stack_[s]);
+      FullyConnected* fc = static_cast<FullyConnected*>(stack_[s]);
       fc->ChangeType(NT_TANH);
     }
     master_series->AddToStack(stack_[s]);
@@ -176,7 +176,7 @@ void Series::SplitAt(int last_start, Series** start, Series** end) {
 // deleting it.
 void Series::AppendSeries(Network* src) {
   ASSERT_HOST(src->type() == NT_SERIES);
-  Series* src_series = reinterpret_cast<Series*>(src);
+  Series* src_series = static_cast<Series*>(src);
   for (int s = 0; s < src_series->stack_.size(); ++s) {
     AddToStack(src_series->stack_[s]);
     src_series->stack_[s] = NULL;

--- a/textord/bbgrid.h
+++ b/textord/bbgrid.h
@@ -372,8 +372,8 @@ template<class BBC, class BBC_CLIST, class BBC_C_IT> class GridSearch {
 template<class BBC>
 int SortByBoxLeft(const void* void1, const void* void2) {
   // The void*s are actually doubly indirected, so get rid of one level.
-  const BBC* p1 = *reinterpret_cast<const BBC* const *>(void1);
-  const BBC* p2 = *reinterpret_cast<const BBC* const *>(void2);
+  const BBC* p1 = *static_cast<const BBC* const *>(void1);
+  const BBC* p2 = *static_cast<const BBC* const *>(void2);
   int result = p1->bounding_box().left() - p2->bounding_box().left();
   if (result != 0)
     return result;
@@ -390,8 +390,8 @@ int SortByBoxLeft(const void* void1, const void* void2) {
 template<class BBC>
 int SortRightToLeft(const void* void1, const void* void2) {
   // The void*s are actually doubly indirected, so get rid of one level.
-  const BBC* p1 = *reinterpret_cast<const BBC* const *>(void1);
-  const BBC* p2 = *reinterpret_cast<const BBC* const *>(void2);
+  const BBC* p1 = *static_cast<const BBC* const *>(void1);
+  const BBC* p2 = *static_cast<const BBC* const *>(void2);
   int result = p2->bounding_box().right() - p1->bounding_box().right();
   if (result != 0)
     return result;
@@ -408,8 +408,8 @@ int SortRightToLeft(const void* void1, const void* void2) {
 template<class BBC>
 int SortByBoxBottom(const void* void1, const void* void2) {
   // The void*s are actually doubly indirected, so get rid of one level.
-  const BBC* p1 = *reinterpret_cast<const BBC* const *>(void1);
-  const BBC* p2 = *reinterpret_cast<const BBC* const *>(void2);
+  const BBC* p1 = *static_cast<const BBC* const *>(void1);
+  const BBC* p2 = *static_cast<const BBC* const *>(void2);
   int result = p1->bounding_box().bottom() - p2->bounding_box().bottom();
   if (result != 0)
     return result;

--- a/textord/cjkpitch.cpp
+++ b/textord/cjkpitch.cpp
@@ -91,8 +91,8 @@ class SimpleStats {
 
  private:
   static int float_compare(const void* a, const void* b) {
-    const float* f_a = reinterpret_cast<const float*>(a);
-    const float* f_b = reinterpret_cast<const float*>(b);
+    const float* f_a = static_cast<const float*>(a);
+    const float* f_b = static_cast<const float*>(b);
     return (*f_a > *f_b) ? 1 : ((*f_a < *f_b) ? -1 : 0);
   }
 
@@ -159,8 +159,8 @@ class LocalCorrelation {
 
  private:
   static int float_pair_compare(const void* a, const void* b) {
-    const float_pair* f_a = reinterpret_cast<const float_pair*>(a);
-    const float_pair* f_b = reinterpret_cast<const float_pair*>(b);
+    const float_pair* f_a = static_cast<const float_pair*>(a);
+    const float_pair* f_b = static_cast<const float_pair*>(b);
     return (f_a->x > f_b->x) ? 1 : ((f_a->x < f_b->x) ? -1 : 0);
   }
 

--- a/textord/colpartition.h
+++ b/textord/colpartition.h
@@ -707,9 +707,9 @@ class ColPartition : public ELIST2_LINK {
   // Sort function to sort by bounding box.
   static int SortByBBox(const void* p1, const void* p2) {
     const ColPartition* part1 =
-        *reinterpret_cast<const ColPartition* const*>(p1);
+        *static_cast<const ColPartition* const*>(p1);
     const ColPartition* part2 =
-        *reinterpret_cast<const ColPartition* const*>(p2);
+        *static_cast<const ColPartition* const*>(p2);
     int mid_y1 = part1->bounding_box_.y_middle();
     int mid_y2 = part2->bounding_box_.y_middle();
     if ((part2->bounding_box_.bottom() <= mid_y1 &&

--- a/textord/tabvector.h
+++ b/textord/tabvector.h
@@ -292,8 +292,8 @@ class TabVector : public ELIST2_LINK {
 
   // Sort function for E2LIST::sort to sort by sort_key_.
   static int SortVectorsByKey(const void* v1, const void* v2) {
-    const TabVector* tv1 = *reinterpret_cast<const TabVector* const *>(v1);
-    const TabVector* tv2 = *reinterpret_cast<const TabVector* const *>(v2);
+    const TabVector* tv1 = *static_cast<const TabVector* const *>(v1);
+    const TabVector* tv2 = *static_cast<const TabVector* const *>(v2);
     return tv1->sort_key_ - tv2->sort_key_;
   }
 

--- a/training/classifier_tester.cpp
+++ b/training/classifier_tester.cpp
@@ -26,6 +26,7 @@
 #include "params.h"
 #include "strngs.h"
 #include "tessclassifier.h"
+#include "tesseractclass.h"
 
 STRING_PARAM_FLAG(classifier, "", "Classifier to test");
 STRING_PARAM_FLAG(lang, "eng", "Language to test");
@@ -70,7 +71,7 @@ static tesseract::ShapeClassifier* InitializeClassifier(
       return nullptr;
     }
     tesseract = const_cast<tesseract::Tesseract*>((*api)->tesseract());
-    classify = reinterpret_cast<tesseract::Classify*>(tesseract);
+    classify = static_cast<tesseract::Classify*>(tesseract);
     if (classify->shape_table() == nullptr) {
       fprintf(stderr, "Tesseract must contain a ShapeTable!\n");
       return nullptr;

--- a/training/lstmtester.cpp
+++ b/training/lstmtester.cpp
@@ -119,7 +119,7 @@ STRING LSTMTester::RunEvalSync(int iteration, const double* training_errors,
 // it will call UnlockRunning to release the lock after RunEvalSync completes.
 /* static */
 void* LSTMTester::ThreadFunc(void* lstmtester_void) {
-  LSTMTester* lstmtester = reinterpret_cast<LSTMTester*>(lstmtester_void);
+  LSTMTester* lstmtester = static_cast<LSTMTester*>(lstmtester_void);
   lstmtester->test_result_ = lstmtester->RunEvalSync(
       lstmtester->test_iteration_, lstmtester->test_training_errors_,
       lstmtester->test_model_data_, lstmtester->test_training_stage_);

--- a/viewer/scrollview.cpp
+++ b/viewer/scrollview.cpp
@@ -322,7 +322,7 @@ void ScrollView::Initialize(const char* name, int x_pos, int y_pos, int x_size,
 
 /// Sits and waits for events on this window.
 void* ScrollView::StartEventHandler(void* a) {
-  ScrollView* sv = reinterpret_cast<ScrollView*>(a);
+  ScrollView* sv = static_cast<ScrollView*>(a);
   SVEvent* new_event;
 
   do {

--- a/wordrec/lm_state.h
+++ b/wordrec/lm_state.h
@@ -125,9 +125,9 @@ struct ViterbiStateEntry : public ELIST_LINK {
   /// non-increasing order of costs.
   static int Compare(const void *e1, const void *e2) {
     const ViterbiStateEntry *ve1 =
-      *reinterpret_cast<const ViterbiStateEntry * const *>(e1);
+      *static_cast<const ViterbiStateEntry * const *>(e1);
     const ViterbiStateEntry *ve2 =
-      *reinterpret_cast<const ViterbiStateEntry * const *>(e2);
+      *static_cast<const ViterbiStateEntry * const *>(e2);
     return (ve1->cost < ve2->cost) ? -1 : 1;
   }
   inline bool Consistent() const {

--- a/wordrec/pieces.cpp
+++ b/wordrec/pieces.cpp
@@ -75,16 +75,16 @@ BLOB_CHOICE_LIST *Wordrec::classify_piece(const GenericVector<SEAM*>& seams,
 
 template<class BLOB_CHOICE>
 int SortByUnicharID(const void *void1, const void *void2) {
-  const BLOB_CHOICE *p1 = *reinterpret_cast<const BLOB_CHOICE * const *>(void1);
-  const BLOB_CHOICE *p2 = *reinterpret_cast<const BLOB_CHOICE * const *>(void2);
+  const BLOB_CHOICE *p1 = *static_cast<const BLOB_CHOICE * const *>(void1);
+  const BLOB_CHOICE *p2 = *static_cast<const BLOB_CHOICE * const *>(void2);
 
   return p1->unichar_id() - p2->unichar_id();
 }
 
 template<class BLOB_CHOICE>
 int SortByRating(const void *void1, const void *void2) {
-  const BLOB_CHOICE *p1 = *reinterpret_cast<const BLOB_CHOICE * const *>(void1);
-  const BLOB_CHOICE *p2 = *reinterpret_cast<const BLOB_CHOICE * const *>(void2);
+  const BLOB_CHOICE *p1 = *static_cast<const BLOB_CHOICE * const *>(void1);
+  const BLOB_CHOICE *p2 = *static_cast<const BLOB_CHOICE * const *>(void2);
 
   if (p1->rating() < p2->rating())
     return 1;


### PR DESCRIPTION
In most cases static_cast was sufficient, and sometimes there was no need for casting at all.