### PR TITLE
Fix script for UNLV tests

### DIFF
--- a/unlvtests/counttestset.sh
+++ b/unlvtests/counttestset.sh
@@ -55,5 +55,5 @@ done <"$pages"
 echo "$accfiles"
 echo "$wafiles"
 
-  unlvtests/ocreval/bin/accsum "$accfiles" >"unlvtests/reports/$setname.characc"
-  unlvtests/ocreval/bin/ocrevalutf8 unlvtests/ocreval/bin/wordaccsum "$wafiles" >"unlvtests/reports/$setname.wordacc"
+  unlvtests/ocreval/bin/accsum $accfiles >"unlvtests/reports/$setname.characc"
+  unlvtests/ocreval/bin/ocrevalutf8 unlvtests/ocreval/bin/wordaccsum $wafiles >"unlvtests/reports/$setname.wordacc"

--- a/unlvtests/runtestset.sh
+++ b/unlvtests/runtestset.sh
@@ -64,7 +64,7 @@ do
      srcdir="$imdir"
   fi
 #  echo "$srcdir/$page.tif"
-  $tess "$srcdir/$page.tif" "$resdir/$page" --tessdata-dir ../tessdata_fast --oem 1 -l eng --psm 6 $config 2>&1 |grep -v "OCR Engine"
+  $tess "$srcdir/$page.tif" "$resdir/$page" --tessdata-dir ../tessdata_fast --oem 1 -l eng --psm 6 $config 2>&1 |grep -v "OCR Engine" |grep -v "Page 1"
   if [ -r times.txt ]
   then
     read t <times.txt


### PR DESCRIPTION
Commit 934e612a3e64201708a86fd71b225ae4c97411d2 added too many quotes.

Signed-off-by: Stefan Weil <sw@weilnetz.de>