### PR TITLE
Use -ffast-math for calculation of dot product

### DIFF
--- a/src/arch/Makefile.am
+++ b/src/arch/Makefile.am
@@ -18,13 +18,13 @@ noinst_LTLIBRARIES = libtesseract_avx.la libtesseract_avx2.la libtesseract_sse.l
 noinst_LTLIBRARIES += libtesseract_arch.la
 
 if AVX_OPT
-libtesseract_avx_la_CXXFLAGS = -mavx
+libtesseract_avx_la_CXXFLAGS = -ffast-math -mavx
 endif
 if AVX2_OPT
-libtesseract_avx2_la_CXXFLAGS = -mavx2
+libtesseract_avx2_la_CXXFLAGS = -ffast-math -mavx2
 endif
 if SSE41_OPT
-libtesseract_sse_la_CXXFLAGS = -msse4.1
+libtesseract_sse_la_CXXFLAGS = -ffast-math -msse4.1
 endif
 
 libtesseract_arch_la_SOURCES = intsimdmatrix.cpp simddetect.cpp


### PR DESCRIPTION
This reduces the code size for intsimdmatrixavx2 from 2700 to 2668
and slightly improves the performance for fast models with AVX2.

Signed-off-by: Stefan Weil <sw@weilnetz.de>