### PR TITLE
 Replace tprintf_internal by tprintf and clean tprintf code 

### DIFF
--- a/src/ccmain/thresholder.cpp
+++ b/src/ccmain/thresholder.cpp
@@ -21,6 +21,7 @@
 
 #include "thresholder.h"
 
+#include <cstdint>      // for uint32_t
 #include <cstring>
 
 #include "otsuthr.h"

--- a/src/ccstruct/rect.cpp
+++ b/src/ccstruct/rect.cpp
@@ -1,8 +1,7 @@
 /**********************************************************************
  * File:        rect.cpp  (Formerly box.c)
  * Description: Bounding box class definition.
- * Author:          Phil Cheatle
- * Created:         Wed Oct 16 15:18:45 BST 1991
+ * Author:      Phil Cheatle
  *
  * (C) Copyright 1991, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +16,8 @@
  *
  **********************************************************************/
 
-#include          "rect.h"
+#include "rect.h"
+#include "strngs.h"     // for STRING
 
 // Include automatically generated configuration file if running autoconf.
 #ifdef HAVE_CONFIG_H

--- a/src/ccutil/tprintf.cpp
+++ b/src/ccutil/tprintf.cpp
@@ -22,23 +22,20 @@
 #include "config_auto.h"
 #endif
 
-#include          <stdio.h>
-#include          <stdarg.h>
-#include          "ccutil.h"
-#include          "params.h"
-#include          "strngs.h"
-#include          "tprintf.h"
+#include <cstdio>
+#include <cstdarg>
+#include "ccutil.h"
+#include "params.h"
+#include "strngs.h"
+#include "tprintf.h"
 
 #define MAX_MSG_LEN     65536
 
-#define EXTERN
-// Since tprintf is protected by a mutex, these parameters can remain global.
-DLLSYM STRING_VAR(debug_file, "", "File to send tprintf output to");
+static STRING_VAR(debug_file, "", "File to send tprintf output to");
 
-DLLSYM void
-tprintf_internal(                       // Trace printf
-    const char *format, ...             // Message
-) {
+// Trace printf
+DLLSYM void tprintf(const char *format, ...)
+{
   tesseract::tprintfMutex.Lock();
   va_list args;                  // variable args
   static FILE *debugfp = nullptr;   // debug file

--- a/src/ccutil/tprintf.h
+++ b/src/ccutil/tprintf.h
@@ -17,20 +17,13 @@
  *
  **********************************************************************/
 
-#ifndef           TESSERACT_CCUTIL_TPRINTF_H
-#define           TESSERACT_CCUTIL_TPRINTF_H
+#ifndef TESSERACT_CCUTIL_TPRINTF_H
+#define TESSERACT_CCUTIL_TPRINTF_H
 
-#include "params.h"
-
-extern DLLSYM STRING_VAR_H(debug_file, "",
-                           "File to send tprintf output to");
-extern DLLSYM BOOL_VAR_H(debug_window_on, TRUE,
-                         "Send tprintf to window unless file set");
+#include "platform.h"   // for TESS_API
 
 // Main logging function.
-#define tprintf(...) tprintf_internal(__VA_ARGS__)
-
-extern TESS_API void tprintf_internal(  // Trace printf
-    const char *format, ...);           // Message
+extern TESS_API void tprintf(  // Trace printf
+    const char *format, ...);  // Message
 
 #endif  // define TESSERACT_CCUTIL_TPRINTF_H

--- a/src/training/tlog.h
+++ b/src/training/tlog.h
@@ -32,7 +32,7 @@ DECLARE_INT_PARAM_FLAG(tlog_level);
 // config file like other params.
 #define tlog(level, ...) {                        \
   if (FLAGS_tlog_level >= level) {                \
-    tprintf_internal(__VA_ARGS__);                \
+    tprintf(__VA_ARGS__);                         \
   }                                               \
 }
 


### PR DESCRIPTION
Commit 4d514d5a606f43b5fbbb163a7244f5e19d0f6e88 introduced tprintf_internal
with an additional argument "level" which was removed again in commit
7dc5296fe992c4a0bbfb9a0672363e7c12d32460.

So we can now restore the original state without tprintf_internal.

Remove also the declaration of debug_window_on (it does not exist since
commit 030aae98969d41cabb500560b3bac2262b91a344) and make the
configuration parameter debug_file local as it is only used by tprintf.

Signed-off-by: Stefan Weil <sw@weilnetz.de>