### PR TITLE
Renamed GetGlyphConfidences() to GetChoices() and glyph_confidences t…

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -1560,8 +1560,8 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
 
     // Now, process the word...
     std::vector<std::vector<std::pair<const char*, float>>>* confidencemap = nullptr;
-    if (tesseract_->glyph_confidences) {
-      confidencemap = res_it->GetGlyphConfidences();
+    if (tesseract_->lstm_choice_mode) {
+      confidencemap = res_it->GetChoices();
     }
     hocr_str += "\n      <span class='ocrx_word'";
     AddIdTohOCR(&hocr_str, "word", page_id, wcnt);
@@ -1621,8 +1621,8 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
     } while (!res_it->Empty(RIL_BLOCK) && !res_it->IsAtBeginningOf(RIL_WORD));
     if (italic) hocr_str += "</em>";
     if (bold) hocr_str += "</strong>";
-    // If glyph confidence is required it is added here
-    if (tesseract_->glyph_confidences == 1 && confidencemap != nullptr) {
+    // If the lstm choice mode is required it is added here
+    if (tesseract_->lstm_choice_mode == 1 && confidencemap != nullptr) {
       for (size_t i = 0; i < confidencemap->size(); i++) {
         hocr_str += "\n       <span class='ocrx_cinfo'";
         AddIdTohOCR(&hocr_str, "timestep", page_id, wcnt, tcnt);
@@ -1630,7 +1630,7 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
         std::vector<std::pair<const char*, float>> timestep = (*confidencemap)[i];
         for (std::pair<const char*, float> conf : timestep) {
           hocr_str += "<span class='ocr_glyph'";
-          AddIdTohOCR(&hocr_str, "glyph", page_id, wcnt, gcnt);
+          AddIdTohOCR(&hocr_str, "choice", page_id, wcnt, gcnt);
           hocr_str.add_str_int(" title='x_confs ", int(conf.second * 100));
           hocr_str += "'";
           hocr_str += ">";
@@ -1641,18 +1641,18 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
         hocr_str += "</span>";
         tcnt++;
       }
-    } else if (tesseract_->glyph_confidences == 2 && confidencemap != nullptr) {
+    } else if (tesseract_->lstm_choice_mode == 2 && confidencemap != nullptr) {
       for (size_t i = 0; i < confidencemap->size(); i++) {
         std::vector<std::pair<const char*, float>> timestep = (*confidencemap)[i];
         if (timestep.size() > 0) {
           hocr_str += "\n       <span class='ocrx_cinfo'";
-          AddIdTohOCR(&hocr_str, "alternative_glyphs", page_id, wcnt, tcnt);
+          AddIdTohOCR(&hocr_str, "lstm_choices", page_id, wcnt, tcnt);
           hocr_str += " chosen='";
           hocr_str += timestep[0].first;
           hocr_str += "'>";
           for (size_t j = 1; j < timestep.size(); j++) {
             hocr_str += "<span class='ocr_glyph'";
-            AddIdTohOCR(&hocr_str, "glyph", page_id, wcnt, gcnt);
+            AddIdTohOCR(&hocr_str, "choice", page_id, wcnt, gcnt);
             hocr_str.add_str_int(" title='x_confs ", int(timestep[j].second * 100));
             hocr_str += "'";
             hocr_str += ">";

--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -239,7 +239,7 @@ void Tesseract::LSTMRecognizeWord(const BLOCK& block, ROW *row, WERD_RES *word,
   if (im_data == nullptr) return;
   lstm_recognizer_->RecognizeLine(*im_data, true, classify_debug_level > 0,
                                   kWorstDictCertainty / kCertaintyScale,
-                                  word_box, words, glyph_confidences);
+                                  word_box, words, lstm_choice_mode);
   delete im_data;
   SearchWords(words);
 }

--- a/src/ccmain/resultiterator.cpp
+++ b/src/ccmain/resultiterator.cpp
@@ -604,7 +604,7 @@ char* ResultIterator::GetUTF8Text(PageIteratorLevel level) const {
   return result;
 }
 
-std::vector<std::vector<std::pair<const char*, float>>>* ResultIterator::GetGlyphConfidences() const {
+std::vector<std::vector<std::pair<const char*, float>>>* ResultIterator::GetChoices() const {
   if (it_->word() != nullptr) {
     return &it_->word()->timesteps;
   } else {

--- a/src/ccmain/resultiterator.h
+++ b/src/ccmain/resultiterator.h
@@ -98,9 +98,9 @@ class TESS_API ResultIterator : public LTRResultIterator {
   virtual char* GetUTF8Text(PageIteratorLevel level) const;
 
   /**
-   * Returns the glyph confidences for every LSTM timestep for the current Word
+   * Returns the lstm choices for every LSTM timestep for the current Word
   */
-  virtual std::vector<std::vector<std::pair<const char*, float>>>* GetGlyphConfidences() const;
+  virtual std::vector<std::vector<std::pair<const char*, float>>>* GetChoices() const;
 
   /**
    * Return whether the current paragraph's dominant reading direction

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -514,12 +514,12 @@ Tesseract::Tesseract()
       STRING_MEMBER(page_separator, "\f",
                     "Page separator (default is form feed control character)",
                     this->params()),
-      INT_MEMBER(glyph_confidences, 0,
-                  "Allows to include glyph confidences in the hOCR output. "
-                  "Valid input values are 0, 1 and 2. 0 is the default value. "
-                  "With 1 the glyph confidences of all timesteps are included. "
-                  "With 2 the glyph confidences are accumulated per charakter.",
-                   this->params()),
+      INT_MEMBER(lstm_choice_mode, 0,
+          "Allows to include alternative symbols choices in the hOCR output. "
+          "Valid input values are 0, 1 and 2. 0 is the default value. "
+          "With 1 the alternative symbol choices per timestep are included. "
+          "With 2 the alternative symbol choices are accumulated per character.",
+          this->params()),
 
       backup_config_file_(nullptr),
       pix_binary_(nullptr),

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -1118,11 +1118,11 @@ class Tesseract : public Wordrec {
              "Preserve multiple interword spaces");
   STRING_VAR_H(page_separator, "\f",
                "Page separator (default is form feed control character)");
-  INT_VAR_H(glyph_confidences, 0,
-            "Allows to include glyph confidences in the hOCR output. "
+  INT_VAR_H(lstm_choice_mode, 0,
+            "Allows to include alternative symbols choices in the hOCR output. "
             "Valid input values are 0, 1 and 2. 0 is the default value. "
-            "With 1 the glyph confidences of all timesteps are included. "
-            "With 2 the glyph confidences are accumulated per charakter.");
+            "With 1 the alternative symbol choices per timestep are included. "
+            "With 2 the alternative symbol choices are accumulated per character.");
 
   //// ambigsrecog.cpp /////////////////////////////////////////////////////////
   FILE *init_recog_training(const STRING &fname);

--- a/src/ccstruct/pageres.h
+++ b/src/ccstruct/pageres.h
@@ -220,7 +220,7 @@ class WERD_RES : public ELIST_LINK {
   // Gaps between blobs in chopped_word. blob_gaps[i] is the gap between
   // blob i and blob i+1.
   GenericVector<int> blob_gaps;
-  // Stores the glyph confidences of every timestep of the lstm
+  // Stores the lstm choices of every timestep
   std::vector<std::vector<std::pair<const char*, float>>> timesteps;
   // Ratings matrix contains classifier choices for each classified combination
   // of blobs. The dimension is the same as the number of blobs in chopped_word

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -173,7 +173,7 @@ void LSTMRecognizer::RecognizeLine(const ImageData& image_data, bool invert,
                                    bool debug, double worst_dict_cert,
                                    const TBOX& line_box,
                                    PointerVector<WERD_RES>* words,
-                                   int glyph_confidences) {
+                                   int lstm_choice_mode) {
   NetworkIO outputs;
   float scale_factor;
   NetworkIO inputs;
@@ -185,10 +185,9 @@ void LSTMRecognizer::RecognizeLine(const ImageData& image_data, bool invert,
         new RecodeBeamSearch(recoder_, null_char_, SimpleTextOutput(), dict_);
   }
   search_->Decode(outputs, kDictRatio, kCertOffset, worst_dict_cert,
-                  &GetUnicharset(), glyph_confidences);
+                  &GetUnicharset(), lstm_choice_mode);
   search_->ExtractBestPathAsWords(line_box, scale_factor, debug,
-                                  &GetUnicharset(), words,
-                                  glyph_confidences);
+                                  &GetUnicharset(), words, lstm_choice_mode);
 }
 
 // Helper computes min and mean best results in the output.

--- a/src/lstm/lstmrecognizer.h
+++ b/src/lstm/lstmrecognizer.h
@@ -184,8 +184,7 @@ class LSTMRecognizer {
   // will be used in a dictionary word.
   void RecognizeLine(const ImageData& image_data, bool invert, bool debug,
                      double worst_dict_cert, const TBOX& line_box,
-                     PointerVector<WERD_RES>* words,
-                     int glyph_confidences = 0);
+                     PointerVector<WERD_RES>* words, int lstm_choice_mode = 0);
 
   // Helper computes min and mean best results in the output.
   void OutputStats(const NetworkIO& outputs,

--- a/src/lstm/recodebeam.h
+++ b/src/lstm/recodebeam.h
@@ -186,7 +186,7 @@ class RecodeBeamSearch {
   // If charset is not null, it enables detailed debugging of the beam search.
   void Decode(const NetworkIO& output, double dict_ratio, double cert_offset,
               double worst_dict_cert, const UNICHARSET* charset,
-              int glyph_confidence = 0);
+              int lstm_choice_mode = 0);
   void Decode(const GENERIC_2D_ARRAY<float>& output, double dict_ratio,
               double cert_offset, double worst_dict_cert,
               const UNICHARSET* charset);
@@ -206,7 +206,7 @@ class RecodeBeamSearch {
   void ExtractBestPathAsWords(const TBOX& line_box, float scale_factor,
                               bool debug, const UNICHARSET* unicharset,
                               PointerVector<WERD_RES>* words,
-                              int glyph_confidence = 0);
+                              int lstm_choice_mode = 0);
 
   // Generates debug output of the content of the beams after a Decode.
   void DebugBeams(const UNICHARSET& unicharset) const;
@@ -282,7 +282,7 @@ class RecodeBeamSearch {
       const GenericVector<const RecodeNode*>& best_nodes,
       GenericVector<int>* unichar_ids, GenericVector<float>* certs,
       GenericVector<float>* ratings, GenericVector<int>* xcoords,
-      std::deque<std::pair<int,int>>* best_glyphs = nullptr);
+      std::deque<std::pair<int,int>>* best_choices = nullptr);
 
   // Sets up a word with the ratings matrix and fake blobs with boxes in the
   // right places.
@@ -303,8 +303,8 @@ class RecodeBeamSearch {
                   double cert_offset, double worst_dict_cert,
                   const UNICHARSET* charset, bool debug = false);
 
-  //Saves the most certain glyphs for the current time-step
-  void SaveMostCertainGlyphs(const float* outputs, int num_outputs, const UNICHARSET* charset, int xCoord);
+  //Saves the most certain choices for the current time-step
+  void SaveMostCertainChoices(const float* outputs, int num_outputs, const UNICHARSET* charset, int xCoord);
 
   // Adds to the appropriate beams the legal (according to recoder)
   // continuations of context prev, which is from the given index to beams_,


### PR DESCRIPTION
…o lstm_choice_mode

Renamed the global attribute glyph_confidences to lstm_choice_mode and the method GetGlyphConfidences() to GetChoices(). All Variables and comments contained in related methods were renamed as well.

Signed-off-by: Noah Metzger <noah.metzger@bib.uni-mannheim.de>