### PR TITLE
configure: Don't use AM_MAINTAINER_MODE by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,6 @@ AC_SUBST([GENERIC_RELEASE])
 AC_SUBST([GENERIC_VERSION])
 
 AC_CONFIG_HEADERS([config_auto.h:config/config.h.in])
-AM_MAINTAINER_MODE
 
 # default conditional
 AM_CONDITIONAL([T_WIN], false)

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,4 +1,4 @@
-if MAINTAINER_MODE
+# doc/Makefile.am
 
 asciidoc=asciidoc -d manpage
 
@@ -28,5 +28,3 @@ man_MANS = \
 	$(asciidoc) -o $@ $<
 
 MAINTAINERCLEANFILES = $(man_MANS) Doxyfile
-
-endif # MAINTAINER_MODE


### PR DESCRIPTION
That macro disables automated updates when configure.ac or a Makefile.am
changes. Normally those updates are wanted because users typically
forget running ./autogen.sh.

See also the GNU documentation why AM_MAINTAINER_MODE should not be used:
https://www.gnu.org/software/automake/manual/html_node/maintainer_002dmode.html

Signed-off-by: Stefan Weil <sw@weilnetz.de>