### PR TITLE
configure.ac: Check for the presence of pango 1.22.0 or higher

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -477,9 +477,10 @@ if !($have_icu_uc && $have_icu_i18n); then
 fi
 
 # Check location of pango headers
-PKG_CHECK_MODULES([pango], [pango], [have_pango=true], [have_pango=false])
+PKG_CHECK_MODULES([pango], [pango >= 1.22.0], [have_pango=true], [have_pango=false])
 if !($have_pango); then
-        AC_MSG_WARN([Training tools WILL NOT be built because of missing pango library.])
+        AC_MSG_WARN([pango 1.22.0 or higher is required, but was not found.])
+        AC_MSG_WARN([Training tools WILL NOT be built.])
         AC_MSG_WARN([Try to install libpango1.0-dev package.])
         AM_CONDITIONAL([ENABLE_TRAINING], false)
 else


### PR DESCRIPTION
Tesseract's training tool text2image uses these two functions: 
pango_glyph_item_iter_init_start
pango_glyph_item_iter_next_cluster

That means it requires Pango >= 1.22.0:
https://developer.gnome.org/pango/stable/api-index-1-22.html
https://developer.gnome.org/pango/stable/pango-Glyph-Storage.html#pango-glyph-item-iter-init-start
https://developer.gnome.org/pango/stable/pango-Glyph-Storage.html#pango-glyph-item-iter-next-cluster