### PR TITLE
Add missing cerrno includes - fixes #1986

### DIFF
--- a/src/training/combine_tessdata.cpp
+++ b/src/training/combine_tessdata.cpp
@@ -18,6 +18,7 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
+#include <cerrno>
 #include "commontraining.h"     // CheckSharedLibraryVersion
 #include "lstmrecognizer.h"
 #include "tessdatamanager.h"

--- a/src/training/lstmtraining.cpp
+++ b/src/training/lstmtraining.cpp
@@ -19,6 +19,7 @@
 #ifdef GOOGLE_TESSERACT
 #include "base/commandlineflags.h"
 #endif
+#include <cerrno>
 #include "commontraining.h"
 #include "lstmtester.h"
 #include "lstmtrainer.h"


### PR DESCRIPTION
This PR adds the missing header includes for recently added errno code in a couple of training modules.