### PR TITLE
ccutil: Remove unneeded include statement

### DIFF
--- a/ccutil/ccutil.h
+++ b/ccutil/ccutil.h
@@ -22,7 +22,6 @@
 #include "ambigs.h"
 #include "errcode.h"
 #include "strngs.h"
-#include "tessdatamanager.h"
 #include "params.h"
 #include "unicharset.h"
 


### PR DESCRIPTION
Signed-off-by: Stefan Weil <sw@weilnetz.de>