### PR TITLE
Remove unneeded include statements for string / strings.h

### DIFF
--- a/cmake/Configure.cmake
+++ b/cmake/Configure.cmake
@@ -88,7 +88,6 @@ set(include_files_list
     stdbool.h
     stdint.h
     stdlib.h
-    strings.h
     string.h
     sys/ipc.h
     sys/shm.h

--- a/cppan.yml
+++ b/cppan.yml
@@ -105,7 +105,6 @@ projects:
           - stdbool.h
           - stdint.h
           - stdlib.h
-          - strings.h
           - string.h
           - sys/ipc.h
           - sys/shm.h

--- a/src/ccmain/paragraphs_internal.h
+++ b/src/ccmain/paragraphs_internal.h
@@ -21,11 +21,6 @@
 #define TESSERACT_CCMAIN_PARAGRAPHS_INTERNAL_H_
 
 #include "paragraphs.h"
-#ifdef _MSC_VER
-#include <string>
-#else
-#include "strings.h"
-#endif
 
 // NO CODE OUTSIDE OF paragraphs.cpp AND TESTS SHOULD NEED TO ACCESS
 // DATA STRUCTURES OR FUNCTIONS IN THIS FILE.


### PR DESCRIPTION
Tesseract code does not use strings.h (strngs.h was once called strings.h),
so that dependency can also be removed from cmake and cppan configuration.

Signed-off-by: Stefan Weil <sw@weilnetz.de>