### PR TITLE
Require tesseract/ for API header files (fixes potential name conflicts)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,7 @@ EXTRA_DIST = README.md\
 DIST_SUBDIRS = $(SUBDIRS) $(TRAINING_SUBDIR)
 
 uninstall-hook:
-	rm -rf $(DESTDIR)$(includedir)
+	rm -rf $(DESTDIR)$(pkgincludedir)
 
 dist-hook:
 # Need to remove .svn directories from directories

--- a/configure.ac
+++ b/configure.ac
@@ -131,8 +131,6 @@ if $sse41; then
     AM_CONDITIONAL([SSE41_OPT], true)
 fi
 
-includedir="${includedir}/tesseract"
-
 AC_ARG_WITH([extra-includes],
             [AS_HELP_STRING([--with-extra-includes=DIR],
                        [Define an additional directory for include files])],

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -19,7 +19,7 @@ if VISIBILITY
 AM_CPPFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
 endif
 
-include_HEADERS = apitypes.h baseapi.h capi.h renderer.h tess_version.h
+pkginclude_HEADERS = apitypes.h baseapi.h capi.h renderer.h tess_version.h
 lib_LTLIBRARIES = 
 
 noinst_LTLIBRARIES = libtesseract_api.la

--- a/src/arch/Makefile.am
+++ b/src/arch/Makefile.am
@@ -8,7 +8,7 @@ AM_CXXFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
 AM_CPPFLAGS += -DTESS_EXPORTS
 endif
 
-include_HEADERS = intsimdmatrix.h
+pkginclude_HEADERS = intsimdmatrix.h
 
 noinst_HEADERS = dotproductavx.h dotproductsse.h
 noinst_HEADERS += intsimdmatrixavx2.h intsimdmatrixsse.h

--- a/src/ccmain/Makefile.am
+++ b/src/ccmain/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS += -DTESS_EXPORTS \
     -fvisibility=hidden -fvisibility-inlines-hidden
 endif
 
-include_HEADERS = \
+pkginclude_HEADERS = \
     thresholder.h ltrresultiterator.h pageiterator.h resultiterator.h \
     osdetect.h
 noinst_HEADERS = \

--- a/src/ccstruct/Makefile.am
+++ b/src/ccstruct/Makefile.am
@@ -10,7 +10,7 @@ AM_CPPFLAGS += -DTESS_EXPORTS \
     -fvisibility=hidden -fvisibility-inlines-hidden
 endif
 
-include_HEADERS = publictypes.h
+pkginclude_HEADERS = publictypes.h
 noinst_HEADERS = \
     blamer.h blckerr.h blobbox.h blobs.h blread.h boxread.h boxword.h ccstruct.h coutln.h crakedge.h \
     debugpixa.h detlinefit.h dppoint.h fontinfo.h genblob.h hpdsizes.h \

--- a/src/ccutil/Makefile.am
+++ b/src/ccutil/Makefile.am
@@ -11,7 +11,7 @@ AM_CXXFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
 AM_CPPFLAGS += -DTESS_EXPORTS
 endif
 
-include_HEADERS = \
+pkginclude_HEADERS = \
 	basedir.h errcode.h fileerr.h genericvector.h helpers.h host.h memry.h \
 	ndminx.h params.h ocrclass.h platform.h serialis.h strngs.h \
 	tesscallback.h unichar.h unicharcompress.h unicharmap.h unicharset.h

--- a/src/lstm/Makefile.am
+++ b/src/lstm/Makefile.am
@@ -20,7 +20,7 @@ AM_CXXFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
 AM_CPPFLAGS += -DTESS_EXPORTS
 endif
 
-include_HEADERS = \
+pkginclude_HEADERS = \
         convolve.h ctc.h fullyconnected.h functions.h input.h \
         lstm.h lstmrecognizer.h lstmtrainer.h maxpool.h \
         networkbuilder.h network.h networkio.h networkscratch.h \

--- a/tesseract.pc.cmake
+++ b/tesseract.pc.cmake
@@ -9,4 +9,4 @@ URL: https://github.com/tesseract-ocr/tesseract
 Version: @tesseract_VERSION@
 Libs: -L${libdir} -l@tesseract_OUTPUT_NAME@
 Libs.private:
-Cflags: -I${includedir} -I${includedir}/tesseract
+Cflags: -I${includedir}


### PR DESCRIPTION
The tesseract/ subdirectory is no longer automatically added to the
include path of the compiler. Therefore old code which used code like

    #include "capi.h"

must now change that to

    #include "tesseract/capi.h"

This avoids name conflicts with header files from other projects.

Signed-off-by: Stefan Weil <sw@weilnetz.de>