### PR TITLE
combine_tessdata, lstmtraining: Check for write failures

### DIFF
--- a/src/training/combine_tessdata.cpp
+++ b/src/training/combine_tessdata.cpp
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
   tesseract::TessdataManager tm;
   if (argc > 1 && (!strcmp(argv[1], "-v") || !strcmp(argv[1], "--version"))) {
     printf("%s\n", tesseract::TessBaseAPI::Version());
-    return 0;
+    return EXIT_SUCCESS;
   } else if (argc == 2) {
     printf("Combining tessdata files\n");
     STRING lang = argv[1];
@@ -92,16 +92,22 @@ int main(int argc, char **argv) {
     // Initialize TessdataManager with the data in the given traineddata file.
     if (!tm.Init(argv[2])) {
       tprintf("Failed to read %s\n", argv[2]);
-      exit(1);
+      return EXIT_FAILURE;
     }
     printf("Extracting tessdata components from %s\n", argv[2]);
     if (strcmp(argv[1], "-e") == 0) {
       for (i = 3; i < argc; ++i) {
+        errno = 0;
         if (tm.ExtractToFile(argv[i])) {
           printf("Wrote %s\n", argv[i]);
-        } else {
+        } else if (errno == 0) {
           printf("Not extracting %s, since this component"
                  " is not present\n", argv[i]);
+          return EXIT_FAILURE;
+        } else {
+          printf("Error, could not extract %s: %s\n",
+                 argv[i], strerror(errno));
+          return EXIT_FAILURE;
         }
       }
     } else {  // extract all the components
@@ -111,8 +117,13 @@ int main(int argc, char **argv) {
         if (*last != '.')
           filename += '.';
         filename += tesseract::kTessdataFileSuffixes[i];
+        errno = 0;
         if (tm.ExtractToFile(filename.string())) {
           printf("Wrote %s\n", filename.string());
+        } else if (errno != 0) {
+          printf("Error, could not extract %s: %s\n",
+                 filename.string(), strerror(errno));
+          return EXIT_FAILURE;
         }
       }
     }
@@ -124,7 +135,7 @@ int main(int argc, char **argv) {
     if (rename(new_traineddata_filename, traineddata_filename.string()) != 0) {
       tprintf("Failed to create a temporary file %s\n",
               traineddata_filename.string());
-      exit(1);
+      return EXIT_FAILURE;
     }
 
     // Initialize TessdataManager with the data in the given traineddata file.
@@ -135,17 +146,17 @@ int main(int argc, char **argv) {
   } else if (argc == 3 && strcmp(argv[1], "-c") == 0) {
     if (!tm.Init(argv[2])) {
       tprintf("Failed to read %s\n", argv[2]);
-      exit(1);
+      return EXIT_FAILURE;
     }
     tesseract::TFile fp;
     if (!tm.GetComponent(tesseract::TESSDATA_LSTM, &fp)) {
       tprintf("No LSTM Component found in %s!\n", argv[2]);
-      exit(1);
+      return EXIT_FAILURE;
     }
     tesseract::LSTMRecognizer recognizer;
     if (!recognizer.DeSerialize(&tm, &fp)) {
       tprintf("Failed to deserialize LSTM in %s!\n", argv[2]);
-      exit(1);
+      return EXIT_FAILURE;
     }
     recognizer.ConvertToInt();
     GenericVector<char> lstm_data;
@@ -155,7 +166,7 @@ int main(int argc, char **argv) {
                       lstm_data.size());
     if (!tm.SaveFile(argv[2], nullptr)) {
       tprintf("Failed to write modified traineddata:%s!\n", argv[2]);
-      exit(1);
+      return EXIT_FAILURE;
     }
   } else if (argc == 3 && strcmp(argv[1], "-d") == 0) {
     // Initialize TessdataManager with the data in the given traineddata file.
@@ -186,4 +197,5 @@ int main(int argc, char **argv) {
     return 1;
   }
   tm.Directory();
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This is done by creating a temporary file.
Report an error and terminate if that fails.

Use also EXIT_SUCCESS and EXIT_FAILURE for the return values of main().

Signed-off-by: Stefan Weil <sw@weilnetz.de>