### PR TITLE
Fix broken builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 #
 ###############################################################################
 
-option(CPPAN_BUILD "Build with cppan" ON)
+option(CPPAN_BUILD "Build with cppan" OFF)
 
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.cppan OR NOT CPPAN_BUILD)
     if (NOT Leptonica_DIR AND NOT MSVC)


### PR DESCRIPTION
Don't use CPPAN by default because it fails with an error message:

    /usr/bin/ld: cannot find -lpvt.cppan.demo.danbloomberg.leptonica

Signed-off-by: Stefan Weil <sw@weilnetz.de>