### PR TITLE
Avoid linking pthread on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,9 @@ endif()
 if (UNIX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
 
-    set(LIB_pthread pthread)
+    if (NOT ANDROID)
+        set(LIB_pthread pthread)
+    endif()
 endif()
 
 ###############################################################################


### PR DESCRIPTION
I tried building this on android-ndk-r18b and platform android-28 and got an error in the linking step.

Abbreviated:

```
... && :
/android-sdk/ndk-bundle/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9.x/../../../../arm-linux-androideabi/bin/ld: error: cannot find -lpthread
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
The command '/bin/sh -c ninja -j6' returned a non-zero code: 1
make: *** [tesseract-armv7-a/4.0.0] Error 1
```

Since pthreads is part of Bionic on Android, it has to be left out explicitly.