### PR TITLE
Partial fix for autotools configuration after source tree reorganisation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,15 +2,15 @@
 ACLOCAL_AMFLAGS = -I m4
 
 if ENABLE_TRAINING
-TRAINING_SUBDIR = training
+TRAINING_SUBDIR = src/training
 training: all
-	@$(MAKE) -C training
+	@$(MAKE) -C src/training
 training-install: training
-	@$(MAKE) -C training install
+	@$(MAKE) -C src/training install
 training-uninstall:
-	@$(MAKE) -C training uninstall
+	@$(MAKE) -C src/training uninstall
 clean-local:
-	@$(MAKE) -C training clean
+	@$(MAKE) -C src/training clean
 else
 training:
 	@echo "Need to reconfigure project, so there are no errors"
@@ -18,8 +18,9 @@ endif
 
 .PHONY: doc install-langs ScrollView.jar install-jars training
 
-SUBDIRS = arch ccutil viewer cutil opencl ccstruct dict classify wordrec textord lstm
-SUBDIRS += ccmain api . tessdata doc unittest
+SUBDIRS = src/arch src/ccutil src/viewer src/cutil src/opencl src/ccstruct
+SUBDIRS += src/dict src/classify src/wordrec src/textord src/lstm
+SUBDIRS += src/ccmain src/api . tessdata doc unittest
 
 EXTRA_DIST = README.md\
 	aclocal.m4 config configure.ac autogen.sh contrib \

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -1,11 +1,17 @@
-AM_CPPFLAGS += -DLOCALEDIR=\"$(localedir)\"\
-    -I$(top_srcdir)/arch -I$(top_srcdir)/lstm \
-    -I$(top_srcdir)/ccutil -I$(top_srcdir)/ccstruct \
-    -I$(top_srcdir)/viewer \
-    -I$(top_srcdir)/textord -I$(top_srcdir)/dict \
-    -I$(top_srcdir)/classify -I$(top_srcdir)/ccmain \
-    -I$(top_srcdir)/wordrec -I$(top_srcdir)/cutil \
-    -I$(top_srcdir)/opencl -I$(top_builddir)/api
+AM_CPPFLAGS += -DLOCALEDIR=\"$(localedir)\" \
+    -I$(top_srcdir)/src/arch \
+    -I$(top_srcdir)/src/lstm \
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/ccstruct \
+    -I$(top_srcdir)/src/viewer \
+    -I$(top_srcdir)/src/textord \
+    -I$(top_srcdir)/src/dict \
+    -I$(top_srcdir)/src/classify \
+    -I$(top_srcdir)/src/ccmain \
+    -I$(top_srcdir)/src/wordrec \
+    -I$(top_srcdir)/src/cutil \
+    -I$(top_srcdir)/src/opencl \
+    -I$(top_builddir)/api
 
 AM_CPPFLAGS += $(OPENCL_CPPFLAGS)
 

--- a/src/arch/Makefile.am
+++ b/src/arch/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS += -I$(top_srcdir)/ccstruct -I$(top_srcdir)/ccutil -I$(top_srcdir)/viewer
+AM_CPPFLAGS += -I$(top_srcdir)/src/ccstruct -I$(top_srcdir)/src/ccutil -I$(top_srcdir)/src/viewer
 
 SUBDIRS =
 AM_CXXFLAGS =

--- a/src/ccmain/Makefile.am
+++ b/src/ccmain/Makefile.am
@@ -1,10 +1,15 @@
 AM_CPPFLAGS += \
-    -I$(top_srcdir)/ccutil -I$(top_srcdir)/ccstruct \
-    -I$(top_srcdir)/arch -I$(top_srcdir)/lstm \
-    -I$(top_srcdir)/viewer \
-    -I$(top_srcdir)/classify  -I$(top_srcdir)/dict \
-    -I$(top_srcdir)/wordrec -I$(top_srcdir)/cutil \
-    -I$(top_srcdir)/textord -I$(top_srcdir)/opencl
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/ccstruct \
+    -I$(top_srcdir)/src/arch \
+    -I$(top_srcdir)/src/lstm \
+    -I$(top_srcdir)/src/viewer \
+    -I$(top_srcdir)/src/classify \
+    -I$(top_srcdir)/src/dict \
+    -I$(top_srcdir)/src/wordrec \
+    -I$(top_srcdir)/src/cutil \
+    -I$(top_srcdir)/src/textord \
+    -I$(top_srcdir)/src/opencl
 
 AM_CPPFLAGS += $(OPENCL_CPPFLAGS)
 AM_CPPFLAGS += $(OPENMP_CXXFLAGS)

--- a/src/ccstruct/Makefile.am
+++ b/src/ccstruct/Makefile.am
@@ -1,7 +1,8 @@
 AM_CPPFLAGS += \
-    -I$(top_srcdir)/ccutil -I$(top_srcdir)/cutil \
-    -I$(top_srcdir)/viewer \
-    -I$(top_srcdir)/opencl
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/cutil \
+    -I$(top_srcdir)/src/viewer \
+    -I$(top_srcdir)/src/opencl
 AM_CPPFLAGS += $(OPENCL_CPPFLAGS)
     
 if VISIBILITY

