### PR TITLE
Prevent uninitialized integer from being used for x_fsize output

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -1526,9 +1526,9 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
     if (font_info) {
       if (font_name) {
         hocr_str += "; x_font ";
-        hocr_str += HOcrEscape(font_name);
+        hocr_str += HOcrEscape(font_name);      
+        hocr_str.add_str_int("; x_fsize ", pointsize);
       }
-      hocr_str.add_str_int("; x_fsize ", pointsize);
     }
     hocr_str += "'";
     const char* lang = res_it->WordRecognitionLanguage();


### PR DESCRIPTION
If font_name is false, then res_it->WordFontAttributes and pointsize is uninitialized.  This results in seemingly random data being written to the hocr output for x_fsize.  This change moves the output of x_fsize into the check that verifies the function that initializes pointsize actually ran, preventing the output of the uninitialized value.