### PR TITLE
Fixed Resource Leak, detected by Coverity

### DIFF
--- a/ccstruct/pdblock.h
+++ b/ccstruct/pdblock.h
@@ -50,7 +50,7 @@ class PDBLK {
   void set_sides(ICOORDELT_LIST *left, ICOORDELT_LIST *right);
 
   /// destructor
-  ~PDBLK() { delete hand_poly; }
+  virtual ~PDBLK() { delete hand_poly; }
 
   POLY_BLOCK *poly_block() const { return hand_poly; }
   /// set the poly block


### PR DESCRIPTION
CID 1164748: Class BLOCK has a destructor and a pointer to it is upcast to class PDBLK which doesn't have a virtual destructor

Signed-off-by: Noah Metzger <noah.metzger@bib.uni-mannheim.de>