### PR TITLE
Avoid crash with --psm 0 and LSTM traineddata

### DIFF
--- a/src/classify/adaptmatch.cpp
+++ b/src/classify/adaptmatch.cpp
@@ -1541,6 +1541,10 @@ void Classify::DoAdaptiveMatch(TBLOB *Blob, ADAPT_RESULTS *Results) {
                            &bl_features);
   if (sample == nullptr) return;
 
+  // TODO: With LSTM, static_classifier_ is nullptr.
+  // Return to avoid crash in CharNormClassifier.
+  if (static_classifier_ == nullptr) return;
+
   if (AdaptedTemplates->NumPermClasses < matcher_permanent_classes_min ||
       tess_cn_matching) {
     CharNormClassifier(Blob, *sample, Results);


### PR DESCRIPTION
Orientation and script detect only worked with legacy models
and crashed with LSTM models.

Signed-off-by: Stefan Weil <sw@weilnetz.de>