### PR TITLE
autogen: Fix typo in comment

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -121,7 +121,7 @@ if grep -q AX_CHECK_COMPILE_FLAG configure; then
 fi
 
 if grep -q PKG_CHECK_MODULES configure; then
-  # The generated configure is invalid because pkg-confg is unavailable.
+  # The generated configure is invalid because pkg-config is unavailable.
   rm configure
   echo "Missing pkg-config. Check the build requirements."
   bail_out


### PR DESCRIPTION
It was introduced by commit d50769dc01df85c993439b2943bac4d884901441.

Signed-off-by: Stefan Weil <sw@weilnetz.de>