### PR TITLE
 IntFeatureSpace: Remove unused DeSerialize method

### DIFF
--- a/src/classify/intfeaturespace.cpp
+++ b/src/classify/intfeaturespace.cpp
@@ -44,19 +44,6 @@ bool IntFeatureSpace::Serialize(FILE* fp) const {
   return true;
 }
 
-// DeSerializes the feature space definition from the given file.
-// If swap is true, the data is big/little-endian swapped.
-// Returns false on error.
-bool IntFeatureSpace::DeSerialize(bool swap, FILE* fp) {
-  if (fread(&x_buckets_, sizeof(x_buckets_), 1, fp) != 1)
-    return false;
-  if (fread(&y_buckets_, sizeof(y_buckets_), 1, fp) != 1)
-    return false;
-  if (fread(&theta_buckets_, sizeof(theta_buckets_), 1, fp) != 1)
-    return false;
-  return true;
-}
-
 // Returns an INT_FEATURE_STRUCT corresponding to the given index.
 // This is the inverse of the Index member.
 INT_FEATURE_STRUCT IntFeatureSpace::PositionFromIndex(int index) const {

--- a/src/classify/intfeaturespace.h
+++ b/src/classify/intfeaturespace.h
@@ -47,11 +47,6 @@ class IntFeatureSpace {
   // Returns false on error.
   bool Serialize(FILE* fp) const;
 
-  // DeSerializes the feature space definition from the given file.
-  // If swap is true, the data is big/little-endian swapped.
-  // Returns false on error.
-  bool DeSerialize(bool swap, FILE* fp);
-
   // Returns the total size of the feature space.
   int Size() const {
     return static_cast<int>(x_buckets_) * y_buckets_ * theta_buckets_;

--- a/src/training/commontraining.cpp
+++ b/src/training/commontraining.cpp
@@ -201,7 +201,7 @@ void WriteShapeTable(const STRING& file_prefix, const ShapeTable& shape_table) {
 }
 
 /**
- * Creates a MasterTraininer and loads the training data into it:
+ * Creates a MasterTrainer and loads the training data into it:
  * Initializes feature_defs and IntegerFX.
  * Loads the shape_table if shape_table != nullptr.
  * Loads initial unicharset from -U command-line option.
@@ -211,6 +211,7 @@ void WriteShapeTable(const STRING& file_prefix, const ShapeTable& shape_table) {
  *  - Loads samples from .tr files in remaining command-line args.
  *  - Deletes outliers and computes canonical samples.
  *  - If FLAGS_output_trainer is set, saves the trainer for future use.
+ *    TODO: Who uses that? There is currently no code which reads it.
  * Computes canonical and cloud features.
  * If shape_table is not nullptr, but failed to load, make a fake flat one,
  * as shape clustering was not run.


### PR DESCRIPTION
The Serialize method is used indirectly by MasterTrainer::Serialize,
but there is no corresponding MasterTrainer::DeSerialize.

Signed-off-by: Stefan Weil <sw@weilnetz.de>