### PR TITLE
Remove most libtiff dependencies

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -85,9 +85,8 @@ tesseract_LDFLAGS = $(OPENCL_LDFLAGS)
 tesseract_LDADD += $(LEPTONICA_LIBS)
 tesseract_LDADD += $(OPENMP_CXXFLAGS)
 
-tesseract_LDADD += -ltiff
-
 if T_WIN
+tesseract_LDADD += -ltiff
 tesseract_LDADD += -lws2_32
 libtesseract_la_LDFLAGS += -no-undefined -Wl,--as-needed -lws2_32
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,7 @@ AM_CONDITIONAL([GRAPHICS_DISABLED], false)
 AC_SUBST([AM_CPPFLAGS])
 
 OPENCL_INC="/opt/AMDAPP/include"
-OPENCL_LIBS="-lOpenCL -ltiff"
+OPENCL_LIBS="-lOpenCL"
 #############################
 #
 # Platform specific setup
@@ -226,7 +226,7 @@ case "${host_os}" in
       fi
       AM_CPPFLAGS="-DUSE_OPENCL $AM_CPPFLAGS"
       OPENCL_CPPFLAGS=""
-      OPENCL_LDFLAGS="-framework OpenCL -ltiff"
+      OPENCL_LDFLAGS="-framework OpenCL"
     fi
     ;;
   *)
@@ -239,9 +239,6 @@ case "${host_os}" in
         fi
         if !($have_opencl_lib); then
             AC_MSG_ERROR([Required OpenCL library not found!])
-        fi
-        if !($have_tiff); then
-            AC_MSG_ERROR([Required TIFF headers not found! Try to install libtiff-dev?? package.])
         fi
         AM_CPPFLAGS="-DUSE_OPENCL $AM_CPPFLAGS"
         OPENCL_CPPFLAGS="-I${OPENCL_INC}"

--- a/opencl/openclwrapper.h
+++ b/opencl/openclwrapper.h
@@ -14,10 +14,6 @@
 #include <stdio.h>
 #include "allheaders.h"
 #include "pix.h"
-#ifdef USE_OPENCL
-#include "tiff.h"
-#include "tiffio.h"
-#endif
 #include "tprintf.h"
 
 // including CL/cl.h doesn't occur until USE_OPENCL defined below


### PR DESCRIPTION
libtiff is no longer needed for OpenCL, so remove that dependency.

It is still suggested for Windows to redirect warning messages
from the tesseract executable to the console.

Signed-off-by: Stefan Weil <sw@weilnetz.de>