### PR TITLE
autogen: Report missing requirements

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -113,6 +113,13 @@ automake --add-missing --copy --warnings=all || bail_out
 echo "Running autoconf"
 autoconf || bail_out
 
+if grep -q AX_CHECK_COMPILE_FLAG configure; then
+  # The generated configure is invalid because autoconf-archive is unavailable.
+  rm configure
+  echo "Missing autoconf-archive. Check the build requirements."
+  bail_out
+fi
+
 echo ""
 echo "All done."
 echo "To build the software now, do something like:"

--- a/autogen.sh
+++ b/autogen.sh
@@ -120,6 +120,13 @@ if grep -q AX_CHECK_COMPILE_FLAG configure; then
   bail_out
 fi
 
+if grep -q PKG_CHECK_MODULES configure; then
+  # The generated configure is invalid because pkg-confg is unavailable.
+  rm configure
+  echo "Missing pkg-config. Check the build requirements."
+  bail_out
+fi
+
 echo ""
 echo "All done."
 echo "To build the software now, do something like:"


### PR DESCRIPTION
autoconf-archive and pkg-config are required, but users often missed that requirements.

The script now detects and reports those missing requirements and removes
the incomplete generated configure script.

Signed-off-by: Stefan Weil <sw@weilnetz.de>