### PR TITLE
Remove unused cube OCR engine modes

### DIFF
--- a/ccstruct/publictypes.h
+++ b/ccstruct/publictypes.h
@@ -277,8 +277,6 @@ enum OcrEngineMode {
                                 // command-line configs, or if not specified
                                 // in any of the above should be set to the
                                 // default OEM_TESSERACT_ONLY.
-  OEM_CUBE_ONLY,                // Run Cube only - better accuracy, but slower
-  OEM_TESSERACT_CUBE_COMBINED,  // Run both and combine results - best accuracy
   OEM_COUNT			// Number of OEMs
 };
 


### PR DESCRIPTION
Since commit cdc35338c53a1af1fcb95473445f2aabfdb3f6d1 Tesseract checks
the value passed for `--oem NUM`.

That only works as expected when the old (now unused) engine mode values
for cube are removed.

Signed-off-by: Stefan Weil <sw@weilnetz.de>