### PR TITLE
Fix for mktemp bug on MAC OS X

### DIFF
--- a/training/tesstrain_utils.sh
+++ b/training/tesstrain_utils.sh
@@ -192,7 +192,11 @@ parse_flags() {
 
 # Function initializes font config with a unique font cache dir.
 initialize_fontconfig() {
-    export FONT_CONFIG_CACHE=$(mktemp -d --tmpdir font_tmp.XXXXXXXXXX)
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      export FONT_CONFIG_CACHE=$(mktemp -d -t font_tmp.XXXXXXXXXX)
+    else
+      export FONT_CONFIG_CACHE=$(mktemp -d --tmpdir font_tmp.XXXXXXXXXX)
+    fi
     local sample_path=${FONT_CONFIG_CACHE}/sample_text.txt
     echo "Text" >${sample_path}
     run_command text2image --fonts_dir=${FONTS_DIR} \


### PR DESCRIPTION
as reported on #1453 `mktemp --tmpdir` doesn't work for MAC, so you need to use `mktemp -t`