### PR TITLE
Fixed CID 1164537 (possible division by zero)

### DIFF
--- a/src/textord/colpartition.cpp
+++ b/src/textord/colpartition.cpp
@@ -1343,6 +1343,8 @@ bool ColPartition::HasGoodBaseline() {
     width = last_pt.x() - first_pt.x();
   }
   // Maximum median error allowed to be a good text line.
+  if (height_count == 0) 
+    return false;
   double max_error = kMaxBaselineError * total_height / height_count;
   ICOORD start_pt, end_pt;
   double error = linepoints.Fit(&start_pt, &end_pt);


### PR DESCRIPTION
If height_count stays zero the maximal error calculation contains a division by zero.

Signed-off-by: Noah Metzger <noah.metzger@bib.uni-mannheim.de>