### PR TITLE
Use more override specifiers

### DIFF
--- a/src/lstm/convolve.h
+++ b/src/lstm/convolve.h
@@ -37,7 +37,7 @@ class Convolve : public Network {
   Convolve(const STRING& name, int ni, int half_x, int half_y);
   virtual ~Convolve();
 
-  virtual STRING spec() const {
+  STRING spec() const override {
     STRING spec;
     spec.add_str_int("C", half_x_ * 2 + 1);
     spec.add_str_int(",", half_y_ * 2 + 1);
@@ -45,21 +45,21 @@ class Convolve : public Network {
   }
 
   // Writes to the given file. Returns false in case of error.
-  virtual bool Serialize(TFile* fp) const;
+  bool Serialize(TFile* fp) const override;
   // Reads from the given file. Returns false in case of error.
-  virtual bool DeSerialize(TFile* fp);
+  bool DeSerialize(TFile* fp) override;
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.
-  virtual void Forward(bool debug, const NetworkIO& input,
-                       const TransposedArray* input_transpose,
-                       NetworkScratch* scratch, NetworkIO* output);
+  void Forward(bool debug, const NetworkIO& input,
+               const TransposedArray* input_transpose,
+               NetworkScratch* scratch, NetworkIO* output) override;
 
   // Runs backward propagation of errors on the deltas line.
   // See Network for a detailed discussion of the arguments.
-  virtual bool Backward(bool debug, const NetworkIO& fwd_deltas,
-                        NetworkScratch* scratch,
-                        NetworkIO* back_deltas);
+  bool Backward(bool debug, const NetworkIO& fwd_deltas,
+                NetworkScratch* scratch,
+                NetworkIO* back_deltas) override;
 
  protected:
   // Serialized data.

--- a/src/lstm/input.h
+++ b/src/lstm/input.h
@@ -31,7 +31,7 @@ class Input : public Network {
   Input(const STRING& name, const StaticShape& shape);
   virtual ~Input();
 
-  virtual STRING spec() const {
+  STRING spec() const override {
     STRING spec;
     spec.add_str_int("", shape_.batch());
     spec.add_str_int(",", shape_.height());
@@ -41,17 +41,17 @@ class Input : public Network {
   }
 
   // Returns the required shape input to the network.
-  virtual StaticShape InputShape() const { return shape_; }
+  StaticShape InputShape() const override { return shape_; }
   // Returns the shape output from the network given an input shape (which may
   // be partially unknown ie zero).
-  virtual StaticShape OutputShape(const StaticShape& input_shape) const {
+  StaticShape OutputShape(const StaticShape& input_shape) const override {
     return shape_;
   }
   // Writes to the given file. Returns false in case of error.
   // Should be overridden by subclasses, but called by their Serialize.
-  virtual bool Serialize(TFile* fp) const;
+  bool Serialize(TFile* fp) const override;
   // Reads from the given file. Returns false in case of error.
-  virtual bool DeSerialize(TFile* fp);
+  bool DeSerialize(TFile* fp) override;
 
   // Returns an integer reduction factor that the network applies to the
   // time sequence. Assumes that any 2-d is already eliminated. Used for
@@ -59,23 +59,23 @@ class Input : public Network {
   // WARNING: if GlobalMinimax is used to vary the scale, this will return
   // the last used scale factor. Call it before any forward, and it will return
   // the minimum scale factor of the paths through the GlobalMinimax.
-  virtual int XScaleFactor() const;
+  int XScaleFactor() const override;
 
   // Provides the (minimum) x scale factor to the network (of interest only to
   // input units) so they can determine how to scale bounding boxes.
-  virtual void CacheXScaleFactor(int factor);
+  void CacheXScaleFactor(int factor) override;
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.
-  virtual void Forward(bool debug, const NetworkIO& input,
-                       const TransposedArray* input_transpose,
-                       NetworkScratch* scratch, NetworkIO* output);
+  void Forward(bool debug, const NetworkIO& input,
+               const TransposedArray* input_transpose,
+               NetworkScratch* scratch, NetworkIO* output) override;
 
   // Runs backward propagation of errors on the deltas line.
   // See Network for a detailed discussion of the arguments.
-  virtual bool Backward(bool debug, const NetworkIO& fwd_deltas,
-                        NetworkScratch* scratch,
-                        NetworkIO* back_deltas);
+  bool Backward(bool debug, const NetworkIO& fwd_deltas,
+                NetworkScratch* scratch,
+                NetworkIO* back_deltas) override;
   // Creates and returns a Pix of appropriate size for the network from the
   // image_data. If non-null, *image_scale returns the image scale factor used.
   // Returns nullptr on error.

--- a/src/lstm/maxpool.h
+++ b/src/lstm/maxpool.h
@@ -32,7 +32,7 @@ class Maxpool : public Reconfig {
   virtual ~Maxpool();
 
   // Accessors.
-  virtual STRING spec() const {
+  STRING spec() const override {
     STRING spec;
     spec.add_str_int("Mp", y_scale_);
     spec.add_str_int(",", x_scale_);
@@ -40,19 +40,19 @@ class Maxpool : public Reconfig {
   }
 
   // Reads from the given file. Returns false in case of error.
-  virtual bool DeSerialize(TFile* fp);
+  bool DeSerialize(TFile* fp) override;
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.
-  virtual void Forward(bool debug, const NetworkIO& input,
-                       const TransposedArray* input_transpose,
-                       NetworkScratch* scratch, NetworkIO* output);
+  void Forward(bool debug, const NetworkIO& input,
+               const TransposedArray* input_transpose,
+               NetworkScratch* scratch, NetworkIO* output) override;
 
   // Runs backward propagation of errors on the deltas line.
   // See Network for a detailed discussion of the arguments.
-  virtual bool Backward(bool debug, const NetworkIO& fwd_deltas,
-                        NetworkScratch* scratch,
-                        NetworkIO* back_deltas);
+  bool Backward(bool debug, const NetworkIO& fwd_deltas,
+                NetworkScratch* scratch,
+                NetworkIO* back_deltas) override;
 
  private:
   // Memory of which input was the max.

--- a/src/lstm/parallel.h
+++ b/src/lstm/parallel.h
@@ -32,9 +32,9 @@ class Parallel : public Plumbing {
 
   // Returns the shape output from the network given an input shape (which may
   // be partially unknown ie zero).
-  virtual StaticShape OutputShape(const StaticShape& input_shape) const;
+  StaticShape OutputShape(const StaticShape& input_shape) const override;
 
-  virtual STRING spec() const {
+  STRING spec() const override {
     STRING spec;
     if (type_ == NT_PAR_2D_LSTM) {
       // We have 4 LSTMs operating in parallel here, so the size of each is
@@ -63,15 +63,15 @@ class Parallel : public Plumbing {
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.
-  virtual void Forward(bool debug, const NetworkIO& input,
-                       const TransposedArray* input_transpose,
-                       NetworkScratch* scratch, NetworkIO* output);
+  void Forward(bool debug, const NetworkIO& input,
+               const TransposedArray* input_transpose,
+               NetworkScratch* scratch, NetworkIO* output) override;
 
   // Runs backward propagation of errors on the deltas line.
   // See Network for a detailed discussion of the arguments.
-  virtual bool Backward(bool debug, const NetworkIO& fwd_deltas,
-                        NetworkScratch* scratch,
-                        NetworkIO* back_deltas);
+  bool Backward(bool debug, const NetworkIO& fwd_deltas,
+                NetworkScratch* scratch,
+                NetworkIO* back_deltas) override;
 
  private:
   // If *this is a NT_REPLICATED, then it feeds a replicated network with

--- a/src/lstm/reconfig.h
+++ b/src/lstm/reconfig.h
@@ -37,9 +37,9 @@ class Reconfig : public Network {
 
   // Returns the shape output from the network given an input shape (which may
   // be partially unknown ie zero).
-  virtual StaticShape OutputShape(const StaticShape& input_shape) const;
+  StaticShape OutputShape(const StaticShape& input_shape) const override;
 
-  virtual STRING spec() const {
+  STRING spec() const override {
     STRING spec;
     spec.add_str_int("S", y_scale_);
     spec.add_str_int(",", x_scale_);
@@ -52,24 +52,24 @@ class Reconfig : public Network {
   // WARNING: if GlobalMinimax is used to vary the scale, this will return
   // the last used scale factor. Call it before any forward, and it will return
   // the minimum scale factor of the paths through the GlobalMinimax.
-  virtual int XScaleFactor() const;
+  int XScaleFactor() const override;
 
   // Writes to the given file. Returns false in case of error.
-  virtual bool Serialize(TFile* fp) const;
+  bool Serialize(TFile* fp) const override;
   // Reads from the given file. Returns false in case of error.
-  virtual bool DeSerialize(TFile* fp);
+  bool DeSerialize(TFile* fp) override;
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.
-  virtual void Forward(bool debug, const NetworkIO& input,
-                       const TransposedArray* input_transpose,
-                       NetworkScratch* scratch, NetworkIO* output);
+  void Forward(bool debug, const NetworkIO& input,
+               const TransposedArray* input_transpose,
+               NetworkScratch* scratch, NetworkIO* output) override;
 
   // Runs backward propagation of errors on the deltas line.
   // See Network for a detailed discussion of the arguments.
-  virtual bool Backward(bool debug, const NetworkIO& fwd_deltas,
-                        NetworkScratch* scratch,
-                        NetworkIO* back_deltas);
+  bool Backward(bool debug, const NetworkIO& fwd_deltas,
+                NetworkScratch* scratch,
+                NetworkIO* back_deltas) override;
 
  protected:
   // Non-serialized data used to store parameters between forward and back.

--- a/src/lstm/reversed.h
+++ b/src/lstm/reversed.h
@@ -32,9 +32,9 @@ class Reversed : public Plumbing {
 
   // Returns the shape output from the network given an input shape (which may
   // be partially unknown ie zero).
-  virtual StaticShape OutputShape(const StaticShape& input_shape) const;
+  StaticShape OutputShape(const StaticShape& input_shape) const override;
 
-  virtual STRING spec() const {
+  STRING spec() const override {
     STRING spec(type_ == NT_XREVERSED ? "Rx"
                                       : (type_ == NT_YREVERSED ? "Ry" : "Txy"));
     // For most simple cases, we will output Rx<net> or Ry<net> where <net> is
@@ -69,15 +69,15 @@ class Reversed : public Plumbing {
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.
-  virtual void Forward(bool debug, const NetworkIO& input,
-                       const TransposedArray* input_transpose,
-                       NetworkScratch* scratch, NetworkIO* output);
+  void Forward(bool debug, const NetworkIO& input,
+               const TransposedArray* input_transpose,
+               NetworkScratch* scratch, NetworkIO* output) override;
 
   // Runs backward propagation of errors on the deltas line.
   // See Network for a detailed discussion of the arguments.
-  virtual bool Backward(bool debug, const NetworkIO& fwd_deltas,
-                        NetworkScratch* scratch,
-                        NetworkIO* back_deltas);
+  bool Backward(bool debug, const NetworkIO& fwd_deltas,
+                NetworkScratch* scratch,
+                NetworkIO* back_deltas) override;
 
  private:
   // Copies src to *dest with the reversal according to type_.

--- a/src/lstm/tfnetwork.h
+++ b/src/lstm/tfnetwork.h
@@ -39,14 +39,14 @@ class TFNetwork : public Network {
   virtual ~TFNetwork();
 
   // Returns the required shape input to the network.
-  virtual StaticShape InputShape() const { return input_shape_; }
+  StaticShape InputShape() const override { return input_shape_; }
   // Returns the shape output from the network given an input shape (which may
   // be partially unknown ie zero).
-  virtual StaticShape OutputShape(const StaticShape& input_shape) const {
+  StaticShape OutputShape(const StaticShape& input_shape) const override {
     return output_shape_;
   }
 
-  virtual STRING spec() const { return spec_.c_str(); }
+  STRING spec() const override { return spec_.c_str(); }
 
   // Deserializes *this from a serialized TFNetwork proto. Returns 0 if failed,
   // otherwise the global step of the serialized graph.
@@ -57,16 +57,16 @@ class TFNetwork : public Network {
 
   // Writes to the given file. Returns false in case of error.
   // Should be overridden by subclasses, but called by their Serialize.
-  virtual bool Serialize(TFile* fp) const;
+  bool Serialize(TFile* fp) const override;
   // Reads from the given file. Returns false in case of error.
   // Should be overridden by subclasses, but NOT called by their DeSerialize.
-  virtual bool DeSerialize(TFile* fp);
+  bool DeSerialize(TFile* fp) override;
 
   // Runs forward propagation of activations on the input line.
   // See Network for a detailed discussion of the arguments.
-  virtual void Forward(bool debug, const NetworkIO& input,
-                       const TransposedArray* input_transpose,
-                       NetworkScratch* scratch, NetworkIO* output);
+  void Forward(bool debug, const NetworkIO& input,
+               const TransposedArray* input_transpose,
+               NetworkScratch* scratch, NetworkIO* output) override;
 
  private:
   int InitFromProto();


### PR DESCRIPTION
Now all methods which override Network methods use the override specifier.

Signed-off-by: Stefan Weil <sw@weilnetz.de>