### PR TITLE
Use default keyword instead of empty ctors/dtors.

### DIFF
--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -37,9 +37,6 @@ LTRResultIterator::LTRResultIterator(PAGE_RES* page_res, Tesseract* tesseract,
     paragraph_separator_("\n") {
 }
 
-LTRResultIterator::~LTRResultIterator() {
-}
-
 // Returns the null terminated UTF-8 encoded text string for the current
 // object at the given level. Use delete [] to free after use.
 char* LTRResultIterator::GetUTF8Text(PageIteratorLevel level) const {

--- a/src/ccmain/ltrresultiterator.h
+++ b/src/ccmain/ltrresultiterator.h
@@ -62,7 +62,8 @@ class TESS_API LTRResultIterator : public PageIterator {
                     int scale, int scaled_yres,
                     int rect_left, int rect_top,
                     int rect_width, int rect_height);
-  virtual ~LTRResultIterator();
+
+  virtual ~LTRResultIterator() = default;
 
   // LTRResultIterators may be copied! This makes it possible to iterate over
   // all the objects at a lower level, while maintaining an iterator to

--- a/src/ccmain/mutableiterator.h
+++ b/src/ccmain/mutableiterator.h
@@ -51,7 +51,7 @@ class MutableIterator : public ResultIterator {
       : ResultIterator(
           LTRResultIterator(page_res, tesseract, scale, scaled_yres, rect_left,
                             rect_top, rect_width, rect_height)) {}
-  virtual ~MutableIterator() {}
+  virtual ~MutableIterator() = default;
 
   // See PageIterator and ResultIterator for most calls.
 

--- a/src/ccmain/paramsd.h
+++ b/src/ccmain/paramsd.h
@@ -52,8 +52,7 @@ class ParamContent : public ELIST_LINK {
   static ParamContent* GetParamContentById(int id);
 
   // Constructors for the various ParamTypes.
-  ParamContent() {
-  }
+  ParamContent() = default;
   explicit ParamContent(tesseract::StringParam* it);
   explicit ParamContent(tesseract::IntParam* it);
   explicit ParamContent(tesseract::BoolParam* it);

--- a/src/ccmain/resultiterator.h
+++ b/src/ccmain/resultiterator.h
@@ -43,7 +43,7 @@ class TESS_API ResultIterator : public LTRResultIterator {
    * ResultIterator is copy constructible!
    * The default copy constructor works just fine for us.
    */
-  virtual ~ResultIterator() {}
+  virtual ~ResultIterator() = default;
 
   // ============= Moving around within the page ============.
   /**

--- a/src/ccstruct/boxword.cpp
+++ b/src/ccstruct/boxword.cpp
@@ -37,9 +37,6 @@ BoxWord::BoxWord(const BoxWord& src) {
   CopyFrom(src);
 }
 
-BoxWord::~BoxWord() {
-}
-
 BoxWord& BoxWord::operator=(const BoxWord& src) {
   CopyFrom(src);
   return *this;

--- a/src/ccstruct/boxword.h
+++ b/src/ccstruct/boxword.h
@@ -40,7 +40,7 @@ class BoxWord {
  public:
   BoxWord();
   explicit BoxWord(const BoxWord& src);
-  ~BoxWord();
+  ~BoxWord() = default;
 
   BoxWord& operator=(const BoxWord& src);
 

--- a/src/ccstruct/ccstruct.cpp
+++ b/src/ccstruct/ccstruct.cpp
@@ -28,9 +28,4 @@ const double CCStruct::kAscenderFraction = 0.25;
 const double CCStruct::kXHeightCapRatio = CCStruct::kXHeightFraction /
     (CCStruct::kXHeightFraction + CCStruct::kAscenderFraction);
 
-CCStruct::CCStruct() {}
-
-CCStruct::~CCStruct() {
-}
-
 }

--- a/src/ccstruct/ccstruct.h
+++ b/src/ccstruct/ccstruct.h
@@ -24,8 +24,8 @@
 namespace tesseract {
 class CCStruct : public CUtil {
  public:
-  CCStruct();
-  ~CCStruct();
+  CCStruct() = default;
+  ~CCStruct() = default;
 
   // Globally accessible constants.
   // APPROXIMATIONS of the fractions of the character cell taken by

--- a/src/ccstruct/crakedge.h
+++ b/src/ccstruct/crakedge.h
@@ -25,7 +25,7 @@
 
 class CRACKEDGE {
  public:
-  CRACKEDGE() {}
+  CRACKEDGE() = default;
 
   ICOORD pos;                  /*position of crack */
   int8_t stepx;                  //edge step

--- a/src/ccstruct/detlinefit.cpp
+++ b/src/ccstruct/detlinefit.cpp
@@ -41,9 +41,6 @@ const int kMaxRealDistance = 2.0;
 DetLineFit::DetLineFit() : square_length_(0.0) {
 }
 
-DetLineFit::~DetLineFit() {
-}
-
 // Delete all Added points.
 void DetLineFit::Clear() {
   pts_.clear();

--- a/src/ccstruct/detlinefit.h
+++ b/src/ccstruct/detlinefit.h
@@ -56,7 +56,7 @@ namespace tesseract {
 class DetLineFit {
  public:
   DetLineFit();
-  ~DetLineFit();
+  ~DetLineFit() = default;
 
   // Delete all Added points.
   void Clear();

--- a/src/ccstruct/fontinfo.h
+++ b/src/ccstruct/fontinfo.h
@@ -61,7 +61,7 @@ struct FontSpacingInfo {
  */
 struct FontInfo {
   FontInfo() : name(nullptr), properties(0), universal_id(0), spacing_vec(nullptr) {}
-  ~FontInfo() {}
+  ~FontInfo() = default;
 
   // Writes to the given file. Returns false in case of error.
   bool Serialize(FILE* fp) const;

--- a/src/ccstruct/mod128.h
+++ b/src/ccstruct/mod128.h
@@ -29,8 +29,7 @@
 class DLLSYM DIR128
 {
   public:
-    DIR128() {
-    }                            //empty constructor
+    DIR128() = default;
 
     DIR128(                //constructor
            int16_t value) {  //value to assign

--- a/src/ccstruct/ocrblock.h
+++ b/src/ccstruct/ocrblock.h
@@ -48,8 +48,7 @@ class BLOCK:public ELIST_LINK
         int16_t xmax,        //< top right
         int16_t ymax);
 
-  ~BLOCK () {
-  }
+  ~BLOCK () = default;
 
   /**
    * set space size etc.

--- a/src/ccstruct/ocrrow.h
+++ b/src/ccstruct/ocrrow.h
@@ -33,8 +33,7 @@ class ROW:public ELIST_LINK
 {
   friend void tweak_row_baseline(ROW *, double, double);
   public:
-    ROW() {
-    }                            //empty constructor
+    ROW() = default;
     ROW(                    //constructor
         int32_t spline_size,  //no of segments
         int32_t *xstarts,     //segment boundaries

--- a/src/ccstruct/pageres.h
+++ b/src/ccstruct/pageres.h
@@ -86,8 +86,7 @@ class PAGE_RES {                 // page result
            BLOCK_LIST *block_list,   // real blocks
            WERD_CHOICE **prev_word_best_choice_ptr);
 
-  ~PAGE_RES () {               // destructor
-  }
+  ~PAGE_RES () = default;
 };
 
 /*************************************************************************
@@ -109,13 +108,11 @@ class BLOCK_RES:public ELIST_LINK {
 
   ROW_RES_LIST row_res_list;
 
-  BLOCK_RES() {
-  }                            // empty constructor
+  BLOCK_RES() = default;
 
   BLOCK_RES(bool merge_similar_words, BLOCK *the_block);  // real block
 
-  ~BLOCK_RES () {              // destructor
-  }
+  ~BLOCK_RES () = default;
 };
 
 /*************************************************************************
@@ -130,13 +127,11 @@ class ROW_RES:public ELIST_LINK {
   int32_t whole_word_rej_count;  // rejs in total rej wds
   WERD_RES_LIST word_res_list;
 
-  ROW_RES() {
-  }                            // empty constructor
+  ROW_RES() = default;
 
   ROW_RES(bool merge_similar_words, ROW *the_row);  // real row
 
-  ~ROW_RES() {                // destructor
-  }
+  ~ROW_RES() = default;
 };
 
 /*************************************************************************
@@ -660,8 +655,7 @@ class PAGE_RES_IT {
  public:
   PAGE_RES * page_res;         // page being iterated
 
-  PAGE_RES_IT() {
-  }                            // empty contructor
+  PAGE_RES_IT() = default;
 
   PAGE_RES_IT(PAGE_RES *the_page_res) {    // page result
     page_res = the_page_res;

--- a/src/ccstruct/params_training_featdef.h
+++ b/src/ccstruct/params_training_featdef.h
@@ -126,7 +126,7 @@ using ParamsTrainingHypothesisList = GenericVector<ParamsTrainingHypothesis>;
 // explored on PASS1, PASS2, fix xheight pass, etc).
 class ParamsTrainingBundle {
  public:
-  ParamsTrainingBundle() {}
+  ParamsTrainingBundle() = default;
   // Starts a new hypothesis list.
   // Should be called at the beginning of a new run of the segmentation search.
   void StartHypothesisList() {

--- a/src/ccstruct/points.h
+++ b/src/ccstruct/points.h
@@ -45,8 +45,7 @@ class ICOORD
       ycoord = yin;
     }
     ///destructor
-    ~ICOORD () {
-    }
+    ~ICOORD () = default;
 
     ///access function
     int16_t x() const {
@@ -163,8 +162,7 @@ class DLLSYM ICOORDELT:public ELIST_LINK, public ICOORD
 {
   public:
     ///empty constructor
-    ICOORDELT() {  
-    }
+    ICOORDELT() = default;
     ///constructor from ICOORD
     ICOORDELT (ICOORD icoord):ICOORD (icoord) {
     }
@@ -190,8 +188,7 @@ class DLLSYM FCOORD
 {
   public:
     ///empty constructor
-    FCOORD() {
-    }
+    FCOORD() = default;
     ///constructor
     ///@param xvalue x value
     ///@param yvalue y value

--- a/src/ccstruct/polyblk.h
+++ b/src/ccstruct/polyblk.h
@@ -27,13 +27,11 @@
 
 class DLLSYM POLY_BLOCK {
  public:
-  POLY_BLOCK() {
-  }
+  POLY_BLOCK() = default;
   // Initialize from box coordinates.
   POLY_BLOCK(const TBOX& box, PolyBlockType type);
   POLY_BLOCK(ICOORDELT_LIST *points, PolyBlockType type);
-  ~POLY_BLOCK () {
-  }
+  ~POLY_BLOCK () = default;
 
   TBOX *bounding_box() {  // access function
     return &box;

--- a/src/ccstruct/quadratc.h
+++ b/src/ccstruct/quadratc.h
@@ -25,8 +25,7 @@
 class QUAD_COEFFS
 {
   public:
-    QUAD_COEFFS() {
-    }                            //empty constructor
+    QUAD_COEFFS() = default;
     QUAD_COEFFS(             //constructor
                 double xsq,  //coefficients
                 float x,

--- a/src/ccstruct/ratngs.h
+++ b/src/ccstruct/ratngs.h
@@ -71,7 +71,7 @@ class BLOB_CHOICE: public ELIST_LINK
                 float yshift,           // the larger of y shift (top or bottom)
                 BlobChoiceClassifier c);   // adapted match or other
     BLOB_CHOICE(const BLOB_CHOICE &other);
-    ~BLOB_CHOICE() {}
+    ~BLOB_CHOICE() = default;
 
     UNICHAR_ID unichar_id() const {
       return unichar_id_;

--- a/src/ccstruct/rejctmap.h
+++ b/src/ccstruct/rejctmap.h
@@ -116,8 +116,7 @@ class REJ
   BOOL8 rej_before_quality_accept();
 
   public:
-    REJ() {  //constructor
-    }
+    REJ() = default;
 
     REJ(  //classwise copy
         const REJ &source) {

--- a/src/ccstruct/stepblob.h
+++ b/src/ccstruct/stepblob.h
@@ -30,8 +30,7 @@ ELISTIZEH(C_BLOB)
 class C_BLOB:public ELIST_LINK
 {
   public:
-    C_BLOB() {
-    }
+    C_BLOB() = default;
     explicit C_BLOB(C_OUTLINE_LIST *outline_list);
     // Simpler constructor to build a blob from a single outline that has
     // already been fully initialized.

--- a/src/ccstruct/werd.h
+++ b/src/ccstruct/werd.h
@@ -59,7 +59,7 @@ class ROW;                       //forward decl
 
 class WERD : public ELIST2_LINK {
   public:
-    WERD() {}
+    WERD() = default;
     // WERD constructed with:
     //   blob_list - blobs of the word (we take this list's contents)
     //   blanks - number of blanks before the word
@@ -75,8 +75,7 @@ class WERD : public ELIST2_LINK {
     // W_BOL and W_EOL flags are set according to the given values.
     WERD* ConstructFromSingleBlob(bool bol, bool eol, C_BLOB* blob);
 
-    ~WERD() {
-    }
+    ~WERD() = default;
 
     // assignment
     WERD & operator= (const WERD &source);

--- a/src/ccutil/ambigs.h
+++ b/src/ccutil/ambigs.h
@@ -114,7 +114,7 @@ class UnicharIdArrayUtils {
 class AmbigSpec : public ELIST_LINK {
  public:
   AmbigSpec();
-  ~AmbigSpec() {}
+  ~AmbigSpec() = default;
 
   // Comparator function for sorting AmbigSpec_LISTs. The lists will
   // be sorted by their wrong_ngram arrays. Example of wrong_ngram vectors
@@ -142,7 +142,7 @@ using UnicharAmbigsVector = GenericVector<AmbigSpec_LIST *>;
 
 class UnicharAmbigs {
  public:
-  UnicharAmbigs() {}
+  UnicharAmbigs() = default;
   ~UnicharAmbigs() {
     replace_ambigs_.delete_data_pointers();
     dang_ambigs_.delete_data_pointers();

--- a/src/ccutil/ccutil.cpp
+++ b/src/ccutil/ccutil.cpp
@@ -27,10 +27,6 @@ CCUtil::CCUtil() :
               " whether to adapt to a character", &params_) {
 }
 
-CCUtil::~CCUtil() {
-}
-
-
 CCUtilMutex::CCUtilMutex() {
 #ifdef _WIN32
   mutex_ = CreateMutex(0, FALSE, 0);

--- a/src/ccutil/ccutil.h
+++ b/src/ccutil/ccutil.h
@@ -51,7 +51,7 @@ class CCUtilMutex {
 class CCUtil {
  public:
   CCUtil();
-  virtual ~CCUtil();
+  virtual ~CCUtil() = default;
 
  public:
   // Read the arguments and set up the data path.

--- a/src/ccutil/genericheap.h
+++ b/src/ccutil/genericheap.h
@@ -57,7 +57,7 @@ namespace tesseract {
 template <typename Pair>
 class GenericHeap {
  public:
-  GenericHeap() {}
+  GenericHeap() = default;
   // The initial size is only a GenericVector::reserve. It is not enforced as
   // the size limit of the heap. Caller must implement their own enforcement.
   explicit GenericHeap(int initial_size) {

--- a/src/ccutil/indexmapbidi.h
+++ b/src/ccutil/indexmapbidi.h
@@ -41,7 +41,7 @@ class IndexMapBiDi;
 // It must be initialized by copying from an IndexMapBiDi or by DeSerialize.
 class IndexMap {
  public:
-  virtual ~IndexMap() {}
+  virtual ~IndexMap() = default;
 
   // SparseToCompact takes a sparse index to an index in the compact space.
   // Uses a binary search to find the result. For faster speed use

--- a/src/ccutil/kdpair.h
+++ b/src/ccutil/kdpair.h
@@ -32,7 +32,7 @@ namespace tesseract {
 // of simple or smart-pointer data using a separate key. Similar to STL pair.
 template <typename Key, typename Data>
 struct KDPair {
-  KDPair() {}
+  KDPair() = default;
   KDPair(Key k, Data d) : data(d), key(k) {}
 
   int operator==(const KDPair<Key, Data>& other) const {
@@ -49,7 +49,7 @@ struct KDPair {
 // and recasting of data pointers for use with DoublePtr.
 template <typename Key, typename Data>
 struct KDPairInc : public KDPair<Key, Data> {
-  KDPairInc() {}
+  KDPairInc() = default;
   KDPairInc(Key k, Data d) : KDPair<Key, Data>(k, d) {}
   // Operator< facilitates sorting in increasing order.
   int operator<(const KDPairInc<Key, Data>& other) const {
@@ -65,7 +65,7 @@ struct KDPairInc : public KDPair<Key, Data> {
 // and recasting of data pointers for use with DoublePtr.
 template <typename Key, typename Data>
 struct KDPairDec : public KDPair<Key, Data> {
-  KDPairDec() {}
+  KDPairDec() = default;
   KDPairDec(Key k, Data d) : KDPair<Key, Data>(k, d) {}
   // Operator< facilitates sorting in decreasing order by using operator> on
   // the key values.

--- a/src/ccutil/object_cache.h
+++ b/src/ccutil/object_cache.h
@@ -34,7 +34,7 @@ namespace tesseract {
 template<typename T>
 class ObjectCache {
  public:
-  ObjectCache() {}
+  ObjectCache() = default;
   ~ObjectCache() {
     mu_.Lock();
     for (int i = 0; i < cache_.size(); i++) {

--- a/src/ccutil/ocrclass.h
+++ b/src/ccutil/ocrclass.h
@@ -34,7 +34,7 @@
 #else
 #include          <sys/time.h>
 #endif
-#include          <time.h>
+#include          <ctime>
 #include          "host.h"
 
 /*Maximum lengths of various strings*/

--- a/src/ccutil/params.h
+++ b/src/ccutil/params.h
@@ -111,7 +111,7 @@ class ParamUtils {
 // Definition of various parameter types.
 class Param {
  public:
-  ~Param() {}
+  ~Param() = default;
 
   const char *name_str() const { return name_; }
   const char *info_str() const { return info_; }

--- a/src/ccutil/strngs.h
+++ b/src/ccutil/strngs.h
@@ -49,7 +49,7 @@ class TESS_API STRING
     STRING(const STRING &string);
     STRING(const char *string);
     STRING(const char *data, int length);
-    ~STRING ();
+    ~STRING();
 
     // Writes to the given file. Returns false in case of error.
     bool Serialize(FILE* fp) const;

--- a/src/ccutil/tessdatamanager.h
+++ b/src/ccutil/tessdatamanager.h
@@ -128,7 +128,7 @@ class TessdataManager {
   TessdataManager();
   explicit TessdataManager(FileReader reader);
 
-  ~TessdataManager() {}
+  ~TessdataManager() = default;
 
   bool swap() const { return swap_; }
   bool is_loaded() const { return is_loaded_; }

--- a/src/ccutil/unicharmap.cpp
+++ b/src/ccutil/unicharmap.cpp
@@ -17,7 +17,7 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#include <assert.h>
+#include <cassert>
 #include "unichar.h"
 #include "host.h"
 #include "unicharmap.h"

--- a/src/classify/errorcounter.cpp
+++ b/src/classify/errorcounter.cpp
@@ -163,8 +163,6 @@ ErrorCounter::ErrorCounter(const UNICHARSET& unicharset, int fontsize)
   font_counts_.init_to_size(fontsize, empty_counts);
   multi_unichar_counts_.init_to_size(unicharset.size(), 0);
 }
-ErrorCounter::~ErrorCounter() {
-}
 
 // Accumulates the errors from the classifier results on a single sample.
 // Returns true if debug is true and a CT_UNICHAR_TOPN_ERR error occurred.

--- a/src/classify/errorcounter.h
+++ b/src/classify/errorcounter.h
@@ -153,7 +153,7 @@ class ErrorCounter {
   // Constructor is private. Only anticipated use of ErrorCounter is via
   // the static ComputeErrorRate.
   ErrorCounter(const UNICHARSET& unicharset, int fontsize);
-  ~ErrorCounter();
+  ~ErrorCounter() = default;
 
   // Accumulates the errors from the classifier results on a single sample.
   // Returns true if debug is true and a CT_UNICHAR_TOPN_ERR error occurred.

--- a/src/classify/intmatcher.h
+++ b/src/classify/intmatcher.h
@@ -93,7 +93,7 @@ class IntegerMatcher {
   // Center of Similarity Curve.
   static const float kSimilarityCenter;
 
-  IntegerMatcher() : classify_debug_level_(0) {}
+  IntegerMatcher() : classify_debug_level_(nullptr) {}
 
   void Init(tesseract::IntParam *classify_debug_level);
 

--- a/src/classify/shapeclassifier.h
+++ b/src/classify/shapeclassifier.h
@@ -42,7 +42,7 @@ struct UnicharRating;
 // Interface base class for classifiers that produce ShapeRating results.
 class ShapeClassifier {
  public:
-  virtual ~ShapeClassifier() {}
+  virtual ~ShapeClassifier() = default;
 
   // Classifies the given [training] sample, writing to results.
   // If page_pix is not nullptr, the overriding function may call

--- a/src/classify/tessclassifier.h
+++ b/src/classify/tessclassifier.h
@@ -37,7 +37,7 @@ class TessClassifier : public ShapeClassifier {
  public:
   TessClassifier(bool pruner_only, tesseract::Classify* classify)
     : pruner_only_(pruner_only), classify_(classify) {}
-  virtual ~TessClassifier() {}
+  virtual ~TessClassifier() = default;
 
   // Classifies the given [training] sample, writing to results.
   // See ShapeClassifier for a full description.

--- a/src/cutil/cutil_class.cpp
+++ b/src/cutil/cutil_class.cpp
@@ -20,10 +20,4 @@
 
 namespace tesseract {
 
-CUtil::CUtil() {
-}
-
-CUtil::~CUtil() {
-}
-
 }  // namespace tesseract

--- a/src/cutil/cutil_class.h
+++ b/src/cutil/cutil_class.h
@@ -27,8 +27,8 @@ namespace tesseract {
 
 class CUtil : public CCUtil {
  public:
-  CUtil();
-  ~CUtil();
+  CUtil() = default;
+  ~CUtil() = default;
   void read_variables(const char *filename, bool global_only);
 };
 

--- a/src/dict/dawg.h
+++ b/src/dict/dawg.h
@@ -129,7 +129,7 @@ class Dawg {
   inline const STRING &lang() const { return lang_; }
   inline PermuterType permuter() const { return perm_; }
 
-  virtual ~Dawg() {}
+  virtual ~Dawg() = default;
 
   /// Returns true if the given word is in the Dawg.
   bool word_in_dawg(const WERD_CHOICE &word) const;

--- a/src/lstm/convolve.cpp
+++ b/src/lstm/convolve.cpp
@@ -30,9 +30,6 @@ Convolve::Convolve(const STRING& name, int ni, int half_x, int half_y)
     half_x_(half_x), half_y_(half_y) {
 }
 
-Convolve::~Convolve() {
-}
-
 // Writes to the given file. Returns false in case of error.
 bool Convolve::Serialize(TFile* fp) const {
   if (!Network::Serialize(fp)) return false;

--- a/src/lstm/convolve.h
+++ b/src/lstm/convolve.h
@@ -35,7 +35,7 @@ class Convolve : public Network {
   // The area of convolution is 2*half_x + 1 by 2*half_y + 1, forcing it to
   // always be odd, so the center is the current pixel.
   Convolve(const STRING& name, int ni, int half_x, int half_y);
-  virtual ~Convolve();
+  virtual ~Convolve() = default;
 
   STRING spec() const override {
     STRING spec;

--- a/src/lstm/fullyconnected.cpp
+++ b/src/lstm/fullyconnected.cpp
@@ -41,9 +41,6 @@ FullyConnected::FullyConnected(const STRING& name, int ni, int no,
   : Network(type, name, ni, no), external_source_(nullptr), int_mode_(false) {
 }
 
-FullyConnected::~FullyConnected() {
-}
-
 // Returns the shape output from the network given an input shape (which may
 // be partially unknown ie zero).
 StaticShape FullyConnected::OutputShape(const StaticShape& input_shape) const {

--- a/src/lstm/fullyconnected.h
+++ b/src/lstm/fullyconnected.h
@@ -28,7 +28,7 @@ namespace tesseract {
 class FullyConnected : public Network {
  public:
   FullyConnected(const STRING& name, int ni, int no, NetworkType type);
-  virtual ~FullyConnected();
+  virtual ~FullyConnected() = default;
 
   // Returns the shape output from the network given an input shape (which may
   // be partially unknown ie zero).

--- a/src/lstm/input.cpp
+++ b/src/lstm/input.cpp
@@ -37,9 +37,6 @@ Input::Input(const STRING& name, const StaticShape& shape)
   if (shape.height() == 1) ni_ = shape.depth();
 }
 
-Input::~Input() {
-}
-
 // Writes to the given file. Returns false in case of error.
 bool Input::Serialize(TFile* fp) const {
   return Network::Serialize(fp) && shape_.Serialize(fp);

--- a/src/lstm/input.h
+++ b/src/lstm/input.h
@@ -29,7 +29,7 @@ class Input : public Network {
  public:
   Input(const STRING& name, int ni, int no);
   Input(const STRING& name, const StaticShape& shape);
-  virtual ~Input();
+  virtual ~Input() = default;
 
   STRING spec() const override {
     STRING spec;

--- a/src/lstm/maxpool.cpp
+++ b/src/lstm/maxpool.cpp
@@ -27,9 +27,6 @@ Maxpool::Maxpool(const STRING& name, int ni, int x_scale, int y_scale)
   no_ = ni;
 }
 
-Maxpool::~Maxpool() {
-}
-
 // Reads from the given file. Returns false in case of error.
 bool Maxpool::DeSerialize(TFile* fp) {
   bool result = Reconfig::DeSerialize(fp);

--- a/src/lstm/maxpool.h
+++ b/src/lstm/maxpool.h
@@ -29,7 +29,7 @@ namespace tesseract {
 class Maxpool : public Reconfig {
  public:
   Maxpool(const STRING& name, int ni, int x_scale, int y_scale);
-  virtual ~Maxpool();
+  virtual ~Maxpool() = default;
 
   // Accessors.
   STRING spec() const override {

--- a/src/lstm/network.cpp
+++ b/src/lstm/network.cpp
@@ -97,8 +97,6 @@ Network::Network(NetworkType type, const STRING& name, int ni, int no)
       backward_win_(nullptr),
       randomizer_(nullptr) {}
 
-Network::~Network() {
-}
 
 // Suspends/Enables/Permanently disables training by setting the training_
 // flag. Serialize and DeSerialize only operate on the run-time data if state

--- a/src/lstm/network.h
+++ b/src/lstm/network.h
@@ -106,7 +106,7 @@ class Network {
  public:
   Network();
   Network(NetworkType type, const STRING& name, int ni, int no);
-  virtual ~Network();
+  virtual ~Network() = default;
 
   // Accessors.
   NetworkType type() const {

--- a/src/lstm/networkscratch.h
+++ b/src/lstm/networkscratch.h
@@ -36,7 +36,7 @@ namespace tesseract {
 class NetworkScratch {
  public:
   NetworkScratch() : int_mode_(false) {}
-  ~NetworkScratch() {}
+  ~NetworkScratch() = default;
 
   // Sets the network representation. If the representation is integer, then
   // default (integer) NetworkIOs are separated from the always-float variety.

--- a/src/lstm/parallel.cpp
+++ b/src/lstm/parallel.cpp
@@ -32,9 +32,6 @@ Parallel::Parallel(const STRING& name, NetworkType type) : Plumbing(name) {
   type_ = type;
 }
 
-Parallel::~Parallel() {
-}
-
 // Returns the shape output from the network given an input shape (which may
 // be partially unknown ie zero).
 StaticShape Parallel::OutputShape(const StaticShape& input_shape) const {

--- a/src/lstm/parallel.h
+++ b/src/lstm/parallel.h
@@ -28,7 +28,7 @@ class Parallel : public Plumbing {
  public:
   // ni_ and no_ will be set by AddToStack.
   Parallel(const STRING& name, NetworkType type);
-  virtual ~Parallel();
+  virtual ~Parallel() = default;
 
   // Returns the shape output from the network given an input shape (which may
   // be partially unknown ie zero).

--- a/src/lstm/plumbing.cpp
+++ b/src/lstm/plumbing.cpp
@@ -26,9 +26,6 @@ Plumbing::Plumbing(const STRING& name)
   : Network(NT_PARALLEL, name, 0, 0) {
 }
 
-Plumbing::~Plumbing() {
-}
-
 // Suspends/Enables training by setting the training_ flag. Serialize and
 // DeSerialize only operate on the run-time data if state is false.
 void Plumbing::SetEnableTraining(TrainingState state) {

--- a/src/lstm/plumbing.h
+++ b/src/lstm/plumbing.h
@@ -31,7 +31,7 @@ class Plumbing : public Network {
  public:
   // ni_ and no_ will be set by AddToStack.
   explicit Plumbing(const STRING& name);
-  virtual ~Plumbing();
+  virtual ~Plumbing() = default;
 
   // Returns the required shape input to the network.
   StaticShape InputShape() const override { return stack_[0]->InputShape(); }

--- a/src/lstm/reconfig.cpp
+++ b/src/lstm/reconfig.cpp
@@ -26,9 +26,6 @@ Reconfig::Reconfig(const STRING& name, int ni, int x_scale, int y_scale)
     x_scale_(x_scale), y_scale_(y_scale) {
 }
 
-Reconfig::~Reconfig() {
-}
-
 // Returns the shape output from the network given an input shape (which may
 // be partially unknown ie zero).
 StaticShape Reconfig::OutputShape(const StaticShape& input_shape) const {

--- a/src/lstm/reconfig.h
+++ b/src/lstm/reconfig.h
@@ -33,7 +33,7 @@ namespace tesseract {
 class Reconfig : public Network {
  public:
   Reconfig(const STRING& name, int ni, int x_scale, int y_scale);
-  virtual ~Reconfig();
+  virtual ~Reconfig() = default;
 
   // Returns the shape output from the network given an input shape (which may
   // be partially unknown ie zero).

--- a/src/lstm/reversed.cpp
+++ b/src/lstm/reversed.cpp
@@ -27,8 +27,6 @@ namespace tesseract {
 Reversed::Reversed(const STRING& name, NetworkType type) : Plumbing(name) {
   type_ = type;
 }
-Reversed::~Reversed() {
-}
 
 // Returns the shape output from the network given an input shape (which may
 // be partially unknown ie zero).

--- a/src/lstm/reversed.h
+++ b/src/lstm/reversed.h
@@ -28,7 +28,7 @@ namespace tesseract {
 class Reversed : public Plumbing {
  public:
   explicit Reversed(const STRING& name, NetworkType type);
-  virtual ~Reversed();
+  virtual ~Reversed() = default;
 
   // Returns the shape output from the network given an input shape (which may
   // be partially unknown ie zero).

--- a/src/lstm/series.cpp
+++ b/src/lstm/series.cpp
@@ -30,9 +30,6 @@ Series::Series(const STRING& name) : Plumbing(name) {
   type_ = NT_SERIES;
 }
 
-Series::~Series() {
-}
-
 // Returns the shape output from the network given an input shape (which may
 // be partially unknown ie zero).
 StaticShape Series::OutputShape(const StaticShape& input_shape) const {

--- a/src/lstm/series.h
+++ b/src/lstm/series.h
@@ -28,7 +28,7 @@ class Series : public Plumbing {
  public:
   // ni_ and no_ will be set by AddToStack.
   explicit Series(const STRING& name);
-  virtual ~Series();
+  virtual ~Series() = default;
 
   // Returns the shape output from the network given an input shape (which may
   // be partially unknown ie zero).

--- a/src/lstm/stridemap.h
+++ b/src/lstm/stridemap.h
@@ -18,7 +18,7 @@
 #ifndef TESSERACT_LSTM_STRIDEMAP_H_
 #define TESSERACT_LSTM_STRIDEMAP_H_
 
-#include <string.h>
+#include <cstring>
 #include <vector>
 #include "tprintf.h"
 

--- a/src/lstm/tfnetwork.cpp
+++ b/src/lstm/tfnetwork.cpp
@@ -32,8 +32,6 @@ namespace tesseract {
 
 TFNetwork::TFNetwork(const STRING& name) : Network(NT_TENSORFLOW, name, 0, 0) {}
 
-TFNetwork::~TFNetwork() {}
-
 int TFNetwork::InitFromProtoStr(const string& proto_str) {
   if (!model_proto_.ParseFromString(proto_str)) return 0;
   return InitFromProto();

--- a/src/lstm/tfnetwork.h
+++ b/src/lstm/tfnetwork.h
@@ -36,7 +36,7 @@ namespace tesseract {
 class TFNetwork : public Network {
  public:
   explicit TFNetwork(const STRING& name);
-  virtual ~TFNetwork();
+  virtual ~TFNetwork() = default;
 
   // Returns the required shape input to the network.
   StaticShape InputShape() const override { return input_shape_; }

--- a/src/textord/alignedblob.cpp
+++ b/src/textord/alignedblob.cpp
@@ -147,9 +147,6 @@ AlignedBlob::AlignedBlob(int gridsize,
   : BlobGrid(gridsize, bleft, tright) {
 }
 
-AlignedBlob::~AlignedBlob() {
-}
-
 // Return true if the given coordinates are within the test rectangle
 // and the debug level is at least the given detail level.
 bool AlignedBlob::WithinTestRegion(int detail_level, int x, int y) {

--- a/src/textord/alignedblob.h
+++ b/src/textord/alignedblob.h
@@ -81,7 +81,7 @@ struct AlignedBlobParams {
 class AlignedBlob : public BlobGrid {
  public:
   AlignedBlob(int gridsize, const ICOORD& bleft, const ICOORD& tright);
-  virtual ~AlignedBlob();
+  virtual ~AlignedBlob() = default;
 
   // Return true if the given coordinates are within the test rectangle
   // and the debug level is at least the given detail level.

--- a/src/textord/baselinedetect.cpp
+++ b/src/textord/baselinedetect.cpp
@@ -808,9 +808,6 @@ BaselineDetect::BaselineDetect(int debug_level, const FCOORD& page_skew,
   }
 }
 
-BaselineDetect::~BaselineDetect() {
-}
-
 // Finds the initial baselines for each TO_ROW in each TO_BLOCK, gathers
 // block-wise and page-wise data to smooth small blocks/rows, and applies
 // smoothing based on block/page-level skew and block-level linespacing.

--- a/src/textord/baselinedetect.h
+++ b/src/textord/baselinedetect.h
@@ -244,7 +244,7 @@ class BaselineDetect {
   BaselineDetect(int debug_level, const FCOORD& page_skew,
                  TO_BLOCK_LIST* blocks);
 
-  ~BaselineDetect();
+  ~BaselineDetect() = default;
 
   // Finds the initial baselines for each TO_ROW in each TO_BLOCK, gathers
   // block-wise and page-wise data to smooth small blocks/rows, and applies

--- a/src/textord/bbgrid.cpp
+++ b/src/textord/bbgrid.cpp
@@ -27,14 +27,8 @@ namespace tesseract {
 ///////////////////////////////////////////////////////////////////////
 // BBGrid IMPLEMENTATION.
 ///////////////////////////////////////////////////////////////////////
-GridBase::GridBase() {
-}
-
 GridBase::GridBase(int gridsize, const ICOORD& bleft, const ICOORD& tright) {
   Init(gridsize, bleft, tright);
-}
-
-GridBase::~GridBase() {
 }
 
 // (Re)Initialize the grid. The gridsize is the size in pixels of each cell,

--- a/src/textord/bbgrid.h
+++ b/src/textord/bbgrid.h
@@ -52,9 +52,9 @@ template<class BBC, class BBC_CLIST, class BBC_C_IT> class GridSearch;
 // It holds the geometry and scale of the grid.
 class GridBase {
  public:
-  GridBase();
+  GridBase() = default;
   GridBase(int gridsize, const ICOORD& bleft, const ICOORD& tright);
-  virtual ~GridBase();
+  virtual ~GridBase() = default;
 
   // (Re)Initialize the grid. The gridsize is the size in pixels of each cell,
   // and bleft, tright are the bounding box of everything to go in it.

--- a/src/textord/blkocc.h
+++ b/src/textord/blkocc.h
@@ -52,7 +52,7 @@ class REGION_OCC:public ELIST_LINK
     float max_x;                 //Highest x in region
     int16_t region_type;           //Type of crossing
 
-    REGION_OCC() {}  // constructor used
+    REGION_OCC() = default;  // constructor used
     // only in COPIER etc
     REGION_OCC(  //constructor
                float min,
@@ -133,8 +133,7 @@ class BAND
     int16_t min;                   //nominal min
     int16_t min_min;               //lower min
 
-    BAND() {
-    }                            // constructor
+    BAND() = default; // constructor
 
     void set(                      // initialise a band
              int16_t new_max_max,    // upper max

--- a/src/textord/blobgrid.cpp
+++ b/src/textord/blobgrid.cpp
@@ -25,9 +25,6 @@ BlobGrid::BlobGrid(int gridsize, const ICOORD& bleft, const ICOORD& tright)
   : BBGrid<BLOBNBOX, BLOBNBOX_CLIST, BLOBNBOX_C_IT>(gridsize, bleft, tright) {
 }
 
-BlobGrid::~BlobGrid() {
-}
-
 // Inserts all the blobs from the given list, with x and y spreading,
 // without removing from the source list, so ownership remains with the
 // source list.

--- a/src/textord/blobgrid.h
+++ b/src/textord/blobgrid.h
@@ -33,7 +33,7 @@ using BlobGridSearch = GridSearch<BLOBNBOX, BLOBNBOX_CLIST, BLOBNBOX_C_IT>;
 class BlobGrid : public BBGrid<BLOBNBOX, BLOBNBOX_CLIST, BLOBNBOX_C_IT> {
  public:
   BlobGrid(int gridsize, const ICOORD& bleft, const ICOORD& tright);
-  virtual ~BlobGrid();
+  virtual ~BlobGrid() = default;
 
   // Inserts all the blobs from the given list, with x and y spreading,
   // without removing from the source list, so ownership remains with the

--- a/src/textord/colpartition.h
+++ b/src/textord/colpartition.h
@@ -68,11 +68,11 @@ CLISTIZEH(ColPartition)
  */
 class ColPartition : public ELIST2_LINK {
  public:
-  ColPartition() {
-    // This empty constructor is here only so that the class can be ELISTIZED.
-    // TODO(rays) change deep_copy in elst.h line 955 to take a callback copier
-    // and eliminate CLASSNAME##_copier.
-  }
+  // This empty constructor is here only so that the class can be ELISTIZED.
+  // TODO(rays) change deep_copy in elst.h line 955 to take a callback copier
+  // and eliminate CLASSNAME##_copier.
+  ColPartition() = default;
+
   /**
    * @param blob_type is the blob_region_type_ of the blobs in this partition.
    * @param vertical is the direction of logical vertical on the possibly skewed image.

--- a/src/textord/colpartitiongrid.cpp
+++ b/src/textord/colpartitiongrid.cpp
@@ -66,15 +66,10 @@ const double kMaxPartitionSpacing = 1.75;
 // decision in GridSmoothNeighbour.
 const int kSmoothDecisionMargin = 4;
 
-ColPartitionGrid::ColPartitionGrid() {
-}
 ColPartitionGrid::ColPartitionGrid(int gridsize,
                                    const ICOORD& bleft, const ICOORD& tright)
   : BBGrid<ColPartition, ColPartition_CLIST, ColPartition_C_IT>(gridsize,
                                                                 bleft, tright) {
-}
-
-ColPartitionGrid::~ColPartitionGrid() {
 }
 
 // Handles a click event in a display window.

--- a/src/textord/colpartitiongrid.h
+++ b/src/textord/colpartitiongrid.h
@@ -34,10 +34,10 @@ class ColPartitionGrid : public BBGrid<ColPartition,
                                        ColPartition_CLIST,
                                        ColPartition_C_IT> {
  public:
-  ColPartitionGrid();
+  ColPartitionGrid() = default;
   ColPartitionGrid(int gridsize, const ICOORD& bleft, const ICOORD& tright);
 
-  virtual ~ColPartitionGrid();
+  virtual ~ColPartitionGrid() = default;
 
   // Handles a click event in a display window.
   void HandleClick(int x, int y);

--- a/src/textord/colpartitionset.cpp
+++ b/src/textord/colpartitionset.cpp
@@ -46,9 +46,6 @@ ColPartitionSet::ColPartitionSet(ColPartition* part) {
   ComputeCoverage();
 }
 
-ColPartitionSet::~ColPartitionSet() {
-}
-
 // Returns the number of columns of good width.
 int ColPartitionSet::GoodColumnCount() const {
   int num_good_cols = 0;

--- a/src/textord/colpartitionset.h
+++ b/src/textord/colpartitionset.h
@@ -39,12 +39,11 @@ using PartSetVector = GenericVector<ColPartitionSet*>;
 // ColPartitionSets are used in building the column layout of a page.
 class ColPartitionSet : public ELIST_LINK {
  public:
-  ColPartitionSet() {
-  }
+  ColPartitionSet() = default;
   explicit ColPartitionSet(ColPartition_LIST* partitions);
   explicit ColPartitionSet(ColPartition* partition);
 
-  ~ColPartitionSet();
+  ~ColPartitionSet() = default;
 
   // Simple accessors.
   const TBOX& bounding_box() const {

--- a/src/textord/equationdetectbase.cpp
+++ b/src/textord/equationdetectbase.cpp
@@ -23,12 +23,6 @@
 
 namespace tesseract {
 
-EquationDetectBase::EquationDetectBase() {
-}
-
-EquationDetectBase::~EquationDetectBase() {
-}
-
 void EquationDetectBase::RenderSpecialText(Pix* pix,
                                            BLOBNBOX* blob) {
   ASSERT_HOST(pix != nullptr && pixGetDepth(pix) == 32 && blob != nullptr);

--- a/src/textord/equationdetectbase.h
+++ b/src/textord/equationdetectbase.h
@@ -31,8 +31,8 @@ class ColPartitionSet;
 
 class EquationDetectBase {
  public:
-  EquationDetectBase();
-  virtual ~EquationDetectBase();
+  EquationDetectBase() = default;
+  virtual ~EquationDetectBase() = default;
 
   // Iterate over the blobs inside to_block, and set the blobs that we want to
   // process to BSTT_NONE. (By default, they should be BSTT_SKIP). The function

--- a/src/textord/pithsync.h
+++ b/src/textord/pithsync.h
@@ -29,8 +29,7 @@ class FPSEGPT_LIST;
 class FPCUTPT
 {
   public:
-    FPCUTPT() {  //empty
-    }
+    FPCUTPT() = default;
     void setup (                 //start of cut
       FPCUTPT cutpts[],          //predecessors
       int16_t array_origin,        //start coord

--- a/src/textord/pitsync1.h
+++ b/src/textord/pitsync1.h
@@ -32,8 +32,7 @@ class FPSEGPT_LIST;
 class FPSEGPT:public ELIST_LINK
 {
   public:
-    FPSEGPT() {  //empty
-    }
+    FPSEGPT() = default;
     FPSEGPT(           //constructor
             int16_t x);  //position
     FPSEGPT(                           //constructor

--- a/src/textord/sortflts.h
+++ b/src/textord/sortflts.h
@@ -27,8 +27,7 @@ class SORTED_FLOAT:public ELIST_LINK
   friend class SORTED_FLOATS;
 
   public:
-    SORTED_FLOAT() {
-    }                            //empty constructor
+    SORTED_FLOAT() = default;
     SORTED_FLOAT(              //create one
                  float value,  //value of entry
                  int32_t key) {  //reference

--- a/src/textord/tablefind.cpp
+++ b/src/textord/tablefind.cpp
@@ -2066,8 +2066,6 @@ ColSegment::ColSegment()
       num_text_cells_(0),
       type_(COL_UNKNOWN) {
 }
-ColSegment::~ColSegment() {
-}
 
 // Provides a color for BBGrid to draw the rectangle.
 ScrollView::Color  ColSegment::BoxColor() const {

--- a/src/textord/tablefind.h
+++ b/src/textord/tablefind.h
@@ -46,7 +46,7 @@ CLISTIZEH(ColSegment)
 class ColSegment : public ELIST_LINK {
  public:
   ColSegment();
-  ~ColSegment();
+  ~ColSegment() = default;
 
   // Simple accessors and mutators
   const TBOX& bounding_box() const {

--- a/src/textord/tablerecog.cpp
+++ b/src/textord/tablerecog.cpp
@@ -79,9 +79,6 @@ StructuredTable::StructuredTable()
       max_text_height_(INT32_MAX) {
 }
 
-StructuredTable::~StructuredTable() {
-}
-
 void StructuredTable::Init() {
 }
 

--- a/src/textord/tablerecog.h
+++ b/src/textord/tablerecog.h
@@ -72,7 +72,7 @@ namespace tesseract {
 class StructuredTable {
  public:
   StructuredTable();
-  ~StructuredTable();
+  ~StructuredTable() = default;
 
   // Initialization code. Must be called after the constructor.
   void Init();

--- a/src/textord/tabvector.cpp
+++ b/src/textord/tabvector.cpp
@@ -165,9 +165,6 @@ CLISTIZE(TabVector)
 
 // The constructor is private. See the bottom of the file...
 
-TabVector::~TabVector() {
-}
-
 
 // Public factory to build a TabVector from a list of boxes.
 // The TabVector will be of the given alignment type.

--- a/src/textord/tabvector.h
+++ b/src/textord/tabvector.h
@@ -70,11 +70,10 @@ ELISTIZEH(TabConstraint)
 // by implicit reference counting via the elements of the list.
 class TabConstraint : public ELIST_LINK {
  public:
-  TabConstraint() {
-    // This empty constructor is here only so that the class can be ELISTIZED.
-    // TODO(rays) change deep_copy in elst.h line 955 to take a callback copier
-    // and eliminate CLASSNAME##_copier.
-  }
+  // This empty constructor is here only so that the class can be ELISTIZED.
+  // TODO(rays) change deep_copy in elst.h line 955 to take a callback copier
+  // and eliminate CLASSNAME##_copier.
+  TabConstraint() = default;
 
   // Create a constraint for the top or bottom of this TabVector.
   static void CreateConstraint(TabVector* vector, bool is_top);
@@ -112,11 +111,10 @@ class TabConstraint : public ELIST_LINK {
 // that represents a tab stop or a rule line.
 class TabVector : public ELIST2_LINK {
  public:
-  TabVector() {
-    // TODO(rays) fix this in elst.h line 1076, where it should use the
-    // copy constructor instead of operator=.
-  }
-  ~TabVector();
+  // TODO(rays) fix this in elst.h line 1076, where it should use the
+  // copy constructor instead of operator=.
+  TabVector() = default;
+  ~TabVector() = default;
 
   // Public factory to build a TabVector from a list of boxes.
   // The TabVector will be of the given alignment type.

--- a/src/textord/textord.cpp
+++ b/src/textord/textord.cpp
@@ -226,9 +226,6 @@ Textord::Textord(CCStruct* ccstruct)
       double_MEMBER(textord_blshift_xfraction, 9.99,
                     "Min size of baseline shift", ccstruct_->params()) {}
 
-Textord::~Textord() {
-}
-
 // Make the textlines and words inside each block.
 void Textord::TextordPage(PageSegMode pageseg_mode, const FCOORD& reskew,
                           int width, int height, Pix* binary_pix,

--- a/src/textord/textord.h
+++ b/src/textord/textord.h
@@ -68,7 +68,7 @@ using WordSearch = GridSearch<WordWithBox, WordWithBox_CLIST, WordWithBox_C_IT>;
 class Textord {
  public:
   explicit Textord(CCStruct* ccstruct);
-  ~Textord();
+  ~Textord() = default;
 
   // Make the textlines and words inside each block.
   // binary_pix is mandatory and is the binarized input after line removal.


### PR DESCRIPTION
In C++11 was introduced default keyword. It's useful for declaring empty ctors/dtors. In this PR I have replaced empty ctors/dtors by default keyword.