### PR TITLE
Revert "Change default width for images output by text2image"

### DIFF
--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -219,7 +219,7 @@ generate_font_image() {
 
     local common_args="--fontconfig_tmpdir=${FONT_CONFIG_CACHE}"
     common_args+=" --fonts_dir=${FONTS_DIR} --strip_unrenderable_words"
-    common_args+=" --leading=${LEADING} --xsize 2560"
+    common_args+=" --leading=${LEADING}"
     common_args+=" --char_spacing=${CHAR_SPACING} --exposure=${EXPOSURE}"
     common_args+=" --outputbase=${outbase} --max_pages=0"
 


### PR DESCRIPTION
This reverts commit fdc243b3638fa799cae3b921e2b137d6121425b1 because
it caused a regression reported in issue #1798.

Signed-off-by: Stefan Weil <sw@weilnetz.de>