### PR TITLE
tessdatamanager: Use PACKAGE_VERSION instead of TESSERACT_VERSION_STR

### DIFF
--- a/ccutil/tessdatamanager.cpp
+++ b/ccutil/tessdatamanager.cpp
@@ -21,6 +21,10 @@
 #pragma warning(disable:4244)  // Conversion warnings
 #endif
 
+#ifdef HAVE_CONFIG_H
+#include "config_auto.h"
+#endif
+
 #include "tessdatamanager.h"
 
 #include <stdio.h>
@@ -32,6 +36,17 @@
 #include "params.h"
 
 namespace tesseract {
+
+TessdataManager::TessdataManager() : reader_(nullptr), is_loaded_(false), swap_(false) {
+  SetVersionString(PACKAGE_VERSION);
+}
+
+TessdataManager::TessdataManager(FileReader reader)
+  : reader_(reader),
+    is_loaded_(false),
+    swap_(false) {
+  SetVersionString(PACKAGE_VERSION);
+}
 
 // Lazily loads from the the given filename. Won't actually read the file
 // until it needs it.

--- a/ccutil/tessdatamanager.h
+++ b/ccutil/tessdatamanager.h
@@ -20,12 +20,7 @@
 #ifndef TESSERACT_CCUTIL_TESSDATAMANAGER_H_
 #define TESSERACT_CCUTIL_TESSDATAMANAGER_H_
 
-#include <stdio.h>
-
-#include "host.h"
-#include "strngs.h"
-#include "tprintf.h"
-#include "version.h"
+#include "genericvector.h"
 
 static const char kTrainedDataSuffix[] = "traineddata";
 
@@ -130,13 +125,9 @@ static const int kMaxNumTessdataEntries = 1000;
 
 class TessdataManager {
  public:
-  TessdataManager() : reader_(nullptr), is_loaded_(false), swap_(false) {
-    SetVersionString(TESSERACT_VERSION_STR);
-  }
-  explicit TessdataManager(FileReader reader)
-      : reader_(reader), is_loaded_(false), swap_(false) {
-    SetVersionString(TESSERACT_VERSION_STR);
-  }
+  TessdataManager();
+  explicit TessdataManager(FileReader reader);
+
   ~TessdataManager() {}
 
   bool swap() const { return swap_; }


### PR DESCRIPTION
This allows further simplifications for the version handling.

Move the implementation for the constructors from .h file to .cpp file
to reduce dependencies.

Remove unneeded include statements from the .h file to reduce more
dependencies.

Signed-off-by: Stefan Weil <sw@weilnetz.de>