### PR TITLE
Autotools build: Remove the option 'USING_MULTIPLELIBS'

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -17,28 +17,7 @@ endif
 include_HEADERS = apitypes.h baseapi.h capi.h renderer.h
 lib_LTLIBRARIES = 
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_api.la
-else
-lib_LTLIBRARIES += libtesseract_api.la
-libtesseract_api_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_api_la_LIBADD = \
-    ../ccmain/libtesseract_main.la \
-    ../textord/libtesseract_textord.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_arch.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_avx2.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccutil/libtesseract_ccutil.la \
-    ../opencl/libtesseract_opencl.la 
-endif
 
 libtesseract_api_la_CPPFLAGS = $(AM_CPPFLAGS)
 if VISIBILITY

--- a/arch/Makefile.am
+++ b/arch/Makefile.am
@@ -12,17 +12,8 @@ include_HEADERS = dotproductavx.h dotproductsse.h intsimdmatrix.h intsimdmatrixa
 
 noinst_HEADERS =
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_avx.la libtesseract_avx2.la libtesseract_sse.la
 noinst_LTLIBRARIES += libtesseract_arch.la
-else
-lib_LTLIBRARIES = libtesseract_avx.la libtesseract_avx2.la libtesseract_sse.la
-lib_LTLIBRARIES += libtesseract_arch.la
-libtesseract_arch_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_avx_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_avx2_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_sse_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-endif
 
 if AVX_OPT
 libtesseract_avx_la_CXXFLAGS = -mavx

--- a/ccmain/Makefile.am
+++ b/ccmain/Makefile.am
@@ -23,25 +23,7 @@ noinst_HEADERS = \
     output.h paragraphs.h paragraphs_internal.h paramsd.h pgedit.h \
     reject.h tessbox.h tessedit.h tesseractclass.h tessvars.h werdit.h
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_main.la
-else
-lib_LTLIBRARIES = libtesseract_main.la
-libtesseract_main_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_main_la_LIBADD = \
-    ../wordrec/libtesseract_wordrec.la \
-    ../textord/libtesseract_textord.la \
-    ../ccutil/libtesseract_ccutil.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../viewer/libtesseract_viewer.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../classify/libtesseract_classify.la \
-    ../cutil/libtesseract_cutil.la \
-    ../opencl/libtesseract_opencl.la
-endif
 
 libtesseract_main_la_SOURCES = \
     adaptions.cpp applybox.cpp control.cpp  \

--- a/ccstruct/Makefile.am
+++ b/ccstruct/Makefile.am
@@ -22,17 +22,7 @@ noinst_HEADERS = \
     quadlsq.h quadratc.h quspline.h ratngs.h rect.h rejctmap.h \
     seam.h split.h statistc.h stepblob.h vecfuncs.h werd.h
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_ccstruct.la
-else
-lib_LTLIBRARIES = libtesseract_ccstruct.la
-libtesseract_ccstruct_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_ccstruct_la_LIBADD = \
-    ../ccutil/libtesseract_ccutil.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../opencl/libtesseract_opencl.la 
-endif
 
 libtesseract_ccstruct_la_SOURCES = \
     blamer.cpp blobbox.cpp blobs.cpp blread.cpp boxread.cpp boxword.cpp ccstruct.cpp coutln.cpp \

--- a/ccutil/Makefile.am
+++ b/ccutil/Makefile.am
@@ -25,12 +25,7 @@ noinst_HEADERS = \
     scanutils.h tessdatamanager.h tprintf.h unicity_table.h unicodes.h \
     universalambigs.h
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_ccutil.la
-else
-lib_LTLIBRARIES = libtesseract_ccutil.la
-libtesseract_ccutil_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-endif
 
 libtesseract_ccutil_la_SOURCES = \
     ambigs.cpp basedir.cpp bits16.cpp bitvector.cpp \

--- a/classify/Makefile.am
+++ b/classify/Makefile.am
@@ -21,18 +21,7 @@ noinst_HEADERS = \
     sampleiterator.h shapeclassifier.h shapetable.h \
     tessclassifier.h trainingsample.h trainingsampleset.h
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_classify.la
-else
-lib_LTLIBRARIES = libtesseract_classify.la
-libtesseract_classify_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_classify_la_LIBADD = \
-    ../ccutil/libtesseract_ccutil.la \
-    ../cutil/libtesseract_cutil.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../dict/libtesseract_dict.la \
-    ../viewer/libtesseract_viewer.la
-endif
 
 libtesseract_classify_la_SOURCES = \
     adaptive.cpp adaptmatch.cpp blobclass.cpp \

