### PR TITLE
Remove unneeded type casts

### DIFF
--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -196,7 +196,7 @@ void TessPDFRenderer::AppendPDFObjectDIY(size_t objectsize) {
 
 void TessPDFRenderer::AppendPDFObject(const char *data) {
   AppendPDFObjectDIY(strlen(data));
-  AppendString((const char *)data);
+  AppendString(data);
 }
 
 // Helper function to prevent us from accidentally writing

--- a/src/ccutil/clst.cpp
+++ b/src/ccutil/clst.cpp
@@ -149,7 +149,7 @@ const void *, const void *)) {
   }
 
   /* Sort the pointer array */
-  qsort ((char *) base, count, sizeof (*base), comparator);
+  qsort(base, count, sizeof(*base), comparator);
 
   /* Rebuild the list from the sorted pointers */
   current = base;

--- a/src/ccutil/elst.cpp
+++ b/src/ccutil/elst.cpp
@@ -126,7 +126,7 @@ const void *, const void *)) {
   }
 
   /* Sort the pointer array */
-  qsort ((char *) base, count, sizeof (*base), comparator);
+  qsort(base, count, sizeof(*base), comparator);
 
   /* Rebuild the list from the sorted pointers */
   current = base;

--- a/src/ccutil/elst2.cpp
+++ b/src/ccutil/elst2.cpp
@@ -127,7 +127,7 @@ const void *, const void *)) {
   }
 
   /* Sort the pointer array */
-  qsort ((char *) base, count, sizeof (*base), comparator);
+  qsort(base, count, sizeof(*base), comparator);
 
   /* Rebuild the list from the sorted pointers */
   current = base;

