### PR TITLE
Fix empty statements

### DIFF
--- a/src/lstm/network.cpp
+++ b/src/lstm/network.cpp
@@ -258,7 +258,7 @@ Network* Network::CreateFromFile(TFile* fp) {
       network = new FullyConnected(stub.name_, stub.ni_, stub.no_, stub.type_);
       break;
     default:
-      ;
+      break;
   }
   if (network) {
     network->training_ = stub.training_;

--- a/src/opencl/openclwrapper.cpp
+++ b/src/opencl/openclwrapper.cpp
@@ -2304,7 +2304,6 @@ static double thresholdRectToPixMicroBench(GPUEnv* env,
     stop = mach_absolute_time();
     if (retVal == 0) {
       time = ((stop - start) * (double)info.numer / info.denom) / 1.0E9;
-      ;
     } else {
       time = FLT_MAX;
     }


### PR DESCRIPTION
* Add break in default case to avoid potential problems with
  future case statements following the default case.

* Remove empty statement.

Signed-off-by: Stefan Weil <sw@weilnetz.de>