### PR TITLE
TFile: Improve handling of potential integer overflow

### DIFF
--- a/src/ccutil/serialis.h
+++ b/src/ccutil/serialis.h
@@ -72,9 +72,9 @@ class TFile {
   // Replicates fread, followed by a swap of the bytes if needed, returning the
   // number of items read. If swap_ is true then the count items will each have
   // size bytes reversed.
-  int FReadEndian(void* buffer, int size, int count);
+  int FReadEndian(void* buffer, size_t size, int count);
   // Replicates fread, returning the number of items read.
-  int FRead(void* buffer, int size, int count);
+  int FRead(void* buffer, size_t size, int count);
   // Resets the TFile as if it has been Opened, but nothing read.
   // Only allowed while reading!
   void Rewind();
@@ -87,7 +87,7 @@ class TFile {
 
   // Replicates fwrite, returning the number of items written.
   // To use fprintf, use snprintf and FWrite.
-  int FWrite(const void* buffer, int size, int count);
+  int FWrite(const void* buffer, size_t size, int count);
 
  private:
   // The number of bytes used so far.


### PR DESCRIPTION
Raise an assertion for unexpected arguments and use size_t instead of int
for the size argument which is typically sizeof(some_datatype).

Signed-off-by: Stefan Weil <sw@weilnetz.de>