### PR TITLE
unittest: Fix path for libtesseract in out of tree builds

### DIFF
--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -24,8 +24,7 @@ libgtest_main_la_SOURCES = ../googletest/googletest/src/gtest_main.cc
 
 # Build unittests
 GTEST_LIBS =  libgtest.la libgtest_main.la
-TESS_LIBS = \
-    $(top_srcdir)/api/libtesseract.la
+TESS_LIBS = $(top_builddir)/api/libtesseract.la
 AM_CPPFLAGS +=   -isystem $(top_srcdir)/googletest/googletest/include  
 
 check_PROGRAMS = \


### PR DESCRIPTION
The library is provided in the build path (which is not
the same as the source path for out of tree builds).

Signed-off-by: Stefan Weil <sw@weilnetz.de>