### PR TITLE
Remove more header files from public API

### DIFF
--- a/src/ccmain/Makefile.am
+++ b/src/ccmain/Makefile.am
@@ -20,11 +20,11 @@ AM_CPPFLAGS += -DTESS_EXPORTS \
 endif
 
 pkginclude_HEADERS = \
-    thresholder.h ltrresultiterator.h pageiterator.h resultiterator.h \
-    osdetect.h
+    thresholder.h ltrresultiterator.h pageiterator.h resultiterator.h
+
 noinst_HEADERS = \
     control.h docqual.h equationdetect.h fixspace.h mutableiterator.h \
-    output.h paragraphs.h paragraphs_internal.h paramsd.h pgedit.h \
+    output.h paragraphs.h paragraphs_internal.h osdetect.h paramsd.h pgedit.h \
     reject.h tessbox.h tessedit.h tesseractclass.h tessvars.h werdit.h
 
 noinst_LTLIBRARIES = libtesseract_main.la

--- a/src/ccutil/Makefile.am
+++ b/src/ccutil/Makefile.am
@@ -12,15 +12,16 @@ AM_CPPFLAGS += -DTESS_EXPORTS
 endif
 
 pkginclude_HEADERS = \
-	basedir.h errcode.h fileerr.h genericvector.h helpers.h host.h memry.h \
-	ndminx.h params.h ocrclass.h platform.h serialis.h strngs.h \
-	tesscallback.h unichar.h unicharcompress.h unicharmap.h unicharset.h
+    errcode.h genericvector.h helpers.h host.h memry.h \
+    ndminx.h ocrclass.h platform.h serialis.h strngs.h \
+    tesscallback.h unichar.h
 
 noinst_HEADERS = \
-    ambigs.h bits16.h bitvector.h ccutil.h clst.h doubleptr.h elst2.h \
-    elst.h genericheap.h globaloc.h indexmapbidi.h kdpair.h lsterr.h \
-    nwmain.h object_cache.h qrsequence.h sorthelper.h stderr.h \
-    scanutils.h tessdatamanager.h tprintf.h unicity_table.h unicodes.h \
+    ambigs.h basedir.h bits16.h bitvector.h ccutil.h clst.h doubleptr.h elst2.h \
+    elst.h fileerr.h genericheap.h globaloc.h indexmapbidi.h kdpair.h lsterr.h \
+    nwmain.h object_cache.h params.h qrsequence.h sorthelper.h stderr.h \
+    scanutils.h tessdatamanager.h tprintf.h \
+    unicharcompress.h unicharmap.h unicharset.h unicity_table.h unicodes.h \
     universalambigs.h
 
 noinst_LTLIBRARIES = libtesseract_ccutil.la

--- a/src/lstm/Makefile.am
+++ b/src/lstm/Makefile.am
@@ -21,13 +21,15 @@ AM_CPPFLAGS += -DTESS_EXPORTS
 endif
 
 pkginclude_HEADERS = \
-        convolve.h ctc.h fullyconnected.h functions.h input.h \
-        lstm.h lstmrecognizer.h lstmtrainer.h maxpool.h \
-        networkbuilder.h network.h networkio.h networkscratch.h \
-        parallel.h plumbing.h recodebeam.h reconfig.h reversed.h \
-        series.h static_shape.h stridemap.h tfnetwork.h weightmatrix.h
+        network.h networkio.h networkscratch.h \
+        static_shape.h stridemap.h weightmatrix.h
 
-noinst_HEADERS = 
+noinst_HEADERS = convolve.h ctc.h
+noinst_HEADERS += fullyconnected.h functions.h input.h
+noinst_HEADERS += lstm.h lstmrecognizer.h lstmtrainer.h maxpool.h
+noinst_HEADERS += networkbuilder.h
+noinst_HEADERS += parallel.h plumbing.h recodebeam.h reconfig.h reversed.h
+noinst_HEADERS += series.h tfnetwork.h
 
 noinst_LTLIBRARIES = libtesseract_lstm.la
 


### PR DESCRIPTION
Install only those headers which are needed by third party applications.

Signed-off-by: Stefan Weil <sw@weilnetz.de>