### PR TITLE
Remove deprecated method DumpPGM

### DIFF
--- a/api/baseapi.cpp
+++ b/api/baseapi.cpp
@@ -760,25 +760,6 @@ int TessBaseAPI::GetThresholdedImageScaleFactor() const {
   return thresholder_->GetScaleFactor();
 }
 
-/** Dump the internal binary image to a PGM file. */
-void TessBaseAPI::DumpPGM(const char* filename) {
-  if (tesseract_ == NULL)
-    return;
-  FILE *fp = fopen(filename, "wb");
-  Pix* pix = tesseract_->pix_binary();
-  int width = pixGetWidth(pix);
-  int height = pixGetHeight(pix);
-  l_uint32* data = pixGetData(pix);
-  fprintf(fp, "P5 %d %d 255\n", width, height);
-  for (int y = 0; y < height; ++y, data += pixGetWpl(pix)) {
-    for (int x = 0; x < width; ++x) {
-      uint8_t b = GET_DATA_BIT(data, x) ? 0 : 255;
-      fwrite(&b, 1, 1, fp);
-    }
-  }
-  fclose(fp);
-}
-
 /**
  * Runs page layout analysis in the mode set by SetPageSegMode.
  * May optionally be called prior to Recognize to get access to just

--- a/api/baseapi.h
+++ b/api/baseapi.h
@@ -472,13 +472,6 @@ class TESS_API TessBaseAPI {
   int GetThresholdedImageScaleFactor() const;
 
   /**
-   * Dump the internal binary image to a PGM file.
-   * @deprecated Use GetThresholdedImage and write the image using pixWrite
-   * instead if possible.
-   */
-  void DumpPGM(const char* filename);
-
-  /**
    * Runs page layout analysis in the mode set by SetPageSegMode.
    * May optionally be called prior to Recognize to get access to just
    * the page layout results. Returns an iterator to the results.

--- a/api/capi.cpp
+++ b/api/capi.cpp
@@ -419,11 +419,6 @@ TESS_API int TESS_CALL TessBaseAPIGetThresholdedImageScaleFactor(const TessBaseA
     return handle->GetThresholdedImageScaleFactor();
 }
 
-TESS_API void TESS_CALL TessBaseAPIDumpPGM(TessBaseAPI* handle, const char* filename)
-{
-    handle->DumpPGM(filename);
-}
-
 TESS_API TessPageIterator* TESS_CALL TessBaseAPIAnalyseLayout(TessBaseAPI* handle)
 {
     return handle->AnalyseLayout();

--- a/api/capi.h
+++ b/api/capi.h
@@ -246,8 +246,6 @@ TESS_API struct Boxa*
 
 TESS_API int   TESS_CALL TessBaseAPIGetThresholdedImageScaleFactor(const TessBaseAPI* handle);
 
-TESS_API void  TESS_CALL TessBaseAPIDumpPGM(TessBaseAPI* handle, const char* filename);
-
 TESS_API TessPageIterator*
                TESS_CALL TessBaseAPIAnalyseLayout(TessBaseAPI* handle);
 


### PR DESCRIPTION
It was deprecated in commit a18816f83 more than 7 years ago.

Signed-off-by: Stefan Weil <sw@weilnetz.de>