### PR TITLE
Fix wrong environment test that breaks clang++ builds.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,8 +135,8 @@ fi
 if $avx -o $avx2 -o $sse41; then
   case "${host_os}" in
     *darwin* | *-macos10*)
-       if test -z "$CLANG"; then
-         # When using AVX, AVX2, or SSE4.1:
+       if test g++ = "$CXX"; then
+         # When using AVX, AVX2, or SSE4.1 with g++:
          # Must tell AS to use clang integrated assembler,
          # instead of the GNU based system assembler.
          CXXFLAGS="$CXXFLAGS -Wa,-q"


### PR DESCRIPTION
g++ builds require extra flags rejected by clang++. The bug is that the
flags are actually added unconditionally. This commit fixes the
condition.

See https://github.com/tesseract-ocr/tesseract/pull/1474 and related.

Tests conducted and report: https://github.com/tesseract-ocr/tesseract/pull/1474#issuecomment-383437228