### PR TITLE
Overload method ForwardTimeStep (CID 1385636 Explicit null dereferenced)

### DIFF
--- a/lstm/fullyconnected.h
+++ b/lstm/fullyconnected.h
@@ -91,8 +91,9 @@ class FullyConnected : public Network {
   // Components of Forward so FullyConnected can be reused inside LSTM.
   void SetupForward(const NetworkIO& input,
                     const TransposedArray* input_transpose);
-  void ForwardTimeStep(const double* d_input, const int8_t* i_input, int t,
-                       double* output_line);
+  void ForwardTimeStep(int t, double* output_line);
+  void ForwardTimeStep(const double* d_input, int t, double* output_line);
+  void ForwardTimeStep(const int8_t* i_input, int t, double* output_line);
 
   // Runs backward propagation of errors on the deltas line.
   // See Network for a detailed discussion of the arguments.

--- a/lstm/lstm.cpp
+++ b/lstm/lstm.cpp
@@ -396,9 +396,9 @@ void LSTM::Forward(bool debug, const NetworkIO& input,
     if (softmax_ != nullptr) {
       if (input.int_mode()) {
         int_output->WriteTimeStepPart(0, 0, ns_, curr_output);
-        softmax_->ForwardTimeStep(nullptr, int_output->i(0), t, softmax_output);
+        softmax_->ForwardTimeStep(int_output->i(0), t, softmax_output);
       } else {
-        softmax_->ForwardTimeStep(curr_output, nullptr, t, softmax_output);
+        softmax_->ForwardTimeStep(curr_output, t, softmax_output);
       }
       output->WriteTimeStep(t, softmax_output);
       if (type_ == NT_LSTM_SOFTMAX_ENCODED) {


### PR DESCRIPTION
This avoids NULL parameters and fixes a warning from Coverity Scan.

Signed-off-by: Stefan Weil <sw@weilnetz.de>