### PR TITLE
Fix unittest (missing include path)

### DIFF
--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -9,6 +9,7 @@ TESTING_DIR=$(shell cd $(top_srcdir) && pwd)/testing
 AM_CPPFLAGS += -DTESSDATA_DIR="\"$(TESSDATA_DIR)\""
 AM_CPPFLAGS += -DTESTING_DIR="\"$(TESTING_DIR)\""
 AM_CPPFLAGS += -DPANGO_ENABLE_ENGINE
+AM_CPPFLAGS += -I$(top_builddir)/api
 AM_CPPFLAGS += -I$(top_srcdir)/api
 AM_CPPFLAGS += -I$(top_srcdir)/arch 
 AM_CPPFLAGS += -I$(top_srcdir)/ccmain


### PR DESCRIPTION
Add include path for api/tess_version.h.

Signed-off-by: Stefan Weil <sw@weilnetz.de>