### PR TITLE
cmake install fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,7 @@ install(FILES
     ccutil/unicharcompress.h 
     ccutil/unicharmap.h 
     ccutil/unicharset.h
+    ccutil/version.h
 
     #from lstm/makefile.am
     lstm/convolve.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,8 @@ set_target_properties           (libtesseract PROPERTIES SOVERSION ${VERSION_MAJ
 if (WIN32)
 set_target_properties           (libtesseract PROPERTIES OUTPUT_NAME tesseract${VERSION_MAJOR}${VERSION_MINOR})
 set_target_properties           (libtesseract PROPERTIES DEBUG_OUTPUT_NAME tesseract${VERSION_MAJOR}${VERSION_MINOR}d)
+else()
+set_target_properties           (libtesseract PROPERTIES OUTPUT_NAME tesseract)
 endif()
 
 if (NOT CPPAN_BUILD)


### PR DESCRIPTION
On non win32 platforms the library was being built as `liblibtesseract.4.0.0.dylib` (osx shared) or `liblibtesseract.a` (linux static).

Also the `version.h` file was not being installed.