### PR TITLE
Use lept_free to free memory allocated by Leptonica

### DIFF
--- a/ccstruct/imagedata.cpp
+++ b/ccstruct/imagedata.cpp
@@ -331,7 +331,7 @@ void ImageData::SetPixInternal(Pix* pix, GenericVector<char>* image_data) {
   pixDestroy(&pix);
   image_data->resize_no_init(size);
   memcpy(&(*image_data)[0], data, size);
-  free(data);
+  lept_free(data);
 }
 
 // Returns the Pix image for the image_data. Must be pixDestroyed after use.

--- a/viewer/scrollview.cpp
+++ b/viewer/scrollview.cpp
@@ -809,7 +809,7 @@ void ScrollView::Image(struct Pix* image, int x_pos, int y_pos) {
     base64[code_len++] = kBase64Table[remainder & 63];
   SendRawMessage(base64);
   delete [] base64;
-  free(data);
+  lept_free(data);
 }
 
 // Escapes the ' character with a \, so it can be processed by LUA.


### PR DESCRIPTION
This fixes problems on Windows when Tesseract and Leptonica use different
C runtime libraries.

Signed-off-by: Stefan Weil <sw@weilnetz.de>