### PR TITLE
fix unbound variables errors

### DIFF
--- a/src/training/language-specific.sh
+++ b/src/training/language-specific.sh
@@ -868,6 +868,8 @@ VERTICAL_FONTS=( \
     "Baekmuk Batang Patched" \ # for kor
     )
 
+FLAGS_webtext_prefix=${FLAGS_webtext_prefix:-}
+
 # Set language-specific values for several global variables, including
 #   ${TEXT_CORPUS}
 #      holds the text corpus file for the language, used in phase F
@@ -1164,16 +1166,16 @@ set_lang_specific_parameters() {
 
     *) err_exit "Error: ${lang} is not a valid language code"
   esac
-  if [[ ${FLAGS_mean_count} -gt 0 ]]; then
+  if [[ ${FLAGS_mean_count:-} -gt 0 ]]; then
     TRAINING_DATA_ARGUMENTS+=" --mean_count=${FLAGS_mean_count}"
-  elif [[ ! -z ${MEAN_COUNT} ]]; then
+  elif [[ ! -z ${MEAN_COUNT:-} ]]; then
     TRAINING_DATA_ARGUMENTS+=" --mean_count=${MEAN_COUNT}"
   fi
   # Default to Latin fonts if none have been set
   test -z "$FONTS" && FONTS=( "${LATIN_FONTS[@]}" )
 
   # Default to 0 exposure if it hasn't been set
-  test -z "$EXPOSURES" && EXPOSURES=0
+  test -z "${EXPOSURES:-}" && EXPOSURES=0
   # Set right-to-left and normalization mode.
   case "${LANG_CODE}" in
     ara | div| fas | pus | snd | syr | uig | urd | kur_ara | heb | yid )

--- a/src/training/language-specific.sh
+++ b/src/training/language-specific.sh
@@ -1,4 +1,4 @@
-#
+#!/bin/bash
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -259,7 +259,7 @@ generate_font_image() {
     done
 
     run_command text2image ${common_args} --font="${font}" \
-        --text=${TRAINING_TEXT}  ${TEXT2IMAGE_EXTRA_ARGS}
+        --text=${TRAINING_TEXT}  ${TEXT2IMAGE_EXTRA_ARGS:-}
     check_file_readable ${outbase}.box ${outbase}.tif
 
     if ((EXTRACT_FONT_PROPERTIES)) &&


### PR DESCRIPTION
Since `set -u ` has been introduced in `tesstrain_utils.sh` several unbound variable errors have occured when using `tesstrain.sh`.
This PR assigns empty default values to several variables to avoid these errors.