### PR TITLE
use  `git describe --abbrev=4 --always`  for version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 # ----------------------------------------
 AC_PREREQ([2.63])
 AC_INIT([tesseract],
-        [m4_esyscmd_s([test -d .git && git describe --abbrev=4 || cat VERSION])],
+        [m4_esyscmd_s([test -d .git && git describe --abbrev=4 --always || cat VERSION])],
         [https://github.com/tesseract-ocr/tesseract/issues],,
         [https://github.com/tesseract-ocr/tesseract/])
 AC_PROG_CXX([g++ clang++])


### PR DESCRIPTION
if github repo is cloned with  shallow copy.
the command git describe --abbrev=4  fails

$ git describe --abbrev=4
fatal: No tags can describe 'f8b689f85f6c302e4f286bfa249f2f247963ed02'.
Try --always, or create some tags.