### PR TITLE
fix(configure) Don't add rt on Android

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,9 @@ case "${host_os}" in
         OPENCL_INC=""
         AM_CONDITIONAL([ADD_RT], false)
         ;;
+    *android*)
+        AM_CONDITIONAL([ADD_RT], false)
+        ;;
     powerpc-*-darwin*)
         OPENCL_LIBS=""
         ;;


### PR DESCRIPTION
Library rt is included in the libc on Android: https://developer.android.com/ndk/guides/stable_apis#a3