### PR TITLE
Fix for unicharcompress_test

### DIFF
--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -244,7 +244,7 @@ unichar_test_SOURCES = unichar_test.cc
 unichar_test_LDADD = $(GTEST_LIBS) $(TRAINING_LIBS) $(TESS_LIBS) $(ICU_UC_LIBS)
 
 unicharcompress_test_SOURCES = unicharcompress_test.cc
-unicharcompress_test_LDADD = $(GTEST_LIBS) $(TRAINING_LIBS) $(TESS_LIBS) $(ICU_UC_LIBS)
+unicharcompress_test_LDADD = $(ABSEIL_LIBS) $(GTEST_LIBS) $(TRAINING_LIBS) $(TESS_LIBS) $(ICU_UC_LIBS)
 
 unicharset_test_SOURCES = unicharset_test.cc
 unicharset_test_LDADD = $(GTEST_LIBS) $(TRAINING_LIBS) $(TESS_LIBS) $(ICU_UC_LIBS)

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -127,6 +127,7 @@ if ENABLE_TRAINING
 check_PROGRAMS += commandlineflags_test
 check_PROGRAMS += unichar_test
 check_PROGRAMS += unicharset_test
+check_PROGRAMS += unicharcompress_test
 check_PROGRAMS += validator_test
 endif
 
@@ -241,6 +242,9 @@ tfile_test_LDADD = $(GTEST_LIBS) $(TESS_LIBS)
 
 unichar_test_SOURCES = unichar_test.cc
 unichar_test_LDADD = $(GTEST_LIBS) $(TRAINING_LIBS) $(TESS_LIBS) $(ICU_UC_LIBS)
+
+unicharcompress_test_SOURCES = unicharcompress_test.cc
+unicharcompress_test_LDADD = $(GTEST_LIBS) $(TRAINING_LIBS) $(TESS_LIBS) $(ICU_UC_LIBS)
 
 unicharset_test_SOURCES = unicharset_test.cc
 unicharset_test_LDADD = $(GTEST_LIBS) $(TRAINING_LIBS) $(TESS_LIBS) $(ICU_UC_LIBS)

