### PR TITLE
fix filenames in comments (trivial)

### DIFF
--- a/api/tesseractmain.cpp
+++ b/api/tesseractmain.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
-* File:        tessedit.cpp  (Formerly tessedit.c)
+* File:        tesseractmain.cpp  (Formerly tessedit.c)
 * Description: Main program for merge of tess and editor.
 * Author:                  Ray Smith
 * Created:                 Tue Jan 07 15:21:46 GMT 1992

--- a/arch/simddetect.cpp
+++ b/arch/simddetect.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        simddetect.h
+// File:        simddetect.cpp
 // Description: Architecture detector.
 // Author:      Stefan Weil (based on code from Ray Smith)
 //

--- a/ccmain/paragraphs_internal.h
+++ b/ccmain/paragraphs_internal.h
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        paragraphs.h
+ * File:        paragraphs_internal.h
  * Description: Paragraph Detection internal data structures.
  * Author:      David Eger
  * Created:     11 March 2011

--- a/ccmain/paramsd.h
+++ b/ccmain/paramsd.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        paramsd.cpp
+// File:        paramsd.h
 // Description: Tesseract parameter editor
 // Author:      Joern Wanke
 // Created:     Wed Jul 18 10:05:01 PDT 2007

--- a/ccmain/werdit.h
+++ b/ccmain/werdit.h
@@ -1,8 +1,8 @@
 /**********************************************************************
- * File:			wordit.c
+ * File:        wordit.h
  * Description: An iterator for passing over all the words in a document.
- * Author:		Ray Smith
- * Created:		Mon Apr 27 08:51:22 BST 1992
+ * Author:      Ray Smith
+ * Created:     Mon Apr 27 08:51:22 BST 1992
  *
  * (C) Copyright 1992, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");

--- a/ccstruct/blobs.cpp
+++ b/ccstruct/blobs.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        blobs.c  (Formerly blobs.c)
+ * File:         blobs.cpp  (Formerly blobs.c)
  * Description:  Blob definition
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 27 15:39:52 1989

--- a/ccstruct/boxread.h
+++ b/ccstruct/boxread.h
@@ -1,8 +1,8 @@
 /**********************************************************************
- * File:        boxread.cpp
+ * File:        boxread.h
  * Description: Read data from a box file.
- * Author:		Ray Smith
- * Created:		Fri Aug 24 17:47:23 PDT 2007
+ * Author:	Ray Smith
+ * Created:	Fri Aug 24 17:47:23 PDT 2007
  *
  * (C) Copyright 2007, Google Inc.
  ** Licensed under the Apache License, Version 2.0 (the "License");

--- a/ccstruct/boxword.cpp
+++ b/ccstruct/boxword.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        boxword.h
+// File:        boxword.cpp
 // Description: Class to represent the bounding boxes of the output.
 // Author:      Ray Smith
 // Created:     Tue May 25 14:18:14 PDT 2010

--- a/ccstruct/coutln.cpp
+++ b/ccstruct/coutln.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        coutln.c  (Formerly coutline.c)
+ * File:        coutln.cpp  (Formerly coutline.c)
  * Description: Code for the C_OUTLINE class.
  * Author:                  Ray Smith
  * Created:                 Mon Oct 07 16:01:57 BST 1991

--- a/ccstruct/coutln.h
+++ b/ccstruct/coutln.h
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:						coutln.c      (Formerly:  coutline.c)
+ * File:					coutln.h      (Formerly:  coutline.c)
  * Description: Code for the C_OUTLINE class.
  * Author:					Ray Smith
  * Created:					Mon Oct 07 16:01:57 BST 1991

--- a/ccstruct/imagedata.cpp
+++ b/ccstruct/imagedata.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        imagedata.h
+// File:        imagedata.cpp
 // Description: Class to hold information about a single multi-page tiff
 //              training file and its corresponding boxes or text file.
 // Author:      Ray Smith

--- a/ccstruct/matrix.cpp
+++ b/ccstruct/matrix.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        matrix.c  (Formerly matrix.c)
+ * File:         matrix.cpp  (Formerly matrix.c)
  * Description:  Ratings matrix code. (Used by associator)
  * Author:       Mark Seaman, OCR Technology
  * Created:      Wed May 16 13:18:47 1990

--- a/ccstruct/mod128.cpp
+++ b/ccstruct/mod128.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        mod128.c  (Formerly dir128.c)
+ * File:        mod128.cpp  (Formerly dir128.c)
  * Description: Code to convert a DIR128 to an ICOORD.
  * Author:          Ray Smith
  * Created:         Tue Oct 22 11:56:09 BST 1991

--- a/ccstruct/ocrpara.cpp
+++ b/ccstruct/ocrpara.cpp
@@ -1,5 +1,5 @@
 /////////////////////////////////////////////////////////////////////
-// File:        ocrpara.h
+// File:        ocrpara.cpp
 // Description: OCR Paragraph Output Type
 // Author:      David Eger
 // Created:     2010-11-15

--- a/ccstruct/pdblock.cpp
+++ b/ccstruct/pdblock.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        pdblock.c  (Formerly pdblk.c)
+ * File:        pdblock.cpp  (Formerly pdblk.c)
  * Description: PDBLK member functions and iterator functions.
  * Author:					Ray Smith
  * Created:					Fri Mar 15 09:41:28 GMT 1991

--- a/ccstruct/points.cpp
+++ b/ccstruct/points.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        points.c  (Formerly coords.c)
+ * File:        points.cpp  (Formerly coords.c)
  * Description: Member functions for coordinate classes.
  * Author:					Ray Smith
  * Created:					Fri Mar 15 08:58:17 GMT 1991

--- a/ccstruct/polyblk.cpp
+++ b/ccstruct/polyblk.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        polyblk.c  (Formerly poly_block.c)
+ * File:        polyblk.cpp  (Formerly poly_block.c)
  * Description: Polygonal blocks
  * Author:          Sheelagh Lloyd?
  * Created:

--- a/ccstruct/rect.cpp
+++ b/ccstruct/rect.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        rect.c  (Formerly box.c)
+ * File:        rect.cpp  (Formerly box.c)
  * Description: Bounding box class definition.
  * Author:          Phil Cheatle
  * Created:         Wed Oct 16 15:18:45 BST 1991

--- a/ccstruct/seam.cpp
+++ b/ccstruct/seam.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        seam.c  (Formerly seam.c)
+ * File:         seam.cpp  (Formerly seam.c)
  * Description:
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/ccstruct/split.cpp
+++ b/ccstruct/split.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        split.c  (Formerly split.c)
+ * File:         split.cpp  (Formerly split.c)
  * Description:
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/ccstruct/statistc.cpp
+++ b/ccstruct/statistc.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        statistc.c  (Formerly stats.c)
+ * File:        statistc.cpp  (Formerly stats.c)
  * Description: Simple statistical package for integer values.
  * Author:          Ray Smith
  * Created:         Mon Feb 04 16:56:05 GMT 1991

--- a/ccstruct/vecfuncs.cpp
+++ b/ccstruct/vecfuncs.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        vecfuncs.c  (Formerly vecfuncs.c)
+ * File:         vecfuncs.cpp  (Formerly vecfuncs.c)
  * Description:  Blob definition
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 27 15:39:52 1989

--- a/ccstruct/werd.h
+++ b/ccstruct/werd.h
@@ -1,8 +1,8 @@
 /**********************************************************************
- * File:			word.c
+ * File:	word.h
  * Description: Code for the WERD class.
- * Author:		Ray Smith
- * Created:		Tue Oct 08 14:32:12 BST 1991
+ * Author:	Ray Smith
+ * Created:	Tue Oct 08 14:32:12 BST 1991
  *
  * (C) Copyright 1991, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");

--- a/ccutil/ambigs.cpp
+++ b/ccutil/ambigs.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        ambigs.cc
+// File:        ambigs.cpp
 // Description: Functions for dealing with ambiguities
 //              (training and recognition).
 // Author:      Daria Antonova

--- a/ccutil/basedir.cpp
+++ b/ccutil/basedir.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        basedir.c  (Formerly getpath.c)
+ * File:        basedir.cpp  (Formerly getpath.c)
  * Description: Find the directory location of the current executable using PATH.
  * Author:      Ray Smith
  * Created:     Mon Jul 09 09:06:39 BST 1990

--- a/ccutil/bits16.cpp
+++ b/ccutil/bits16.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        bits16.h  (Formerly bits8.h)
+ * File:        bits16.cpp  (Formerly bits8.h)
  * Description: Code for 8 bit field class.
  * Author:					Phil Cheatle
  * Created:					Thu Oct 17 10:10:05 BST 1991

--- a/ccutil/clst.cpp
+++ b/ccutil/clst.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        clst.c  (Formerly clist.c)
+ * File:        clst.cpp  (Formerly clist.c)
  * Description: CONS cell list handling code which is not in the include file.
  * Author:      Phil Cheatle
  * Created:     Mon Jan 28 08:33:13 GMT 1991

--- a/ccutil/elst.cpp
+++ b/ccutil/elst.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        elst.c  (Formerly elist.c)
+ * File:        elst.cpp  (Formerly elist.c)
  * Description: Embedded list handling code which is not in the include file.
  * Author:      Phil Cheatle
  * Created:     Fri Jan 04 13:55:49 GMT 1991

--- a/ccutil/elst2.cpp
+++ b/ccutil/elst2.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        elst2.c  (Formerly elist2.c)
+ * File:        elst2.cpp  (Formerly elist2.c)
  * Description: Doubly linked embedded list code not in the include file.
  * Author:      Phil Cheatle
  * Created:     Wed Jan 23 11:04:47 GMT 1991

--- a/ccutil/errcode.cpp
+++ b/ccutil/errcode.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        errcode.c  (Formerly error.c)
+ * File:        errcode.cpp  (Formerly error.c)
  * Description: Generic error handler function
  * Author:      Ray Smith
  * Created:     Tue May  1 16:28:39 BST 1990

--- a/ccutil/globaloc.cpp
+++ b/ccutil/globaloc.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        errcode.c  (Formerly error.c)
+ * File:        errcode.cpp  (Formerly error.c)
  * Description: Generic error handler function
  * Author:      Ray Smith
  * Created:     Tue May  1 16:28:39 BST 1990

--- a/ccutil/globaloc.h
+++ b/ccutil/globaloc.h
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        errcode.h  (Formerly error.h)
+ * File:        globaloc.h  (Formerly error.h)
  * Description: Header file for generic error handler class
  * Author:      Ray Smith
  * Created:     Tue May  1 16:23:36 BST 1990

--- a/ccutil/mainblk.cpp
+++ b/ccutil/mainblk.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        mainblk.c  (Formerly main.c)
+ * File:        mainblk.cpp  (Formerly main.c)
  * Description: Function to call from main() to setup.
  * Author:      Ray Smith
  * Created:     Tue Oct 22 11:09:40 BST 1991

--- a/ccutil/memry.cpp
+++ b/ccutil/memry.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        memry.c  (Formerly memory.c)
+ * File:        memry.cpp  (Formerly memory.c)
  * Description: Memory allocation with builtin safety checks.
  * Author:					Ray Smith
  * Created:					Wed Jan 22 09:43:33 GMT 1992

--- a/ccutil/serialis.cpp
+++ b/ccutil/serialis.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        serialis.h  (Formerly serialmac.h)
+ * File:        serialis.cpp  (Formerly serialmac.h)
  * Description: Inline routines and macros for serialisation functions
  * Author:      Phil Cheatle
  * Created:     Tue Oct 08 08:33:12 BST 1991

--- a/ccutil/strngs.cpp
+++ b/ccutil/strngs.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        strngs.c  (Formerly strings.c)
+ * File:        strngs.cpp  (Formerly strings.c)
  * Description: STRING class functions.
  * Author:          Ray Smith
  * Created:         Fri Feb 15 09:13:30 GMT 1991

--- a/ccutil/tprintf.cpp
+++ b/ccutil/tprintf.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        tprintf.c
+ * File:        tprintf.cpp
  * Description: Trace version of printf - portable between UX and NT
  * Author:      Phil Cheatle
  * Created:     Wed Jun 28 15:01:15 BST 1995

--- a/ccutil/unicity_table.h
+++ b/ccutil/unicity_table.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        UnicityTable.h
+// File:        unicity_table.h
 // Description: a class to uniquify objects, manipulating them using integers
 // ids.
 // Author:      Samuel Charron

--- a/ccutil/unicodes.cpp
+++ b/ccutil/unicodes.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        unicodes.h
+ * File:        unicodes.cpp
  * Description: Unicode related machinery
  * Author:      David Eger
  * Created:     Wed Jun 15 16:37:50 PST 2011

--- a/classify/protos.cpp
+++ b/classify/protos.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        protos.c  (Formerly protos.c)
+ * File:        protos.cpp  (Formerly protos.c)
  * Description:
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/classify/shapeclassifier.cpp
+++ b/classify/shapeclassifier.cpp
@@ -1,7 +1,7 @@
 // Copyright 2011 Google Inc. All Rights Reserved.
 // Author: rays@google.com (Ray Smith)
 ///////////////////////////////////////////////////////////////////////
-// File:        shapeclassifier.h
+// File:        shapeclassifier.cpp
 // Description: Base interface class for classifiers that return a
 //              shape index.
 // Author:      Ray Smith

--- a/cutil/cutil.cpp
+++ b/cutil/cutil.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:         cutil.c
+ * File:         cutil.cpp
  * Description:  General utility functions
  * Author:       Mark Seaman, SW Productivity
  * Created:      Fri Oct 16 14:37:00 1987

--- a/cutil/cutil_class.cpp
+++ b/cutil/cutil_class.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        cutil.cpp
+// File:        cutil_class.cpp
 // Description: cutil class.
 // Author:      Samuel Charron
 //

--- a/cutil/cutil_class.h
+++ b/cutil/cutil_class.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        cutil.h
+// File:        cutil_class.h
 // Description: cutil class.
 // Author:      Samuel Charron
 //

--- a/cutil/oldlist.cpp
+++ b/cutil/oldlist.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
 ###############################################################################
 #
-# File:         list.c
+# File:         oldlist.cpp
 # Description:  List processing procedures.
 # Author:       Mark Seaman, Software Productivity
 # Created:      Thu Jul 23 13:24:09 1987

--- a/cutil/oldlist.h
+++ b/cutil/oldlist.h
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        list.h  (Formerly list.h)
+ * File:         oldlist.h  (Formerly list.h)
  * Description:  List processing procedures declarations.
  * Author:       Mark Seaman, SW Productivity
  * Created:      Fri Oct 16 14:37:00 1987

--- a/cutil/structures.cpp
+++ b/cutil/structures.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        structures.c  (Formerly structures.c)
+ * File:         structures.cpp  (Formerly structures.c)
  * Description:  Allocate all the different types of structures.
  * Author:       Mark Seaman, OCR Technology
  * Created:      Wed May 30 10:27:26 1990

--- a/dict/context.cpp
+++ b/dict/context.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        context.c  (Formerly context.c)
+ * File:         context.cpp  (Formerly context.c)
  * Description:  Context checking functions
  * Author:       Mark Seaman, OCR Technology
  * Created:      Thu Feb 15 11:18:24 1990

--- a/dict/dawg.cpp
+++ b/dict/dawg.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        dawg.c  (Formerly dawg.c)
+ * File:         dawg.cpp  (Formerly dawg.c)
  * Description:  Use a Directed Accyclic Word Graph
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/dict/dawg_cache.cpp
+++ b/dict/dawg_cache.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        dawg_cache.h
+// File:        dawg_cache.cpp
 // Description: A class that knows about loading and caching dawgs.
 // Author:      David Eger
 // Created:     Fri Jan 27 12:08:00 PST 2012

--- a/dict/hyphen.cpp
+++ b/dict/hyphen.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
- * File:        hyphen.c  (Formerly hyphen.c)
- * Description: Functions for maintaining information about hyphenated words.
+ * File:	 hyphen.cpp  (Formerly hyphen.c)
+ * Description:  Functions for maintaining information about hyphenated words.
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987
  * Modified:     Thu Mar 14 11:09:43 1991 (Mark Seaman) marks@hpgrlt

--- a/dict/permdawg.cpp
+++ b/dict/permdawg.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        permdawg.c  (Formerly permdawg.c)
+ * File:         permdawg.cpp  (Formerly permdawg.c)
  * Description:  Scale word choices by a dictionary
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/dict/trie.cpp
+++ b/dict/trie.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        trie.c  (Formerly trie.c)
+ * File:         trie.cpp  (Formerly trie.c)
  * Description:  Functions to build a trie data structure.
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/lstm/maxpool.cpp
+++ b/lstm/maxpool.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        maxpool.h
+// File:        maxpool.cpp
 // Description: Standard Max-Pooling layer.
 // Author:      Ray Smith
 // Created:     Tue Mar 18 16:28:18 PST 2014

--- a/lstm/networkbuilder.cpp
+++ b/lstm/networkbuilder.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        networkbuilder.h
+// File:        networkbuilder.cpp
 // Description: Class to parse the network description language and
 //              build a corresponding network.
 // Author:      Ray Smith

--- a/lstm/tfnetwork.cpp
+++ b/lstm/tfnetwork.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        tfnetwork.h
+// File:        tfnetwork.cpp
 // Description: Encapsulation of an entire tensorflow graph as a
 //              Tesseract Network.
 // Author:      Ray Smith

--- a/lstm/weightmatrix.cpp
+++ b/lstm/weightmatrix.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        weightmatrix.h
+// File:        weightmatrix.cpp
 // Description: Hides distinction between float/int implementations.
 // Author:      Ray Smith
 // Created:     Tue Jun 17 11:46:20 PST 2014

--- a/textord/blobgrid.cpp
+++ b/textord/blobgrid.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        blobgrid.h
+// File:        blobgrid.cpp
 // Description: BBGrid of BLOBNBOX with useful BLOBNBOX-specific methods.
 // Copyright 2011 Google Inc. All Rights Reserved.
 // Author: rays@google.com (Ray Smith)

--- a/textord/colpartitiongrid.cpp
+++ b/textord/colpartitiongrid.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        colpartitionrid.h
+// File:        colpartitiongrid.cpp
 // Description: Class collecting code that acts on a BBGrid of ColPartitions.
 // Author:      Ray Smith
 // Created:     Mon Oct 05 08:42:01 PDT 2009

--- a/textord/colpartitiongrid.h
+++ b/textord/colpartitiongrid.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        colpartitionrid.h
+// File:        colpartitiongrid.h
 // Description: Class collecting code that acts on a BBGrid of ColPartitions.
 // Author:      Ray Smith
 // Created:     Mon Oct 05 08:42:01 PDT 2009

--- a/textord/drawedg.cpp
+++ b/textord/drawedg.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        drawedg.c  (Formerly drawedge.c)
+ * File:        drawedg.cpp  (Formerly drawedge.c)
  * Description: Collection of functions to draw things to do with edge detection.
  * Author:                  Ray Smith
  * Created:                 Thu Jun 06 13:29:20 BST 1991

--- a/textord/edgblob.cpp
+++ b/textord/edgblob.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        edgblob.c (Formerly edgeloop.c)
+ * File:        edgblob.cpp (Formerly edgeloop.c)
  * Description: Functions to clean up an outline before approximation.
  * Author:		Ray Smith
  * Created:		Tue Mar 26 16:56:25 GMT 1991

--- a/textord/edgloop.cpp
+++ b/textord/edgloop.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        edgloop.c  (Formerly edgeloop.c)
+ * File:        edgloop.cpp  (Formerly edgeloop.c)
  * Description: Functions to clean up an outline before approximation.
  * Author:					Ray Smith
  * Created:					Tue Mar 26 16:56:25 GMT 1991

--- a/textord/scanedg.cpp
+++ b/textord/scanedg.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        scanedg.c  (Formerly scanedge.c)
+ * File:        scanedg.cpp  (Formerly scanedge.c)
  * Description: Raster scanning crack based edge extractor.
  * Author:					Ray Smith
  * Created:					Fri Mar 22 16:11:50 GMT 1991

--- a/textord/tabfind.cpp
+++ b/textord/tabfind.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        TabFind.cpp
+// File:        tabfind.cpp
 // Description: Subclass of BBGrid to find vertically aligned blobs.
 // Author:      Ray Smith
 // Created:     Fri Mar 21 15:03:01 PST 2008

--- a/training/combine_tessdata.cpp
+++ b/training/combine_tessdata.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        combine_tessdata
+// File:        combine_tessdata.cpp
 // Description: Creates a unified traineddata file from several
 //              data files produced by the training process.
 // Author:      Daria Antonova

--- a/training/tessopt.cpp
+++ b/training/tessopt.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        getopt.c
+ * File:        tessopt.cpp
  * Description: Re-implementation of the unix code.
  * Author:					Ray Smith
  * Created:					Tue Nov 28 05:52:50 MST 1995

--- a/training/tessopt.h
+++ b/training/tessopt.h
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        getopt.h
+ * File:        tessopt.h
  * Description: Re-implementation of the unix code.
  * Author:					Ray Smith
  * Created:					Tue Nov 28 05:52:50 MST 1995

--- a/viewer/scrollview.cpp
+++ b/viewer/scrollview.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        scrollview.cc
+// File:        scrollview.cpp
 // Description: ScrollView
 // Author:      Joern Wanke
 // Created:     Thu Nov 29 2007

--- a/wordrec/chop.cpp
+++ b/wordrec/chop.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        chop.c  (Formerly chop.c)
+ * File:        chop.cpp  (Formerly chop.c)
  * Description:
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/wordrec/chopper.cpp
+++ b/wordrec/chopper.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        chopper.c  (Formerly chopper.c)
+ * File:         chopper.cpp  (Formerly chopper.c)
  * Description:
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/wordrec/findseam.cpp
+++ b/wordrec/findseam.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        findseam.c  (Formerly findseam.c)
+ * File:         findseam.cpp  (Formerly findseam.c)
  * Description:
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/wordrec/gradechop.cpp
+++ b/wordrec/gradechop.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        gradechop.c  (Formerly gradechop.c)
+ * File:         gradechop.cpp  (Formerly gradechop.c)
  * Description:
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/wordrec/lm_pain_points.cpp
+++ b/wordrec/lm_pain_points.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        pain_points.cpp
+// File:        lm_pain_points.cpp
 // Description: Functions that utilize the knowledge about the properties
 //              of the paths explored by the segmentation search in order
 //              to "pain points" - the locations in the ratings matrix

--- a/wordrec/outlines.cpp
+++ b/wordrec/outlines.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        outlines.c  (Formerly outlines.c)
+ * File:         outlines.cpp  (Formerly outlines.c)
  * Description:  Combinatorial Splitter
  * Author:       Mark Seaman, OCR Technology
  * Created:      Thu Jul 27 08:59:01 1989

--- a/wordrec/pieces.cpp
+++ b/wordrec/pieces.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        pieces.c  (Formerly pieces.c)
+ * File:         pieces.cpp  (Formerly pieces.c)
  * Description:
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Oct 16 14:37:00 1987

--- a/wordrec/plotedges.cpp
+++ b/wordrec/plotedges.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        plotedges.c  (Formerly plotedges.c)
+ * File:         plotedges.cpp  (Formerly plotedges.c)
  * Description:  Graphics routines for "Edges" and "Outlines" windows
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Jul 28 13:14:48 1989

--- a/wordrec/render.cpp
+++ b/wordrec/render.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        render.c  (Formerly render.c)
+ * File:         render.cpp  (Formerly render.c)
  * Description:  Convert the various data type into line lists
  * Author:       Mark Seaman, OCR Technology
  * Created:      Fri Jul 28 13:14:48 1989

--- a/wordrec/segsearch.cpp
+++ b/wordrec/segsearch.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////
-// File:        segsearch.h
+// File:        segsearch.cpp
 // Description: Segmentation search functions.
 // Author:      Daria Antonova
 // Created:     Mon Jun 23 11:26:43 PDT 2008

--- a/wordrec/tface.cpp
+++ b/wordrec/tface.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * File:        tface.c  (Formerly tface.c)
+ * File:        tface.cpp  (Formerly tface.c)
  * Description: C side of the Tess/tessedit C/C++ interface.
  * Author:		Ray Smith
  * Created:		Mon Apr 27 11:57:06 BST 1992

--- a/wordrec/wordclass.cpp
+++ b/wordrec/wordclass.cpp
@@ -1,7 +1,7 @@
 /* -*-C-*-
  ********************************************************************************
  *
- * File:        wordclass.c  (Formerly wordclass.c)
+ * File:         wordclass.cpp  (Formerly wordclass.c)
  * Description:  Word classifier
  * Author:       Mark Seaman, OCR Technology
  * Created:      Tue Jan 30 14:03:25 1990


### PR DESCRIPTION
A few of the filenames in the comments do not list the actual name of the file. It looks like some were accidentally left (maybe after a regression?) or were copied.

I was working on something where I had to touch many files, and decided to break out this fix and push it.