### PR TITLE
Fix crash if output file could not be opened

### DIFF
--- a/api/renderer.cpp
+++ b/api/renderer.cpp
@@ -47,10 +47,12 @@ TessResultRenderer::TessResultRenderer(const char *outputbase,
 }
 
 TessResultRenderer::~TessResultRenderer() {
- if (fout_ != stdout)
-    fclose(fout_);
-  else
-    clearerr(fout_);
+  if (fout_ != nullptr) {
+    if (fout_ != stdout)
+      fclose(fout_);
+    else
+      clearerr(fout_);
+  }
   delete next_;
 }
 


### PR DESCRIPTION
This error case results in fout_ == nullptr.
Closing a nullptr file is not allowed.

Signed-off-by: Stefan Weil <sw@weilnetz.de>