### PR TITLE
Fixed access to uninitialized variable

### DIFF
--- a/src/training/stringrenderer.cpp
+++ b/src/training/stringrenderer.cpp
@@ -120,6 +120,7 @@ StringRenderer::StringRenderer(const std::string& font_desc, int page_width,
       font_index_(0),
       last_offset_(0) {
   set_resolution(kDefaultOutputResolution);
+  set_font(font_desc);
 }
 
 bool StringRenderer::set_font(const std::string& desc) {


### PR DESCRIPTION
Coverity ID: 1386084 the set_font method has accessed resolution_ before it was initialized by the set_resolution method.

Signed-off-by: Noah Metzger <noah.metzger@bib.uni-mannheim.de>