### PR TITLE
cmake switch to turn off test building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ endif()
 find_package(OpenCL QUIET)
 
 option(BUILD_TRAINING_TOOLS "Build training tools" ON)
+option(BUILD_TESTS "Build tests" ON)
 
 ###############################################################################
 #
@@ -300,7 +301,7 @@ target_link_libraries           (tesseract libtesseract)
 
 ########################################
 
-if (EXISTS ${PROJECT_SOURCE_DIR}/googletest/CMakeLists.txt)
+if (BUILD_GTEST AND EXISTS ${PROJECT_SOURCE_DIR}/googletest/CMakeLists.txt)
     add_subdirectory(googletest)
     add_executable(tesseract_tests tests/tesseracttests.cpp)
     target_link_libraries(tesseract_tests gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ target_link_libraries           (tesseract libtesseract)
 
 ########################################
 
-if (BUILD_GTEST AND EXISTS ${PROJECT_SOURCE_DIR}/googletest/CMakeLists.txt)
+if (BUILD_TESTS AND EXISTS ${PROJECT_SOURCE_DIR}/googletest/CMakeLists.txt)
     add_subdirectory(googletest)
     add_executable(tesseract_tests tests/tesseracttests.cpp)
     target_link_libraries(tesseract_tests gtest_main)


### PR DESCRIPTION
adds a switch to suppress building googletest and tests

reason: when adding tesseract to another project via [ExternalProject_Add](https://cmake.org/cmake/help/v3.0/module/ExternalProject.html) it is impossible to not clone submodules, which forces tesseracts cmake to build the tests. the added switch retains current default behaviour.