### PR TITLE
Fix CID 1164569 (Dereference after null check)

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -2275,7 +2275,11 @@ int TessBaseAPI::FindLines() {
     if (equ_detect_ == NULL && datapath_ != NULL) {
       equ_detect_ = new EquationDetect(datapath_->string(), NULL);
     }
-    tesseract_->SetEquationDetect(equ_detect_);
+    if (equ_detect_ == nullptr) {
+      tprintf("Warning: Could not set equation detector\n");
+    } else {
+      tesseract_->SetEquationDetect(equ_detect_);
+    }
   }
 
   Tesseract* osd_tess = osd_tesseract_;


### PR DESCRIPTION
If equ_detect_ can be NULL, we must catch that case and show a warning
instead of crashing in method SetEquationDetect.

Signed-off-by: Stefan Weil <sw@weilnetz.de>