### PR TITLE
Update from Leptonica 1.74.1 to 1.74.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ before_install:
 install:
   #- if [[ $LINUX && "$CXX" = "g++" ]]; then export CXX="g++-6" CC="gcc-6"; fi
   - if test ! -d leptonica-$LEPT_VER/src; then curl -Ls https://github.com/DanBloomberg/leptonica/archive/$LEPT_VER.tar.gz | tar -xz; fi
-  - if test ! -d leptonica-$LEPT_VER/build/src; then cmake -Hleptonica-$LEPT_VER -Bleptonica-$LEPT_VER/build; fi
-  - if test ! -e leptonica-$LEPT_VER/build/src/libleptonica.so; then make -C leptonica-$LEPT_VER/build; fi
+  - if test ! -d leptonica-$LEPT_VER/usr; then cmake -Hleptonica-$LEPT_VER -Bleptonica-$LEPT_VER/build -DCMAKE_INSTALL_PREFIX=leptonica-$LEPT_VER/usr; fi
+  - if test ! -e leptonica-$LEPT_VER/usr/lib/libleptonica.so; then make -C leptonica-$LEPT_VER/build install; fi
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: cpp
 dist: trusty
 
 env:
-  - LEPT_VER=1.74.1
+  - LEPT_VER=1.74.2
 
 notifications:
   email: false

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,5 +30,5 @@ parts:
       - libcairo2-dev
     after: [leptonica]
   leptonica:
-    source: http://www.leptonica.org/source/leptonica-1.74.1.tar.gz
+    source: http://www.leptonica.org/source/leptonica-1.74.2.tar.gz
     plugin: autotools


### PR DESCRIPTION
The newer version contains fixes for the pixUnsharpMaskingGray*
functions which are relevant for Tesseract (used in ImageData::PreScale
which calls pixScale).

Signed-off-by: Stefan Weil <sw@weilnetz.de>