--- a/src/classify/Makefile.am
+++ b/src/classify/Makefile.am
@@ -1,7 +1,9 @@
 AM_CPPFLAGS += \
-    -I$(top_srcdir)/cutil -I$(top_srcdir)/ccutil \
-    -I$(top_srcdir)/ccstruct -I$(top_srcdir)/dict \
-    -I$(top_srcdir)/viewer
+    -I$(top_srcdir)/src/cutil \
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/ccstruct \
+    -I$(top_srcdir)/src/dict \
+    -I$(top_srcdir)/src/viewer
     
 if VISIBILITY
 AM_CPPFLAGS += -DTESS_EXPORTS \

--- a/src/cutil/Makefile.am
+++ b/src/cutil/Makefile.am
@@ -1,4 +1,6 @@
-AM_CPPFLAGS += -I$(top_srcdir)/ccutil -I$(top_srcdir)/viewer
+AM_CPPFLAGS += \
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/viewer
 
 if VISIBILITY
 AM_CPPFLAGS += -DTESS_EXPORTS \

--- a/src/dict/Makefile.am
+++ b/src/dict/Makefile.am
@@ -1,5 +1,8 @@
-AM_CPPFLAGS += -I$(top_srcdir)/cutil -I$(top_srcdir)/ccutil \
-    -I$(top_srcdir)/ccstruct -I$(top_srcdir)/viewer
+AM_CPPFLAGS += \
+    -I$(top_srcdir)/src/cutil \
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/ccstruct \
+    -I$(top_srcdir)/src/viewer
     
 if VISIBILITY
 AM_CPPFLAGS += -DTESS_EXPORTS \

--- a/src/lstm/Makefile.am
+++ b/src/lstm/Makefile.am
@@ -1,7 +1,12 @@
 AM_CPPFLAGS += \
-    -I$(top_srcdir)/ccutil -I$(top_srcdir)/cutil -I$(top_srcdir)/ccstruct \
-    -I$(top_srcdir)/arch -I$(top_srcdir)/viewer -I$(top_srcdir)/classify \
-    -I$(top_srcdir)/dict -I$(top_srcdir)/lstm
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/cutil \
+    -I$(top_srcdir)/src/ccstruct \
+    -I$(top_srcdir)/src/arch \
+    -I$(top_srcdir)/src/viewer \
+    -I$(top_srcdir)/src/classify \
+    -I$(top_srcdir)/src/dict \
+    -I$(top_srcdir)/src/lstm
 
 SUBDIRS =
 AM_CXXFLAGS = $(OPENMP_CXXFLAGS)

--- a/src/opencl/Makefile.am
+++ b/src/opencl/Makefile.am
@@ -1,4 +1,8 @@
-AM_CPPFLAGS += -I$(top_srcdir)/ccutil -I$(top_srcdir)/ccstruct -I$(top_srcdir)/ccmain $(OPENCL_CFLAGS)
+AM_CPPFLAGS += $(OPENCL_CFLAGS) \
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/ccstruct \
+    -I$(top_srcdir)/src/ccmain
+
 noinst_HEADERS = \
     openclwrapper.h oclkernels.h opencl_device_selection.h
 

--- a/src/textord/Makefile.am
+++ b/src/textord/Makefile.am
@@ -1,9 +1,14 @@
 AM_CPPFLAGS += \
-    -I$(top_srcdir)/ccstruct -I$(top_srcdir)/ccutil \
-    -I$(top_srcdir)/viewer \
-    -I$(top_srcdir)/ccmain -I$(top_srcdir)/wordrec -I$(top_srcdir)/api \
-    -I$(top_srcdir)/cutil -I$(top_srcdir)/classify -I$(top_srcdir)/dict \
-    -I$(top_srcdir)/opencl
+    -I$(top_srcdir)/src/ccstruct \
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/viewer \
+    -I$(top_srcdir)/src/ccmain \
+    -I$(top_srcdir)/src/wordrec \
+    -I$(top_srcdir)/src/api \
+    -I$(top_srcdir)/src/cutil \
+    -I$(top_srcdir)/src/classify \
+    -I$(top_srcdir)/src/dict \
+    -I$(top_srcdir)/src/opencl
 
 AM_CPPFLAGS += $(OPENCL_CPPFLAGS)
         

--- a/src/training/Makefile.am
+++ b/src/training/Makefile.am
@@ -1,13 +1,19 @@
 AM_CPPFLAGS += \
     -DPANGO_ENABLE_ENGINE \
