### PR TITLE
Revert failed attempt to support MacPort's g++

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,20 +131,6 @@ if $sse41; then
     AM_CONDITIONAL([SSE41_OPT], true)
 fi
 
-# Add platform-specific flags for the supported compiler options.
-if $avx -o $avx2 -o $sse41; then
-  case "${host_os}" in
-    *darwin* | *-macos10*)
-       if test g++ = "$CXX"; then
-         # When using AVX, AVX2, or SSE4.1 with g++:
-         # Must tell AS to use clang integrated assembler,
-         # instead of the GNU based system assembler.
-         CXXFLAGS="$CXXFLAGS -Wa,-q"
-       fi
-      ;;
-  esac
-fi
-
 includedir="${includedir}/tesseract"
 
 AC_ARG_WITH([extra-includes],


### PR DESCRIPTION
The support will require more work, and postpone for now.

This contributes to #1500, and removes #1474 and #1516.