### PR TITLE
arch: Fix some compiler warnings (-Wignored-qualifiers)

### DIFF
--- a/arch/dotproductavx.cpp
+++ b/arch/dotproductavx.cpp
@@ -50,8 +50,8 @@ double DotProductAVX(const double* u, const double* v, int n) {
   if (offset <= max_offset) {
     offset = 4;
     // Aligned load is reputedly faster but requires 32 byte aligned input.
-    if ((reinterpret_cast<const uintptr_t>(u) & 31) == 0 &&
-        (reinterpret_cast<const uintptr_t>(v) & 31) == 0) {
+    if ((reinterpret_cast<uintptr_t>(u) & 31) == 0 &&
+        (reinterpret_cast<uintptr_t>(v) & 31) == 0) {
       // Use aligned load.
       __m256d floats1 = _mm256_load_pd(u);
       __m256d floats2 = _mm256_load_pd(v);

--- a/arch/dotproductsse.cpp
+++ b/arch/dotproductsse.cpp
@@ -56,8 +56,8 @@ double DotProductSSE(const double* u, const double* v, int n) {
   if (offset <= max_offset) {
     offset = 2;
     // Aligned load is reputedly faster but requires 16 byte aligned input.
-    if ((reinterpret_cast<const uintptr_t>(u) & 15) == 0 &&
-        (reinterpret_cast<const uintptr_t>(v) & 15) == 0) {
+    if ((reinterpret_cast<uintptr_t>(u) & 15) == 0 &&
+        (reinterpret_cast<uintptr_t>(v) & 15) == 0) {
       // Use aligned load.
       sum = _mm_load_pd(u);
       __m128d floats2 = _mm_load_pd(v);


### PR DESCRIPTION
Fix these gcc warnings:

arch/dotproductavx.cpp:53:45: warning:
 type qualifiers ignored on cast result type [-Wignored-qualifiers]
arch/dotproductavx.cpp:54:45: warning:
 type qualifiers ignored on cast result type [-Wignored-qualifiers]
arch/dotproductsse.cpp:59:45: warning:
 type qualifiers ignored on cast result type [-Wignored-qualifiers]
arch/dotproductsse.cpp:60:45: warning:
 type qualifiers ignored on cast result type [-Wignored-qualifiers]

Signed-off-by: Stefan Weil <sw@weilnetz.de>