### PR TITLE
Don't add empty line to text output

### DIFF
--- a/ccmain/resultiterator.cpp
+++ b/ccmain/resultiterator.cpp
@@ -658,8 +658,9 @@ void ResultIterator::IterateAndAppendUTF8TextlineText(STRING *text) {
   }
   *text += line_separator_;
   // If we just finished a paragraph, add an extra newline.
-  if (it_->block() == NULL || IsAtBeginningOf(RIL_PARA))
+  if (IsAtBeginningOf(RIL_PARA)) {
     *text += paragraph_separator_;
+  }
 }
 
 void ResultIterator::AppendUTF8ParagraphText(STRING *text) const {


### PR DESCRIPTION
Empty lines in text output are needed to separate paragraphs,
but there should not be an empty line at the end of the text.

Signed-off-by: Stefan Weil <sw@weilnetz.de>