### PR TITLE
capi: Fix regression caused by use of bool data type

### DIFF
--- a/src/api/capi.h
+++ b/src/api/capi.h
@@ -30,6 +30,7 @@
 #   include "renderer.h"
 #else
 #   include "platform.h"
+#   include <stdbool.h>
 #   include <stdio.h>
 #endif
 


### PR DESCRIPTION
Commit 87d33b6c9ed87699ff0d6588279d8268f5df6db3 added code which uses bool.
Therefore stdbool.h must be included for compilations with a C compiler.

Signed-off-by: Stefan Weil <sw@weilnetz.de>