--- a/configure.ac
+++ b/configure.ac
@@ -267,15 +267,6 @@ AC_ARG_ENABLE([visibility],
 AC_MSG_RESULT([$enable_visibility])
 AM_CONDITIONAL([VISIBILITY], [test "$enable_visibility" = "yes"])
 
-# check whether to build multiple libraries
-AC_MSG_CHECKING([--enable-multiple-libraries argument])
-AC_ARG_ENABLE([multiple-libraries],
-    [AS_HELP_STRING([--enable-multiple-libraries],[enable multiple libraries (default=no)])],
-    [enable_mlibs=$enableval],
-    [enable_mlibs="no"])
-AC_MSG_RESULT([$enable_mlibs])
-AM_CONDITIONAL([USING_MULTIPLELIBS], [test "$enable_mlibs" = "yes"])
-
 # Check if tessdata-prefix is disabled
 AC_MSG_CHECKING([whether to use tessdata-prefix])
 AC_ARG_ENABLE([tessdata-prefix],

--- a/cutil/Makefile.am
+++ b/cutil/Makefile.am
@@ -10,15 +10,7 @@ noinst_HEADERS = \
     emalloc.h globals.h \
     oldlist.h structures.h
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_cutil.la
-else
-lib_LTLIBRARIES = libtesseract_cutil.la
-libtesseract_cutil_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_cutil_la_LIBADD = \
-	../ccutil/libtesseract_ccutil.la \
-	../viewer/libtesseract_viewer.la	
-endif
 
 libtesseract_cutil_la_SOURCES = \
     bitvec.cpp callcpp.cpp cutil.cpp cutil_class.cpp danerror.cpp efio.cpp \

--- a/dict/Makefile.am
+++ b/dict/Makefile.am
@@ -10,17 +10,7 @@ noinst_HEADERS = \
     dawg.h dawg_cache.h dict.h matchdefs.h \
     stopper.h trie.h
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_dict.la
-else
-lib_LTLIBRARIES = libtesseract_dict.la
-libtesseract_dict_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_dict_la_LIBADD = \
-    ../ccutil/libtesseract_ccutil.la \
-    ../cutil/libtesseract_cutil.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../viewer/libtesseract_viewer.la
-endif
 
 libtesseract_dict_la_SOURCES = \
     context.cpp \

--- a/lstm/Makefile.am
+++ b/lstm/Makefile.am
@@ -24,12 +24,7 @@ include_HEADERS = \
 
 noinst_HEADERS = 
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_lstm.la
-else
-lib_LTLIBRARIES = libtesseract_lstm.la
-libtesseract_lstm_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-endif
 
 libtesseract_lstm_la_SOURCES = \
 	convolve.cpp ctc.cpp fullyconnected.cpp functions.cpp input.cpp \

--- a/opencl/Makefile.am
+++ b/opencl/Makefile.am
@@ -2,15 +2,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/ccutil -I$(top_srcdir)/ccstruct -I$(top_srcdir)/c
 noinst_HEADERS = \
     openclwrapper.h oclkernels.h opencl_device_selection.h 
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_opencl.la
-else
-lib_LTLIBRARIES = libtesseract_opencl.la
-libtesseract_opencl_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION) $(OPENCL_LDFLAGS)
-libtesseract_opencl_la_LIBADD = \
-    ../ccutil/libtesseract_ccutil.la \
-    ../viewer/libtesseract_viewer.la
-endif
 
 libtesseract_opencl_la_SOURCES = \
     openclwrapper.cpp

--- a/textord/Makefile.am
+++ b/textord/Makefile.am
@@ -27,21 +27,7 @@ noinst_HEADERS = \
     topitch.h tordmain.h tovars.h \
     underlin.h wordseg.h workingpartset.h
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_textord.la
-else
-lib_LTLIBRARIES = libtesseract_textord.la
-libtesseract_textord_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_textord_la_LIBADD = \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../ccutil/libtesseract_ccutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../cutil/libtesseract_cutil.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../opencl/libtesseract_opencl.la 
-endif
 
 libtesseract_textord_la_SOURCES = \
     alignedblob.cpp baselinedetect.cpp bbgrid.cpp blkocc.cpp blobgrid.cpp \

--- a/training/Makefile.am
+++ b/training/Makefile.am
@@ -62,50 +62,16 @@ ambiguous_words_SOURCES = ambiguous_words.cpp
 ambiguous_words_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la
-if USING_MULTIPLELIBS
-ambiguous_words_LDADD += \
-    ../api/libtesseract_api.la \
-    ../textord/libtesseract_textord.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 ambiguous_words_LDADD += \
     ../api/libtesseract.la
-endif
 
 classifier_tester_SOURCES = classifier_tester.cpp
 #classifier_tester_LDFLAGS = -static
 classifier_tester_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la
-if USING_MULTIPLELIBS
-classifier_tester_LDADD += \
-    ../api/libtesseract_api.la \
-    ../textord/libtesseract_textord.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 classifier_tester_LDADD += \
     ../api/libtesseract.la
-endif
 
 combine_lang_model_SOURCES = combine_lang_model.cpp
 #combine_lang_model_LDFLAGS = -static
@@ -113,71 +79,28 @@ combine_lang_model_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la \
     $(ICU_I18N_LIBS) $(ICU_UC_LIBS)
-if USING_MULTIPLELIBS
-combine_lang_model_LDADD += \
-    ../ccutil/libtesseract_ccutil.la
-else
 combine_lang_model_LDADD += \
     ../api/libtesseract.la
-endif
 
 combine_tessdata_SOURCES = combine_tessdata.cpp
 #combine_tessdata_LDFLAGS = -static
-if USING_MULTIPLELIBS
-combine_tessdata_LDADD = \
-    ../ccutil/libtesseract_ccutil.la \
-    ../lstm/libtesseract_lstm.la
-else
 combine_tessdata_LDADD = \
     ../api/libtesseract.la
-endif
 
 cntraining_SOURCES = cntraining.cpp
 #cntraining_LDFLAGS = -static
 cntraining_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la
-if USING_MULTIPLELIBS
-cntraining_LDADD += \
-    ../textord/libtesseract_textord.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 cntraining_LDADD += \
     ../api/libtesseract.la
-endif
 
 dawg2wordlist_SOURCES = dawg2wordlist.cpp
 #dawg2wordlist_LDFLAGS = -static
 dawg2wordlist_LDADD = \
     libtesseract_tessopt.la
-if USING_MULTIPLELIBS
-dawg2wordlist_LDADD += \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../textord/libtesseract_textord.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 dawg2wordlist_LDADD += \
     ../api/libtesseract.la
-endif
 
 lstmeval_SOURCES = lstmeval.cpp
 #lstmeval_LDFLAGS = -static
@@ -185,24 +108,8 @@ lstmeval_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la \
     $(ICU_UC_LIBS)
-if USING_MULTIPLELIBS
-lstmeval_LDADD += \
-    ../textord/libtesseract_textord.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 lstmeval_LDADD += \
     ../api/libtesseract.la
-endif
 
 lstmtraining_SOURCES = lstmtraining.cpp
 #lstmtraining_LDFLAGS = -static
@@ -210,37 +117,15 @@ lstmtraining_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la \
     $(ICU_I18N_LIBS) $(ICU_UC_LIBS)
-if USING_MULTIPLELIBS
-lstmtraining_LDADD += \
-    ../textord/libtesseract_textord.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 lstmtraining_LDADD += \
     ../api/libtesseract.la
-endif
 
 merge_unicharsets_SOURCES = merge_unicharsets.cpp
 #merge_unicharsets_LDFLAGS = -static
 merge_unicharsets_LDADD = \
     libtesseract_tessopt.la
-if USING_MULTIPLELIBS
-merge_unicharsets_LDADD += \
-    ../ccutil/libtesseract_ccutil.la \
-    ../ccstruct/libtesseract_ccstruct.la
-else
 merge_unicharsets_LDADD += \
     ../api/libtesseract.la
-endif
 
 mftraining_SOURCES = mftraining.cpp mergenf.cpp
 #mftraining_LDFLAGS = -static
@@ -248,72 +133,24 @@ mftraining_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la \
     $(ICU_UC_LIBS)
-if USING_MULTIPLELIBS
-mftraining_LDADD += \
-    ../textord/libtesseract_textord.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 mftraining_LDADD += \
     ../api/libtesseract.la
-endif
 
 set_unicharset_properties_SOURCES = set_unicharset_properties.cpp
 set_unicharset_properties_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la \
     $(ICU_I18N_LIBS) $(ICU_UC_LIBS)
-if USING_MULTIPLELIBS
-set_unicharset_properties_LDADD += \
-    ../textord/libtesseract_textord.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 set_unicharset_properties_LDADD += \
     ../api/libtesseract.la
-endif
 
 shapeclustering_SOURCES = shapeclustering.cpp
 #shapeclustering_LDFLAGS = -static
 shapeclustering_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la
-if USING_MULTIPLELIBS
-shapeclustering_LDADD += \
-    ../textord/libtesseract_textord.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 shapeclustering_LDADD += \
     ../api/libtesseract.la
-endif
 
 text2image_SOURCES = text2image.cpp
 #text2image_LDFLAGS = -static
@@ -321,24 +158,8 @@ text2image_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la \
     $(ICU_I18N_LIBS) $(ICU_UC_LIBS)
-if USING_MULTIPLELIBS
-text2image_LDADD += \
-    ../textord/libtesseract_textord.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 text2image_LDADD += \
     ../api/libtesseract.la
-endif
 text2image_LDADD += $(ICU_UC_LIBS) -lpango-1.0 -lpangocairo-1.0 \
 		    -lgobject-2.0 -lglib-2.0 -lcairo -lpangoft2-1.0 -lfontconfig
 
@@ -348,37 +169,15 @@ unicharset_extractor_LDADD = \
     libtesseract_training.la \
     libtesseract_tessopt.la \
     $(ICU_I18N_LIBS) $(ICU_UC_LIBS)
-if USING_MULTIPLELIBS
-unicharset_extractor_LDADD += \
-    ../ccutil/libtesseract_ccutil.la \
-    ../ccstruct/libtesseract_ccstruct.la
-else
 unicharset_extractor_LDADD += \
     ../api/libtesseract.la
-endif
 
 wordlist2dawg_SOURCES = wordlist2dawg.cpp
 #wordlist2dawg_LDFLAGS = -static
 wordlist2dawg_LDADD = \
     libtesseract_tessopt.la
-if USING_MULTIPLELIBS
-wordlist2dawg_LDADD += \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../arch/libtesseract_avx.la \
-    ../arch/libtesseract_sse.la \
-    ../lstm/libtesseract_lstm.la \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../cutil/libtesseract_cutil.la \
-    ../viewer/libtesseract_viewer.la \
-    ../ccmain/libtesseract_main.la \
-    ../wordrec/libtesseract_wordrec.la \
-    ../textord/libtesseract_textord.la \
-    ../ccutil/libtesseract_ccutil.la
-else
 wordlist2dawg_LDADD += \
     ../api/libtesseract.la
-endif
 
 if T_WIN
 ambiguous_words_LDADD += -lws2_32

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -24,18 +24,8 @@ libgtest_main_la_SOURCES = ../googletest/googletest/src/gtest_main.cc
 
 # Build unittests
 GTEST_LIBS =  libgtest.la libgtest_main.la
-if USING_MULTIPLELIBS
-TESS_LIBS = \
-    $(top_srcdir)/ccutil/libtesseract_ccutil.la \
-    $(top_srcdir)/arch/libtesseract_arch.la \
-    $(top_srcdir)/arch/libtesseract_avx.la \
-    $(top_srcdir)/arch/libtesseract_avx2.la \
-    $(top_srcdir)/arch/libtesseract_sse.la \
-    $(top_srcdir)/ccstruct/libtesseract_ccstruct.la
-else
 TESS_LIBS = \
     $(top_srcdir)/api/libtesseract.la
-endif
 AM_CPPFLAGS +=   -isystem $(top_srcdir)/googletest/googletest/include  
 
 check_PROGRAMS = \

--- a/viewer/Makefile.am
+++ b/viewer/Makefile.am
@@ -8,12 +8,7 @@ endif
 noinst_HEADERS = \
     scrollview.h svmnode.h svutil.h
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_viewer.la
-else
-lib_LTLIBRARIES = libtesseract_viewer.la
-libtesseract_viewer_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-endif
 
 libtesseract_viewer_la_SOURCES = \
     scrollview.cpp svmnode.cpp svutil.cpp svpaint.cpp

--- a/wordrec/Makefile.am
+++ b/wordrec/Makefile.am
@@ -18,19 +18,7 @@ noinst_HEADERS = \
     render.h \
     wordrec.h
 
-if !USING_MULTIPLELIBS
 noinst_LTLIBRARIES = libtesseract_wordrec.la
-else
-lib_LTLIBRARIES = libtesseract_wordrec.la
-libtesseract_wordrec_la_LDFLAGS = -version-info $(GENERIC_LIBRARY_VERSION)
-libtesseract_wordrec_la_LIBADD = \
-    ../ccstruct/libtesseract_ccstruct.la \
-    ../ccutil/libtesseract_ccutil.la \
-    ../cutil/libtesseract_cutil.la \
-    ../classify/libtesseract_classify.la \
-    ../dict/libtesseract_dict.la \
-    ../viewer/libtesseract_viewer.la
-endif
 
 libtesseract_wordrec_la_SOURCES = \
     associate.cpp chop.cpp chopper.cpp \


### PR DESCRIPTION
Libtool's convenience libraries should never be installed. Fixes #985.