### PR TITLE
Fix linker regression for Visual Studio

### DIFF
--- a/ccutil/unicharset.h
+++ b/ccutil/unicharset.h
@@ -1006,7 +1006,7 @@ class UNICHARSET {
   // The substitutions clean up text that should exists for rendering of
   // synthetic data, but not in the recognition set.
   static const char* kCleanupMaps[][2];
-  static const char* null_script;
+  static TESS_API const char* null_script;
 
   UNICHAR_SLOT* unichars;
   UNICHARMAP ids;


### PR DESCRIPTION
Commit cb77067f554683fcf972cff0b497e9c4bfd3d877 changed the declaration of
null_script. An additional TESS_API is needed to satisfy the VS linker.

Signed-off-by: Stefan Weil <sw@weilnetz.de>