### PR TITLE
download and install eng and osd traineddata

### DIFF
--- a/tessdata/Makefile.am
+++ b/tessdata/Makefile.am
@@ -1,4 +1,4 @@
-datadir = @datadir@/tessdata
+datadir = @datadir@/tesseract-ocr/4.00/tessdata
 
 data_DATA = pdf.ttf
 EXTRA_DIST = $(data_DATA)
@@ -7,7 +7,17 @@ SUBDIRS = configs tessconfigs
 
 engosddata = eng.traineddata osd.traineddata
 
-engosddata-install:
+engosddata-best-install:
+	wget  -nc https://github.com/tesseract-ocr/tessdata_best/raw/master/eng.traineddata
+	wget  -nc https://github.com/tesseract-ocr/tessdata_best/raw/master/osd.traineddata
+	cp   $(engosddata) $(DESTDIR)$(datadir)
+	
+engosddata-fast-install:
+	wget  -nc https://github.com/tesseract-ocr/tessdata_fast/raw/master/eng.traineddata
+	wget  -nc https://github.com/tesseract-ocr/tessdata_fast/raw/master/osd.traineddata
+	cp   $(engosddata) $(DESTDIR)$(datadir)
+
+engosddata-legacy-install:
 	wget  -nc https://github.com/tesseract-ocr/tessdata/raw/master/eng.traineddata
 	wget  -nc https://github.com/tesseract-ocr/tessdata/raw/master/osd.traineddata
 	cp   $(engosddata) $(DESTDIR)$(datadir)

--- a/tessdata/Makefile.am
+++ b/tessdata/Makefile.am
@@ -5,30 +5,16 @@ EXTRA_DIST = $(data_DATA)
 
 SUBDIRS = configs tessconfigs
 
-langdata = bul.traineddata mlt.traineddata chr.traineddata \
-	slk.traineddata dan-frak.traineddata eng.traineddata \
-	ces.traineddata afr.traineddata swa.traineddata \
-	kan.traineddata bel.traineddata ind.traineddata \
-	lit.traineddata nld.traineddata osd.traineddata \
-	mkd.traineddata est.traineddata fra.traineddata \
-	hin.traineddata lat_lid.traineddata nor.traineddata \
-	por.traineddata ron.traineddata swe.traineddata \
-	pol.traineddata ara.traineddata tel.traineddata \
-	ell.traineddata mal.traineddata vie.traineddata \
-	heb.traineddata deu.traineddata eus.traineddata \
-	ita_old.traineddata rus.traineddata sqi.traineddata \
-	spa.traineddata glg.traineddata slk-frak.traineddata \
-	equ.traineddata hrv.traineddata frk.traineddata \
-	cat.traineddata lav.traineddata ukr.traineddata \
-	enm.traineddata dan.traineddata fin.traineddata \
-	ben.traineddata srp.traineddata tha.traineddata \
-	hun.traineddata tgl.traineddata frm.traineddata \
-	slv.traineddata chi_sim.traineddata tam.traineddata \
-	tur.traineddata epo.traineddata msa.traineddata \
-	kor.traineddata isl.traineddata jpn.traineddata \
-	chi_tra.traineddata ita.traineddata spa_old.traineddata \
-	deu-frak.traineddata aze.traineddata
+engosddata = eng.traineddata osd.traineddata
 
-uninstall-local:
+engosddata-install:
+	wget  -nc https://github.com/tesseract-ocr/tessdata/raw/master/best/eng.traineddata
+	wget  -nc https://github.com/tesseract-ocr/tessdata/raw/master/best/osd.traineddata
+	cp   $(engosddata) $(DESTDIR)$(datadir)
+  
+engosddata-remove: 
+	rm -f $(engosddata)
+
+engosddata-uninstall:
 	cd $(DESTDIR)$(datadir); \
-	rm -f $(langdata)
+	rm -f $(engosddata)

--- a/tessdata/Makefile.am
+++ b/tessdata/Makefile.am
@@ -8,8 +8,8 @@ SUBDIRS = configs tessconfigs
 engosddata = eng.traineddata osd.traineddata
 
 engosddata-install:
-	wget  -nc https://github.com/tesseract-ocr/tessdata/raw/master/best/eng.traineddata
-	wget  -nc https://github.com/tesseract-ocr/tessdata/raw/master/best/osd.traineddata
+	wget  -nc https://github.com/tesseract-ocr/tessdata/raw/master/eng.traineddata
+	wget  -nc https://github.com/tesseract-ocr/tessdata/raw/master/osd.traineddata
 	cp   $(engosddata) $(DESTDIR)$(datadir)
   
 engosddata-remove: 


### PR DESCRIPTION
eng and osd traineddata files are required for default functioning of tesseract.
Added option to download the files with --no-clobber option and copy to tessdata directory
Removed option related to langdata, as tesseract does not install all langdata files