### PR TITLE
Updates File::DeleteMatchingFiles

### DIFF
--- a/src/ccutil/fileio.h
+++ b/src/ccutil/fileio.h
@@ -48,7 +48,7 @@ class File {
   static std::string JoinPath(const std::string& prefix, const std::string& suffix);
   // Delete a filename or all filenames matching a glob pattern.
   static bool Delete(const char* pathname);
-  static bool DeleteMatchingFiles(const char* pattern);
+  static bool DeleteMatchingFiles(const char *directory, const char* pattern);
 };
 
 // A class to manipulate Files for reading.

--- a/src/training/pango_font_info.cpp
+++ b/src/training/pango_font_info.cpp
@@ -123,8 +123,7 @@ void PangoFontInfo::SoftInitFontConfig() {
 void PangoFontInfo::HardInitFontConfig(const std::string& fonts_dir,
                                        const std::string& cache_dir) {
   if (!cache_dir_.empty()) {
-    File::DeleteMatchingFiles(
-        File::JoinPath(cache_dir_.c_str(), "*cache-?").c_str());
+    File::DeleteMatchingFiles(cache_dir_.c_str(), "*cache-?");
   }
   const int MAX_FONTCONF_FILESIZE = 1024;
   char fonts_conf_template[MAX_FONTCONF_FILESIZE];


### PR DESCRIPTION
This adds and ANDROID specific version of DeleteMatchingFiles, without
the use of glob.h, in order to be backwards compatible with Android 6.0.

cc @theraysmith @zdenop 