### PR TITLE
Remove unneeded macro definition for M_PI

### DIFF
--- a/src/training/mftraining.cpp
+++ b/src/training/mftraining.cpp
@@ -28,11 +28,6 @@
 #include <cstdio>
 #define _USE_MATH_DEFINES
 #include <cmath>
-#ifdef _WIN32
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-#endif
 
 #include "classify.h"
 #include "cluster.h"


### PR DESCRIPTION
There is already one in platform.h.

Signed-off-by: Stefan Weil <sw@weilnetz.de>