### PR TITLE
lstmtraining: Fix handling of --max_iterations

### DIFF
--- a/training/lstmtraining.cpp
+++ b/training/lstmtraining.cpp
@@ -195,7 +195,8 @@ int main(int argc, char **argv) {
     // Train a few.
     int iteration = trainer.training_iteration();
     for (int target_iteration = iteration + kNumPagesPerBatch;
-         iteration < target_iteration;
+         iteration < target_iteration &&
+         (iteration < FLAGS_max_iterations || FLAGS_max_iterations == 0);
          iteration = trainer.training_iteration()) {
       trainer.TrainOnLine(&trainer, false);
     }


### PR DESCRIPTION
The iteration counter should be checked for each iteration,
not only at the end of a batch.

Signed-off-by: Stefan Weil <sw@weilnetz.de>