### PR TITLE
Add /utf-8 for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if (WIN32)
     if (MSVC)
         add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /openmp")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /openmp /utf-8")
     endif()
 
     set(LIB_Ws2_32 Ws2_32)


### PR DESCRIPTION
This fixes 208 compiler warnings of this form:

C4566: character represented by universal-character-name [...]
       cannot be represented in the current code page (1252)

Signed-off-by: Stefan Weil <sw@weilnetz.de>