### PR TITLE
Remove unused include statements for tprintf.h

### DIFF
--- a/src/ccutil/errcode.cpp
+++ b/src/ccutil/errcode.cpp
@@ -2,7 +2,6 @@
  * File:        errcode.cpp  (Formerly error.c)
  * Description: Generic error handler function
  * Author:      Ray Smith
- * Created:     Tue May  1 16:28:39 BST 1990
  *
  * (C) Copyright 1989, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +20,6 @@
 #include <cstdlib>
 #include <cstdarg>
 #include <cstring>
-#include "tprintf.h"
 #include "errcode.h"
 
 const ERRCODE BADERRACTION = "Illegal error action";

--- a/src/ccutil/scanutils.cpp
+++ b/src/ccutil/scanutils.cpp
@@ -36,7 +36,6 @@
 #include <fcntl.h>
 
 #include "scanutils.h"
-#include "tprintf.h"
 
 enum Flags {
   FL_SPLAT  = 0x01,   // Drop the value, do not assign

--- a/src/ccutil/unicharset.cpp
+++ b/src/ccutil/unicharset.cpp
@@ -2,7 +2,6 @@
 // File:        unicharset.cpp
 // Description: Unicode character/ligature set class.
 // Author:      Thomas Kielbus
-// Created:     Wed Jun 28 17:05:01 PDT 2006
 //
 // (C) Copyright 2006, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +26,6 @@
 #include "params.h"
 #include "serialis.h"
 #include "tesscallback.h"
-#include "tprintf.h"
 #include "unichar.h"
 
 // TODO(rays) Move UNICHARSET to tesseract namespace.

--- a/src/cutil/bitvec.cpp
+++ b/src/cutil/bitvec.cpp
@@ -23,7 +23,6 @@
 #include <cstdio>
 
 #include "emalloc.h"
-#include "tprintf.h"
 
 /*-----------------------------------------------------------------------------
               Public Code

--- a/src/cutil/callcpp.cpp
+++ b/src/cutil/callcpp.cpp
@@ -2,7 +2,6 @@
  * File:        callcpp.cpp
  * Description: extern C interface calling C++ from C.
  * Author:      Ray Smith
- * Created:     Sun Feb 04 20:39:23 MST 1996
  *
  * (C) Copyright 1996, Hewlett-Packard Co.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +39,7 @@ const char *format, ...          //special message
   vsprintf(msg, format, args);  //Format into msg
   va_end(args);
 
-  tprintf ("%s", msg);
+  tprintf("%s", msg);
 }
 
 

--- a/src/dict/context.cpp
+++ b/src/dict/context.cpp
@@ -4,11 +4,6 @@
  * File:         context.cpp  (Formerly context.c)
  * Description:  Context checking functions
  * Author:       Mark Seaman, OCR Technology
- * Created:      Thu Feb 15 11:18:24 1990
- * Modified:     Tue Jul  9 17:38:16 1991 (Mark Seaman) marks@hpgrlt
- * Language:     C
- * Package:      N/A
- * Status:       Experimental (Do Not Distribute)
  *
  * (c) Copyright 1990, Hewlett-Packard Company.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +19,6 @@
  *********************************************************************************/
 
 #include "dict.h"
-#include "tprintf.h"
 #include "unicharset.h"
 
 namespace tesseract {

--- a/src/lstm/functions.h
+++ b/src/lstm/functions.h
@@ -2,7 +2,6 @@
 // File:        functions.h
 // Description: Collection of function-objects used by the network layers.
 // Author:      Ray Smith
-// Created:     Fri Jun 20 10:45:37 PST 2014
 //
 // (C) Copyright 2014, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +20,6 @@
 
 #include <cmath>
 #include "helpers.h"
-#include "tprintf.h"
 
 // Setting this to 1 or more causes massive dumps of debug data: weights,
 // updates, internal calculations etc, and reduces the number of test iterations

--- a/src/lstm/maxpool.cpp
+++ b/src/lstm/maxpool.cpp
@@ -2,7 +2,6 @@
 // File:        maxpool.cpp
 // Description: Standard Max-Pooling layer.
 // Author:      Ray Smith
-// Created:     Tue Mar 18 16:28:18 PST 2014
 //
 // (C) Copyright 2014, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +16,6 @@
 ///////////////////////////////////////////////////////////////////////
 
 #include "maxpool.h"
-#include "tprintf.h"
 
 namespace tesseract {
 

--- a/src/lstm/networkscratch.h
+++ b/src/lstm/networkscratch.h
@@ -3,7 +3,6 @@
 // Description: Scratch space for Network layers that hides distinction
 //              between float/int implementations.
 // Author:      Ray Smith
-// Created:     Thu Jun 19 10:50:29 PST 2014
 //
 // (C) Copyright 2014, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +23,6 @@
 #include "matrix.h"
 #include "networkio.h"
 #include "svutil.h"
-#include "tprintf.h"
 
 namespace tesseract {
 

--- a/src/lstm/reconfig.cpp
+++ b/src/lstm/reconfig.cpp
@@ -3,7 +3,6 @@
 // Description: Network layer that reconfigures the scaling vs feature
 //              depth.
 // Author:      Ray Smith
-// Created:     Wed Feb 26 15:42:25 PST 2014
 //
 // (C) Copyright 2014, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////
+
 #include "reconfig.h"
-#include "tprintf.h"
 
 namespace tesseract {
 

--- a/src/lstm/stridemap.h
+++ b/src/lstm/stridemap.h
@@ -2,7 +2,6 @@
 // File:        stridemap.h
 // Description: Indexing into a 4-d tensor held in a 2-d Array.
 // Author:      Ray Smith
-// Created:     Fri Sep 20 16:00:31 PST 2016
 //
 // (C) Copyright 2016, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +19,6 @@
 
 #include <cstring>
 #include <vector>
-#include "tprintf.h"
 
 namespace tesseract {
 

--- a/src/training/commandlineflags.cpp
+++ b/src/training/commandlineflags.cpp
@@ -11,6 +11,7 @@
 #include "baseapi.h"            // TessBaseAPI::Version
 #include "commandlineflags.h"
 #include "errcode.h"
+#include "tprintf.h"            // for tprintf
 
 #ifndef GOOGLE_TESSERACT
 

--- a/src/training/commandlineflags.h
+++ b/src/training/commandlineflags.h
@@ -2,7 +2,6 @@
  * File:        commandlineflags.h
  * Description: Header file for commandline flag parsing.
  * Author:      Ranjith Unnikrishnan
- * Created:     July 2013
  *
  * (C) Copyright 2013, Google Inc.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +21,6 @@
 #ifndef GOOGLE_TESSERACT
 
 #include <cstdlib>
-#include "tprintf.h"
 #include "params.h"
 
 #define INT_PARAM_FLAG(name, val, comment)      \

--- a/unittest/matrix_test.cc
+++ b/unittest/matrix_test.cc
@@ -17,7 +17,6 @@
 #include "matrix.h"
 #include "genericvector.h"
 #include "include_gunit.h"
-#include "tprintf.h"
 
 namespace {
 


### PR DESCRIPTION
Format also a call of tprintf and add a missing explicit include statement.

Signed-off-by: Stefan Weil <sw@weilnetz.de>