### PR TITLE
configure: Use m4_esyscmd_s to suppress linefeed (fix needed for macOS)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 # ----------------------------------------
 AC_PREREQ([2.59])
 AC_INIT([tesseract],
-        [m4_esyscmd([echo -n $(test -d .git && git describe --abbrev=4 || cat VERSION)])],
+        [m4_esyscmd_s([test -d .git && git describe --abbrev=4 || cat VERSION])],
         [https://github.com/tesseract-ocr/tesseract/issues],,
         [https://github.com/tesseract-ocr/tesseract/])
 AC_PROG_CXX([g++ clang++])


### PR DESCRIPTION
While "echo -n" works on Debian GNU Linux, it fails to produce a valid
configure file on macOS, so try a different shorter solution.

Signed-off-by: Stefan Weil <sw@weilnetz.de>