### PR TITLE
Fix typo in cppan.yml affecting /openmp

### DIFF
--- a/cppan.yml
+++ b/cppan.yml
@@ -25,7 +25,7 @@ common_settings:
 
     options:
         any:
-            compiler_options:
+            compile_options:
                 msvc:
                     private:
                         - /openmp


### PR DESCRIPTION
As far as I can tell the "official" cppan builds are fine, but when building from source, openmp wasn't working.