### PR TITLE
Added downward compatibility for older APIs

### DIFF
--- a/src/api/renderer.h
+++ b/src/api/renderer.h
@@ -187,7 +187,7 @@ class TESS_API TessPDFRenderer : public TessResultRenderer {
  public:
   // datadir is the location of the TESSDATA. We need it because
   // we load a custom PDF font from this location.
-  TessPDFRenderer(const char* outputbase, const char* datadir, bool textonly);
+  TessPDFRenderer(const char* outputbase, const char* datadir, bool textonly = false);
 
  protected:
   virtual bool BeginDocumentHandler();


### PR DESCRIPTION
The commit effa574 in 20.01.2017 added the bool textonly to the constructor of TessPDFRenderer. To maintain the compatibility to older APIs which are still using only two parameter, a default value for the textonly parameter is set.

Signed-off-by: Noah Metzger <noah.metzger@bib.uni-mannheim.de>