### PR TITLE
Simplify API for serialization and add first users

### DIFF
--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -669,7 +669,7 @@ bool TessPDFRenderer::BeginDocumentHandler() {
   }
   fseek(fp, 0, SEEK_SET);
   const std::unique_ptr<char[]> buffer(new char[size]);
-  if (fread(buffer.get(), 1, size, fp) != static_cast<size_t>(size)) {
+  if (!tesseract::DeSerialize(fp, buffer.get(), size)) {
     fclose(fp);
     return false;
   }

--- a/src/api/renderer.cpp
+++ b/src/api/renderer.cpp
@@ -104,8 +104,7 @@ void TessResultRenderer::AppendString(const char* s) {
 }
 
 void TessResultRenderer::AppendData(const char* s, int len) {
-  int n = fwrite(s, 1, len, fout_);
-  if (n != len) happy_ = false;
+  if (!tesseract::Serialize(fout_, s, len)) happy_ = false;
 }
 
 bool TessResultRenderer::BeginDocumentHandler() {

--- a/src/ccutil/serialis.cpp
+++ b/src/ccutil/serialis.cpp
@@ -100,6 +100,99 @@ TFile::~TFile() {
     delete data_;
 }
 
+bool TFile::DeSerialize(char* buffer, size_t count) {
+  return FRead(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::DeSerialize(double* buffer, size_t count) {
+  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::DeSerialize(float* buffer, size_t count) {
+  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::DeSerialize(int8_t* buffer, size_t count) {
+  return FRead(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::DeSerialize(int16_t* buffer, size_t count) {
+  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::DeSerialize(int32_t* buffer, size_t count) {
+  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::DeSerialize(int64_t* buffer, size_t count) {
+  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::DeSerialize(uint8_t* buffer, size_t count) {
+  return FRead(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::DeSerialize(uint16_t* buffer, size_t count) {
+  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::DeSerialize(uint32_t* buffer, size_t count) {
+  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::DeSerialize(uint64_t* buffer, size_t count) {
+  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const char* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const double* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const float* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const int8_t* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const int16_t* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const int32_t* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const int64_t* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const uint8_t* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const uint16_t* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const uint32_t* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Serialize(const uint64_t* buffer, size_t count) {
+  return FWrite(buffer, sizeof(*buffer), count) == count;
+}
+
+bool TFile::Skip(size_t count) {
+  offset_ += count;
+  return true;
+}
+
 bool TFile::Open(const STRING& filename, FileReader reader) {
   if (!data_is_owned_) {
     data_ = new GenericVector<char>;

--- a/src/ccutil/serialis.cpp
+++ b/src/ccutil/serialis.cpp
@@ -24,6 +24,70 @@
 
 namespace tesseract {
 
+bool DeSerialize(FILE* fp, char* data, size_t n) {
+  return fread(data, sizeof(*data), n, fp) == n;
+}
+
+bool DeSerialize(FILE* fp, float* data, size_t n) {
+  return fread(data, sizeof(*data), n, fp) == n;
+}
+
+bool DeSerialize(FILE* fp, int8_t* data, size_t n) {
+  return fread(data, sizeof(*data), n, fp) == n;
+}
+
+bool DeSerialize(FILE* fp, int16_t* data, size_t n) {
+  return fread(data, sizeof(*data), n, fp) == n;
+}
+
+bool DeSerialize(FILE* fp, int32_t* data, size_t n) {
+  return fread(data, sizeof(*data), n, fp) == n;
+}
+
+bool DeSerialize(FILE* fp, uint8_t* data, size_t n) {
+  return fread(data, sizeof(*data), n, fp) == n;
+}
+
+bool DeSerialize(FILE* fp, uint16_t* data, size_t n) {
+  return fread(data, sizeof(*data), n, fp) == n;
+}
+
+bool DeSerialize(FILE* fp, uint32_t* data, size_t n) {
+  return fread(data, sizeof(*data), n, fp) == n;
+}
+
+bool Serialize(FILE* fp, const char* data, size_t n) {
+  return fwrite(data, sizeof(*data), n, fp) == n;
+}
+
+bool Serialize(FILE* fp, const float* data, size_t n) {
+  return fwrite(data, sizeof(*data), n, fp) == n;
+}
+
+bool Serialize(FILE* fp, const int8_t* data, size_t n) {
+  return fwrite(data, sizeof(*data), n, fp) == n;
+}
+
+bool Serialize(FILE* fp, const int16_t* data, size_t n) {
+  return fwrite(data, sizeof(*data), n, fp) == n;
+}
+
+bool Serialize(FILE* fp, const int32_t* data, size_t n) {
+  return fwrite(data, sizeof(*data), n, fp) == n;
+}
+
+bool Serialize(FILE* fp, const uint8_t* data, size_t n) {
+  return fwrite(data, sizeof(*data), n, fp) == n;
+}
+
+bool Serialize(FILE* fp, const uint16_t* data, size_t n) {
+  return fwrite(data, sizeof(*data), n, fp) == n;
+}
+
+bool Serialize(FILE* fp, const uint32_t* data, size_t n) {
+  return fwrite(data, sizeof(*data), n, fp) == n;
+}
+
 TFile::TFile()
     : offset_(0),
       data_(nullptr),
@@ -171,6 +235,5 @@ int TFile::FWrite(const void* buffer, size_t size, int count) {
     data_->push_back(buf[i]);
   return count;
 }
-
 
 }  // namespace tesseract.

--- a/src/ccutil/serialis.h
+++ b/src/ccutil/serialis.h
@@ -38,6 +38,12 @@ Replace <parm> with "<parm>".  <parm> may be an arbitrary number of tokens
 
 namespace tesseract {
 
+// Return number of elements of an array.
+template <typename T, size_t N>
+constexpr size_t countof(T const (&)[N]) noexcept {
+  return N;
+}
+
 // Function to read a GenericVector<char> from a whole file.
 // Returns false on failure.
 typedef bool (*FileReader)(const STRING& filename, GenericVector<char>* data);
@@ -45,6 +51,26 @@ typedef bool (*FileReader)(const STRING& filename, GenericVector<char>* data);
 // Returns false on failure.
 typedef bool (*FileWriter)(const GenericVector<char>& data,
                            const STRING& filename);
+
+// Deserialize data from file.
+bool DeSerialize(FILE* fp, char* data, size_t n = 1);
+bool DeSerialize(FILE* fp, float* data, size_t n = 1);
+bool DeSerialize(FILE* fp, int8_t* data, size_t n = 1);
+bool DeSerialize(FILE* fp, int16_t* data, size_t n = 1);
+bool DeSerialize(FILE* fp, int32_t* data, size_t n = 1);
+bool DeSerialize(FILE* fp, uint8_t* data, size_t n = 1);
+bool DeSerialize(FILE* fp, uint16_t* data, size_t n = 1);
+bool DeSerialize(FILE* fp, uint32_t* data, size_t n = 1);
+
+// Serialize data to file.
+bool Serialize(FILE* fp, const char* data, size_t n = 1);
+bool Serialize(FILE* fp, const float* data, size_t n = 1);
+bool Serialize(FILE* fp, const int8_t* data, size_t n = 1);
+bool Serialize(FILE* fp, const int16_t* data, size_t n = 1);
+bool Serialize(FILE* fp, const int32_t* data, size_t n = 1);
+bool Serialize(FILE* fp, const uint8_t* data, size_t n = 1);
+bool Serialize(FILE* fp, const uint16_t* data, size_t n = 1);
+bool Serialize(FILE* fp, const uint32_t* data, size_t n = 1);
 
 // Simple file class.
 // Allows for portable file input from memory and from foreign file systems.

--- a/src/ccutil/serialis.h
+++ b/src/ccutil/serialis.h
@@ -90,6 +90,35 @@ class TFile {
   // Sets the value of the swap flag, so that FReadEndian does the right thing.
   void set_swap(bool value) { swap_ = value; }
 
+  // Deserialize data.
+  bool DeSerialize(char* data, size_t count = 1);
+  bool DeSerialize(double* data, size_t count = 1);
+  bool DeSerialize(float* data, size_t count = 1);
+  bool DeSerialize(int8_t* data, size_t count = 1);
+  bool DeSerialize(int16_t* data, size_t count = 1);
+  bool DeSerialize(int32_t* data, size_t count = 1);
+  bool DeSerialize(int64_t* data, size_t count = 1);
+  bool DeSerialize(uint8_t* data, size_t count = 1);
+  bool DeSerialize(uint16_t* data, size_t count = 1);
+  bool DeSerialize(uint32_t* data, size_t count = 1);
+  bool DeSerialize(uint64_t* data, size_t count = 1);
+
+  // Serialize data.
+  bool Serialize(const char* data, size_t count = 1);
+  bool Serialize(const double* data, size_t count = 1);
+  bool Serialize(const float* data, size_t count = 1);
+  bool Serialize(const int8_t* data, size_t count = 1);
+  bool Serialize(const int16_t* data, size_t count = 1);
+  bool Serialize(const int32_t* data, size_t count = 1);
+  bool Serialize(const int64_t* data, size_t count = 1);
+  bool Serialize(const uint8_t* data, size_t count = 1);
+  bool Serialize(const uint16_t* data, size_t count = 1);
+  bool Serialize(const uint32_t* data, size_t count = 1);
+  bool Serialize(const uint64_t* data, size_t count = 1);
+
+  // Skip data.
+  bool Skip(size_t count);
+
   // Reads a line like fgets. Returns nullptr on EOF, otherwise buffer.
   // Reads at most buffer_size bytes, including '\0' terminator, even if
   // the line is longer. Does nothing if buffer_size <= 0.

--- a/src/classify/blobclass.cpp
+++ b/src/classify/blobclass.cpp
@@ -104,9 +104,8 @@ bool Classify::WriteTRFile(const STRING& filename) {
   STRING tr_filename = filename + ".tr";
   FILE* fp = fopen(tr_filename.string(), "wb");
   if (fp) {
-    const size_t len = tr_file_data_.length();
     result =
-        fwrite(&tr_file_data_[0], sizeof(tr_file_data_[0]), len, fp) == len;
+      tesseract::Serialize(fp, &tr_file_data_[0], tr_file_data_.length());
     fclose(fp);
   }
   tr_file_data_.truncate_at(0);

--- a/src/lstm/network.cpp
+++ b/src/lstm/network.cpp
@@ -150,17 +150,17 @@ bool Network::SetupNeedsBackprop(bool needs_backprop) {
 // Writes to the given file. Returns false in case of error.
 bool Network::Serialize(TFile* fp) const {
   int8_t data = NT_NONE;
-  if (fp->FWrite(&data, sizeof(data), 1) != 1) return false;
+  if (!fp->Serialize(&data)) return false;
   STRING type_name = kTypeNames[type_];
   if (!type_name.Serialize(fp)) return false;
   data = training_;
-  if (fp->FWrite(&data, sizeof(data), 1) != 1) return false;
+  if (!fp->Serialize(&data)) return false;
   data = needs_to_backprop_;
-  if (fp->FWrite(&data, sizeof(data), 1) != 1) return false;
-  if (fp->FWrite(&network_flags_, sizeof(network_flags_), 1) != 1) return false;
-  if (fp->FWrite(&ni_, sizeof(ni_), 1) != 1) return false;
-  if (fp->FWrite(&no_, sizeof(no_), 1) != 1) return false;
-  if (fp->FWrite(&num_weights_, sizeof(num_weights_), 1) != 1) return false;
+  if (!fp->Serialize(&data)) return false;
+  if (!fp->Serialize(&network_flags_)) return false;
+  if (!fp->Serialize(&ni_)) return false;
+  if (!fp->Serialize(&no_)) return false;
+  if (!fp->Serialize(&num_weights_)) return false;
   if (!name_.Serialize(fp)) return false;
   return true;
 }
@@ -168,8 +168,8 @@ bool Network::Serialize(TFile* fp) const {
 // Reads from the given file. Returns false in case of error.
 // Should be overridden by subclasses, but NOT called by their DeSerialize.
 bool Network::DeSerialize(TFile* fp) {
-  int8_t data = 0;
-  if (fp->FRead(&data, sizeof(data), 1) != 1) return false;
+  int8_t data;
+  if (!fp->DeSerialize(&data)) return false;
   if (data == NT_NONE) {
     STRING type_name;
     if (!type_name.DeSerialize(fp)) return false;
@@ -181,16 +181,14 @@ bool Network::DeSerialize(TFile* fp) {
     }
   }
   type_ = static_cast<NetworkType>(data);
-  if (fp->FRead(&data, sizeof(data), 1) != 1) return false;
+  if (!fp->DeSerialize(&data)) return false;
   training_ = data == TS_ENABLED ? TS_ENABLED : TS_DISABLED;
-  if (fp->FRead(&data, sizeof(data), 1) != 1) return false;
+  if (!fp->DeSerialize(&data)) return false;
   needs_to_backprop_ = data != 0;
-  if (fp->FReadEndian(&network_flags_, sizeof(network_flags_), 1) != 1)
-    return false;
-  if (fp->FReadEndian(&ni_, sizeof(ni_), 1) != 1) return false;
-  if (fp->FReadEndian(&no_, sizeof(no_), 1) != 1) return false;
-  if (fp->FReadEndian(&num_weights_, sizeof(num_weights_), 1) != 1)
-    return false;
+  if (!fp->DeSerialize(&network_flags_)) return false;
+  if (!fp->DeSerialize(&ni_)) return false;
+  if (!fp->DeSerialize(&no_)) return false;
+  if (!fp->DeSerialize(&num_weights_)) return false;
   if (!name_.DeSerialize(fp)) return false;
   return true;
 }

--- a/src/lstm/plumbing.cpp
+++ b/src/lstm/plumbing.cpp
@@ -181,10 +181,10 @@ float* Plumbing::LayerLearningRatePtr(const char* id) const {
 // Writes to the given file. Returns false in case of error.
 bool Plumbing::Serialize(TFile* fp) const {
   if (!Network::Serialize(fp)) return false;
-  int32_t size = stack_.size();
+  uint32_t size = stack_.size();
   // Can't use PointerVector::Serialize here as we need a special DeSerialize.
-  if (fp->FWrite(&size, sizeof(size), 1) != 1) return false;
-  for (int i = 0; i < size; ++i)
+  if (!fp->Serialize(&size)) return false;
+  for (uint32_t i = 0; i < size; ++i)
     if (!stack_[i]->Serialize(fp)) return false;
   if ((network_flags_ & NF_LAYER_SPECIFIC_LR) &&
       !learning_rates_.Serialize(fp)) {
@@ -197,9 +197,9 @@ bool Plumbing::Serialize(TFile* fp) const {
 bool Plumbing::DeSerialize(TFile* fp) {
   stack_.truncate(0);
   no_ = 0;  // We will be modifying this as we AddToStack.
-  int32_t size;
-  if (fp->FReadEndian(&size, sizeof(size), 1) != 1) return false;
-  for (int i = 0; i < size; ++i) {
+  uint32_t size;
+  if (!fp->DeSerialize(&size)) return false;
+  for (uint32_t i = 0; i < size; ++i) {
     Network* network = CreateFromFile(fp);
     if (network == nullptr) return false;
     AddToStack(network);

--- a/src/lstm/reconfig.cpp
+++ b/src/lstm/reconfig.cpp
@@ -49,16 +49,15 @@ int Reconfig::XScaleFactor() const {
 
 // Writes to the given file. Returns false in case of error.
 bool Reconfig::Serialize(TFile* fp) const {
-  if (!Network::Serialize(fp)) return false;
-  if (fp->FWrite(&x_scale_, sizeof(x_scale_), 1) != 1) return false;
-  if (fp->FWrite(&y_scale_, sizeof(y_scale_), 1) != 1) return false;
-  return true;
+  return Network::Serialize(fp) &&
+         fp->Serialize(&x_scale_) &&
+         fp->Serialize(&y_scale_);
 }
 
 // Reads from the given file. Returns false in case of error.
 bool Reconfig::DeSerialize(TFile* fp) {
-  if (fp->FReadEndian(&x_scale_, sizeof(x_scale_), 1) != 1) return false;
-  if (fp->FReadEndian(&y_scale_, sizeof(y_scale_), 1) != 1) return false;
+  if (!fp->DeSerialize(&x_scale_)) return false;
+  if (!fp->DeSerialize(&y_scale_)) return false;
   no_ = ni_ * x_scale_ * y_scale_;
   return true;
 }

--- a/src/lstm/static_shape.h
+++ b/src/lstm/static_shape.h
@@ -64,11 +64,11 @@ class StaticShape {
   bool DeSerialize(TFile *fp) {
     int32_t tmp = LT_NONE;
     bool result =
-      fp->FReadEndian(&batch_, sizeof(batch_), 1) == 1 &&
-      fp->FReadEndian(&height_, sizeof(height_), 1) == 1 &&
-      fp->FReadEndian(&width_, sizeof(width_), 1) == 1 &&
-      fp->FReadEndian(&depth_, sizeof(depth_), 1) == 1 &&
-      fp->FReadEndian(&tmp, sizeof(tmp), 1) == 1;
+      fp->DeSerialize(&batch_) &&
+      fp->DeSerialize(&height_) &&
+      fp->DeSerialize(&width_) &&
+      fp->DeSerialize(&depth_) &&
+      fp->DeSerialize(&tmp);
     loss_type_ = static_cast<LossType>(tmp);
     return result;
   }
@@ -76,11 +76,11 @@ class StaticShape {
   bool Serialize(TFile *fp) const {
     int32_t tmp = loss_type_;
     return
-      fp->FWrite(&batch_, sizeof(batch_), 1) == 1 &&
-      fp->FWrite(&height_, sizeof(height_), 1) == 1 &&
-      fp->FWrite(&width_, sizeof(width_), 1) == 1 &&
-      fp->FWrite(&depth_, sizeof(depth_), 1) == 1 &&
-      fp->FWrite(&tmp, sizeof(tmp), 1) == 1;
+      fp->Serialize(&batch_) &&
+      fp->Serialize(&height_) &&
+      fp->Serialize(&width_) &&
+      fp->Serialize(&depth_) &&
+      fp->Serialize(&tmp);
   }
 
  private:

--- a/src/lstm/weightmatrix.cpp
+++ b/src/lstm/weightmatrix.cpp
@@ -148,7 +148,7 @@ bool WeightMatrix::Serialize(bool training, TFile* fp) const {
   // format, without errs, so we can detect and read old format weight matrices.
   uint8_t mode =
       (int_mode_ ? kInt8Flag : 0) | (use_adam_ ? kAdamFlag : 0) | kDoubleFlag;
-  if (fp->FWrite(&mode, sizeof(mode), 1) != 1) return false;
+  if (!fp->Serialize(&mode)) return false;
   if (int_mode_) {
     if (!wi_.Serialize(fp)) return false;
     if (!scales_.Serialize(fp)) return false;
@@ -163,8 +163,8 @@ bool WeightMatrix::Serialize(bool training, TFile* fp) const {
 // Reads from the given file. Returns false in case of error.
 
 bool WeightMatrix::DeSerialize(bool training, TFile* fp) {
-  uint8_t mode = 0;
-  if (fp->FRead(&mode, sizeof(mode), 1) != 1) return false;
+  uint8_t mode;
+  if (!fp->DeSerialize(&mode)) return false;
   int_mode_ = (mode & kInt8Flag) != 0;
   use_adam_ = (mode & kAdamFlag) != 0;
   if ((mode & kDoubleFlag) == 0) return DeSerializeOld(training, fp);


### PR DESCRIPTION
The current code uses fread (+ byte swapping) / fwrite (without byte swapping) and FRead or FReadEndian/ FWrite for de-serialization and serialization. The resulting file is always written in host endianness, so reading on a host with different endianness requires byte swapping. All functions return the number of elements read or written which must be compared with the intended value.

The new code always uses Deserialize / Serialize methods which return true for success or false for failure, like it is already done with the existing Deserialize / Serialize methods for a lot of classes.

With the new API it will be very easy to switch to a fixed little endian file format as soon as it is used for all serialization code.