### PR TITLE
Don't set page segmentation mode for unlv config

### DIFF
--- a/tessdata/configs/unlv
+++ b/tessdata/configs/unlv
@@ -1,2 +1,1 @@
 tessedit_write_unlv 1
-tessedit_pageseg_mode 6


### PR DESCRIPTION
Setting the page segmentation mode to 6 ("Assume a single uniform block
of text") typically improves the layout detection for such texts, but
should not be done in the config file.

unlvtests/runtestset.sh adds `--psm 6` explicitly, so test results
won't change when using that script.

This is similar to commit ecfee53bac59e5467f8a8fb5026928a1d39b5c6d.

Signed-off-by: Stefan Weil <sw@weilnetz.de>