### PR TITLE
RFC: Add initial support for traineddata files in compressed archive formats (don't merge)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ addons:
     sources:
     #- ubuntu-toolchain-r-test
     packages:
+      # Try different packages for compressed archives.
+      - libarchive-dev
+      # Trusty does not support libminizip-dev (requires Zenial).
+      #libminizip-dev
+      - libzip-dev
+      - libzzip-dev
     #- g++-6
 
 #matrix:

--- a/configure.ac
+++ b/configure.ac
@@ -422,6 +422,30 @@ else
   AC_MSG_ERROR([Leptonica 1.74 or higher is required. Try to install libleptonica-dev package.])
 fi
 
+PKG_CHECK_MODULES([libarchive], [libarchive], [have_libarchive=true], [have_libarchive=false])
+AM_CONDITIONAL([HAVE_LIBARCHIVE], [$have_libarchive])
+if $have_libarchive; then
+  AC_DEFINE([HAVE_LIBARCHIVE], [], [Enable libarchive])
+fi
+
+PKG_CHECK_MODULES([libzip], [libzip], [have_libzip=true], [have_libzip=false])
+AM_CONDITIONAL([HAVE_LIBZIP], [$have_libzip])
+if $have_libzip; then
+  AC_DEFINE([HAVE_LIBZIP], [], [Enable libzip])
+fi
+
+PKG_CHECK_MODULES([minizip], [minizip], [have_minizip=true], [have_minizip=false])
+AM_CONDITIONAL([HAVE_MINIZIP], [$have_minizip])
+if $have_minizip; then
+  AC_DEFINE([HAVE_MINIZIP], [], [Enable minizip])
+fi
+
+PKG_CHECK_MODULES([zziplib], [zziplib], [have_zziplib=true], [have_zziplib=false])
+AM_CONDITIONAL([HAVE_ZZIPLIB], $have_zziplib)
+if $have_zziplib; then
+  AC_DEFINE([HAVE_ZZIPLIB], [], [Enable zziplib])
+fi
+
 AM_CONDITIONAL([ENABLE_TRAINING], true)
 
 # Check availability of ICU packages.

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -88,6 +88,17 @@ tesseract_LDFLAGS = $(OPENCL_LDFLAGS)
 
 tesseract_LDADD += $(LEPTONICA_LIBS)
 tesseract_LDADD += $(OPENMP_CXXFLAGS)
+if HAVE_LIBARCHIVE
+tesseract_LDADD += $(libarchive_LIBS)
+else
+if HAVE_LIBZIP
+tesseract_LDADD += $(libzip_LIBS)
+else
+if HAVE_MINIZIP
+tesseract_LDADD += $(minizip_LIBS)
+endif
+endif
+endif
 
 if T_WIN
 tesseract_LDADD += -ltiff

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -96,6 +96,10 @@ tesseract_LDADD += $(libzip_LIBS)
 else
 if HAVE_MINIZIP
 tesseract_LDADD += $(minizip_LIBS)
+else
+if HAVE_ZZIPLIB
+tesseract_LDADD += $(zziplib_LIBS)
+endif
 endif
 endif
 endif

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -90,18 +90,15 @@ tesseract_LDADD += $(LEPTONICA_LIBS)
 tesseract_LDADD += $(OPENMP_CXXFLAGS)
 if HAVE_LIBARCHIVE
 tesseract_LDADD += $(libarchive_LIBS)
-else
+endif
 if HAVE_LIBZIP
 tesseract_LDADD += $(libzip_LIBS)
-else
+endif
 if HAVE_MINIZIP
 tesseract_LDADD += $(minizip_LIBS)
-else
+endif
 if HAVE_ZZIPLIB
 tesseract_LDADD += $(zziplib_LIBS)
-endif
-endif
-endif
 endif
 
 if T_WIN

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -477,8 +477,7 @@ int TessBaseAPI::InitLangMod(const char* datapath, const char* language) {
     tesseract_ = new Tesseract;
   else
     ParamUtils::ResetToDefaults(tesseract_->params());
-  TessdataManager mgr;
-  return tesseract_->init_tesseract_lm(datapath, nullptr, language, &mgr);
+  return tesseract_->init_tesseract_lm(datapath, nullptr, language);
 }
 #endif  // ndef DISABLED_LEGACY_ENGINE
 

--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -460,12 +460,13 @@ void Tesseract::SetupUniversalFontIds() {
 
 // init the LM component
 int Tesseract::init_tesseract_lm(const char *arg0, const char *textbase,
-                                 const char *language, TessdataManager *mgr) {
+                                 const char *language) {
+  TessdataManager mgr;
   if (!init_tesseract_lang_data(arg0, textbase, language, OEM_TESSERACT_ONLY,
-                                nullptr, 0, nullptr, nullptr, false, mgr))
+                                nullptr, 0, nullptr, nullptr, false, &mgr))
     return -1;
   getDict().SetupForLoad(Dict::GlobalDawgCache());
-  getDict().Load(lang, mgr);
+  getDict().Load(lang, &mgr);
   getDict().FinishLoad();
   return 0;
 }

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -556,7 +556,7 @@ class Tesseract : public Wordrec {
   void SetupUniversalFontIds();
 
   int init_tesseract_lm(const char* arg0, const char* textbase,
-                        const char* language, TessdataManager* mgr);
+                        const char* language);
 
   void recognize_page(STRING& image_name);
   void end_tesseract();

