### PR TITLE
Fix unittest/apiexample_test

### DIFF
--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -59,3 +59,12 @@ tesseracttests_LDADD  += -lws2_32
 
 AM_CPPFLAGS += -I$(top_srcdir)/vs2010/port
 endif
+
+EXTRA_apiexample_test_DEPENDENCIES = $(abs_top_builddir)/testing/phototest.tif
+EXTRA_apiexample_test_DEPENDENCIES += $(abs_top_builddir)/testing/phototest.txt
+
+$(abs_top_builddir)/testing/phototest.tif:
+	ln -s $(top_srcdir)/testing/phototest.tif $(top_builddir)/testing/phototest.tif
+
+$(abs_top_builddir)/testing/phototest.txt:
+	ln -s $(top_srcdir)/testing/phototest.txt $(top_builddir)/testing/phototest.txt

--- a/unittest/apiexample_test.cc
+++ b/unittest/apiexample_test.cc
@@ -24,7 +24,7 @@
 TEST(TesseractTest, ApiExample) 
 {
     char *outText;
-    std::locale loc("en_US.UTF-8"); // You can also use "" for the default system locale
+    std::locale loc("C"); // You can also use "" for the default system locale
     std::ifstream file("../testing/phototest.txt");
     file.imbue(loc); // Use it for file input
     std::string gtText((std::istreambuf_iterator<char>(file)),

--- a/unittest/apiexample_test.cc
+++ b/unittest/apiexample_test.cc
@@ -39,11 +39,12 @@ TEST(TesseractTest, ApiExample)
 
     // Open input image with leptonica library
     Pix *image = pixRead("../testing/phototest.tif");
+    ASSERT_TRUE(image != nullptr) << "Failed to read test image.";
     api->SetImage(image);
     // Get OCR result
     outText = api->GetUTF8Text();
 
-   ASSERT_EQ(gtText,outText) << "Phototest.tif with default values OCR does not match ground truth";
+    ASSERT_EQ(gtText,outText) << "Phototest.tif with default values OCR does not match ground truth";
 
     // Destroy used object and release memory
     api->End();

--- a/unittest/apiexample_test.cc
+++ b/unittest/apiexample_test.cc
@@ -32,10 +32,7 @@ TEST(TesseractTest, ApiExample)
 	
     tesseract::TessBaseAPI *api = new tesseract::TessBaseAPI();
     // Initialize tesseract-ocr with English, without specifying tessdata path
-    if (api->Init(NULL, "eng")) {
-        fprintf(stderr, "Could not initialize tesseract.\n");
-        exit(1);
-    }
+    ASSERT_FALSE(api->Init(nullptr, "eng")) << "Could not initialize tesseract.";
 
     // Open input image with leptonica library
     Pix *image = pixRead("../testing/phototest.tif");


### PR DESCRIPTION
The test failed for out-of-tree builds with autotools because it could not find the required files.
It also failed when the "en_US.UTF-8" locale was missing.

Now it passes. This completes my previous PR #1123.