### PR TITLE
automake: Enable all warnings and fix a warning

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -104,7 +104,7 @@ autoheader -f || bail_out
 # they are copied from the system so they can be used in a distribution.
 
 echo "Running automake --add-missing --copy"
-automake --add-missing -c  -Wno-portability > /dev/null || bail_out
+automake --add-missing --copy --warnings=all || bail_out
 
 # --- Step 5: Generate configure and include/miaconfig.h from:
 #             . configure.ac

--- a/java/Makefile.am
+++ b/java/Makefile.am
@@ -64,7 +64,7 @@ uninstall:
 	rm -f $(scrollview_path)/*.jar
 endif
 
-clean :
+clean-local:
 	rm -f ScrollView.jar $(SCROLLVIEW_CLASSES)
 
 # all-am does nothing, to make the java part optional.


### PR DESCRIPTION
Fix this automake warning for java/Makefile.am:

    java/Makefile.am:67: warning: user target 'clean' defined here ...
    automake: ... overrides Automake target 'clean' defined here
    java/Makefile.am:67: consider using clean-local instead of clean

Signed-off-by: Stefan Weil <sw@weilnetz.de>