--- a/unittest/include_gunit.h
+++ b/unittest/include_gunit.h
@@ -23,7 +23,10 @@ class file : public tesseract::File {
 public:
 
 // Create a file and write a string to it.
-  static bool WriteStringToFile(const std::string& contents, const std::string& name);
+  static bool WriteStringToFile(const std::string& contents, const std::string& filename) {
+    File::WriteStringToFileOrDie(contents, filename);
+    return true;
+  }
 
   static bool GetContents(const std::string& filename, std::string* out, int) {
     return File::ReadFileToString(filename, out);

--- a/unittest/include_gunit.h
+++ b/unittest/include_gunit.h
@@ -21,8 +21,16 @@ const char* FLAGS_test_tmpdir = ".";
 
 class file : public tesseract::File {
 public:
+
+// Create a file and write a string to it.
+  static bool WriteStringToFile(const std::string& contents, const std::string& name);
+
   static bool GetContents(const std::string& filename, std::string* out, int) {
     return File::ReadFileToString(filename, out);
+  }
+
+  static bool SetContents(const std::string& name, const std::string& contents, bool /*is_default*/) {
+    return WriteStringToFile(contents, name);
   }
 
   static int Defaults() {

--- a/unittest/unicharcompress_test.cc
+++ b/unittest/unicharcompress_test.cc
@@ -237,7 +237,7 @@ TEST_F(UnicharcompressTest, GetEncodingAsString) {
   ExpectCorrect("trivial");
   STRING encoding = compressed_.GetEncodingAsString(unicharset_);
   std::string encoding_str(&encoding[0], encoding.length());
-  std::vector<string> lines =
+  std::vector<std::string> lines =
       absl::StrSplit(encoding_str, "\n", absl::SkipEmpty());
   EXPECT_EQ(5, lines.size());
   // The first line is always space.

--- a/unittest/unicharcompress_test.cc
+++ b/unittest/unicharcompress_test.cc
@@ -8,10 +8,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "unicharcompress.h"
-#include "gunit.h"
-#include "printf.h"
+
+#include <string>
+
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
+#include "allheaders.h"
+
+#include "include_gunit.h"
+#include "log.h"                        // for LOG
 #include "serialis.h"
+#include "tprintf.h"
+#include "unicharcompress.h"
 
 namespace tesseract {
 namespace {
@@ -19,14 +28,14 @@ namespace {
 class UnicharcompressTest : public ::testing::Test {
  protected:
   // Loads and compresses the given unicharset.
-  void LoadUnicharset(const string& unicharset_name) {
-    string radical_stroke_file =
-        file::JoinPath(FLAGS_test_srcdir, "langdata/radical-stroke.txt");
-    string unicharset_file =
-        file::JoinPath(FLAGS_test_srcdir, "testdata", unicharset_name);
-    string uni_data;
+  void LoadUnicharset(const std::string& unicharset_name) {
+    std::string radical_stroke_file =
+        file::JoinPath(LANGDATA_DIR, "radical-stroke.txt");
+    std::string unicharset_file =
+        file::JoinPath(TESTDATA_DIR, unicharset_name);
+    std::string uni_data;
     CHECK_OK(file::GetContents(unicharset_file, &uni_data, file::Defaults()));
-    string radical_data;
+    std::string radical_data;
     CHECK_OK(file::GetContents(radical_stroke_file, &radical_data,
                                file::Defaults()));
     CHECK(
@@ -39,10 +48,10 @@ class UnicharcompressTest : public ::testing::Test {
     RecodedCharID code;
     compressed_.EncodeUnichar(null_char_, &code);
     encoded_null_char_ = code(0);
-    string output_name = file::JoinPath(
+    std::string output_name = file::JoinPath(
         FLAGS_test_tmpdir, absl::StrCat(unicharset_name, ".encoding.txt"));
     STRING encoding = compressed_.GetEncodingAsString(unicharset_);
-    string encoding_str(&encoding[0], encoding.size());
+    std::string encoding_str(&encoding[0], encoding.size());
     CHECK_OK(file::SetContents(output_name, encoding_str, file::Defaults()));
     LOG(INFO) << "Wrote encoding to:" << output_name;
   }
@@ -57,12 +66,12 @@ class UnicharcompressTest : public ::testing::Test {
     EXPECT_TRUE(compressed_.DeSerialize(&rfp));
   }
   // Returns true if the lang is in CJK.
-  bool IsCJKLang(const string& lang) {
+  bool IsCJKLang(const std::string& lang) {
     return lang == "chi_sim" || lang == "chi_tra" || lang == "kor" ||
            lang == "jpn";
   }
   // Returns true if the lang is Indic.
-  bool IsIndicLang(const string& lang) {
+  bool IsIndicLang(const std::string& lang) {
     return lang == "asm" || lang == "ben" || lang == "bih" || lang == "hin" ||
            lang == "mar" || lang == "nep" || lang == "san" || lang == "bod" ||
            lang == "dzo" || lang == "guj" || lang == "kan" || lang == "mal" ||
@@ -71,13 +80,13 @@ class UnicharcompressTest : public ::testing::Test {
   }
 
   // Expects the appropriate results from the compressed_  unicharset_.
-  void ExpectCorrect(const string& lang) {
+  void ExpectCorrect(const std::string& lang) {
     // Count the number of times each code is used in each element of
     // RecodedCharID.
     RecodedCharID zeros;
     for (int i = 0; i < RecodedCharID::kMaxCodeLen; ++i) zeros.Set(i, 0);
     int code_range = compressed_.code_range();
-    std::vector<RecodedCharID> times_seen(code_range, zeros);
+   std::vector<RecodedCharID> times_seen(code_range, zeros);
     for (int u = 0; u <= unicharset_.size(); ++u) {
       if (u != UNICHAR_SPACE && u != null_char_ &&
           (u == unicharset_.size() || (unicharset_.has_special_codes() &&
@@ -227,9 +236,9 @@ TEST_F(UnicharcompressTest, GetEncodingAsString) {
   LoadUnicharset("trivial.unicharset");
   ExpectCorrect("trivial");
   STRING encoding = compressed_.GetEncodingAsString(unicharset_);
-  string encoding_str(&encoding[0], encoding.length());
+  std::string encoding_str(&encoding[0], encoding.length());
   std::vector<string> lines =
-      strings::Split(encoding_str, "\n", strings::SkipEmpty());
+      absl::StrSplit(encoding_str, "\n", absl::SkipEmpty());
   EXPECT_EQ(5, lines.size());
   // The first line is always space.
   EXPECT_EQ("0\t ", lines[0]);

--- a/unittest/unicharset_test.cc
+++ b/unittest/unicharset_test.cc
@@ -77,7 +77,7 @@ TEST(UnicharsetTest, Multibyte) {
   EXPECT_EQ(u.size(), 9);
   EXPECT_EQ(u.unichar_to_id("\u0627"), 3);
   EXPECT_EQ(u.unichar_to_id("\u062c"), 4);
-  // The first two bytes of this std::string is \u0627, which matches id 3;
+  // The first two bytes of this string is \u0627, which matches id 3;
   EXPECT_EQ(u.unichar_to_id("\u0627\u062c", 2), 3);
   EXPECT_EQ(u.unichar_to_id("\u062f"), 5);
   // Individual f and i are not present, but they are there as a pair.


### PR DESCRIPTION
@stweil Please review and fix.

Still getting the following errors:

unicharcompress_test.cc: In member function ‘virtual void tesseract::{anonymous}::UnicharcompressTest_GetEncodingAsString_Test::TestBody()’:
unicharcompress_test.cc:242:15: error: ‘string’ was not declared in this scope
   std::vector<string> lines =
               ^~~~~~
unicharcompress_test.cc:242:15: note: suggested alternatives:
In file included from /usr/include/c++/6/string:39:0,
                 from unicharcompress_test.cc:12:
/usr/include/c++/6/bits/stringfwd.h:74:33: note:   ‘std::__cxx11::string’
   typedef basic_string<char>    string;
                                 ^~~~~~
/usr/include/c++/6/bits/stringfwd.h:74:33: note:   ‘std::__cxx11::string’
In file included from ../googletest/googletest/include/gtest/internal/gtest-internal.h:40:0,
                 from ../googletest/googletest/include/gtest/gtest.h:59,
                 from include_gunit.h:18,
                 from unicharcompress_test.cc:21:
../googletest/googletest/include/gtest/internal/gtest-port.h:1178:23: note:   ‘testing::internal::string’
 typedef ::std::string string;
                       ^~~~~~
unicharcompress_test.cc:242:21: error: template argument 1 is invalid
   std::vector<string> lines =
                     ^
unicharcompress_test.cc:242:21: error: template argument 2 is invalid
unicharcompress_test.cc:243:59: error: cannot convert ‘absl::strings_internal::Splitter<absl::ByString, absl::SkipEmpty>’ to ‘int’ in initialization
       absl::StrSplit(encoding_str, "\n", absl::SkipEmpty());
                                                           ^
In file included from ../googletest/googletest/include/gtest/gtest.h:382:0,
                 from include_gunit.h:18,
                 from unicharcompress_test.cc:21:
unicharcompress_test.cc:244:22: error: request for member ‘size’ in ‘lines’, which is of non-class type ‘int’
   EXPECT_EQ(5, lines.size());
                      ^
unicharcompress_test.cc:246:28: error: invalid types ‘int[int]’ for array subscript
   EXPECT_EQ("0\t ", lines[0]);
                            ^
unicharcompress_test.cc:248:28: error: invalid types ‘int[int]’ for array subscript
   EXPECT_EQ("1\ti", lines[1]);
                            ^
unicharcompress_test.cc:250:28: error: invalid types ‘int[int]’ for array subscript
   EXPECT_EQ("2\tf", lines[2]);
                            ^
unicharcompress_test.cc:253:32: error: invalid types ‘int[int]’ for array subscript
   EXPECT_EQ("2,1\tﬁ", lines[3]);
                                ^
unicharcompress_test.cc:255:32: error: invalid types ‘int[int]’ for array subscript
   EXPECT_EQ("3\t<nul>", lines[4]);
                                ^
