### PR TITLE
Improve robustness of TessdataManager

### DIFF
--- a/ccutil/tessdatamanager.cpp
+++ b/ccutil/tessdatamanager.cpp
@@ -54,6 +54,7 @@ bool TessdataManager::LoadMemBuffer(const char *name, const char *data,
   swap_ = num_entries > kMaxNumTessdataEntries || num_entries < 0;
   fp.set_swap(swap_);
   if (swap_) ReverseN(&num_entries, sizeof(num_entries));
+  if (num_entries > kMaxNumTessdataEntries || num_entries < 0) return false;
   GenericVector<inT64> offset_table;
   offset_table.resize_no_init(num_entries);
   if (fp.FReadEndian(&offset_table[0], sizeof(offset_table[0]), num_entries) !=


### PR DESCRIPTION
Tesseract crashes with an unhandled exception (std::bad_alloc) if it gets
a bad tessdata file where the numEntries data field is very large (also
after swapping), for example 0x77777777.

Signed-off-by: Stefan Weil <sw@weilnetz.de>