### PR TITLE
Fixed "Invalid F spec" error while building FullyConnected layer.

### DIFF
--- a/src/lstm/networkbuilder.cpp
+++ b/src/lstm/networkbuilder.cpp
@@ -426,7 +426,7 @@ Network* NetworkBuilder::ParseFullyConnected(const StaticShape& input_shape,
     tprintf("Invalid nonlinearity on F-spec!: %s\n", *str);
     return nullptr;
   }
-  int depth = strtol(*str + 1, str, 10);
+  int depth = strtol(*str + 2, str, 10);
   if (depth <= 0) {
     tprintf("Invalid F spec!:%s\n", *str);
     return nullptr;


### PR DESCRIPTION
`int depth = strtol(*str + 1, str, 10);`
`**str` holds the words in the VGSL specification, and `*str` holds a single word, lets say, `Fr64`. Now, the `strtol` function modifies `str` to point to the first character which a non-digit number, and assumes that ` *str+1 ` points to a number (of valid integer format) as a string (automatically skipping all the white spaces, and no other characters), where in reality, it seems to point to `r` in `Fr164`.This is a bad argument, which results in `strtol` returning 0.
` strtol (*str + 2, str, 10)` should be passed instead.

Kindly check issue #1748 for the full thread of discussion.