### PR TITLE
Add configuration for LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,14 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - libpango1.0-dev
+    configure:
+      command:
+        - ./autogen.sh
+        - mkdir _lgtm_build_dir
+        - cd _lgtm_build_dir
+        - ../configure
+    index:
+      build_command:
+        - make training


### PR DESCRIPTION
LGTM runs "make" by default, so training files are not checked.
This should be fixed by this configuration file.

Signed-off-by: Stefan Weil <sw@weilnetz.de>