### PR TITLE
configure: Remove optimize option for preprocessor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -296,10 +296,10 @@ AC_ARG_ENABLE([debug],
 AC_MSG_RESULT([$debug])
 if test x"$debug" = x"yes"; then
     AM_CXXFLAGS="$AM_CXXFLAGS -g -Wall -O0 -DDEBUG"
-    AM_CPPFLAGS="$AM_CPPFLAGS -g -Wall -O0 -DDEBUG"
+    AM_CPPFLAGS="$AM_CPPFLAGS -g -Wall -DDEBUG"
 else
     AM_CXXFLAGS="$AM_CXXFLAGS -O2 -DNDEBUG"
-    AM_CPPFLAGS="$AM_CPPFLAGS -O2 -DNDEBUG"
+    AM_CPPFLAGS="$AM_CPPFLAGS -DNDEBUG"
 fi
 
 #localedir='${prefix}/share/locale'


### PR DESCRIPTION
It is only used by the compiler.

Signed-off-by: Stefan Weil <sw@weilnetz.de>