### PR TITLE
Clean up cutil.h

### DIFF
--- a/src/ccstruct/blobs.cpp
+++ b/src/ccstruct/blobs.cpp
@@ -34,7 +34,6 @@
 #include "blobs.h"
 #include "ccstruct.h"
 #include "clst.h"
-#include "cutil.h"
 #include "emalloc.h"
 #include "helpers.h"
 #include "linlsq.h"

--- a/src/classify/cluster.cpp
+++ b/src/classify/cluster.cpp
@@ -14,9 +14,10 @@
  ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ** See the License for the specific language governing permissions and
  ** limitations under the License.
- ******************************************************************************/
+ *****************************************************************************/
 
 #include "cluster.h"
+#include "cutil.h"     // for void_proc
 #include "emalloc.h"
 #include "genericheap.h"
 #include "helpers.h"

--- a/src/classify/kdtree.cpp
+++ b/src/classify/kdtree.cpp
@@ -19,6 +19,7 @@
           Include Files and Type Defines
 -----------------------------------------------------------------------------*/
 #include "kdtree.h"
+#include "cutil.h"      // for void_proc
 #include "emalloc.h"
 
 #include <algorithm>

--- a/src/classify/kdtree.h
+++ b/src/classify/kdtree.h
@@ -13,15 +13,15 @@
  ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ** See the License for the specific language governing permissions and
  ** limitations under the License.
- ******************************************************************************/
+ *****************************************************************************/
 #ifndef   KDTREE_H
 #define   KDTREE_H
 
 /*-----------------------------------------------------------------------------
           Include Files and Type Defines
 -----------------------------------------------------------------------------*/
+#include "cutil.h"      // for void_proc
 #include "host.h"
-#include "cutil.h"
 #include "ocrfeatures.h"
 
 /**

--- a/src/classify/protos.cpp
+++ b/src/classify/protos.cpp
@@ -274,6 +274,6 @@ void PrintProtos(CLASS_TYPE Class) {
     PrintProto (ProtoIn (Class, Pid));
     cprintf ("\t");
     PrintProtoLine (ProtoIn (Class, Pid));
-    new_line();
+    tprintf("\n");
   }
 }

--- a/src/classify/protos.h
+++ b/src/classify/protos.h
@@ -30,7 +30,6 @@
               I n c l u d e s
 ----------------------------------------------------------------------*/
 #include "bitvec.h"
-#include "cutil.h"
 #include "params.h"
 #include "unichar.h"
 #include "unicity_table.h"

--- a/src/cutil/cutil.h
+++ b/src/cutil/cutil.h
@@ -27,63 +27,9 @@
 #ifndef CUTILH
 #define CUTILH
 
-/*----------------------------------------------------------------------
-                     I n c l u d e s
-----------------------------------------------------------------------*/
-#include <cstdio>
-#include <cstring>
-#include <cstdlib>
+typedef void (*void_proc)(...);
 
-#include "host.h"
-#include "tprintf.h"
+typedef int (*int_compare)(void*, void*);
+typedef void (*void_dest)(void*);
 
-/*----------------------------------------------------------------------
-                      T y p e s
-----------------------------------------------------------------------*/
-#ifndef TRUE
-#define TRUE 1
-#endif
-
-#ifndef FALSE
-#define FALSE 0
-#endif
-
-#define CHARS_PER_LINE 500
-
-#if defined(__STDC__) || defined(__cplusplus)
-# define _ARGS(s) s
-#else
-# define _ARGS(s) ()
-#endif
-
-typedef void (*void_proc) (...);
-typedef void *(*void_star_proc) _ARGS ((...));
-
-typedef int (*int_void) (void);
-typedef void (*void_void) (void);
-typedef int (*int_compare) (void *, void *);
-typedef void (*void_dest) (void *);
-
-/*----------------------------------------------------------------------
-                     M a c r o s
-----------------------------------------------------------------------*/
-/**********************************************************************
- * new_line
- *
- * Print a new line character on stdout.
- **********************************************************************/
-
-#define new_line()  \
-  tprintf("\n")
-
-/**********************************************************************
- * print_string
- *
- * Print a string on stdout.
- **********************************************************************/
-
-#define print_string(str)  \
-  printf ("%s\n", str)
-
-#include "cutil_class.h"
 #endif

--- a/src/cutil/oldlist.cpp
+++ b/src/cutil/oldlist.cpp
@@ -21,14 +21,7 @@
 ** See the License for the specific language governing permissions and
 ** limitations under the License.
 #
-################################################################################
-
-* Revision 1.13  90/03/06  15:37:54  15:37:54  marks (Mark Seaman)
-* Look for correct file of <malloc.h> or <stdlib.h>
-*
-* Revision 1.12  90/02/26  17:37:36  17:37:36  marks (Mark Seaman)
-* Added pop_off and join_on
-*
+###############################################################################
 
   This file contains a set of general purpose list manipulation routines.
   These routines can be used in a wide variety of ways to provide several
@@ -84,6 +77,8 @@
 ******************************************************************************/
 #include "oldlist.h"
 #include <cstdio>
+#include <cstring>      // for strcmp
+#include "errcode.h"    // for ASSERT_HOST
 #include "structures.h"
 
 /*----------------------------------------------------------------------

--- a/src/cutil/oldlist.h
+++ b/src/cutil/oldlist.h
@@ -117,7 +117,7 @@
 #ifndef LIST_H
 #define LIST_H
 
-#include "cutil.h"
+#include "cutil.h"              // for int_compare, void_dest, ...
 #include "tesscallback.h"
 
 /*----------------------------------------------------------------------

--- a/src/dict/dict.h
+++ b/src/dict/dict.h
@@ -32,6 +32,7 @@
 class MATRIX;
 class WERD_RES;
 
+#define CHARS_PER_LINE 500
 #define MAX_WERD_LENGTH        (int64_t) 128
 #define NO_RATING               -1
 

--- a/src/dict/permdawg.cpp
+++ b/src/dict/permdawg.cpp
@@ -26,7 +26,6 @@
               I n c l u d e s
 ----------------------------------------------------------------------*/
 
-#include "cutil.h"
 #include "dawg.h"
 #include "globals.h"
 #include "stopper.h"

--- a/src/dict/trie.h
+++ b/src/dict/trie.h
@@ -26,7 +26,6 @@
 #define TRIE_H
 
 #include "dawg.h"
-#include "cutil.h"
 #include "genericvector.h"
 
 class UNICHARSET;

--- a/src/wordrec/chopper.h
+++ b/src/wordrec/chopper.h
@@ -26,7 +26,6 @@
 #ifndef CHOPPER_H
 #define CHOPPER_H
 
-#include "cutil.h"
 #include "matrix.h"
 #include "seam.h"
 #include "stopper.h"


### PR DESCRIPTION
* Remove unrelated include statements from cutil.h.
* Remove macros FALSE, TRUE.
* Move macro CHARS_PER_LINE from cutil.h to dict.h.
* Remove unneeded macro _ARGS.
* Remove unused typedef statements.
* Remove macro new_line (only used once).
* Remove unused macro print_string.
* Update include statements for other source files.

Signed-off-by: Stefan Weil <sw@weilnetz.de>