### PR TITLE
Fix compiler warnings [-Wmissing-prototypes]

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -2622,9 +2622,9 @@ void TessBaseAPI::NormalizeTBLOB(TBLOB *tblob, ROW *row, bool numeric_mode) {
  * Return a TBLOB * from the whole pix.
  * To be freed later with delete.
  */
-TBLOB *make_tesseract_blob(float baseline, float xheight,
-                           float descender, float ascender,
-                           bool numeric_mode, Pix* pix) {
+static TBLOB *make_tesseract_blob(float baseline, float xheight,
+                                  float descender, float ascender,
+                                  bool numeric_mode, Pix* pix) {
   TBLOB *tblob = TessBaseAPI::MakeTBLOB(pix);
 
   // Normalize TBLOB

--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -202,7 +202,7 @@ void TessPDFRenderer::AppendPDFObject(const char *data) {
 // Helper function to prevent us from accidentally writing
 // scientific notation to an HOCR or PDF file. Besides, three
 // decimal points are all you really need.
-double prec(double x) {
+static double prec(double x) {
   double kPrecision = 1000.0;
   double a = round(x * kPrecision) / kPrecision;
   if (a == -0)
@@ -210,7 +210,7 @@ double prec(double x) {
   return a;
 }
 
-long dist2(int x1, int y1, int x2, int y2) {
+static long dist2(int x1, int y1, int x2, int y2) {
   return (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1);
 }
 
@@ -222,10 +222,10 @@ long dist2(int x1, int y1, int x2, int y2) {
 // left-to-right no matter what the reading order is. We need the
 // word baseline in reading order, so we do that conversion here. Returns
 // the word's baseline origin and length.
-void GetWordBaseline(int writing_direction, int ppi, int height,
-                     int word_x1, int word_y1, int word_x2, int word_y2,
-                     int line_x1, int line_y1, int line_x2, int line_y2,
-                     double *x0, double *y0, double *length) {
+static void GetWordBaseline(int writing_direction, int ppi, int height,
+                            int word_x1, int word_y1, int word_x2, int word_y2,
+                            int line_x1, int line_y1, int line_x2, int line_y2,
+                            double *x0, double *y0, double *length) {
   if (writing_direction == WRITING_DIRECTION_RIGHT_TO_LEFT) {
     Swap(&word_x1, &word_x2);
     Swap(&word_y1, &word_y2);
@@ -264,9 +264,9 @@ void GetWordBaseline(int writing_direction, int ppi, int height,
 //                           RTL
 // [ x' ] = [ a b ][ x ] = [-1 0 ] [ cos sin ][ x ]
 // [ y' ]   [ c d ][ y ]   [ 0 1 ] [-sin cos ][ y ]
-void AffineMatrix(int writing_direction,
-                  int line_x1, int line_y1, int line_x2, int line_y2,
-                  double *a, double *b, double *c, double *d) {
+static void AffineMatrix(int writing_direction,
+                         int line_x1, int line_y1, int line_x2, int line_y2,
+                         double *a, double *b, double *c, double *d) {
   double theta = atan2(static_cast<double>(line_y1 - line_y2),
                        static_cast<double>(line_x2 - line_x1));
   *a = cos(theta);

--- a/src/ccmain/osdetect.cpp
+++ b/src/ccmain/osdetect.cpp
@@ -156,8 +156,9 @@ void OSResults::accumulate(const OSResults& osr) {
 
 // Detect and erase horizontal/vertical lines and picture regions from the
 // image, so that non-text blobs are removed from consideration.
-void remove_nontext_regions(tesseract::Tesseract *tess, BLOCK_LIST *blocks,
-                            TO_BLOCK_LIST *to_blocks) {
+static void remove_nontext_regions(tesseract::Tesseract *tess,
+                                   BLOCK_LIST *blocks,
+                                   TO_BLOCK_LIST *to_blocks) {
   Pix *pix = tess->pix_binary();
   ASSERT_HOST(pix != nullptr);
   int vertical_x = 0;

--- a/src/ccmain/output.cpp
+++ b/src/ccmain/output.cpp
@@ -42,23 +42,6 @@
 #define CTRL_NEWLINE      '\012' //newline
 #define CTRL_HARDLINE   '\015'   //cr
 
-/**********************************************************************
- * pixels_to_pts
- *
- * Convert an integer number of pixels to the nearest integer
- * number of points.
- **********************************************************************/
-
-int32_t pixels_to_pts(               //convert coords
-                    int32_t pixels,
-                    int32_t pix_res  //resolution
-                   ) {
-  float pts;                     //converted value
-
-  pts = pixels * 72.0 / pix_res;
-  return (int32_t) (pts + 0.5);    //round it
-}
-
 namespace tesseract {
 void Tesseract::output_pass(  //Tess output pass //send to api
                             PAGE_RES_IT &page_res_it,

--- a/src/ccmain/paragraphs_internal.h
+++ b/src/ccmain/paragraphs_internal.h
@@ -291,11 +291,6 @@ bool FirstWordWouldHaveFit(const RowScratchRegisters &before,
 bool RowsFitModel(const GenericVector<RowScratchRegisters> *rows,
                   int start, int end, const ParagraphModel *model);
 
-// Do the text and geometry of two rows support a paragraph break between them?
-bool LikelyParagraphStart(const RowScratchRegisters &before,
-                          const RowScratchRegisters &after,
-                          tesseract::ParagraphJustification j);
-
 // Given a set of row_owners pointing to PARAs or nullptr (no paragraph known),
 // normalize each row_owner to point to an actual PARA, and output the
 // paragraphs in order onto paragraphs.

--- a/src/ccmain/pgedit.cpp
+++ b/src/ccmain/pgedit.cpp
@@ -203,12 +203,9 @@ void build_image_window(int width, int height) {
  *  Display normalized baseline, x-height, ascender limit and descender limit
  */
 
-void display_bln_lines(ScrollView* window,
-                       ScrollView::Color colour,
-                       float scale_factor,
-                       float y_offset,
-                       float minx,
-                       float maxx) {
+static void display_bln_lines(ScrollView* window, ScrollView::Color colour,
+                              float scale_factor, float y_offset,
+                              float minx, float maxx) {
   window->Pen(colour);
   window->Line(minx, y_offset + scale_factor * DESC_HEIGHT,
                maxx, y_offset + scale_factor * DESC_HEIGHT);

--- a/src/ccmain/recogtraining.cpp
+++ b/src/ccmain/recogtraining.cpp
@@ -53,7 +53,7 @@ FILE *Tesseract::init_recog_training(const STRING &fname) {
 }
 
 // Copies the bounding box from page_res_it->word() to the given TBOX.
-bool read_t(PAGE_RES_IT *page_res_it, TBOX *tbox) {
+static bool read_t(PAGE_RES_IT *page_res_it, TBOX *tbox) {
   while (page_res_it->block() != nullptr && page_res_it->word() == nullptr)
     page_res_it->forward();
 

--- a/src/ccmain/superscript.cpp
+++ b/src/ccmain/superscript.cpp
@@ -43,10 +43,11 @@ namespace tesseract {
  * or superscript letter based only on y position.  Also do this for the
  * right side.
  */
-void YOutlierPieces(WERD_RES *word, int rebuilt_blob_index,
-                    int super_y_bottom, int sub_y_top,
-                    ScriptPos *leading_pos, int *num_leading_outliers,
-                    ScriptPos *trailing_pos, int *num_trailing_outliers) {
+static void YOutlierPieces(WERD_RES *word, int rebuilt_blob_index,
+                           int super_y_bottom, int sub_y_top,
+                           ScriptPos *leading_pos, int *num_leading_outliers,
+                           ScriptPos *trailing_pos,
+                           int *num_trailing_outliers) {
   ScriptPos sp_unused1, sp_unused2;
   int unused1, unused2;
   if (!leading_pos) leading_pos = &sp_unused1;

--- a/src/ccstruct/ocrblock.cpp
+++ b/src/ccstruct/ocrblock.cpp
@@ -252,7 +252,7 @@ const BLOCK & source             //from this
 //   margin - return value, the distance from x,y to the left margin of the
 //       block containing it.
 // If all segments were to the right of x, we return false and 0.
-bool LeftMargin(ICOORDELT_LIST *segments, int x, int *margin) {
+static bool LeftMargin(ICOORDELT_LIST *segments, int x, int *margin) {
   bool found = false;
   *margin = 0;
   if (segments->empty())
@@ -282,7 +282,7 @@ bool LeftMargin(ICOORDELT_LIST *segments, int x, int *margin) {
 //   margin - return value, the distance from x,y to the right margin of the
 //       block containing it.
 // If all segments were to the left of x, we return false and 0.
-bool RightMargin(ICOORDELT_LIST *segments, int x, int *margin) {
+static bool RightMargin(ICOORDELT_LIST *segments, int x, int *margin) {
   bool found = false;
   *margin = 0;
   if (segments->empty())

--- a/src/ccstruct/stepblob.cpp
+++ b/src/ccstruct/stepblob.cpp
@@ -359,7 +359,8 @@ void C_BLOB::move(                  // reposition blob
 }
 
 // Static helper for C_BLOB::rotate to allow recursion of child outlines.
-void RotateOutlineList(const FCOORD& rotation, C_OUTLINE_LIST* outlines) {
+static void RotateOutlineList(const FCOORD& rotation,
+                              C_OUTLINE_LIST* outlines) {
   C_OUTLINE_LIST new_outlines;
   C_OUTLINE_IT src_it(outlines);
   C_OUTLINE_IT dest_it(&new_outlines);

--- a/src/ccutil/globaloc.cpp
+++ b/src/ccutil/globaloc.cpp
@@ -17,14 +17,15 @@
  *
  **********************************************************************/
 
-#include          <signal.h>
+#include "globaloc.h"
+#include <signal.h>
 #ifdef __linux__
-#include          <sys/syscall.h>   // For SYS_gettid.
-#include          <unistd.h>        // For syscall itself.
+#include <sys/syscall.h>   // For SYS_gettid.
+#include <unistd.h>        // For syscall itself.
 #endif
-#include          "allheaders.h"
-#include          "errcode.h"
-#include          "tprintf.h"
+#include "allheaders.h"
+#include "errcode.h"
+#include "tprintf.h"
 
 // Size of thread-id array of pixes to keep in case of crash.
 const int kMaxNumThreadPixes = 32768;
@@ -75,20 +76,17 @@ void err_exit() {
   ASSERT_HOST("Fatal error encountered!" == nullptr);
 }
 
-
+// TODO: remove empty function?
 void set_global_loc_code(int loc_code) {
   // global_loc_code = loc_code;
-
 }
 
-
+// TODO: remove empty function?
 void set_global_subloc_code(int loc_code) {
   // global_subloc_code = loc_code;
-
 }
 
-
+// TODO: remove empty function?
 void set_global_subsubloc_code(int loc_code) {
   // global_subsubloc_code = loc_code;
-
 }

--- a/src/ccutil/scanutils.cpp
+++ b/src/ccutil/scanutils.cpp
@@ -103,7 +103,7 @@ static inline int DigitValue(int ch, int base) {
 }
 
 // IO (re-)implementations -----------------------------------------------------
-uintmax_t streamtoumax(FILE* s, int base) {
+static uintmax_t streamtoumax(FILE* s, int base) {
   int minus = 0;
   uintmax_t v = 0;
   int d, c = 0;
@@ -144,7 +144,7 @@ uintmax_t streamtoumax(FILE* s, int base) {
   return minus ? -v : v;
 }
 
-double streamtofloat(FILE* s) {
+static double streamtofloat(FILE* s) {
   int minus = 0;
   int v = 0;
   int d, c = 0;
@@ -187,39 +187,6 @@ double streamtofloat(FILE* s) {
     f *= pow(10.0, static_cast<double>(exponent));
   }
   ungetc(c, s);
-
-  return minus ? -f : f;
-}
-
-double strtofloat(const char* s) {
-  int minus = 0;
-  int v = 0;
-  int d;
-  int k = 1;
-  int w = 0;
-
-  while(*s && isspace(static_cast<unsigned char>(*s))) s++;
-
-  // Single optional + or -
-  if (*s == '-' || *s == '+') {
-    minus = (*s == '-');
-    s++;
-  }
-
-  // Actual number parsing
-  for (; *s && (d = DigitValue(*s, 10)) >= 0; s++)
-    v = v*10 + d;
-  if (*s == '.') {
-    for (++s; *s && (d = DigitValue(*s, 10)) >= 0; s++) {
-      w = w*10 + d;
-      k *= 10;
-    }
-  }
-  if (*s == 'e' || *s == 'E')
-    tprintf("WARNING: Scientific Notation not supported!");
-
-  double f  = static_cast<double>(v)
-            + static_cast<double>(w) / static_cast<double>(k);
 
   return minus ? -f : f;
 }

--- a/src/classify/adaptive.cpp
+++ b/src/classify/adaptive.cpp
@@ -87,7 +87,7 @@ void FreeTempProto(void *arg) {
   free(proto);
 }
 
-void FreePermConfig(PERM_CONFIG Config) {
+static void FreePermConfig(PERM_CONFIG Config) {
   assert(Config != nullptr);
   delete [] Config->Ambigs;
   free(Config);
@@ -475,7 +475,7 @@ void Classify::WriteAdaptedTemplates(FILE *File, ADAPT_TEMPLATES Templates) {
 /**
  * This routine writes a binary representation of a
  * permanent configuration to File.
- * 
+ *
  * @param File  open file to write Config to
  * @param Config  permanent config to write to File
  *

--- a/src/classify/intfx.cpp
+++ b/src/classify/intfx.cpp
@@ -166,8 +166,9 @@ void Classify::SetupBLCNDenorms(const TBLOB& blob, bool nonlinear_norm,
 
 // Helper normalizes the direction, assuming that it is at the given
 // unnormed_pos, using the given denorm, starting at the root_denorm.
-uint8_t NormalizeDirection(uint8_t dir, const FCOORD& unnormed_pos,
-                         const DENORM& denorm, const DENORM* root_denorm) {
+static uint8_t NormalizeDirection(uint8_t dir, const FCOORD& unnormed_pos,
+                                  const DENORM& denorm,
+                                  const DENORM* root_denorm) {
   // Convert direction to a vector.
   FCOORD unnormed_end;
   unnormed_end.from_direction(dir);

--- a/src/classify/intmatcher.cpp
+++ b/src/classify/intmatcher.cpp
@@ -713,11 +713,9 @@ void ScratchEvidence::ClearFeatureEvidence(const INT_CLASS class_template) {
  * Print debugging information for Configurations
  * @return none
  */
-void IMDebugConfiguration(int FeatureNum,
-                          uint16_t ActualProtoNum,
-                          uint8_t Evidence,
-                          BIT_VECTOR ConfigMask,
-                          uint32_t ConfigWord) {
+static void IMDebugConfiguration(int FeatureNum, uint16_t ActualProtoNum,
+                                 uint8_t Evidence, BIT_VECTOR ConfigMask,
+                                 uint32_t ConfigWord) {
   cprintf ("F = %3d, P = %3d, E = %3d, Configs = ",
     FeatureNum, (int) ActualProtoNum, (int) Evidence);
   while (ConfigWord) {
@@ -734,9 +732,8 @@ void IMDebugConfiguration(int FeatureNum,
  * Print debugging information for Configurations
  * @return none
  */
-void IMDebugConfigurationSum(int FeatureNum,
-                             uint8_t *FeatureEvidence,
-                             int32_t ConfigCount) {
+static void IMDebugConfigurationSum(int FeatureNum, uint8_t *FeatureEvidence,
+                                    int32_t ConfigCount) {
   cprintf("F=%3d, C=", FeatureNum);
   for (int ConfigNum = 0; ConfigNum < ConfigCount; ConfigNum++) {
     cprintf("%4d", FeatureEvidence[ConfigNum]);

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -674,8 +674,7 @@ INT_CLASS NewIntClass(int MaxNumProtos, int MaxNumConfigs) {
 
 }                                /* NewIntClass */
 
-
-void free_int_class(INT_CLASS int_class) {
+static void free_int_class(INT_CLASS int_class) {
   int i;
 
   for (i = 0; i < int_class->NumProtoSets; i++) {

--- a/src/classify/mfx.cpp
+++ b/src/classify/mfx.cpp
@@ -2,7 +2,6 @@
  **      Filename:       mfx.c
  **      Purpose:        Micro feature extraction routines
  **      Author:         Dan Johnson
- **      History:        7/21/89, DSJ, Created.
  **
  **      (c) Copyright Hewlett-Packard Company, 1988.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +17,7 @@
 /*----------------------------------------------------------------------------
           Include Files and Type Defines
 ----------------------------------------------------------------------------*/
+#include "mfx.h"
 #include "mfdefs.h"
 #include "mfoutline.h"
 #include "clusttool.h"           //NEEDED
@@ -92,7 +92,6 @@ MICROFEATURES BlobMicroFeatures(TBLOB* Blob, const DENORM& cn_denorm) {
   }
   return MicroFeatures;
 }                                /* BlobMicroFeatures */
-
 
 /*---------------------------------------------------------------------------
             Private Code

--- a/src/classify/mfx.h
+++ b/src/classify/mfx.h
@@ -2,7 +2,6 @@
  ** Filename: mfx.h
  ** Purpose:  Definition of micro-feature extraction routines
  ** Author:   Dan Johnson
- ** History:  5/29/89, DSJ, Created.
  **
  ** (c) Copyright Hewlett-Packard Company, 1988.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,14 +14,19 @@
  ** See the License for the specific language governing permissions and
  ** limitations under the License.
  ******************************************************************************/
-#ifndef   MFX_H
-#define   MFX_H
+
+#ifndef MFX_H
+#define MFX_H
 
 /*----------------------------------------------------------------------------
           Include Files and Type Defines
 ----------------------------------------------------------------------------**/
 #include "mfdefs.h"
 #include "params.h"
+
+class DENORM;
+struct TBLOB;
+
 /*----------------------------------------------------------------------------
           Variables
 ----------------------------------------------------------------------------**/

--- a/src/classify/ocrfeatures.cpp
+++ b/src/classify/ocrfeatures.cpp
@@ -191,37 +191,3 @@ void WriteFeatureSet(FEATURE_SET FeatureSet, STRING* str) {
     }
   }
 }                                /* WriteFeatureSet */
-
-/**
- * Write a textual representation of FeatureDesc to File
- * in the old format (i.e. the format used by the clusterer).
- *
- * This format is:
- * @verbatim
- *  Number of Params
- *  Description of Param 1
- *  ...
- * @endverbatim
- * @param File open text file to write FeatureDesc to
- * @param FeatureDesc feature descriptor to write to File
- * @return none
- */
-void WriteOldParamDesc(FILE* File, const FEATURE_DESC_STRUCT* FeatureDesc) {
-  int i;
-
-  fprintf (File, "%d\n", FeatureDesc->NumParams);
-  for (i = 0; i < FeatureDesc->NumParams; i++) {
-    if (FeatureDesc->ParamDesc[i].Circular)
-      fprintf (File, "circular ");
-    else
-      fprintf (File, "linear   ");
-
-    if (FeatureDesc->ParamDesc[i].NonEssential)
-      fprintf (File, "non-essential  ");
-    else
-      fprintf (File, "essential      ");
-
-    fprintf (File, "%f  %f\n",
-      FeatureDesc->ParamDesc[i].Min, FeatureDesc->ParamDesc[i].Max);
-  }
-}                                /* WriteOldParamDesc */

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -109,7 +109,8 @@ void Dawg::iterate_words(const UNICHARSET &unicharset,
   iterate_words_rec(word, 0, cb);
 }
 
-void CallWithUTF8(TessCallback1<const char *> *cb, const WERD_CHOICE *wc) {
+static void CallWithUTF8(TessCallback1<const char *> *cb,
+                         const WERD_CHOICE *wc) {
   STRING s;
   wc->string_and_lengths(&s, nullptr);
   cb->Run(s.string());

--- a/src/textord/bbgrid.cpp
+++ b/src/textord/bbgrid.cpp
@@ -201,8 +201,8 @@ Pix* IntGrid::ThresholdToPix(int threshold) const {
 }
 
 // Make a Pix of the correct scaled size for the TraceOutline functions.
-Pix* GridReducedPix(const TBOX& box, int gridsize,
-                    ICOORD bleft, int* left, int* bottom) {
+static Pix* GridReducedPix(const TBOX& box, int gridsize,
+                           ICOORD bleft, int* left, int* bottom) {
   // Compute grid bounds of the outline and pad all round by 1.
   int grid_left = (box.left() - bleft.x()) / gridsize - 1;
   int grid_bottom = (box.bottom() - bleft.y()) / gridsize - 1;

--- a/src/textord/makerow.cpp
+++ b/src/textord/makerow.cpp
@@ -133,7 +133,8 @@ static float MakeRowFromBlobs(float line_size,
 
 // Helper to make a row using the children of a single blob.
 // Returns the mean size of the blobs created.
-float MakeRowFromSubBlobs(TO_BLOCK* block, C_BLOB* blob, TO_ROW_IT* row_it) {
+static float MakeRowFromSubBlobs(TO_BLOCK* block, C_BLOB* blob,
+                                 TO_ROW_IT* row_it) {
   // The blobs made from the children will go in the small_blobs list.
   BLOBNBOX_IT bb_it(&block->small_blobs);
   C_OUTLINE_IT ol_it(blob->out_list());

--- a/src/training/commandlineflags.cpp
+++ b/src/training/commandlineflags.cpp
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_TESSERACT
 
 namespace tesseract {
-bool IntFlagExists(const char* flag_name, int32_t* value) {
+static bool IntFlagExists(const char* flag_name, int32_t* value) {
   STRING full_flag_name("FLAGS_");
   full_flag_name += flag_name;
   GenericVector<IntParam*> empty;
@@ -26,7 +26,7 @@ bool IntFlagExists(const char* flag_name, int32_t* value) {
   return true;
 }
 
-bool DoubleFlagExists(const char* flag_name, double* value) {
+static bool DoubleFlagExists(const char* flag_name, double* value) {
   STRING full_flag_name("FLAGS_");
   full_flag_name += flag_name;
   GenericVector<DoubleParam*> empty;
@@ -37,7 +37,7 @@ bool DoubleFlagExists(const char* flag_name, double* value) {
   return true;
 }
 
-bool BoolFlagExists(const char* flag_name, bool* value) {
+static bool BoolFlagExists(const char* flag_name, bool* value) {
   STRING full_flag_name("FLAGS_");
   full_flag_name += flag_name;
   GenericVector<BoolParam*> empty;
@@ -48,7 +48,7 @@ bool BoolFlagExists(const char* flag_name, bool* value) {
   return true;
 }
 
-bool StringFlagExists(const char* flag_name, const char** value) {
+static bool StringFlagExists(const char* flag_name, const char** value) {
   STRING full_flag_name("FLAGS_");
   full_flag_name += flag_name;
   GenericVector<StringParam*> empty;
@@ -58,7 +58,7 @@ bool StringFlagExists(const char* flag_name, const char** value) {
   return p != nullptr;
 }
 
-void SetIntFlagValue(const char* flag_name, const int32_t new_val) {
+static void SetIntFlagValue(const char* flag_name, const int32_t new_val) {
   STRING full_flag_name("FLAGS_");
   full_flag_name += flag_name;
   GenericVector<IntParam*> empty;
@@ -68,7 +68,7 @@ void SetIntFlagValue(const char* flag_name, const int32_t new_val) {
   p->set_value(new_val);
 }
 
-void SetDoubleFlagValue(const char* flag_name, const double new_val) {
+static void SetDoubleFlagValue(const char* flag_name, const double new_val) {
   STRING full_flag_name("FLAGS_");
   full_flag_name += flag_name;
   GenericVector<DoubleParam*> empty;
@@ -78,7 +78,7 @@ void SetDoubleFlagValue(const char* flag_name, const double new_val) {
   p->set_value(new_val);
 }
 
-void SetBoolFlagValue(const char* flag_name, const bool new_val) {
+static void SetBoolFlagValue(const char* flag_name, const bool new_val) {
   STRING full_flag_name("FLAGS_");
   full_flag_name += flag_name;
   GenericVector<BoolParam*> empty;
@@ -88,7 +88,7 @@ void SetBoolFlagValue(const char* flag_name, const bool new_val) {
   p->set_value(new_val);
 }
 
-void SetStringFlagValue(const char* flag_name, const char* new_val) {
+static void SetStringFlagValue(const char* flag_name, const char* new_val) {
   STRING full_flag_name("FLAGS_");
   full_flag_name += flag_name;
   GenericVector<StringParam*> empty;
@@ -98,19 +98,19 @@ void SetStringFlagValue(const char* flag_name, const char* new_val) {
   p->set_value(STRING(new_val));
 }
 
-bool SafeAtoi(const char* str, int* val) {
+static bool SafeAtoi(const char* str, int* val) {
   char* endptr = nullptr;
   *val = strtol(str, &endptr, 10);
   return endptr != nullptr && *endptr == '\0';
 }
 
-bool SafeAtod(const char* str, double* val) {
+static bool SafeAtod(const char* str, double* val) {
   char* endptr = nullptr;
   *val = strtod(str, &endptr);
   return endptr != nullptr && *endptr == '\0';
 }
 
-void PrintCommandLineFlags() {
+static void PrintCommandLineFlags() {
   const char* kFlagNamePrefix = "FLAGS_";
   const int kFlagNamePrefixLen = strlen(kFlagNamePrefix);
   for (int i = 0; i < GlobalParams()->int_params.size(); ++i) {

--- a/src/training/dawg2wordlist.cpp
+++ b/src/training/dawg2wordlist.cpp
@@ -25,8 +25,8 @@
 #include "trie.h"
 #include "unicharset.h"
 
-tesseract::Dawg *LoadSquishedDawg(const UNICHARSET &unicharset,
-                                  const char *filename) {
+static tesseract::Dawg *LoadSquishedDawg(const UNICHARSET &unicharset,
+                                         const char *filename) {
   const int kDictDebugLevel = 1;
   tesseract::TFile dawg_file;
   if (!dawg_file.Open(filename, nullptr)) {
@@ -54,9 +54,9 @@ class WordOutputter {
 };
 
 // returns 0 if successful.
-int WriteDawgAsWordlist(const UNICHARSET &unicharset,
-                        const tesseract::Dawg *dawg,
-                        const char *outfile_name) {
+static int WriteDawgAsWordlist(const UNICHARSET &unicharset,
+                               const tesseract::Dawg *dawg,
+                               const char *outfile_name) {
   FILE *out = fopen(outfile_name, "wb");
   if (out == nullptr) {
     tprintf("Could not open %s for writing.\n", outfile_name);

--- a/src/training/normstrngs.cpp
+++ b/src/training/normstrngs.cpp
@@ -35,7 +35,7 @@
 
 namespace tesseract {
 
-bool is_hyphen_punc(const char32 ch) {
+static bool is_hyphen_punc(const char32 ch) {
   static const int kNumHyphenPuncUnicodes = 13;
   static const char32 kHyphenPuncUnicodes[kNumHyphenPuncUnicodes] = {
       '-',    0x2010, 0x2011, 0x2012,
@@ -53,7 +53,7 @@ bool is_hyphen_punc(const char32 ch) {
   return false;
 }
 
-bool is_single_quote(const char32 ch) {
+static bool is_single_quote(const char32 ch) {
   static const int kNumSingleQuoteUnicodes = 8;
   static const char32 kSingleQuoteUnicodes[kNumSingleQuoteUnicodes] = {
       '\'', '`',
@@ -71,7 +71,7 @@ bool is_single_quote(const char32 ch) {
   return false;
 }
 
-bool is_double_quote(const char32 ch) {
+static bool is_double_quote(const char32 ch) {
   static const int kNumDoubleQuoteUnicodes = 8;
   static const char32 kDoubleQuoteUnicodes[kNumDoubleQuoteUnicodes] = {
       '"',

--- a/src/training/stringrenderer.cpp
+++ b/src/training/stringrenderer.cpp
@@ -68,7 +68,7 @@ static bool RandBool(const double prob, TRand* rand) {
 }
 
 /* static */
-Pix* CairoARGB32ToPixFormat(cairo_surface_t *surface) {
+static Pix* CairoARGB32ToPixFormat(cairo_surface_t *surface) {
   if (cairo_image_surface_get_format(surface) != CAIRO_FORMAT_ARGB32) {
     printf("Unexpected surface format %d\n",
            cairo_image_surface_get_format(surface));

--- a/src/training/text2image.cpp
+++ b/src/training/text2image.cpp
@@ -208,9 +208,9 @@ static std::string StringReplace(const std::string& in,
 // with "T", such that "AT" has spacing of -5, the entry/line for unichar "A"
 // in .fontinfo file will be:
 // A 0 -1 T -5 V -7
-void ExtractFontProperties(const std::string &utf8_text,
-                           StringRenderer *render,
-                           const std::string &output_base) {
+static void ExtractFontProperties(const std::string &utf8_text,
+                                  StringRenderer *render,
+                                  const std::string &output_base) {
   std::map<std::string, SpacingProperties> spacing_map;
   std::map<std::string, SpacingProperties>::iterator spacing_map_it0;
   std::map<std::string, SpacingProperties>::iterator spacing_map_it1;
@@ -308,9 +308,8 @@ void ExtractFontProperties(const std::string &utf8_text,
   File::WriteStringToFileOrDie(output_string, output_base + ".fontinfo");
 }
 
-bool MakeIndividualGlyphs(Pix* pix,
-                          const std::vector<BoxChar*>& vbox,
-                          const int input_tiff_page) {
+static bool MakeIndividualGlyphs(Pix* pix, const std::vector<BoxChar*>& vbox,
+                                 const int input_tiff_page) {
   // If checks fail, return false without exiting text2image
   if (!pix) {
     tprintf("ERROR: MakeIndividualGlyphs(): Input Pix* is nullptr\n");

--- a/src/training/validator.cpp
+++ b/src/training/validator.cpp
@@ -123,8 +123,8 @@ void Validator::MoveResultsToDest(GraphemeNormMode g_mode,
   }
 }
 
-bool CmpPairSecond(const std::pair<int, int>& p1,
-                   const std::pair<int, int>& p2) {
+static bool CmpPairSecond(const std::pair<int, int>& p1,
+                          const std::pair<int, int>& p2) {
   return p1.second < p2.second;
 }
 


### PR DESCRIPTION
Add missing include statements, add missing "static" qualifiers or
remove functions which are not used at all.

Signed-off-by: Stefan Weil <sw@weilnetz.de>