### PR TITLE
Fix and improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
+# Dockerfile for local Travis build test
+
 FROM ubuntu
 MAINTAINER Ian Blenke <ian@blenke.com>
 
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git ruby bundler wget unzip
-RUN gem install travis --no-ri --no-rdoc
-RUN git clone https://github.com/travis-ci/travis-build ~/.travis/travis-build
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y cmake curl git ruby bundler wget unzip
+RUN gem install bundler travis --no-ri --no-rdoc
+RUN git clone --depth 1 https://github.com/travis-ci/travis-build ~/.travis/travis-build
 RUN bundle install --gemfile ~/.travis/travis-build/Gemfile
 
 ADD . /tesseract
 WORKDIR /tesseract
 
 RUN travis compile | sed -e "s/--branch\\\=\\\'\\\'/--branch=master/g" | bash
-


### PR DESCRIPTION
* Add comment.
* Add missing packages cmake, curl.
* Update bundler (fixes warning).
* Only clone the latest release of travis-build (save time and disk space).
* Remove empty line at end of file.

Signed-off-by: Stefan Weil <stefan@v2201612906741603.powersrv.de>