### PR TITLE
Add flag to build compiler options with G++ on macOS/MacPorts for Tesseract 4.x.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,6 +131,21 @@ if $sse41; then
     AM_CONDITIONAL([SSE41_OPT], true)
 fi
 
+# Add platform-specific flags for the supported compiler options.
+if $avx -o $avx2 -o $sse41; then
+  case "${host_os}" in
+    *darwin* | *-macos10*)
+       if test -z "$CLANG"; then
+	 echo "MODIFYING FLAGS"
+         # When using AVX, AVX2, or SSE4.1:
+         # Must tell AS to use clang integrated assembler,
+         # instead of the GNU based system assembler.
+         CXXFLAGS="$CXXFLAGS -Wa,-q"
+       fi
+      ;;
+  esac
+fi
+
 includedir="${includedir}/tesseract"
 
 AC_ARG_WITH([extra-includes],

--- a/configure.ac
+++ b/configure.ac
@@ -136,7 +136,6 @@ if $avx -o $avx2 -o $sse41; then
   case "${host_os}" in
     *darwin* | *-macos10*)
        if test -z "$CLANG"; then
-	 echo "MODIFYING FLAGS"
          # When using AVX, AVX2, or SSE4.1:
          # Must tell AS to use clang integrated assembler,
          # instead of the GNU based system assembler.


### PR DESCRIPTION
Building with G++ on Darwin breaks with the MacPorts toolchain, when either AVX, AVX2, or SSE4.1 compiler option is set, unless G++ is actually CLANG.

This PR allows building with G++, by asking G++ to delegate assembly to the clang integrated assembler, instead of the GNU one.

## Situation
GNU compilers choke when assembling with AS. After `autogen.sh` and `configure`, `make` ends quickly with such error trace:

```
# ... Cut the beginning of the trace
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I.. -O2 -DNDEBUG -I../ccstruct -I../ccutil -I../viewer -I/opt/local/include/leptonica -I/opt/local/include/pango-1.0 -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/include -I/opt/local/include/cairo -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/include -I/opt/local/include/pixman-1 -I/opt/local/include -I/opt/local/include/freetype2 -I/opt/local/include -I/opt/local/include/freetype2 -I/opt/local/include/libpng16 -I/opt/local/include -mavx -g -O2 -std=c++11 -MT libtesseract_avx_la-dotproductavx.lo -MD -MP -MF .deps/libtesseract_avx_la-dotproductavx.Tpo -c dotproductavx.cpp  -fno-common -DPIC -o .libs/libtesseract_avx_la-dotproductavx.o
/var/folders/dy/7c6v04gn4x96qz9w1xrl_6r00000gn/T//cc9mtjB1.s:46:no such instruction: `vmovapd (%rdi), %ymm0'
/var/folders/dy/7c6v04gn4x96qz9w1xrl_6r00000gn/T//cc9mtjB1.s:47:no such instruction: `vmulpd (%rsi), %ymm0,%ymm0'
/var/folders/dy/7c6v04gn4x96qz9w1xrl_6r00000gn/T//cc9mtjB1.s:61:no such instruction: `vmovapd (%rdi,%rax,8), %ymm1'
# ... several more missing instructions
make[3]: *** [libtesseract_avx_la-dotproductavx.lo] Error 1
make[2]: *** [all-recursive] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```

This is a common issue on macOS, where we need to ask the compiler to use the clang integrated assembler by passing `-Wa,-q`.

The problem happens at least from tag `4.0.0-beta.1` to the present `master`  at `742a0875077e16f0010e99f1bf05823cd9bb725d`.

## Tests conducted

### Configuration
* Commit: `742a0875077e16f0010e99f1bf05823cd9bb725d` (current master at this time)
* macOS 10.12.6
* MacPorts 2.4.2
* Build with `/opt/local/bin/g++`, itself built with MacPorts (`g++ (MacPorts gcc6 6.4.0_0) 6.4.0`)
* Leptonica 1.75.3
* Machine with AVX, AVX2, SSE4.1 support.

### Tests after the fix
#### Simple `make`
* Builds fine until completion.
* CLI trial, from the repository home:

```
export TEST_IMG=/tmp/tesseract_test.jpg
curl -o $TEST_IMG https://i.ytimg.com/vi/4KhEQKyByXs/maxresdefault.jpg
export TESSDATA_PREFIX=/path/to/4.0/tessdata
./api/.libs/tesseract $TEST_IMG stdout -l eng
```

Results in:
```
Warning. Invalid resolution 0 dpi. Using 70 instead.
Estimating resolution as 2122
SAMPLE TEXT
```

#### `make training`
* Builds fine until completion.
* Same CLI trial as above.

### Extra Notes

* I am aware of this [issue/documentation](https://github.com/tesseract-ocr/tesseract/issues/1453) where the build seems to work fine on macOS 10.13 with Homebrew. Here I build with MacPorts, so the problem may be due to this toolchain.