### PR TITLE
Don't try to create text output if other renderers failed (fix regres…

### DIFF
--- a/src/api/tesseractmain.cpp
+++ b/src/api/tesseractmain.cpp
@@ -402,6 +402,7 @@ static void PreloadRenderers(
     renderers->push_back(new tesseract::TessOsdRenderer(outputbase));
 #endif  // ndef DISABLED_LEGACY_ENGINE
   } else {
+    bool error = false;
     bool b;
     api->GetBoolVariable("tessedit_create_hocr", &b);
     if (b) {
@@ -415,20 +416,22 @@ static void PreloadRenderers(
         delete renderer;
         tprintf("Error, could not create hOCR output file: %s\n",
                 strerror(errno));
+        error = true;
       }
     }
 
     api->GetBoolVariable("tessedit_create_alto", &b);
     if (b) {
-        tesseract::TessAltoRenderer* renderer =
-                new tesseract::TessAltoRenderer(outputbase);
-        if (renderer->happy()) {
-            renderers->push_back(renderer);
-        } else {
-            delete renderer;
-            tprintf("Error, could not create ALTO output file: %s\n",
-                    strerror(errno));
-        }
+      tesseract::TessAltoRenderer* renderer =
+              new tesseract::TessAltoRenderer(outputbase);
+      if (renderer->happy()) {
+        renderers->push_back(renderer);
+      } else {
+        delete renderer;
+        tprintf("Error, could not create ALTO output file: %s\n",
+                strerror(errno));
+        error = true;
+      }
     }
 
     api->GetBoolVariable("tessedit_create_tsv", &b);
@@ -443,6 +446,7 @@ static void PreloadRenderers(
         delete renderer;
         tprintf("Error, could not create TSV output file: %s\n",
                 strerror(errno));
+        error = true;
       }
     }
 
@@ -463,6 +467,7 @@ static void PreloadRenderers(
         delete renderer;
         tprintf("Error, could not create PDF output file: %s\n",
                 strerror(errno));
+        error = true;
       }
     }
 
@@ -477,6 +482,7 @@ static void PreloadRenderers(
         delete renderer;
         tprintf("Error, could not create UNLV output file: %s\n",
                 strerror(errno));
+        error = true;
       }
     }
 
@@ -490,11 +496,12 @@ static void PreloadRenderers(
         delete renderer;
         tprintf("Error, could not create BOX output file: %s\n",
                 strerror(errno));
+        error = true;
       }
     }
 
     api->GetBoolVariable("tessedit_create_txt", &b);
-    if (b || renderers->empty()) {
+    if (b || !error && renderers->empty()) {
       tesseract::TessTextRenderer* renderer =
         new tesseract::TessTextRenderer(outputbase);
       if (renderer->happy()) {


### PR DESCRIPTION
…sion)

Commit 49d7df6dc3efc61861c783021e06567d3d4780f0 added error handling,
but since that commit Tesseract used the text fallback if the user
selected output failed.

Signed-off-by: Stefan Weil <sw@weilnetz.de>