--- a/src/classify/adaptive.cpp
+++ b/src/classify/adaptive.cpp
@@ -415,25 +415,25 @@ void WriteAdaptedClass(FILE *File, ADAPT_CLASS Class, int NumConfigs) {
   int i;
 
   /* first write high level adapted class structure */
-  fwrite ((char *) Class, sizeof (ADAPT_CLASS_STRUCT), 1, File);
+  fwrite(Class, sizeof(ADAPT_CLASS_STRUCT), 1, File);
 
   /* then write out the definitions of the permanent protos and configs */
-  fwrite ((char *) Class->PermProtos, sizeof (uint32_t),
-    WordsInVectorOfSize (MAX_NUM_PROTOS), File);
-  fwrite ((char *) Class->PermConfigs, sizeof (uint32_t),
-    WordsInVectorOfSize (MAX_NUM_CONFIGS), File);
+  fwrite(Class->PermProtos, sizeof(uint32_t),
+    WordsInVectorOfSize(MAX_NUM_PROTOS), File);
+  fwrite(Class->PermConfigs, sizeof(uint32_t),
+    WordsInVectorOfSize(MAX_NUM_CONFIGS), File);
 
   /* then write out the list of temporary protos */
   NumTempProtos = count (Class->TempProtos);
-  fwrite ((char *) &NumTempProtos, sizeof (int), 1, File);
+  fwrite(&NumTempProtos, sizeof(int), 1, File);
   TempProtos = Class->TempProtos;
   iterate (TempProtos) {
     void* proto = first_node(TempProtos);
-    fwrite ((char *) proto, sizeof (TEMP_PROTO_STRUCT), 1, File);
+    fwrite(proto, sizeof(TEMP_PROTO_STRUCT), 1, File);
   }
 
   /* then write out the adapted configs */
-  fwrite ((char *) &NumConfigs, sizeof (int), 1, File);
+  fwrite(&NumConfigs, sizeof(int), 1, File);
   for (i = 0; i < NumConfigs; i++)
     if (test_bit (Class->PermConfigs, i))
       WritePermConfig (File, Class->Config[i].Perm);
@@ -457,7 +457,7 @@ void Classify::WriteAdaptedTemplates(FILE *File, ADAPT_TEMPLATES Templates) {
   int i;
 
   /* first write the high level adaptive template struct */
-  fwrite ((char *) Templates, sizeof (ADAPT_TEMPLATES_STRUCT), 1, File);
+  fwrite(Templates, sizeof(ADAPT_TEMPLATES_STRUCT), 1, File);
 
   /* then write out the basic integer templates */
   WriteIntTemplates (File, Templates->Templates, unicharset);
@@ -487,7 +487,7 @@ void WritePermConfig(FILE *File, PERM_CONFIG Config) {
   assert (Config != nullptr);
   while (Config->Ambigs[NumAmbigs] > 0) ++NumAmbigs;
 
-  fwrite((char *) &NumAmbigs, sizeof(uint8_t), 1, File);
+  fwrite(&NumAmbigs, sizeof(uint8_t), 1, File);
   fwrite(Config->Ambigs, sizeof(UNICHAR_ID), NumAmbigs, File);
   fwrite(&(Config->FontinfoId), sizeof(int), 1, File);
 }                                /* WritePermConfig */
@@ -506,8 +506,7 @@ void WritePermConfig(FILE *File, PERM_CONFIG Config) {
 void WriteTempConfig(FILE *File, TEMP_CONFIG Config) {
   assert (Config != nullptr);
 
-  fwrite ((char *) Config, sizeof (TEMP_CONFIG_STRUCT), 1, File);
-  fwrite ((char *) Config->Protos, sizeof (uint32_t),
-    Config->ProtoVectorSize, File);
+  fwrite(Config, sizeof (TEMP_CONFIG_STRUCT), 1, File);
+  fwrite(Config->Protos, sizeof (uint32_t), Config->ProtoVectorSize, File);
 
 }                                /* WriteTempConfig */

--- a/src/classify/cluster.cpp
+++ b/src/classify/cluster.cpp
@@ -472,7 +472,7 @@ SAMPLE* MakeSample(CLUSTERER * Clusterer, const float* Feature,
 
   // add the sample to the KD tree - keep track of the total # of samples
   Clusterer->NumberOfSamples++;
-  KDStore (Clusterer->KDTree, Sample->Mean, (char *) Sample);
+  KDStore(Clusterer->KDTree, Sample->Mean, Sample);
   if (CharID >= Clusterer->NumChar)
     Clusterer->NumChar = CharID + 1;
 

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -1071,14 +1071,13 @@ void Classify::WriteIntTemplates(FILE *File, INT_TEMPLATES Templates,
 
     /* then write out the proto lengths */
     if (MaxNumIntProtosIn (Class) > 0) {
-      fwrite ((char *) (Class->ProtoLengths), sizeof (uint8_t),
-              MaxNumIntProtosIn (Class), File);
+      fwrite(Class->ProtoLengths, sizeof(uint8_t),
+             MaxNumIntProtosIn(Class), File);
     }
 
     /* then write out the proto sets */
     for (j = 0; j < Class->NumProtoSets; j++)
-      fwrite ((char *) Class->ProtoSets[j],
-              sizeof (PROTO_SET_STRUCT), 1, File);
+      fwrite(Class->ProtoSets[j], sizeof(PROTO_SET_STRUCT), 1, File);
 
     /* then write the fonts info */
     fwrite(&Class->font_set_id, sizeof(int), 1, File);

--- a/src/opencl/openclwrapper.cpp
+++ b/src/opencl/openclwrapper.cpp
@@ -775,7 +775,7 @@ int OpenclDevice::RegistOpenclKernel() {
   gpuEnv.mnFileCount = 0;  // argc;
   gpuEnv.mnKernelCount = 0UL;
 
-  AddKernelConfig(1, (const char*)"oclAverageSub1");
+  AddKernelConfig(1, "oclAverageSub1");
   return 0;
 }
 
@@ -846,14 +846,13 @@ int OpenclDevice::BinaryGenerated(const char* clFileName, FILE** fhandle) {
   unsigned int i = 0;
   cl_int clStatus;
   int status = 0;
-  char* str = nullptr;
   FILE* fd = nullptr;
   char fileName[256] = {0}, cl_name[128] = {0};
   char deviceName[1024];
   clStatus = clGetDeviceInfo(gpuEnv.mpArryDevsID[i], CL_DEVICE_NAME,
                              sizeof(deviceName), deviceName, nullptr);
   CHECK_OPENCL(clStatus, "clGetDeviceInfo");
-  str = (char*)strstr(clFileName, (char*)".cl");
+  const char* str = strstr(clFileName, ".cl");
   memcpy(cl_name, clFileName, str - clFileName);
   cl_name[str - clFileName] = '\0';
   sprintf(fileName, "%s-%s.bin", cl_name, deviceName);
@@ -897,7 +896,6 @@ int OpenclDevice::GeneratBinFromKernelSource(cl_program program,
   unsigned int i = 0;
   cl_int clStatus;
   cl_uint numDevices;
-  char* str = nullptr;
 
   clStatus = clGetProgramInfo(program, CL_PROGRAM_NUM_DEVICES,
                               sizeof(numDevices), &numDevices, nullptr);
@@ -949,7 +947,7 @@ int OpenclDevice::GeneratBinFromKernelSource(cl_program program,
                                  sizeof(deviceName), deviceName, nullptr);
       CHECK_OPENCL(clStatus, "clGetDeviceInfo");
 
-      str = (char*)strstr(clFileName, (char*)".cl");
+      const char* str = strstr(clFileName, ".cl");
       memcpy(cl_name, clFileName, str - clFileName);
       cl_name[str - clFileName] = '\0';
       sprintf(fileName, "%s-%s.bin", cl_name, deviceName);

--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -364,8 +364,7 @@ static int GetAddrInfoNonLinux(const char* hostname, int port,
 
   // Fill in the appropriate variables to be able to connect to the server.
   address->sin_family = name->h_addrtype;
-  memcpy((char *) &address->sin_addr.s_addr,
-         name->h_addr_list[0], name->h_length);
+  memcpy(&address->sin_addr.s_addr, name->h_addr_list[0], name->h_length);
   address->sin_port = htons(port);
   return 0;
 }


### PR DESCRIPTION
This removes unneded type casts to (char*) and (const char*).

Signed-off-by: Stefan Weil <sw@weilnetz.de>