### PR TITLE
Fix and simplify SIMD tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,9 @@ if (WIN32)
             set_source_files_properties(
                 ${CMAKE_CURRENT_SOURCE_DIR}/src/arch/intsimdmatrixavx2.cpp
                 PROPERTIES COMPILE_FLAGS "/arch:AVX2")
+            set_source_files_properties(
+                ${CMAKE_CURRENT_SOURCE_DIR}/src/arch/simdetect.cpp
+                PROPERTIES COMPILE_FLAGS "/DAVX /DAVX2 /DSSE4_1")
         endif()  # NOT CLANG
     endif()  # MSVC
 else()
@@ -261,6 +264,9 @@ else()
     set_source_files_properties(
             ${CMAKE_CURRENT_SOURCE_DIR}/src/arch/intsimdmatrixavx2.cpp
             PROPERTIES COMPILE_FLAGS "-mavx2")
+    set_source_files_properties(
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/arch/simdetect.cpp
+            PROPERTIES COMPILE_FLAGS "-DAVX -DAVX2 -DSSE4_1")
 endif()
 
 add_library                     (libtesseract ${LIBRARY_TYPE} ${tesseract_src} ${tesseract_hdr}

--- a/src/arch/Makefile.am
+++ b/src/arch/Makefile.am
@@ -19,13 +19,17 @@ noinst_LTLIBRARIES += libtesseract_avx.la libtesseract_avx2.la
 noinst_LTLIBRARIES += libtesseract_sse.la
 noinst_LTLIBRARIES += libtesseract_arch.la
 
+libtesseract_arch_la_CPPFLAGS = $(AM_CPPFLAGS)
 if AVX_OPT
+libtesseract_arch_la_CPPFLAGS += -DAVX
 libtesseract_avx_la_CXXFLAGS = -ffast-math -mavx
 endif
 if AVX2_OPT
+libtesseract_arch_la_CPPFLAGS += -DAVX2
 libtesseract_avx2_la_CXXFLAGS = -ffast-math -mavx2
 endif
 if SSE41_OPT
+libtesseract_arch_la_CPPFLAGS += -DSSE4_1
 libtesseract_sse_la_CXXFLAGS = -ffast-math -msse4.1
 endif
 

--- a/src/arch/dotproductavx.cpp
+++ b/src/arch/dotproductavx.cpp
@@ -16,21 +16,7 @@
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////
 
-#if !defined(__AVX__)
-// Implementation for non-avx archs.
-
-#include "dotproductavx.h"
-#include <cstdio>
-#include <cstdlib>
-
-namespace tesseract {
-double DotProductAVX(const double* u, const double* v, int n) {
-  fprintf(stderr, "DotProductAVX can't be used on Android\n");
-  abort();
-}
-}  // namespace tesseract
-
-#else  // !defined(__AVX__)
+#if defined(__AVX__)
 // Implementation for avx capable archs.
 #include <immintrin.h>
 #include <cstdint>
@@ -111,4 +97,4 @@ double DotProductAVX(const double* u, const double* v, int n) {
 
 }  // namespace tesseract.
 
-#endif  // ANDROID_BUILD
+#endif  // __AVX__

--- a/src/arch/dotproductsse.cpp
+++ b/src/arch/dotproductsse.cpp
@@ -16,26 +16,7 @@
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////
 
-#if !defined(__SSE4_1__)
-// This code can't compile with "-msse4.1", so use dummy stubs.
-
-#include "dotproductsse.h"
-#include <cstdio>
-#include <cstdlib>
-
-namespace tesseract {
-double DotProductSSE(const double* u, const double* v, int n) {
-  fprintf(stderr, "DotProductSSE can't be used on Android\n");
-  abort();
-}
-int32_t IntDotProductSSE(const int8_t* u, const int8_t* v, int n) {
-  fprintf(stderr, "IntDotProductSSE can't be used on Android\n");
-  abort();
-}
-}  // namespace tesseract
-
-#else  // !defined(__SSE4_1__)
-// Non-Android code here
+#if defined(__SSE4_1__)
 
 #include <emmintrin.h>
 #include <smmintrin.h>
@@ -137,4 +118,4 @@ int32_t IntDotProductSSE(const int8_t* u, const int8_t* v, int n) {
 
 }  // namespace tesseract.
 
-#endif  // ANDROID_BUILD
+#endif  // __SSE4_1__


### PR DESCRIPTION
The tests for SSE and AVX must only be done if the correct compiler
flags were used.

Signed-off-by: Stefan Weil <sw@weilnetz.de>