### PR TITLE
configure.ac: Update minimum required autoconf version to 2.63

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 # ----------------------------------------
 # Initialization
 # ----------------------------------------
-AC_PREREQ([2.59])
+AC_PREREQ([2.63])
 AC_INIT([tesseract],
         [m4_esyscmd_s([test -d .git && git describe --abbrev=4 || cat VERSION])],
         [https://github.com/tesseract-ocr/tesseract/issues],,


### PR DESCRIPTION
This is the autoconf version shipped in RHEL/CentOS 6.