### PR TITLE
Fix wrong results from function streamtofloat

### DIFF
--- a/src/ccutil/scanutils.cpp
+++ b/src/ccutil/scanutils.cpp
@@ -143,11 +143,11 @@ static uintmax_t streamtoumax(FILE* s, int base) {
 }
 
 static double streamtofloat(FILE* s) {
-  int minus = 0;
-  int v = 0;
-  int d, c = 0;
-  int k = 1;
-  int w = 0;
+  bool minus = false;
+  uint64_t v = 0;
+  int d, c;
+  uint64_t k = 1;
+  uint64_t w = 0;
 
   for (c = fgetc(s); isascii(c) && isspace(c); c = fgetc(s));
 
@@ -166,8 +166,7 @@ static double streamtofloat(FILE* s) {
       k *= 10;
     }
   }
-  double f  = static_cast<double>(v)
-            + static_cast<double>(w) / static_cast<double>(k);
+  double f = v + static_cast<double>(w) / k;
   if (c == 'e' || c == 'E') {
     c = fgetc(s);
     int expsign = 1;


### PR DESCRIPTION
The local variable k should be 10 ^ (number of digits after comma),
but will overflow when there are more than 9 digits after the comma
because an int value cannot store 10000000000.

This results in wrong double values read from .tr files for example
(or in a runtime exception if Tesseract was compiled with -ftrapv).

Using uint64_t does not fix the general problem but allows more digits
which should be sufficient for the data read by Tesseract.

Signed-off-by: Stefan Weil <sw@weilnetz.de>