### PR TITLE
fixed missing include for std::back_inserter.

### DIFF
--- a/training/validator.cpp
+++ b/training/validator.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <unordered_map>
 #include <vector>
+#include <iterator>
 
 #include "icuerrorcode.h"
 #include "unicode/uchar.h"    // From libicu


### PR DESCRIPTION
with Visual Studio 2015 RTM:

```
Error C2039: 'back_inserter': is not a member of 'std'
Error C3861: 'back_inserter': identifier not found
```

need "iterator" with Visual Studio 2015 (vc14).

```
#include <iterator>
```