### PR TITLE
opencl: Fix crash and clean code a bit

### DIFF
--- a/src/opencl/opencl_device_selection.h
+++ b/src/opencl/opencl_device_selection.h
@@ -27,20 +27,22 @@
 #include <CL/cl.h>
 #endif
 
+struct TessDeviceScore;
+
 // device type
-typedef enum {
+enum ds_device_type {
   DS_DEVICE_NATIVE_CPU = 0,
   DS_DEVICE_OPENCL_DEVICE
-} ds_device_type;
+};
 
-typedef struct {
+struct ds_device {
   ds_device_type type;
   cl_device_id oclDeviceID;
   char* oclDeviceName;
   char* oclDriverVersion;
   // a pointer to the score data, the content/format is application defined.
-  void* score;
-} ds_device;
+  TessDeviceScore* score;
+};
 
 #endif  // USE_OPENCL
 #endif  // DEVICE_SELECTION_H

--- a/src/opencl/openclwrapper.h
+++ b/src/opencl/openclwrapper.h
@@ -169,20 +169,20 @@
 #define GROUPSIZE_HMORX 256
 #define GROUPSIZE_HMORY 1
 
-typedef struct _KernelEnv {
+struct KernelEnv {
   cl_context mpkContext;
   cl_command_queue mpkCmdQueue;
   cl_program mpkProgram;
   cl_kernel mpkKernel;
   char mckKernelName[150];
-} KernelEnv;
+};
 
-typedef struct _OpenCLEnv {
+struct OpenCLEnv {
   cl_platform_id mpOclPlatformID;
   cl_context mpOclContext;
   cl_device_id mpOclDevsID;
   cl_command_queue mpOclCmdQueue;
-} OpenCLEnv;
+};
 typedef int (*cl_kernel_function)(void** userdata, KernelEnv* kenv);
 
 #define CHECK_OPENCL(status, name)                                    \
@@ -190,7 +190,7 @@ typedef int (*cl_kernel_function)(void** userdata, KernelEnv* kenv);
     printf("OpenCL error code is %d at   when %s .\n", status, name); \
   }
 
-typedef struct _GPUEnv {
+struct GPUEnv {
   // share vb in all modules in hb library
   cl_platform_id mpPlatformID;
   cl_device_type mDevType;
@@ -210,8 +210,7 @@ typedef struct _GPUEnv {
                         // opencl wrapper
   int mnKhrFp64Flag;
   int mnAmdFp64Flag;
-
-} GPUEnv;
+};
 
 class OpenclDevice {
  public:


### PR DESCRIPTION
OpenclDevice::getDeviceSelection crashed when outdated information
was read from file and device.score was not set.

Change also the struct definitions from C to C++ and
eliminate some type casts.

Signed-off-by: Stefan Weil <sw@weilnetz.de>