### PR TITLE
Download the leptonica source from github

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,5 +30,5 @@ parts:
       - libcairo2-dev
     after: [leptonica]
   leptonica:
-    source: http://www.leptonica.org/source/leptonica-1.74.2.tar.gz
+    source: https://github.com/DanBloomberg/leptonica/archive/1.74.2.tar.gz
     plugin: autotools


### PR DESCRIPTION
1.74.2 is no longer available from the leptonica website. But anyway, it seems safer going forward to download it from github. It's https, and it won't disappear as easily. Also, this is the same source used by travis, so there's less chance of shipping something untested.