### PR TITLE
fix accidental overwrite because of using old version

### DIFF
--- a/training/Makefile.am
+++ b/training/Makefile.am
@@ -345,7 +345,9 @@ text2image_LDADD += $(ICU_UC_LIBS) -lpango-1.0 -lpangocairo-1.0 \
 unicharset_extractor_SOURCES = unicharset_extractor.cpp
 #unicharset_extractor_LDFLAGS = -static
 unicharset_extractor_LDADD = \
-    libtesseract_tessopt.la
+    libtesseract_training.la \
+    libtesseract_tessopt.la \
+    $(ICU_I18N_LIBS) $(ICU_UC_LIBS)
 if USING_MULTIPLELIBS
 unicharset_extractor_LDADD += \
     ../ccutil/libtesseract_ccutil.la \


### PR DESCRIPTION
Puts back changes from https://github.com/tesseract-ocr/tesseract/commit/9d258e20d339142678f06d3e3c181fc60f83b593