### PR TITLE
Test for correct locale settings

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -43,6 +43,7 @@
 #endif  // _WIN32
 
 #include <algorithm>
+#include <clocale>
 #include <fstream>
 #include <iostream>
 #include <iterator>
@@ -185,7 +186,15 @@ TessBaseAPI::TessBaseAPI()
       rect_width_(0),
       rect_height_(0),
       image_width_(0),
-      image_height_(0) {}
+      image_height_(0) {
+  const char *locale;
+  locale = std::setlocale(LC_ALL, nullptr);
+  ASSERT_HOST(!strcmp(locale, "C"));
+  locale = std::setlocale(LC_CTYPE, nullptr);
+  ASSERT_HOST(!strcmp(locale, "C"));
+  locale = std::setlocale(LC_NUMERIC, nullptr);
+  ASSERT_HOST(!strcmp(locale, "C"));
+}
 
 TessBaseAPI::~TessBaseAPI() {
   End();


### PR DESCRIPTION
Normal C++ programs like those which are built for tesseract automatically
set the locale "C".

There can be different locale settings if the tesseract library is used
in other software.

A wrong locale can cause wrong results from sscanf which is used at
different places in the tesseract code, so make sure that we have the
right locale settings and fail if that is not the case.

Signed-off-by: Stefan Weil <sw@weilnetz.de>