### PR TITLE
Don't try to build manpages if asciidoc is missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -415,6 +415,17 @@ AC_SYS_LARGEFILE
 AC_CHECK_FUNCS([getline])
 
 # ----------------------------------------
+# Check for programs needed to build documentation.
+# ----------------------------------------
+
+AC_CHECK_PROG([have_asciidoc], asciidoc, true, false)
+if $have_asciidoc; then
+  AM_CONDITIONAL([ASCIIDOC], true)
+else
+  AM_CONDITIONAL([ASCIIDOC], false)
+fi
+
+# ----------------------------------------
 # Checks for typedefs, structures, and compiler characteristics.
 # ----------------------------------------
 
@@ -513,6 +524,16 @@ echo "You can now build and install $PACKAGE_NAME by running:"
 echo ""
 echo "$ make"
 echo "$ sudo make install"
+echo ""
+
+AM_COND_IF([ASCIIDOC],
+  [
+   echo "This will also build the documentation."
+  ], [
+   echo "Documentation will not be built because asciidoc is missing."
+  ]
+)
+
 # echo "$ sudo make install LANGS=\"eng ara deu\""
 # echo "  Or:"
 # echo "$ sudo make install-langs"

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,5 +1,7 @@
 # doc/Makefile.am
 
+if ASCIIDOC
+
 asciidoc=asciidoc -d manpage
 
 man_MANS = \
@@ -28,3 +30,5 @@ man_MANS = \
 	$(asciidoc) -o $@ $<
 
 MAINTAINERCLEANFILES = $(man_MANS) Doxyfile
+
+endif


### PR DESCRIPTION
Commit f9157fd91db9140adacc4d7cd9af5677e4f0163e changed the rules for
the documentation, so make always tried to build it and failed if
asciidoc was missing since that commit.

Now configure tests whether asciidoc is available and builds the
documentation conditionally. It also reports that to the user.

Signed-off-by: Stefan Weil <sw@weilnetz.de>