### PR TITLE
DISABLE some tests 

### DIFF
--- a/unittest/apiexample_test.cc
+++ b/unittest/apiexample_test.cc
@@ -1,6 +1,10 @@
 ///////////////////////////////////////////////////////////////////////
 // File:        apiexample_test.cc
 // Description: Api Test for Tesseract using text fixtures and parameters.
+// Tests for Devanagari, Latin and Arabic scripts are disabled by default.
+// Disabled tests can be run when required by using the --gtest_also_run_disabled_tests argument.
+//                 ./unittest/apiexample_test --gtest_also_run_disabled_tests
+//
 // Author:      ShreeDevi Kumar
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +40,7 @@ class QuickTest : public testing::Test {
   }
   virtual void TearDown() {
     const time_t end_time = time(nullptr);
-    EXPECT_TRUE(end_time - start_time_ <=25) << "The test took too long - " << ::testing::PrintToString(end_time - start_time_);
+    EXPECT_TRUE(end_time - start_time_ <=55) << "The test took too long - " << ::testing::PrintToString(end_time - start_time_);
   }
   time_t start_time_;
   };
@@ -84,11 +88,11 @@ class QuickTest : public testing::Test {
 
   INSTANTIATE_TEST_CASE_P( Eng, MatchGroundTruth,
                         ::testing::Values("eng") );
-  INSTANTIATE_TEST_CASE_P( Latin, MatchGroundTruth,
+  INSTANTIATE_TEST_CASE_P( DISABLED_Latin, MatchGroundTruth,
                         ::testing::Values("script/Latin") );
-  INSTANTIATE_TEST_CASE_P( Deva, MatchGroundTruth,
+  INSTANTIATE_TEST_CASE_P( DISABLED_Deva, MatchGroundTruth,
                         ::testing::Values("script/Devanagari") );
-  INSTANTIATE_TEST_CASE_P( Arab, MatchGroundTruth,
+  INSTANTIATE_TEST_CASE_P( DISABLED_Arabic, MatchGroundTruth,
                         ::testing::Values("script/Arabic") );
 
   class EuroText : public QuickTest {
@@ -101,7 +105,7 @@ class QuickTest : public testing::Test {
   }
 
   // script/Latin for eurotext.tif does not match groundtruth
-  // for tessdata & tessdata_best
+  // for tessdata & tessdata_best.
   // so do not test these here.
 
 }  // namespace

--- a/unittest/loadlang_test.cc
+++ b/unittest/loadlang_test.cc
@@ -1,6 +1,8 @@
 ///////////////////////////////////////////////////////////////////////
 // File:        loadlang_test.cc
 // Description: Test loading of All languages and Scripts for Tesseract.
+// Tests for All languages and scripts are Disabled by default.
+// Force the disabled test to run if required by using the --gtest_also_run_disabled_tests argument.
 // Author:      Shree Devi Kumar
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -169,11 +171,11 @@ class QuickTest : public testing::Test {
   TEST_P(LoadLanguage, yid) {LangLoader("yid" , GetParam());}
   TEST_P(LoadLanguage, yor) {LangLoader("yor" , GetParam());}
 
-  INSTANTIATE_TEST_CASE_P( Tessdata_fast, LoadLanguage,
+  INSTANTIATE_TEST_CASE_P( DISABLED_Tessdata_fast, LoadLanguage,
                         ::testing::Values(TESSDATA_DIR "_fast") );
-  INSTANTIATE_TEST_CASE_P( Tessdata_best, LoadLanguage,
+  INSTANTIATE_TEST_CASE_P( DISABLED_Tessdata_best, LoadLanguage,
                         ::testing::Values(TESSDATA_DIR "_best") );
-  INSTANTIATE_TEST_CASE_P( Tessdata, LoadLanguage,
+  INSTANTIATE_TEST_CASE_P( DISABLED_Tessdata, LoadLanguage,
                         ::testing::Values(TESSDATA_DIR) );
 
 // For all scripts
@@ -220,18 +222,22 @@ class QuickTest : public testing::Test {
   TEST_P(LoadScript, Tibetan) {LangLoader("script/Tibetan" , GetParam());}
   TEST_P(LoadScript, Vietnamese) {LangLoader("script/Vietnamese" , GetParam());}
 
-  INSTANTIATE_TEST_CASE_P( Tessdata_fast, LoadScript,
+  INSTANTIATE_TEST_CASE_P( DISABLED_Tessdata_fast, LoadScript,
                         ::testing::Values(TESSDATA_DIR "_fast") );
-  INSTANTIATE_TEST_CASE_P( Tessdata_best, LoadScript,
+  INSTANTIATE_TEST_CASE_P( DISABLED_Tessdata_best, LoadScript,
                         ::testing::Values(TESSDATA_DIR "_best") );
-  INSTANTIATE_TEST_CASE_P( Tessdata, LoadScript,
+  INSTANTIATE_TEST_CASE_P( DISABLED_Tessdata, LoadScript,
                         ::testing::Values(TESSDATA_DIR) );
-
-// Use class LoadLang for languages which are NOT there in all three repos
 
   class LoadLang : public QuickTest {
   };
 
+  // Test Load of English here, as the parameterized tests are disabled by default.
+  TEST_F(LoadLang, engFast) {LangLoader("eng" , TESSDATA_DIR "_fast");}
+  TEST_F(LoadLang, engBest) {LangLoader("eng" , TESSDATA_DIR "_best");}
+  TEST_F(LoadLang, engBestInt) {LangLoader("eng" , TESSDATA_DIR);}
+  
+// Use class LoadLang for languages which are NOT there in all three repos
   TEST_F(LoadLang, kmrFast) {LangLoader("kmr" , TESSDATA_DIR "_fast");}
   TEST_F(LoadLang, kmrBest) {LangLoader("kmr" , TESSDATA_DIR "_best");}
 //  TEST_F(LoadLang, kmrBestInt) {LangLoader("kmr" , TESSDATA_DIR);}


### PR DESCRIPTION
since they take long to run and/or need all three tessdata repositories.
They can be forced to run by --gtest_also_run_disabled_tests argument.