### PR TITLE
Rework check for readable input file

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -1130,6 +1130,15 @@ bool TessBaseAPI::ProcessPagesInternal(const char* filename,
     buf.assign((std::istreambuf_iterator<char>(std::cin)),
                (std::istreambuf_iterator<char>()));
     data = reinterpret_cast<const l_uint8 *>(buf.data());
+  } else {
+    // Check whether the input file can be read.
+    if (FILE* file = fopen(filename, "rb")) {
+      fclose(file);
+    } else {
+      fprintf(stderr, "Error, cannot read input file %s: %s\n",
+              filename, strerror(errno));
+      return false;
+    }
   }
 
   // Here is our autodetection

--- a/src/api/tesseractmain.cpp
+++ b/src/api/tesseractmain.cpp
@@ -534,13 +534,6 @@ int main(int argc, char** argv) {
     return EXIT_SUCCESS;
   }
 
-  if (FILE* file = fopen(image, "r")) {
-    fclose(file);
-  } else {
-    fprintf(stderr, "Cannot open input file: %s\n", image);
-    return EXIT_FAILURE;
-  }
-
   FixPageSegMode(&api, pagesegmode);
 
   if (dpi) {


### PR DESCRIPTION
This reverts commit 1a096441d05a76e72145859cabb5413bf9464dfa and
implements an alternate check which allows input from stdin.

Signed-off-by: Stefan Weil <sw@weilnetz.de>