### PR TITLE
Add IntCastRounded for float argument

### DIFF
--- a/ccutil/helpers.h
+++ b/ccutil/helpers.h
@@ -180,6 +180,11 @@ inline int IntCastRounded(double x) {
   return x >= 0.0 ? static_cast<int>(x + 0.5) : -static_cast<int>(-x + 0.5);
 }
 
+// Return a float cast to int with rounding.
+inline int IntCastRounded(float x) {
+  return x >= 0.0f ? static_cast<int>(x + 0.5f) : -static_cast<int>(-x + 0.5f);
+}
+
 // Reverse the order of bytes in a n byte quantity for big/little-endian switch.
 inline void ReverseN(void* ptr, int num_bytes) {
   char* cptr = static_cast<char*>(ptr);


### PR DESCRIPTION
The method is called with a float argument several times, and the
previous implementation which only supported a double argument
resulted in type conversions and compiler warnings.

Signed-off-by: Stefan Weil <sw@weilnetz.de>