### PR TITLE
Allow orientation detection with any traineddata

### DIFF
--- a/src/api/tesseractmain.cpp
+++ b/src/api/tesseractmain.cpp
@@ -367,11 +367,15 @@ static void ParseArgs(const int argc, char** argv, const char** lang,
   *arg_i = i;
 
   if (*pagesegmode == tesseract::PSM_OSD_ONLY) {
-    // That mode requires osd.traineddata, no other language or script files.
+    // OSD = orientation and script detection.
     if (*lang != nullptr && strcmp(*lang, "osd")) {
-      fprintf(stderr, "Warning, ignoring -l %s for --psm 0\n", *lang);
+      // If the user explicitly specifies a language (other than osd)
+      // or a script, only orientation can be detected.
+      fprintf(stderr, "Warning, detects only orientation with -l %s\n", *lang);
+    } else {
+      // That mode requires osd.traineddata to detect orientation and script.
+      *lang = "osd";
     }
-    *lang = "osd";
   }
 
   if (*outputbase == nullptr && noocr == false) {


### PR DESCRIPTION
While orientation and script detection (OSD) normally requires
osd.traineddata to detect both, it must also be possible to do
only orientation detection with eng.traineddata or any other
traineddata.

Enforce osd.traineddata only if there was no `-l` command line option.

Commit 27ce472666a6332f38888cd6855e1162fb82c729 was too restrictive.

Signed-off-by: Stefan Weil <sw@weilnetz.de>