### PR TITLE
Fix compiler warning (-Wchar-subscript)

### DIFF
--- a/ccstruct/seam.cpp
+++ b/ccstruct/seam.cpp
@@ -62,7 +62,7 @@ void SEAM::CombineWith(const SEAM& other) {
   location_ += other.location_;
   location_ /= 2;
 
-  for (int s = 0; s < other.num_splits_ && num_splits_ < kMaxNumSplits; ++s)
+  for (uint8_t s = 0; s < other.num_splits_ && num_splits_ < kMaxNumSplits; ++s)
     splits_[num_splits_++] = other.splits_[s];
 }
 

--- a/ccstruct/seam.h
+++ b/ccstruct/seam.h
@@ -178,7 +178,7 @@ class SEAM {
 
  private:
   // Maximum number of splits that a SEAM can hold.
-  static const int kMaxNumSplits = 3;
+  static const uint8_t kMaxNumSplits = 3;
   // Priority of this split. Lower is better.
   float priority_;
   // Position of the middle of the seam.
@@ -189,7 +189,7 @@ class SEAM {
   inT8 widthp_;
   inT8 widthn_;
   // Number of splits_ that are used.
-  inT8 num_splits_;
+  uint8_t num_splits_;
   // Set of pairs of points that are the ends of each split in the SEAM.
   SPLIT splits_[kMaxNumSplits];
 };


### PR DESCRIPTION
ccstruct/seam.cpp:66:26: warning:
 array subscript has type 'char' [-Wchar-subscripts]

Fix it by using an unsigned index and use the same type for related values.

Signed-off-by: Stefan Weil <sw@weilnetz.de>