### PR TITLE
Revert "fixes #388 by using raw bytes utf8 encoding"

### DIFF
--- a/src/training/stringrenderer.cpp
+++ b/src/training/stringrenderer.cpp
@@ -46,7 +46,7 @@ static const int kDefaultOutputResolution = 300;
 // Word joiner (U+2060) inserted after letters in ngram mode, as per
 // recommendation in http://unicode.org/reports/tr14/ to avoid line-breaks at
 // hyphens and other non-alpha characters.
-static const char* kWordJoinerUTF8 = "\xE2\x81\xA0";  // u8"\u2060";
+static const char* kWordJoinerUTF8 = "\u2060";
 static const char32 kWordJoiner = 0x2060;
 
 static bool IsCombiner(int ch) {


### PR DESCRIPTION
This reverts commit 941e1c4c84ab3c94bda0da81327238908a1e4192. It is no
longer needed since commit f54800f14b41cdb7861d0769f202e79bb013cd32.

Signed-off-by: Stefan Weil <sw@weilnetz.de>