### PR TITLE
Remove old hack for Visual Studio

### DIFF
--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -16,9 +16,6 @@
  ** limitations under the License.
  *
  **********************************************************************/
-#ifdef _MSC_VER
-#define __func__ __FUNCTION__
-#endif
 
 #include <ctype.h>
 #include <memory>  // std::unique_ptr


### PR DESCRIPTION
It should not be needed with newer versions of Visual Studio.

Signed-off-by: Stefan Weil <sw@weilnetz.de>