### PR TITLE
Revert Makefile.am to beta.2

### DIFF
--- a/src/ccmain/Makefile.am
+++ b/src/ccmain/Makefile.am
@@ -25,6 +25,7 @@ endif
 
 pkginclude_HEADERS = \
     thresholder.h \
+    osdetect.h \
     ltrresultiterator.h \
     pageiterator.h \
     resultiterator.h
@@ -38,7 +39,6 @@ noinst_HEADERS = \
     output.h \
     paragraphs.h \
     paragraphs_internal.h \
-    osdetect.h \
     paramsd.h \
     pgedit.h \
     reject.h \


### PR DESCRIPTION
The 3rd party library [thesserocr](https://github.com/sirfz/tesserocr) needs `osdetect.h'.

Please see below:
 [Build with tesseract-4.0.0-beta-3 fails, missing include file osdetect.h, easy fix · Issue #129 · sirfz/tesserocr](https://github.com/sirfz/tesserocr/issues/129)

Related PR: [Remove more header files from public API · tesseract-ocr/tesseract@e87e896](https://github.com/tesseract-ocr/tesseract/commit/e87e8967d7708edea9c023fcfae1369a9958663b#diff-3e650bdcdc7591189f1b5eb1e328a821)