### PR TITLE
Don't call exit when parameter in file is unknown

### DIFF
--- a/src/ccutil/params.cpp
+++ b/src/ccutil/params.cpp
@@ -79,8 +79,7 @@ bool ParamUtils::ReadParamsFromFp(SetParamConstraint constraint, TFile *fp,
 
       if (!foundit) {
         anyerr = true;         // had an error
-        tprintf("read_params_file: parameter not found: %s\n", line);
-        exit(1);
+        tprintf("Warning: Parameter not found: %s\n", line);
       }
     }
   }


### PR DESCRIPTION
Wrong or old parameters in traineddata files should not terminate
the program, so make that a warning instead of a fatal error.

This fixes issue #1520.

Signed-off-by: Stefan Weil <sw@weilnetz.de>