### PR TITLE
Fix headers

### DIFF
--- a/src/classify/protos.cpp
+++ b/src/classify/protos.cpp
@@ -26,6 +26,7 @@
 #include "globals.h"
 #include "classify.h"
 #include "params.h"
+#include "intproto.h"
 
 #include <cstdio>
 #include <cmath>

--- a/src/training/commontraining.h
+++ b/src/training/commontraining.h
@@ -16,8 +16,9 @@
 
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
-#include "baseapi.h"
 #endif
+
+#include "baseapi.h"
 
 #ifdef DISABLED_LEGACY_ENGINE
 


### PR DESCRIPTION
A couple of places where headers should have been included.

I found these while updating my simplemakev4 branch to build tesseract with make.

protos.cpp needs intproto.h for MAX_NUM_PROTOS.
commontraining.h needs to always use baseapi.h, as otherwise most training binaries won't build, and it doesn't rely on the HAVE_CONFIG_H it's ifdef-ed around.