--- a/src/ccutil/Makefile.am
+++ b/src/ccutil/Makefile.am
@@ -48,6 +48,10 @@ AM_CPPFLAGS += $(libzip_CFLAGS)
 else
 if HAVE_MINIZIP
 AM_CPPFLAGS += $(minizip_CFLAGS)
+else
+if HAVE_ZZIPLIB
+AM_CPPFLAGS += $(zziplib_CFLAGS)
+endif
 endif
 endif
 endif

--- a/src/ccutil/Makefile.am
+++ b/src/ccutil/Makefile.am
@@ -42,18 +42,15 @@ libtesseract_ccutil_la_SOURCES = \
 
 if HAVE_LIBARCHIVE
 AM_CPPFLAGS += $(libarchive_CFLAGS)
-else
+endif
 if HAVE_LIBZIP
 AM_CPPFLAGS += $(libzip_CFLAGS)
-else
+endif
 if HAVE_MINIZIP
 AM_CPPFLAGS += $(minizip_CFLAGS)
-else
+endif
 if HAVE_ZZIPLIB
 AM_CPPFLAGS += $(zziplib_CFLAGS)
-endif
-endif
-endif
 endif
 
 if T_WIN

--- a/src/ccutil/Makefile.am
+++ b/src/ccutil/Makefile.am
@@ -40,6 +40,18 @@ libtesseract_ccutil_la_SOURCES = \
     unichar.cpp unicharcompress.cpp unicharmap.cpp unicharset.cpp unicodes.cpp \
     params.cpp universalambigs.cpp
 
+if HAVE_LIBARCHIVE
+AM_CPPFLAGS += $(libarchive_CFLAGS)
+else
+if HAVE_LIBZIP
+AM_CPPFLAGS += $(libzip_CFLAGS)
+else
+if HAVE_MINIZIP
+AM_CPPFLAGS += $(minizip_CFLAGS)
+endif
+endif
+endif
+
 if T_WIN
 AM_CPPFLAGS += -DWINDLLNAME=\"lib@GENERIC_LIBRARY_NAME@\"
 endif

