### PR TITLE
doc: Add missing language to list

### DIFF
--- a/doc/tesseract.1.asc
+++ b/doc/tesseract.1.asc
@@ -129,6 +129,7 @@ for the following languages are in
 *ben* (Bengali),
 *bod* (Tibetan),
 *bos* (Bosnian),
+*bre* (Breton),
 *bul* (Bulgarian),
 *cat* (Catalan; Valencian),
 *ceb* (Cebuano),


### PR DESCRIPTION
tessdata_fast includes bre.traineddata.

Signed-off-by: Stefan Weil <sw@weilnetz.de>