### PR TITLE
ColPartition: Add missing initialisation for median_left, median_right

### DIFF
--- a/src/textord/colpartition.cpp
+++ b/src/textord/colpartition.cpp
@@ -164,6 +164,8 @@ ColPartition* ColPartition::MakeLinePartition(BlobRegionType blob_type,
   part->median_bottom_ = bottom;
   part->median_top_ = top;
   part->median_size_ = top - bottom;
+  part->median_left_ = left;
+  part->median_right_ = right;
   part->median_width_ = right - left;
   part->left_key_ = part->BoxLeftKey();
   part->right_key_ = part->BoxRightKey();


### PR DESCRIPTION
The following code caused a crash when Tesseract was compiled with -ftrapv:

1259	  int width = right - left;

#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff665c231 in __GI_abort () at abort.c:79
#2  0x00007ffff69e34d8 in __subvsi3 () from /lib/x86_64-linux-gnu/libgcc_s.so.1
#3  0x000055555560c1c5 in tesseract::ColPartitionGrid::FindVPartitionPartners (this=0x55555717e3c0, to_the_left=true, part=0x5555571fa380)
    at ../../../src/textord/colpartitiongrid.cpp:1259
#4  0x000055555560bda0 in tesseract::ColPartitionGrid::FindPartitionPartners (this=0x55555717e3c0) at ../../../src/textord/colpartitiongrid.cpp:1196
#5  0x00005555555f52b6 in tesseract::ColumnFinder::FindBlocks (this=0x55555717e280, pageseg_mode=tesseract::PSM_AUTO, scaled_color=0x0, scaled_factor=-1,
    input_block=0x555555f91390, photo_mask_pix=0x555555f73300, thresholds_pix=0x555555f76290, grey_pix=0x555555f762e0, pixa_debug=0x7ffff7fc88d8, blocks=0x7fffffffd250,
    diacritic_blobs=0x7fffffffd330, to_blocks=0x7fffffffd328) at ../../../src/textord/colfind.cpp:431
#6  0x00005555555c240d in tesseract::Tesseract::AutoPageSeg (this=0x7ffff7fa5010, pageseg_mode=tesseract::PSM_AUTO, blocks=0x555555f761d0, to_blocks=0x7fffffffd328,
    diacritic_blobs=0x7fffffffd330, osd_tess=0x0, osr=0x7fffffffd6d0) at ../../../src/ccmain/pagesegmain.cpp:229
#7  0x00005555555c1ffd in tesseract::Tesseract::SegmentPage (this=0x7ffff7fa5010, input_file=0x555555f7bd90, blocks=0x555555f761d0, osd_tess=0x0, osr=0x7fffffffd6d0)
    at ../../../src/ccmain/pagesegmain.cpp:141
#8  0x0000555555582540 in tesseract::TessBaseAPI::FindLines (this=0x555555a9a580 <main::api>) at ../../../src/api/baseapi.cpp:2291
#9  0x000055555557ce42 in tesseract::TessBaseAPI::Recognize (this=0x555555a9a580 <main::api>, monitor=0x0) at ../../../src/api/baseapi.cpp:802

Signed-off-by: Stefan Weil <sw@weilnetz.de>