### PR TITLE
Fix compiler warning (possible loss of data)

### DIFF
--- a/ccutil/unicharset.cpp
+++ b/ccutil/unicharset.cpp
@@ -1115,11 +1115,11 @@ int UNICHARSET::get_script_id_from_name(const char* script_name) const {
 // Removes/replaces content that belongs in rendered text, but not in the
 // unicharset.
 /* static */
-std::string UNICHARSET::CleanupString(const char* utf8_str, int length) {
+std::string UNICHARSET::CleanupString(const char* utf8_str, size_t length) {
   std::string result;
   result.reserve(length);
   char ch;
-  while ((ch = *utf8_str) != '\0' && --length >= 0) {
+  while ((ch = *utf8_str) != '\0' && length-- > 0) {
     int key_index = 0;
     const char* key;
     while ((key = kCleanupMaps[key_index][0]) != nullptr) {

--- a/ccutil/unicharset.h
+++ b/ccutil/unicharset.h
@@ -241,7 +241,7 @@ class UNICHARSET {
   static std::string CleanupString(const char* utf8_str) {
     return CleanupString(utf8_str, strlen(utf8_str));
   }
-  static std::string CleanupString(const char* utf8_str, int length);
+  static std::string CleanupString(const char* utf8_str, size_t length);
 
   // Return a STRING containing debug information on the unichar, including
   // the id_to_unichar, its hex unicodes and the properties.


### PR DESCRIPTION
Fix 306 warnings from MS C:

tesseract\ccutil\unicharset.h(242): warning C4267:
 'argument': conversion from 'size_t' to 'int', possible loss of data

The change also avoids some type conversions.