### PR TITLE
pdfrenderer: Fix ClipBaseline and optimize code

### DIFF
--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -293,16 +293,16 @@ void AffineMatrix(int writing_direction,
 // these viewers. I chose this threshold large enough to absorb noise,
 // but small enough that lines probably won't cross each other if the
 // whole page is tilted at almost exactly the clipping threshold.
-void ClipBaseline(int ppi, int x1, int y1, int x2, int y2,
-                  int *line_x1, int *line_y1,
-                  int *line_x2, int *line_y2) {
+static void ClipBaseline(int ppi, int x1, int y1, int x2, int y2,
+                         int *line_x1, int *line_y1,
+                         int *line_x2, int *line_y2) {
   *line_x1 = x1;
   *line_y1 = y1;
   *line_x2 = x2;
   *line_y2 = y2;
-  double rise = abs(y2 - y1) * 72 / ppi;
-  double run = abs(x2 - x1) * 72 / ppi;
-  if (rise < 2.0 && 2.0 < run)
+  int rise = abs(y2 - y1) * 72;
+  int run = abs(x2 - x1) * 72;
+  if (rise < 2 * ppi && 2 * ppi < run)
     *line_y1 = *line_y2 = (y1 + y2) / 2;
 }
 


### PR DESCRIPTION
The division was made with integers, giving a wrong result.

* Avoid division and use pure integer operations.
* Add missing "static" attribute.

Signed-off-by: Stefan Weil <sw@weilnetz.de>