### PR TITLE
Fix help message for unicharset_extractor

### DIFF
--- a/training/unicharset_extractor.cpp
+++ b/training/unicharset_extractor.cpp
@@ -95,7 +95,9 @@ int Main(int argc, char** argv) {
 }  // namespace tesseract
 
 int main(int argc, char** argv) {
-  tesseract::ParseCommandLineFlags(argv[0], &argc, &argv, true);
+  if (argc > 1) {
+    tesseract::ParseCommandLineFlags(argv[0], &argc, &argv, true);
+  }
   if (argc < 2) {
     tprintf(
         "Usage: %s [--output_unicharset filename] [--norm_mode mode]"


### PR DESCRIPTION
If unicharset_extractor was called without any argument,
a help message was printed by tesseract::ParseCommandLineFlags.

Replace that by the local help message which is better.

Signed-off-by: Stefan Weil <sw@weilnetz.de>