### PR TITLE
remove non-essential logging function

### DIFF
--- a/unittest/osd_test.cc
+++ b/unittest/osd_test.cc
@@ -1,3 +1,4 @@
+///////////////////////////////////////////////////////////////////////
 // File:        osd_test.cc
 // Description: OSD Tests for Tesseract.
 // Author:      ShreeDevi Kumar
@@ -17,7 +18,7 @@
 
 // expects clones of tessdata, tessdata_fast and tessdata_best repos
 
-#include "log.h"
+//#include "log.h"
 #include "include_gunit.h"
 #include "baseapi.h"
 #include "leptonica/allheaders.h"
@@ -31,7 +32,7 @@ class TestClass : public testing::Test {
   };
   
   void OSDTester( int expected_deg, const char* imgname, const char* tessdatadir) {
-    log.info() << tessdatadir << " for image: " << imgname << std::endl;
+    //log.info() << tessdatadir << " for image: " << imgname << std::endl;
     tesseract::TessBaseAPI *api = new tesseract::TessBaseAPI();
     ASSERT_FALSE(api->Init(tessdatadir, "osd")) << "Could not initialize tesseract.";
     Pix *image = pixRead(imgname);


### PR DESCRIPTION
Also got error while building on  
Linux tesseract-ocr 4.4.0-122-generic #146-Ubuntu SMP Mon Apr 23 15:33:25 UTC 2018 ppc64le ppc64le ppc64le GNU/Linux
with 
g++ (Ubuntu/IBM 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609

```
g++ -DHAVE_CONFIG_H -I. -I..  -DNDEBUG -DTESSDATA_DIR="\"/home/ubuntu/tessdata\"" -DTESTING_DIR="\"/home/ubuntu/tesseract/testing\"" -DPANGO_ENABLE_ENGINE -I../src/api -I../src/api -I../src/arch -I../src/ccmain -I../src/ccstruct -I../src/ccutil -I../src/classify -I../src/cutil -I../src/dict -I../src/display -I../src/lstm -I../src/textord -I../src/viewer -I../src/wordrec -isystem ../googletest/googletest/include -I/usr/local/include/leptonica -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/powerpc64le-linux-gnu/glib-2.0/include -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib/powerpc64le-linux-gnu/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng12  -g -O2 -std=c++11 -MT osd_test.o -MD -MP -MF $depbase.Tpo -c -o osd_test.o osd_test.cc &&\
mv -f $depbase.Tpo $depbase.Po
In file included from /usr/include/features.h:367:0,
                 from /usr/include/powerpc64le-linux-gnu/c++/5/bits/os_defines.h:39,
                 from /usr/include/powerpc64le-linux-gnu/c++/5/bits/c++config.h:482,
                 from /usr/include/c++/5/iostream:38,
                 from log.h:19,
                 from osd_test.cc:20:
/usr/include/powerpc64le-linux-gnu/bits/mathcalls.h:109:1: error: ‘double log(double)’ redeclared as different kind of symbol
 __MATHCALL_VEC (log,, (_Mdouble_ __x));
 ^
In file included from osd_test.cc:20:0:
log.h:26:3: note: previous declaration ‘LOG log’
 } log;
   ^
```