### PR TITLE
Don't disable compiler warnings for Visual Studio

### DIFF
--- a/src/ccmain/adaptions.cpp
+++ b/src/ccmain/adaptions.cpp
@@ -18,11 +18,6 @@
  *
  **********************************************************************/
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#pragma warning(disable:4305)  // int/float warnings
-#endif
-
 #ifdef __UNIX__
 #include          <assert.h>
 #endif

--- a/src/ccmain/applybox.cpp
+++ b/src/ccmain/applybox.cpp
@@ -17,10 +17,6 @@
  *
  **********************************************************************/
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #include <ctype.h>
 #include <string.h>
 #ifdef __UNIX__

--- a/src/ccmain/docqual.cpp
+++ b/src/ccmain/docqual.cpp
@@ -17,10 +17,6 @@
  *
  **********************************************************************/
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #include          <ctype.h>
 #include          "docqual.h"
 #include          "reject.h"

--- a/src/ccmain/output.cpp
+++ b/src/ccmain/output.cpp
@@ -17,10 +17,6 @@
  *
  **********************************************************************/
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #include <string.h>
 #include <ctype.h>
 #ifdef __UNIX__

--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -24,9 +24,6 @@
 #else
 #include <unistd.h>
 #endif  // _WIN32
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
 
 // Include automatically generated configuration file if running autoconf.
 #ifdef HAVE_CONFIG_H

--- a/src/ccmain/pgedit.cpp
+++ b/src/ccmain/pgedit.cpp
@@ -17,10 +17,6 @@
  *
  **********************************************************************/
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 // Include automatically generated configuration file if running autoconf.
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"

--- a/src/ccmain/reject.cpp
+++ b/src/ccmain/reject.cpp
@@ -17,11 +17,6 @@
  *
  **********************************************************************/
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#pragma warning(disable:4305)  // int/float warnings
-#endif
-
 #include          "tessvars.h"
 #ifdef __UNIX__
 #include          <assert.h>

--- a/src/ccmain/tessbox.cpp
+++ b/src/ccmain/tessbox.cpp
@@ -17,10 +17,6 @@
  *
  **********************************************************************/
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #include "mfoutline.h"
 #include "tessbox.h"
 #include "tesseractclass.h"

--- a/src/ccmain/tfacepp.cpp
+++ b/src/ccmain/tfacepp.cpp
@@ -17,12 +17,6 @@
  *
  **********************************************************************/
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#pragma warning(disable:4305)  // int/float warnings
-#pragma warning(disable:4800)  // int/bool warnings
-#endif
-
 #include <math.h>
 
 #include "blamer.h"

--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -17,10 +17,6 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
 #endif

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -26,10 +26,6 @@
               I n c l u d e s
 ----------------------------------------------------------------------*/
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#pragma warning(disable:4800)  // int/bool warnings
-#endif
 #include "dawg.h"
 
 #include "cutil.h"

--- a/src/dict/dict.cpp
+++ b/src/dict/dict.cpp
@@ -21,9 +21,6 @@
 #include "dict.h"
 #include "unicodes.h"
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
 #include "tprintf.h"
 
 namespace tesseract {

--- a/src/dict/stopper.cpp
+++ b/src/dict/stopper.cpp
@@ -36,11 +36,6 @@
 #include "scanutils.h"
 #include "unichar.h"
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#pragma warning(disable:4800)  // int/bool warnings
-#endif
-
 /*----------------------------------------------------------------------------
               Private Code
 ----------------------------------------------------------------------------*/

--- a/src/dict/trie.cpp
+++ b/src/dict/trie.cpp
@@ -25,10 +25,7 @@
 /*----------------------------------------------------------------------
               I n c l u d e s
 ----------------------------------------------------------------------*/
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#pragma warning(disable:4800)  // int/bool warnings
-#endif
+
 #include "trie.h"
 
 #include "callcpp.h"

--- a/src/textord/colfind.cpp
+++ b/src/textord/colfind.cpp
@@ -18,10 +18,6 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 // Include automatically generated configuration file if running autoconf.
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"

--- a/src/textord/colpartition.cpp
+++ b/src/textord/colpartition.cpp
@@ -18,10 +18,6 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
 #endif

--- a/src/textord/imagefind.cpp
+++ b/src/textord/imagefind.cpp
@@ -18,10 +18,6 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
 #endif

--- a/src/textord/linefind.cpp
+++ b/src/textord/linefind.cpp
@@ -18,10 +18,6 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
 #endif

--- a/src/textord/strokewidth.cpp
+++ b/src/textord/strokewidth.cpp
@@ -17,10 +17,6 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
 #endif

--- a/src/textord/tablefind.cpp
+++ b/src/textord/tablefind.cpp
@@ -17,10 +17,6 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
 #endif

--- a/src/textord/tabvector.cpp
+++ b/src/textord/tabvector.cpp
@@ -17,10 +17,6 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-#pragma warning(disable:4244)  // Conversion warnings
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
 #endif

--- a/src/viewer/scrollview.cpp
+++ b/src/viewer/scrollview.cpp
@@ -36,12 +36,6 @@
 
 #include "scrollview.h"
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4786)  // Don't give irrelevant warnings for stl
-#pragma warning(disable : 4018)  // signed/unsigned warnings
-#pragma warning(disable : 4530)  // exception warnings
-#endif
-
 const int kSvPort = 8461;
 const int kMaxMsgSize = 4096;
 const int kMaxIntPairSize = 45;  // Holds %d,%d, for up to 64 bit.

--- a/src/viewer/svutil.h
+++ b/src/viewer/svutil.h
@@ -31,7 +31,6 @@
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
 #endif
-#pragma warning(disable:4786)
 #else
 #include "platform.h"
 #include <windows.h>


### PR DESCRIPTION
It's still possible to set the warning level in the project settings,
but single source files should normally not disable compiler warnings.

Signed-off-by: Stefan Weil <sw@weilnetz.de>