### PR TITLE
Fix compilation with g++-5

### DIFF
--- a/src/classify/featdefs.cpp
+++ b/src/classify/featdefs.cpp
@@ -216,7 +216,7 @@ bool ValidCharDescription(const FEATURE_DEFS_STRUCT &FeatureDefs,
       for (int i = 0; i < CharDesc->FeatureSets[Type]->NumFeatures; i++) {
         FEATURE feat = CharDesc->FeatureSets[Type]->Features[i];
         for (int p = 0; p < feat->Type->NumParams; p++) {
-          if (isnan(feat->Params[p]) || isinf(feat->Params[p]))
+          if (std::isnan(feat->Params[p]) || std::isinf(feat->Params[p]))
             well_formed = false;
           else
             anything_written = true;

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -399,7 +399,7 @@ void AddProtoToProtoPruner(PROTO Proto, int ProtoId,
 
   Angle = Proto->Angle;
 #ifndef _WIN32
-  assert(!isnan(Angle));
+  assert(!std::isnan(Angle));
 #endif
 
   FillPPCircularBits (ProtoSet->ProtoPruner[PRUNER_ANGLE], Index,

--- a/src/classify/mf.cpp
+++ b/src/classify/mf.cpp
@@ -72,7 +72,7 @@ FEATURE_SET ExtractMicros(TBLOB* Blob, const DENORM& cn_denorm) {
     // Assert that feature parameters are well defined.
     int i;
     for (i = 0; i < Feature->Type->NumParams; i++) {
-      ASSERT_HOST(!isnan(Feature->Params[i]));
+      ASSERT_HOST(!std::isnan(Feature->Params[i]));
     }
 #endif
 

--- a/src/classify/ocrfeatures.cpp
+++ b/src/classify/ocrfeatures.cpp
@@ -134,7 +134,7 @@ FEATURE ReadFeature(FILE* File, const FEATURE_DESC_STRUCT* FeatureDesc) {
     if (tfscanf(File, "%f", &(Feature->Params[i])) != 1)
       DoError (ILLEGAL_FEATURE_PARAM, "Illegal feature parameter spec");
 #ifndef _WIN32
-    assert (!isnan(Feature->Params[i]));
+    assert (!std::isnan(Feature->Params[i]));
 #endif
   }
   return (Feature);
@@ -181,7 +181,7 @@ FEATURE_SET ReadFeatureSet(FILE* File, const FEATURE_DESC_STRUCT* FeatureDesc) {
 void WriteFeature(FEATURE Feature, STRING* str) {
   for (int i = 0; i < Feature->Type->NumParams; i++) {
 #ifndef WIN32
-    assert(!isnan(Feature->Params[i]));
+    assert(!std::isnan(Feature->Params[i]));
 #endif
     str->add_str_double(" ", Feature->Params[i]);
   }


### PR DESCRIPTION
Commit 0248c7ff9d785c5cc5e60e8bb74794c4ebb09c02 replaced math.h by cmath.
Therefore isinf and isnan are no longer declared.
Replace them by their C++ 11 variant.

Signed-off-by: Stefan Weil <stweil@ub-blade-02.bib.uni-mannheim.de>