### PR TITLE
Fix compiler warning

### DIFF
--- a/src/ccutil/tesscallback.h
+++ b/src/ccutil/tesscallback.h
@@ -28,7 +28,7 @@ struct TessCallbackUtils_ {
 
 class TessClosure {
  public:
-  virtual ~TessClosure() { }
+  virtual ~TessClosure();
   virtual void Run() = 0;
 };
 


### PR DESCRIPTION
Compiler warning on macOS:

    tesscallback.h:29:7: warning:
      'TessClosure' has no out-of-line virtual method definitions;
      its vtable will be emitted in every translation unit [-Wweak-vtables]

Signed-off-by: Stefan Weil <sw@weilnetz.de>