### PR TITLE
Fix hint for training build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -521,15 +521,16 @@ echo "$ sudo make install"
 # echo "$ sudo make install LANGS=\"eng ara deu\""
 # echo "  Or:"
 # echo "$ sudo make install-langs"
+echo ""
 
 AM_COND_IF([ENABLE_TRAINING],
-  [echo ""
-   echo "Training tools can be build and installed (after building of $PACKAGE_NAME) with:"
+  [
+   echo "Training tools can be built and installed with:"
    echo ""
    echo "$ make training"
    echo "$ sudo make training-install"
    echo ""],
-  [echo ""
+  [
    echo "You can not build training tools because of missing dependency."
    echo "Check configure output for details."
    echo ""]


### PR DESCRIPTION
* Fix grammar.
* Fix text ("after building ..." is not necessary).

Signed-off-by: Stefan Weil <sw@weilnetz.de>