-    -I$(top_srcdir)/ccmain -I$(top_srcdir)/api \
-    -I$(top_srcdir)/ccutil -I$(top_srcdir)/ccstruct \
-    -I$(top_srcdir)/lstm -I$(top_srcdir)/arch \
-    -I$(top_srcdir)/viewer \
-    -I$(top_srcdir)/textord -I$(top_srcdir)/dict \
-    -I$(top_srcdir)/classify -I$(top_srcdir)/display \
-    -I$(top_srcdir)/wordrec -I$(top_srcdir)/cutil \
-    -I$(top_builddir)/api
+    -I$(top_builddir)/src/api \
+    -I$(top_srcdir)/src/api \
+    -I$(top_srcdir)/src/ccmain \
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/ccstruct \
+    -I$(top_srcdir)/src/lstm \
+    -I$(top_srcdir)/src/arch \
+    -I$(top_srcdir)/src/viewer \
+    -I$(top_srcdir)/src/textord \
+    -I$(top_srcdir)/src/dict \
+    -I$(top_srcdir)/src/classify \
+    -I$(top_srcdir)/src/display \
+    -I$(top_srcdir)/src/wordrec \
+    -I$(top_srcdir)/src/cutil
 
 EXTRA_DIST = language-specific.sh tesstrain.sh tesstrain_utils.sh
 

--- a/src/viewer/Makefile.am
+++ b/src/viewer/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS += -I$(top_srcdir)/ccutil
+AM_CPPFLAGS += -I$(top_srcdir)/src/ccutil
 
 if VISIBILITY
 AM_CPPFLAGS += -DTESS_EXPORTS \

--- a/src/wordrec/Makefile.am
+++ b/src/wordrec/Makefile.am
@@ -1,8 +1,10 @@
 AM_CPPFLAGS += \
-    -I$(top_srcdir)/ccstruct -I$(top_srcdir)/ccutil \
-    -I$(top_srcdir)/cutil -I$(top_srcdir)/classify \
-    -I$(top_srcdir)/dict \
-    -I$(top_srcdir)/viewer
+    -I$(top_srcdir)/src/ccstruct \
+    -I$(top_srcdir)/src/ccutil \
+    -I$(top_srcdir)/src/cutil \
+    -I$(top_srcdir)/src/classify \
+    -I$(top_srcdir)/src/dict \
+    -I$(top_srcdir)/src/viewer
 
 if VISIBILITY
 AM_CPPFLAGS += -DTESS_EXPORTS \

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -9,20 +9,20 @@ TESTING_DIR=$(shell cd $(top_srcdir) && pwd)/testing
 AM_CPPFLAGS += -DTESSDATA_DIR="\"$(TESSDATA_DIR)\""
 AM_CPPFLAGS += -DTESTING_DIR="\"$(TESTING_DIR)\""
 AM_CPPFLAGS += -DPANGO_ENABLE_ENGINE
-AM_CPPFLAGS += -I$(top_builddir)/api
-AM_CPPFLAGS += -I$(top_srcdir)/api
-AM_CPPFLAGS += -I$(top_srcdir)/arch 
-AM_CPPFLAGS += -I$(top_srcdir)/ccmain
-AM_CPPFLAGS += -I$(top_srcdir)/ccstruct 
-AM_CPPFLAGS += -I$(top_srcdir)/ccutil 
-AM_CPPFLAGS += -I$(top_srcdir)/classify 
-AM_CPPFLAGS += -I$(top_srcdir)/cutil
-AM_CPPFLAGS += -I$(top_srcdir)/dict 
-AM_CPPFLAGS += -I$(top_srcdir)/display 
-AM_CPPFLAGS += -I$(top_srcdir)/lstm 
-AM_CPPFLAGS += -I$(top_srcdir)/textord 
-AM_CPPFLAGS += -I$(top_srcdir)/viewer 
-AM_CPPFLAGS += -I$(top_srcdir)/wordrec
+AM_CPPFLAGS += -I$(top_builddir)/src/api
+AM_CPPFLAGS += -I$(top_srcdir)/src/api
+AM_CPPFLAGS += -I$(top_srcdir)/src/arch
+AM_CPPFLAGS += -I$(top_srcdir)/src/ccmain
+AM_CPPFLAGS += -I$(top_srcdir)/src/ccstruct
+AM_CPPFLAGS += -I$(top_srcdir)/src/ccutil
+AM_CPPFLAGS += -I$(top_srcdir)/src/classify
+AM_CPPFLAGS += -I$(top_srcdir)/src/cutil
+AM_CPPFLAGS += -I$(top_srcdir)/src/dict
+AM_CPPFLAGS += -I$(top_srcdir)/src/display
+AM_CPPFLAGS += -I$(top_srcdir)/src/lstm
+AM_CPPFLAGS += -I$(top_srcdir)/src/textord
+AM_CPPFLAGS += -I$(top_srcdir)/src/viewer
+AM_CPPFLAGS += -I$(top_srcdir)/src/wordrec
 
 # Build googletest:
 check_LTLIBRARIES = libgtest.la libgtest_main.la
@@ -33,7 +33,7 @@ libgtest_main_la_SOURCES = ../googletest/googletest/src/gtest_main.cc
 
 # Build unittests
 GTEST_LIBS =  libgtest.la libgtest_main.la
-TESS_LIBS = $(top_builddir)/api/libtesseract.la
+TESS_LIBS = $(top_builddir)/src/api/libtesseract.la
 AM_CPPFLAGS +=   -isystem $(top_srcdir)/googletest/googletest/include  
 
 check_PROGRAMS = \


### PR DESCRIPTION
This should fix "make" and "make training".

Signed-off-by: Stefan Weil <sw@weilnetz.de>