--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -79,7 +79,7 @@ bool TessdataManager::LoadArchiveFile(const char *filename) {
   if (a != nullptr) {
     archive_read_support_filter_all(a);
     archive_read_support_format_all(a);
-    if (archive_read_open_filename(a, filename, 4096) == ARCHIVE_OK) {
+    if (archive_read_open_filename(a, filename, 8192) == ARCHIVE_OK) {
       archive_entry *ae;
       while (archive_read_next_header(a, &ae) == ARCHIVE_OK) {
         const char *component = archive_entry_pathname(ae);
@@ -97,6 +97,9 @@ bool TessdataManager::LoadArchiveFile(const char *filename) {
         }
       }
       result = is_loaded_;
+    } else {
+      tprintf("archive_read_open_filename(...,%s,...) failed, %s\n",
+              filename, strerror(archive_errno(a)));
     }
     archive_read_free(a);
   }

--- a/src/ccutil/tessdatamanager.h
+++ b/src/ccutil/tessdatamanager.h
@@ -154,13 +154,11 @@ class TessdataManager {
   // Resets to the initial state, keeping the reader.
   void Clear();
 
-  // Prints a directory of contents.
-  void Directory() const;
-
   // Returns true if the component requested is present.
   bool IsComponentAvailable(TessdataType type) const {
     return !entries_[type].empty();
   }
+
   // Opens the given TFile pointer to the given component type.
   // Returns false in case of failure.
   bool GetComponent(TessdataType type, TFile *fp);
@@ -184,6 +182,11 @@ class TessdataManager {
 
   // Return the name of the underlying data file.
   const STRING &GetDataFileName() const { return data_file_name_; }
+
+  /* The remaining public methods are only used for combine_tessdata. */
+
+  // Prints a directory of contents.
+  void Directory() const;
 
   /**
    * Reads all the standard tesseract config and data files for a language
@@ -214,6 +217,8 @@ class TessdataManager {
    */
   bool ExtractToFile(const char *filename);
 
+ private:
+
   /**
    * Fills type with TessdataType of the tessdata component represented by the
    * given file name. E.g. tessdata/eng.unicharset -> TESSDATA_UNICHARSET.
@@ -230,7 +235,6 @@ class TessdataManager {
   static bool TessdataTypeFromFileName(const char *filename,
                                        TessdataType *type);
 
- private:
   // Name of file it came from.
   STRING data_file_name_;
   // Function to load the file when we need it.

--- a/src/ccutil/tessdatamanager.h
+++ b/src/ccutil/tessdatamanager.h
@@ -219,6 +219,8 @@ class TessdataManager {
 
  private:
 
+  bool LoadZipFile(const char *filename);
+
   /**
    * Fills type with TessdataType of the tessdata component represented by the
    * given file name. E.g. tessdata/eng.unicharset -> TESSDATA_UNICHARSET.

--- a/src/ccutil/tessdatamanager.h
+++ b/src/ccutil/tessdatamanager.h
@@ -219,7 +219,14 @@ class TessdataManager {
 
  private:
 
+  // Use libarchive.
+  bool LoadArchiveFile(const char *filename);
+  // Use libminizip.
+  bool LoadMinizipFile(const char *filename);
+  // Use libzip.
   bool LoadZipFile(const char *filename);
+  // Use libzzip.
+  bool LoadZzipFile(const char *filename);
 
   /**
    * Fills type with TessdataType of the tessdata component represented by the

--- a/src/training/Makefile.am
+++ b/src/training/Makefile.am
@@ -280,3 +280,28 @@ set_unicharset_properties_LDADD += $(LEPTONICA_LIBS)
 text2image_LDADD += $(LEPTONICA_LIBS)
 unicharset_extractor_LDADD += $(LEPTONICA_LIBS)
 wordlist2dawg_LDADD += $(LEPTONICA_LIBS)
+
+if HAVE_LIBARCHIVE
+extralib = $(libarchive_LIBS)
+else
+if HAVE_LIBZIP
+extralib = $(libzip_LIBS)
+else
+if HAVE_MINIZIP
+extralib = $(minizip_LIBS)
+else
+extralib =
+endif
+endif
+endif
+
+ambiguous_words_LDADD += $(extralib)
+classifier_tester_LDADD += $(extralib)
+cntraining_LDADD += $(extralib)
+combine_tessdata_LDADD += $(extralib)
+lstmeval_LDADD += $(extralib)
+lstmtraining_LDADD += $(extralib)
+mftraining_LDADD += $(extralib)
+set_unicharset_properties_LDADD += $(extralib)
+shapeclustering_LDADD += $(extralib)
+wordlist2dawg_LDADD += $(extralib)

--- a/src/training/Makefile.am
+++ b/src/training/Makefile.am
@@ -281,22 +281,18 @@ text2image_LDADD += $(LEPTONICA_LIBS)
 unicharset_extractor_LDADD += $(LEPTONICA_LIBS)
 wordlist2dawg_LDADD += $(LEPTONICA_LIBS)
 
-if HAVE_LIBARCHIVE
-extralib = $(libarchive_LIBS)
-else
-if HAVE_LIBZIP
-extralib = $(libzip_LIBS)
-else
-if HAVE_MINIZIP
-extralib = $(minizip_LIBS)
-else
-if HAVE_ZZIPLIB
-extralib = $(zziplib_LIBS)
-else
 extralib =
+if HAVE_LIBARCHIVE
+extralib += $(libarchive_LIBS)
 endif
+if HAVE_LIBZIP
+extralib += $(libzip_LIBS)
 endif
+if HAVE_MINIZIP
+extralib += $(minizip_LIBS)
 endif
+if HAVE_ZZIPLIB
+extralib += $(zziplib_LIBS)
 endif
 
 ambiguous_words_LDADD += $(extralib)

--- a/src/training/Makefile.am
+++ b/src/training/Makefile.am
@@ -290,7 +290,11 @@ else
 if HAVE_MINIZIP
 extralib = $(minizip_LIBS)
 else
+if HAVE_ZZIPLIB
+extralib = $(zziplib_LIBS)
+else
 extralib =
+endif
 endif
 endif
 endif


### PR DESCRIPTION
This requires libminizip-dev, so expect failures from CI.

Up to now, little endian tesseract works with the new zip format.

More work is needed for training tools and big endian support and also to maintain
compatibility with the current proprietary format.

Signed-off-by: Stefan Weil <sw@weilnetz.de>