### PR TITLE
OpenCL: Remove unused code

### DIFF
--- a/src/opencl/oclkernels.h
+++ b/src/opencl/oclkernels.h
@@ -60,22 +60,6 @@ KERNEL(
 )
 
 KERNEL(
-\n__kernel void pixSubtract(__global int *dword, __global int *sword,
-                            const int wpl, const int h, __global int *outword)
-{
-    const unsigned int row = get_global_id(1);
-    const unsigned int col = get_global_id(0);
-    const unsigned int pos = row * wpl + col;
-
-    //Ignore the execss
-    if (row >= h || col >= wpl)
-        return;
-
-    *(outword + pos) = *(dword + pos) & ~(*(sword + pos));
-}\n
-)
-
-KERNEL(
 \n__kernel void morphoDilateHor_5x5(__global int *sword,__global int *dword,
                             const int wpl, const int h)
 {

--- a/src/opencl/openclwrapper.cpp
+++ b/src/opencl/openclwrapper.cpp
@@ -1510,7 +1510,7 @@ static cl_int pixCloseCL(l_int32 hsize, l_int32 vsize, l_int32 wpl, l_int32 h) {
 
 // output = buffer1 & ~(buffer2)
 static cl_int pixSubtractCL_work(l_uint32 wpl, l_uint32 h, cl_mem buffer1,
-                                 cl_mem buffer2, cl_mem outBuffer = nullptr) {
+                                 cl_mem buffer2) {
   cl_int status;
   size_t globalThreads[2];
   int gsize;
@@ -1521,23 +1521,15 @@ static cl_int pixSubtractCL_work(l_uint32 wpl, l_uint32 h, cl_mem buffer1,
   gsize = (h + GROUPSIZE_Y - 1) / GROUPSIZE_Y * GROUPSIZE_Y;
   globalThreads[1] = gsize;
 
-  if (outBuffer != nullptr) {
-    rEnv.mpkKernel = clCreateKernel(rEnv.mpkProgram, "pixSubtract", &status);
-    CHECK_OPENCL(status, "clCreateKernel pixSubtract");
-  } else {
-    rEnv.mpkKernel =
-        clCreateKernel(rEnv.mpkProgram, "pixSubtract_inplace", &status);
-    CHECK_OPENCL(status, "clCreateKernel pixSubtract_inplace");
-  }
+  rEnv.mpkKernel =
+      clCreateKernel(rEnv.mpkProgram, "pixSubtract_inplace", &status);
+  CHECK_OPENCL(status, "clCreateKernel pixSubtract_inplace");
 
   // Enqueue a kernel run call.
   status = clSetKernelArg(rEnv.mpkKernel, 0, sizeof(cl_mem), &buffer1);
   status = clSetKernelArg(rEnv.mpkKernel, 1, sizeof(cl_mem), &buffer2);
   status = clSetKernelArg(rEnv.mpkKernel, 2, sizeof(wpl), &wpl);
   status = clSetKernelArg(rEnv.mpkKernel, 3, sizeof(h), &h);
-  if (outBuffer != nullptr) {
-    status = clSetKernelArg(rEnv.mpkKernel, 4, sizeof(cl_mem), &outBuffer);
-  }
   status =
       clEnqueueNDRangeKernel(rEnv.mpkCmdQueue, rEnv.mpkKernel, 2, nullptr,
                              globalThreads, localThreads, 0, nullptr, nullptr);


### PR DESCRIPTION
The OpenCL kernel pixSubtract is never used, so remove it.

Signed-off-by: Stefan Weil <sw@weilnetz.de>