### PR TITLE
[WIP] configure.ac: Fix debug mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ AC_INIT([tesseract],
         [m4_esyscmd_s([test -d .git && git describe --abbrev=4 || cat VERSION])],
         [https://github.com/tesseract-ocr/tesseract/issues],,
         [https://github.com/tesseract-ocr/tesseract/])
+: ${CXXFLAGS=""}
 AC_PROG_CXX([g++ clang++])
 AC_LANG([C++])
 AC_LANG_COMPILER_REQUIRE


### PR DESCRIPTION
Debug mode should be "-g -O0".

See: https://www.gnu.org/software/autoconf/manual/autoconf-2.66/html_node/C_002b_002b-Compiler.html