### PR TITLE
Add no-copy version of SetImage

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -631,6 +631,25 @@ void TessBaseAPI::SetImage(Pix* pix) {
 }
 
 /**
+ * Provide an image for Tesseract to recognize. Tesseract takes a clone of
+ * it, so it will persist until after Recognize. Returns true if successful
+ * or false if the input is not suitable.
+ */
+bool TessBaseAPI::SetImageNoCopy(Pix* pix) {
+  if (InternalSetImage()) {
+    if (pixGetSpp(pix) == 4 && pixGetInputFormat(pix) == IFF_PNG) {
+      tprintf("Pix with alpha channel passed to SetImageNoCopy. Use SetImage instead.\n");
+      return false;
+    }
+    if (!thresholder_->SetImageNoCopy(pix)) {
+      return false;
+    }
+    SetInputImage(thresholder_->GetPixRect());
+  }
+  return false;
+}
+
+/**
  * Restrict recognition to a sub-rectangle of the image. Call after SetImage.
  * Each SetRectangle clears the recogntion results so multiple rectangles
  * can be recognized with the same image.

--- a/src/api/baseapi.h
+++ b/src/api/baseapi.h
@@ -354,6 +354,13 @@ class TESS_API TessBaseAPI {
   void SetImage(Pix* pix);
 
   /**
+   * Provide an image for Tesseract to recognize. Tesseract takes a clone of
+   * it, so it will persist until after Recognize. Returns true if successful
+   * or false if the input is not suitable.
+   */
+  bool SetImageNoCopy(Pix* pix);
+
+  /**
    * Set the resolution of the source image in pixels per inch so font size
    * information can be calculated in results.  Call this after SetImage().
    */

--- a/src/api/capi.cpp
+++ b/src/api/capi.cpp
@@ -356,6 +356,14 @@ TESS_API void TESS_CALL TessBaseAPISetImage2(TessBaseAPI* handle, struct Pix* pi
     return handle->SetImage(pix);
 }
 
+TESS_API BOOL TESS_CALL TessBaseAPISetImageNoCopy(TessBaseAPI* handle, struct Pix* pix)
+{
+    if (handle->SetImageNoCopy(pix))
+        return TRUE;
+    else
+        return FALSE;
+}
+
 TESS_API void TESS_CALL TessBaseAPISetSourceResolution(TessBaseAPI* handle, int ppi)
 {
     handle->SetSourceResolution(ppi);

--- a/src/api/capi.h
+++ b/src/api/capi.h
@@ -221,6 +221,7 @@ TESS_API void  TESS_CALL TessBaseAPIClearAdaptiveClassifier(TessBaseAPI* handle)
 TESS_API void  TESS_CALL TessBaseAPISetImage(TessBaseAPI* handle, const unsigned char* imagedata, int width, int height,
                                              int bytes_per_pixel, int bytes_per_line);
 TESS_API void  TESS_CALL TessBaseAPISetImage2(TessBaseAPI* handle, struct Pix* pix);
+TESS_API BOOL  TESS_CALL TessBaseAPISetImageNoCopy(TessBaseAPI* handle, struct Pix* pix);
 
 TESS_API void TESS_CALL TessBaseAPISetSourceResolution(TessBaseAPI* handle, int ppi);
 

--- a/src/ccmain/thresholder.h
+++ b/src/ccmain/thresholder.h
@@ -114,6 +114,11 @@ class TESS_API ImageThresholder {
   /// finished with it.
   void SetImage(const Pix* pix);
 
+  /// SetImageNoCopy takes a clone of its input, so the source pix may be
+  /// pixDestroyed immediately after, but may not go away until after the
+  /// Thresholder has finished with it.
+  bool SetImageNoCopy(const Pix* pix);
+
   /// Threshold the source image as efficiently as possible to the output Pix.
   /// Creates a Pix and sets pix to point to the resulting pointer.
   /// Caller must use pixDestroy to free the created Pix.


### PR DESCRIPTION
This adds SetImageNoCopy on TessBaseAPI and ImageThresholder, which is suitable for cases where you have an image that's already in the right format and won't be using it for anything else.