### PR TITLE
Replace ASSERT_HOST in genericvector.h

### DIFF
--- a/src/ccstruct/dppoint.cpp
+++ b/src/ccstruct/dppoint.cpp
@@ -18,6 +18,7 @@
  **********************************************************************/
 
 #include "dppoint.h"
+#include "errcode.h"
 #include "tprintf.h"
 
 namespace tesseract {

--- a/src/ccstruct/fontinfo.h
+++ b/src/ccstruct/fontinfo.h
@@ -21,6 +21,7 @@
 #ifndef TESSERACT_CCSTRUCT_FONTINFO_H_
 #define TESSERACT_CCSTRUCT_FONTINFO_H_
 
+#include "errcode.h"
 #include "genericvector.h"
 #include "host.h"
 #include "unichar.h"

--- a/src/ccstruct/rejctmap.h
+++ b/src/ccstruct/rejctmap.h
@@ -45,8 +45,9 @@ OF THIS IMPLIED TEMPORAL ORDERING OF THE FLAGS!!!!
 #include          <assert.h>
 #endif
 #include <memory>
-#include          "bits16.h"
-#include                   "params.h"
+#include "bits16.h"
+#include "errcode.h"
+#include "params.h"
 
 enum REJ_FLAGS {
   /* Reject modes which are NEVER overridden */

--- a/src/ccstruct/statistc.cpp
+++ b/src/ccstruct/statistc.cpp
@@ -22,13 +22,14 @@
 #include "config_auto.h"
 #endif
 
-#include          "statistc.h"
-#include          <string.h>
-#include          <math.h>
-#include          <stdlib.h>
-#include          "helpers.h"
-#include          "scrollview.h"
-#include          "tprintf.h"
+#include "statistc.h"
+#include <string.h>
+#include <math.h>
+#include <stdlib.h>
+#include "errcode.h"
+#include "helpers.h"
+#include "scrollview.h"
+#include "tprintf.h"
 
 using tesseract::KDPairInc;
 

--- a/src/ccutil/Makefile.am
+++ b/src/ccutil/Makefile.am
@@ -12,13 +12,14 @@ AM_CPPFLAGS += -DTESS_EXPORTS
 endif
 
 pkginclude_HEADERS = \
-    errcode.h genericvector.h helpers.h host.h memry.h \
+    genericvector.h helpers.h host.h memry.h \
     ndminx.h ocrclass.h platform.h serialis.h strngs.h \
     tesscallback.h unichar.h
 
 noinst_HEADERS = \
     ambigs.h basedir.h bits16.h bitvector.h ccutil.h clst.h doubleptr.h elst2.h \
-    elst.h fileerr.h genericheap.h globaloc.h indexmapbidi.h kdpair.h lsterr.h \
+    elst.h errcode.h fileerr.h genericheap.h globaloc.h \
+    indexmapbidi.h kdpair.h lsterr.h \
     nwmain.h object_cache.h params.h qrsequence.h sorthelper.h stderr.h \
     scanutils.h tessdatamanager.h tprintf.h \
     unicharcompress.h unicharmap.h unicharset.h unicity_table.h unicodes.h \

--- a/src/ccutil/genericvector.h
+++ b/src/ccutil/genericvector.h
@@ -26,7 +26,6 @@
 #include <cstdlib>
 
 #include "tesscallback.h"
-#include "errcode.h"
 #include "helpers.h"
 #include "ndminx.h"
 #include "serialis.h"
@@ -708,7 +707,7 @@ void GenericVector<T>::init_to_size(int size, T t) {
 // Return the object from an index.
 template <typename T>
 T &GenericVector<T>::get(int index) const {
-  ASSERT_HOST(index >= 0 && index < size_used_);
+  assert(index >= 0 && index < size_used_);
   return data_[index];
 }
 
@@ -720,20 +719,20 @@ T &GenericVector<T>::operator[](int index) const {
 
 template <typename T>
 T &GenericVector<T>::back() const {
-  ASSERT_HOST(size_used_ > 0);
+  assert(size_used_ > 0);
   return data_[size_used_ - 1];
 }
 // Returns the last object and removes it.
 template <typename T>
 T GenericVector<T>::pop_back() {
-  ASSERT_HOST(size_used_ > 0);
+  assert(size_used_ > 0);
   return data_[--size_used_];
 }
 
 // Return the object from an index.
 template <typename T>
 void GenericVector<T>::set(T t, int index) {
-  ASSERT_HOST(index >= 0 && index < size_used_);
+  assert(index >= 0 && index < size_used_);
   data_[index] = t;
 }
 
@@ -742,7 +741,7 @@ void GenericVector<T>::set(T t, int index) {
 // at the specified index.
 template <typename T>
 void GenericVector<T>::insert(T t, int index) {
-  ASSERT_HOST(index >= 0 && index <= size_used_);
+  assert(index >= 0 && index <= size_used_);
   if (size_reserved_ == size_used_)
     double_the_size();
   for (int i = size_used_; i > index; --i) {
@@ -756,7 +755,7 @@ void GenericVector<T>::insert(T t, int index) {
 // shifts the remaining elements to the left.
 template <typename T>
 void GenericVector<T>::remove(int index) {
-  ASSERT_HOST(index >= 0 && index < size_used_);
+  assert(index >= 0 && index < size_used_);
   for (int i = index; i < size_used_ - 1; ++i) {
     data_[i] = data_[i+1];
   }
@@ -773,7 +772,7 @@ T GenericVector<T>::contains_index(int index) const {
 template <typename T>
 int GenericVector<T>::get_index(T object) const {
   for (int i = 0; i < size_used_; ++i) {
-    ASSERT_HOST(compare_cb_ != nullptr);
+    assert(compare_cb_ != nullptr);
     if (compare_cb_->Run(object, data_[i]))
       return i;
   }

--- a/src/ccutil/serialis.cpp
+++ b/src/ccutil/serialis.cpp
@@ -19,6 +19,7 @@
 
 #include "serialis.h"
 #include <cstdio>
+#include "errcode.h"
 #include "genericvector.h"
 
 namespace tesseract {

--- a/src/ccutil/strngs.cpp
+++ b/src/ccutil/strngs.cpp
@@ -21,6 +21,7 @@
 
 #include <assert.h>
 
+#include "errcode.h"
 #include "genericvector.h"
 #include "helpers.h"
 #include "serialis.h"

--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -25,6 +25,7 @@
 
 #include <cstdio>
 
+#include "errcode.h"
 #include "helpers.h"
 #include "serialis.h"
 #include "strngs.h"

--- a/src/training/commandlineflags.cpp
+++ b/src/training/commandlineflags.cpp
@@ -10,6 +10,7 @@
 
 #include "baseapi.h"            // TessBaseAPI::Version
 #include "commandlineflags.h"
+#include "errcode.h"
 
 #ifndef GOOGLE_TESSERACT
 

--- a/src/training/fileio.cpp
+++ b/src/training/fileio.cpp
@@ -27,6 +27,7 @@
 #include <cstdio>
 #include <string>
 
+#include "errcode.h"
 #include "fileio.h"
 #include "tprintf.h"
 

--- a/src/training/normstrngs.cpp
+++ b/src/training/normstrngs.cpp
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "errcode.h"
 #include "icuerrorcode.h"
 #include "unichar.h"
 #include "unicode/normalizer2.h"  // From libicu


### PR DESCRIPTION
genericvector.h used a mix of assert and ASSERT_HOST.

By using assert only, it does no longer depend on errcode.h
which defines the ASSERT_HOST macro.

Other files which still use ASSERT_HOST now need an explicit
include statement for errcode.h.

Remove errcode.h from the public Tesseract API.

Signed-off-by: Stefan Weil <sw@weilnetz.de>