### PR TITLE
Update unittest for new script data location and fix out-of-tree build

### DIFF
--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -1,5 +1,15 @@
 AUTOMAKE_OPTIONS = subdir-objects
 
+# Absolute path of directory 'tessdata' with traineddata files
+# (must be on same level as top source directory).
+TESSDATA_DIR=$(shell cd $(top_srcdir) && cd .. && pwd)/tessdata
+
+# Absolute path of directory 'testing' with test images and ground truth texts
+# (must be directly below top source directory).
+TESTING_DIR=$(shell cd $(top_srcdir) && pwd)/testing
+
+AM_CPPFLAGS += -DTESSDATA_DIR="\"$(TESSDATA_DIR)\""
+AM_CPPFLAGS += -DTESTING_DIR="\"$(TESTING_DIR)\""
 AM_CPPFLAGS += -DPANGO_ENABLE_ENGINE
 AM_CPPFLAGS += -I$(top_srcdir)/api
 AM_CPPFLAGS += -I$(top_srcdir)/arch 

--- a/unittest/apiexample_test.cc
+++ b/unittest/apiexample_test.cc
@@ -65,17 +65,21 @@ class QuickTest : public testing::Test {
   };
   
   TEST_P(MatchGroundTruth, FastPhototestOCR) {
-  OCRTester("../testing/phototest.tif" ,"../testing/phototest.txt" , "../../tessdata_fast", GetParam());
+    OCRTester(TESTING_DIR "/phototest.tif",
+              TESTING_DIR "/phototest.txt",
+              TESSDATA_DIR "_fast", GetParam());
   }
   
   INSTANTIATE_TEST_CASE_P( EngLatinDevaArabLang, MatchGroundTruth, 
-                        ::testing::Values("eng", "Latin", "Devanagari", "Arabic") );
+                        ::testing::Values("eng", "script/Latin", "script/Devanagari", "script/Arabic") );
 
   class EuroText : public QuickTest {
   };
   
   TEST_F(EuroText, FastOCR) {
-  OCRTester("../testing/eurotext.tif" ,"../testing/eurotext.txt" , "../../tessdata_fast", "Latin");
+    OCRTester(TESTING_DIR "/eurotext.tif",
+              TESTING_DIR "/eurotext.txt",
+              TESSDATA_DIR "_fast", "script/Latin");
   }
   
 }  // namespace

--- a/unittest/osd_test.cc
+++ b/unittest/osd_test.cc
@@ -62,49 +62,55 @@ class TestClass : public testing::Test {
   INSTANTIATE_TEST_CASE_P( TessdataEngEuroHebrew, OSDTest, 
                         ::testing::Combine(
                         ::testing::Values(0),
-                        ::testing::Values("../testing/phototest.tif" , "../testing/eurotext.tif" , "../testing/hebrew.png"),
-                        ::testing::Values("../../tessdata")));
+                        ::testing::Values(TESTING_DIR "/phototest.tif",
+                                          TESTING_DIR "/eurotext.tif",
+                                          TESTING_DIR "/hebrew.png"),
+                        ::testing::Values(TESSDATA_DIR)));
                         
   INSTANTIATE_TEST_CASE_P( TessdataBestEngEuroHebrew, OSDTest, 
                         ::testing::Combine(
                         ::testing::Values(0),
-                        ::testing::Values("../testing/phototest.tif" , "../testing/eurotext.tif" , "../testing/hebrew.png"),
-                        ::testing::Values("../../tessdata_best")));
+                        ::testing::Values(TESTING_DIR "/phototest.tif",
+                                          TESTING_DIR "/eurotext.tif",
+                                          TESTING_DIR "/hebrew.png"),
+                        ::testing::Values(TESSDATA_DIR "_best")));
                         
   INSTANTIATE_TEST_CASE_P( TessdataFastEngEuroHebrew, OSDTest, 
                         ::testing::Combine(
                         ::testing::Values(0),
-                        ::testing::Values("../testing/phototest.tif" , "../testing/eurotext.tif" , "../testing/hebrew.png"),
-                        ::testing::Values("../../tessdata_fast")));
+                        ::testing::Values(TESTING_DIR "/phototest.tif",
+                                          TESTING_DIR "/eurotext.tif",
+                                          TESTING_DIR "/hebrew.png"),
+                        ::testing::Values(TESSDATA_DIR "_fast")));
                         
   INSTANTIATE_TEST_CASE_P( TessdataFastRotated90, OSDTest, 
                         ::testing::Combine(
                         ::testing::Values(90),
-                        ::testing::Values("../testing/phototest-rotated-R.png"),
-                        ::testing::Values("../../tessdata_fast")));
+                        ::testing::Values(TESTING_DIR "/phototest-rotated-R.png"),
+                        ::testing::Values(TESSDATA_DIR "_fast")));
                         
   INSTANTIATE_TEST_CASE_P( TessdataFastRotated180, OSDTest, 
                         ::testing::Combine(
                         ::testing::Values(180),
-                        ::testing::Values("../testing/phototest-rotated-180.png"),
-                        ::testing::Values("../../tessdata_fast")));
+                        ::testing::Values(TESTING_DIR "/phototest-rotated-180.png"),
+                        ::testing::Values(TESSDATA_DIR "_fast")));
                         
   INSTANTIATE_TEST_CASE_P( TessdataFastRotated270, OSDTest, 
                         ::testing::Combine(
                         ::testing::Values(270),
-                        ::testing::Values("../testing/phototest-rotated-L.png"),
-                        ::testing::Values("../../tessdata_fast")));
+                        ::testing::Values(TESTING_DIR "/phototest-rotated-L.png"),
+                        ::testing::Values(TESSDATA_DIR "_fast")));
                         
   INSTANTIATE_TEST_CASE_P( TessdataFastDevaRotated270, OSDTest, 
                         ::testing::Combine(
                         ::testing::Values(270),
-                        ::testing::Values("../testing/devatest-rotated-270.png"),
-                        ::testing::Values("../../tessdata_fast")));
+                        ::testing::Values(TESTING_DIR "/devatest-rotated-270.png"),
+                        ::testing::Values(TESSDATA_DIR "_fast")));
                         
   INSTANTIATE_TEST_CASE_P( TessdataFastDeva, OSDTest, 
                         ::testing::Combine(
                         ::testing::Values(0),
-                        ::testing::Values("../testing/devatest.png"),
-                        ::testing::Values("../../tessdata_fast")));
+                        ::testing::Values(TESTING_DIR "/devatest.png"),
+                        ::testing::Values(TESSDATA_DIR "_fast")));
                         
 }  // namespace


### PR DESCRIPTION
tessdata_best and tessdata_fast recently changed the path for script data,
so the tests have to be updated, too.

In addition, the relative paths did not work with out-of-tree builds.
Use absolute paths and add them as C macros to the compiler flags.

Signed-off-by: Stefan Weil <sw@weilnetz.de>