### PR TITLE
Fix mktemp in tesstrain_utils.sh

### DIFF
--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -25,14 +25,7 @@ else
 
 UNAME=$(uname -s | tr 'A-Z' 'a-z')
 
-case $UNAME in
-  darwin | *freebsd | dragonfly | cygwin*)
-    MKTEMP_DT="mktemp -d -t"
-    ;;
-  * )
-    MKTEMP_DT="mktemp -d --tmpdir"
-    ;;
-esac
+MKTEMP_DT="mktemp -d -t"
 FONT_CONFIG_CACHE=$(${MKTEMP_DT} font_tmp.XXXXXXXXXX)
 
 if [[ ($UNAME == *darwin*) ]]; then

--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -24,18 +24,16 @@ else
  fi
 
 UNAME=$(uname -s | tr 'A-Z' 'a-z')
-LANG_CODE="ENG"
-TIMESTAMP=`date +%Y-%m-%d`
 
 case $UNAME in
   darwin | *freebsd | dragonfly | cygwin*)
-    MKTEMP_DT=$(mktemp -d -t)
+    MKTEMP_DT="mktemp -d -t"
     ;;
   * )
-    MKTEMP_DT=$(mktemp -d --tmpdir)
+    MKTEMP_DT="mktemp -d --tmpdir"
     ;;
 esac
-FONT_CONFIG_CACHE=(${MKTEMP_DT} font_tmp.XXXXXXXXXX)
+FONT_CONFIG_CACHE=$(${MKTEMP_DT} font_tmp.XXXXXXXXXX)
 
 if [[ ($UNAME == *darwin*) ]]; then
     FONTS_DIR="/Library/Fonts/"
@@ -209,7 +207,7 @@ parse_flags() {
 
     # Location where intermediate files will be created.
     TIMESTAMP=`date +%Y-%m-%d`
-    TMP_DIR=(${MKTEMP_DT} ${LANG_CODE}-${TIMESTAMP}.XXX )
+    TMP_DIR=$(${MKTEMP_DT} ${LANG_CODE}-${TIMESTAMP}.XXX)
     TRAINING_DIR=${TMP_DIR}
     # Location of log file for the whole run.
     LOG_FILE=${TRAINING_DIR}/tesstrain.log


### PR DESCRIPTION
The commit 10f2c45c00 unified the usage of mktemp, but with a
incorrect bash syntax and unnecessary definition of LANG_CODE
and TIMESTAMP. This patch fixes the above problems.