### PR TITLE
Fixed compiler warning

### DIFF
--- a/ccutil/mainblk.cpp
+++ b/ccutil/mainblk.cpp
@@ -62,7 +62,7 @@ void CCUtil::main_setup(const char *argv0, const char *basename) {
     /* Use tessdata prefix from the environment. */
     datadir = tessdata_prefix;
 #if defined(_WIN32)
-  } else if (datadir == NULL || access(datadir.string(), 0) != 0) {
+  } else if (datadir == NULL || _access(datadir.string(), 0) != 0) {
     /* Look for tessdata in directory of executable. */
     char drive[_MAX_DRIVE];
     char dir[_MAX_DIR];


### PR DESCRIPTION
Warning C4996: 'access': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _access.

Signed-off-by: Noah Metzger <noah.metzger@bib.uni-mannheim.de>