### PR TITLE
Returns the correct dictionary if lstm only used

### DIFF
--- a/ccmain/tesseractclass.cpp
+++ b/ccmain/tesseractclass.cpp
@@ -634,6 +634,19 @@ Tesseract::~Tesseract() {
 #endif
 }
 
+Dict& Tesseract::getDict()
+{
+    if (0 == Classify::getDict().NumDawgs() && AnyLSTMLang())
+    {
+        if (lstm_recognizer_ && lstm_recognizer_->GetDict())
+        {
+            return *const_cast<Dict*>(lstm_recognizer_->GetDict());
+        }
+    }
+    return Classify::getDict();
+  }
+
+
 void Tesseract::Clear() {
   STRING debug_name = imagebasename + "_debug.pdf";
   pixa_debug_.WritePDF(debug_name.string());

--- a/ccmain/tesseractclass.h
+++ b/ccmain/tesseractclass.h
@@ -166,6 +166,9 @@ class Tesseract : public Wordrec {
   Tesseract();
   ~Tesseract();
 
+  // Return appropriate dictionary 
+  Dict& getDict() override;
+
   // Clear as much used memory as possible without resetting the adaptive
   // classifier or losing any other classifier data.
   void Clear();

--- a/classify/classify.h
+++ b/classify/classify.h
@@ -62,7 +62,7 @@ class Classify : public CCStruct {
  public:
   Classify();
   virtual ~Classify();
-  Dict& getDict() {
+  virtual Dict& getDict() {
     return dict_;
   }
 


### PR DESCRIPTION
LSTM uses its own dictionary, expose it if LSTM code is used and the old engine's one is empty.