### PR TITLE
training: Fix dubious parsing of command line

### DIFF
--- a/training/commandlineflags.cpp
+++ b/training/commandlineflags.cpp
@@ -170,14 +170,14 @@ void ParseCommandLineFlags(const char* usage,
       break;
     }
     // Position current_arg after startings hyphens. We treat a sequence of
-    // consecutive hyphens of any length identically.
-    while (*current_arg == '-') {
+    // one or two consecutive hyphens identically.
+    ++current_arg;
+    if (current_arg[0] == '-') {
       ++current_arg;
     }
     // If this is asking for usage, print the help message and abort.
-    if (!strcmp(current_arg, "help") ||
-        !strcmp(current_arg, "helpshort")) {
-      printf("USAGE: %s\n", usage);
+    if (!strcmp(current_arg, "help")) {
+      printf("Usage:\n  %s [OPTION ...]\n\n", usage);
       PrintCommandLineFlags();
       exit(0);
     }

--- a/training/commandlineflags.h
+++ b/training/commandlineflags.h
@@ -67,7 +67,7 @@
 namespace tesseract {
 
 // Parse commandline flags and values. Prints the usage string and exits on
-// input of --help or --helpshort.
+// input of --help or --version.
 //
 // If remove_flags is true, the argv pointer is advanced so that (*argv)[1]
 // points to the first non-flag argument, (*argv)[0] points to the same string


### PR DESCRIPTION
- Don't support --helpshort as an undocumented alias for --help
- Don't allow any number of leading '-' characters.
  The preferred form uses --OPTION, and for compatibility reasons the new
  code still supports -OPTION.

Update also related documentation comments.

Signed-off-by: Stefan Weil <sw@weilnetz.de>