### PR TITLE
Fix compiler warning (-Wsign-compare)

### DIFF
--- a/ccutil/genericvector.h
+++ b/ccutil/genericvector.h
@@ -375,7 +375,7 @@ inline bool LoadDataFromFile(const char* filename, GenericVector<char>* data) {
     // Trying to open a directory on Linux sets size to LONG_MAX. Catch it here.
     if (size > 0 && size < LONG_MAX) {
       data->resize_no_init(size);
-      result = fread(&(*data)[0], 1, size, fp) == size;
+      result = static_cast<long>(fread(&(*data)[0], 1, size, fp)) == size;
     }
     fclose(fp);
   }


### PR DESCRIPTION
gcc reports this warning about 250 times:

ccutil/genericvector.h:378:48: warning:
 comparison between signed and unsigned integer expressions [-Wsign-compare]

Signed-off-by: Stefan Weil <sw@weilnetz.de>