### PR TITLE
Revert "change type to UChar32 to fix IsValidCodepoint"

### DIFF
--- a/training/normstrngs.cpp
+++ b/training/normstrngs.cpp
@@ -217,7 +217,7 @@ bool IsOCREquivalent(char32 ch1, char32 ch2) {
 
 bool IsValidCodepoint(const char32 ch) {
   // In the range [0, 0xD800) or [0xE000, 0x10FFFF]
-  return (static_cast<UChar32>(ch) < 0xD800) || (ch >= 0xE000 && ch <= 0x10FFFF);
+  return (static_cast<uint32_t>(ch) < 0xD800) || (ch >= 0xE000 && ch <= 0x10FFFF);
 }
 
 bool IsWhitespace(const char32 ch) {


### PR DESCRIPTION
This reverts commit a404c9cdb3f88a2be1e2cf4dd3bac178b1963b31.
That code no longer matched the specification (see code comment).

Signed-off-by: Stefan Weil <sw@weilnetz.de>