### PR TITLE
Fix symbolic link in unittest

### DIFF
--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -96,7 +96,9 @@ EXTRA_apiexample_test_DEPENDENCIES = $(abs_top_builddir)/test/testing/phototest.
 EXTRA_apiexample_test_DEPENDENCIES += $(abs_top_builddir)/test/testing/phototest.txt
 
 $(abs_top_builddir)/test/testing/phototest.tif:
-	ln -s $(top_srcdir)/test/testing/phototest.tif $(top_builddir)/test/testing/phototest.tif
+	mkdir -p $(top_builddir)/test/testing
+	ln -s $(TESTING_DIR)/phototest.tif $(top_builddir)/test/testing/phototest.tif
 
 $(abs_top_builddir)/test/testing/phototest.txt:
-	ln -s $(top_srcdir)/test/testing/phototest.txt $(top_builddir)/test/testing/phototest.txt
+	mkdir -p $(top_builddir)/test/testing
+	ln -s $(TESTING_DIR)/phototest.txt $(top_builddir)/test/testing/phototest.txt


### PR DESCRIPTION
The unittest could not run when building out of source tree.
Fix the symbolic link and make sure that the directory for it exists.

Signed-off-by: Stefan Weil <sw@weilnetz.de>