### PR TITLE
Remove duplicate include statements

### DIFF
--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -37,8 +37,6 @@ struct addrinfo {
 #include <pthread.h>
 #include <semaphore.h>
 #include <csignal>
-#include <cstdlib>
-#include <cstring>
 #include <sys/select.h>
 #include <sys/socket.h>
 #ifdef __linux__


### PR DESCRIPTION
One of them was reported in issue #1843.

Signed-off-by: Stefan Weil <sw@weilnetz.de>