### PR TITLE
Fix wrong format string

### DIFF
--- a/ccutil/params.cpp
+++ b/ccutil/params.cpp
@@ -102,7 +102,7 @@ bool ParamUtils::SetParam(const char *name, const char* value,
   IntParam *ip = FindParam<IntParam>(name, GlobalParams()->int_params,
                                      member_params->int_params);
   if (ip && ip->constraint_ok(constraint) &&
-      sscanf(value, INT32FORMAT, &intval) == 1) ip->set_value(intval);
+      sscanf(value, "%d", &intval) == 1) ip->set_value(intval);
 
   // Look for the parameter among bool parameters.
   BoolParam *bp = FindParam<BoolParam>(name, GlobalParams()->bool_params,


### PR DESCRIPTION
The local variable intval is of type int.

Signed-off-by: Stefan Weil <sw@weilnetz.de>