### PR TITLE
Fix layout_test and dawg_test

### DIFF
--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -125,10 +125,15 @@ SIMDDetect::SIMDDetect() {
   // Select code for calculation of dot product based on autodetection.
   if (false) {
     // This is a dummy to support conditional compilation.
+#if defined(AVX2)
+  } else if (avx2_available_) {
+    // AVX2 detected.
+    SetDotProduct(DotProductAVX, &IntSimdMatrix::intSimdMatrixAVX2);
+#endif
 #if defined(AVX)
   } else if (avx_available_) {
     // AVX detected.
-    SetDotProduct(DotProductAVX, &IntSimdMatrix::intSimdMatrixAVX2);
+    SetDotProduct(DotProductAVX, &IntSimdMatrix::intSimdMatrixSSE);
 #endif
 #if defined(SSE4_1)
   } else if (sse_available_) {
@@ -152,10 +157,16 @@ void SIMDDetect::Update() {
     // Native optimized code selected by config variable.
     SetDotProduct(DotProductNative);
     dotproduct_method = "native";
+#if defined(AVX2)
+  } else if (!strcmp(dotproduct.string(), "avx2")) {
+    // AVX2 selected by config variable.
+    SetDotProduct(DotProductAVX, &IntSimdMatrix::intSimdMatrixAVX2);
+    dotproduct_method = "avx2";
+#endif
 #if defined(AVX)
   } else if (!strcmp(dotproduct.string(), "avx")) {
     // AVX selected by config variable.
-    SetDotProduct(DotProductAVX, &IntSimdMatrix::intSimdMatrixAVX2);
+    SetDotProduct(DotProductAVX, &IntSimdMatrix::intSimdMatrixSSE);
     dotproduct_method = "avx";
 #endif
 #if defined(SSE4_1)

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -8,8 +8,11 @@ TESSDATA_DIR=$(shell cd $(top_srcdir) && cd .. && pwd)/tessdata
 # Absolute path of directory 'testing' with test images and ground truth texts
 # (using submodule test).
 TESTING_DIR=$(shell cd $(top_srcdir) && pwd)/test/testing
+# Absolute path of directory 'testdata' with test unicharset etc.
+# (using submodule test).
 TESTDATA_DIR=$(shell cd $(top_srcdir) && pwd)/test/testdata
 
+AM_CPPFLAGS += -DTESSBIN_DIR="\"$(abs_top_builddir)\""
 AM_CPPFLAGS += -DLANGDATA_DIR="\"$(LANGDATA_DIR)\""
 AM_CPPFLAGS += -DTESSDATA_DIR="\"$(TESSDATA_DIR)\""
 AM_CPPFLAGS += -DTESTING_DIR="\"$(TESTING_DIR)\""
@@ -27,6 +30,8 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/dict
 AM_CPPFLAGS += -I$(top_srcdir)/src/display
 AM_CPPFLAGS += -I$(top_srcdir)/src/lstm
 AM_CPPFLAGS += -I$(top_srcdir)/src/textord
+AM_CPPFLAGS += -I$(top_srcdir)/unittest/base
+AM_CPPFLAGS += -I$(top_srcdir)/unittest/util
 if ENABLE_TRAINING
 AM_CPPFLAGS += -I$(top_srcdir)/src/training
 endif
@@ -99,6 +104,7 @@ check_PROGRAMS = \
   bitvector_test \
   cleanapi_test \
   colpartition_test \
+  dawg_test \
   denorm_test \
   fileio_test \
   heap_test \
@@ -107,6 +113,7 @@ check_PROGRAMS = \
   intfeaturemap_test \
   intsimdmatrix_test \
   lang_model_test \
+  layout_test \
   linlsq_test \
   loadlang_test \
   mastertrainer_test \
@@ -160,6 +167,9 @@ colpartition_test_LDADD = $(GTEST_LIBS) $(TESS_LIBS)
 commandlineflags_test_SOURCES = commandlineflags_test.cc
 commandlineflags_test_LDADD = $(GTEST_LIBS) $(TRAINING_LIBS) $(TESS_LIBS) $(ICU_UC_LIBS)
 
+dawg_test_SOURCES = dawg_test.cc
+dawg_test_LDADD = $(GTEST_LIBS) $(TESS_LIBS)
+
 denorm_test_SOURCES = denorm_test.cc
 denorm_test_LDADD = $(GTEST_LIBS) $(TESS_LIBS)
 
@@ -190,6 +200,9 @@ endif
 
 lang_model_test_SOURCES = lang_model_test.cc
 lang_model_test_LDADD = $(ABSEIL_LIBS) $(GTEST_LIBS) $(TRAINING_LIBS) $(TESS_LIBS) $(ICU_I18N_LIBS) $(ICU_UC_LIBS)
+
+layout_test_SOURCES = layout_test.cc
+layout_test_LDADD = $(GTEST_LIBS) $(TESS_LIBS)  $(LEPTONICA_LIBS)
 
 linlsq_test_SOURCES = linlsq_test.cc
 linlsq_test_LDADD = $(GTEST_LIBS) $(TESS_LIBS)

--- a/unittest/dawg_test.cc
+++ b/unittest/dawg_test.cc
@@ -1,71 +1,72 @@
+// (C) Copyright 2017, Google Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+#include <cstdlib>      // for system
+#include <fstream>      // for ifstream
 #include <set>
 #include <string>
 #include <vector>
 
-#include "util/process/subprocess.h"
+#include "ratngs.h"
+#include "unicharset.h"
+#include "trie.h"
 
-#include "tesseract/ccstruct/ratngs.h"
-#include "tesseract/ccutil/unicharset.h"
-#include "tesseract/dict/trie.h"
+#include "include_gunit.h"
 
 namespace {
-
-void RemoveTrailingLineTerminators(char* line) {
-  char* end = line + strlen(line) - 1;
-  while (end >= line && ('\n' == *end || '\r' == *end)) {
-    *end-- = 0;
-  }
-}
-
-void AddLineToSet(std::set<string>* words, char* line) {
-  RemoveTrailingLineTerminators(line);
-  words->insert(line);
-}
 
 // Test some basic functionality dealing with Dawgs (compressed dictionaries,
 // aka Directed Acyclic Word Graphs).
 class DawgTest : public testing::Test {
  protected:
-  void LoadWordlist(const string& filename, std::set<string>* words) const {
-    FileLineReader::Options options;
-    options.set_comment_char(0);
-    FileLineReader flr(filename.c_str(), options);
-    flr.set_line_callback(NewPermanentCallback(AddLineToSet, words));
-    flr.Reload();
+  void LoadWordlist(const std::string& filename, std::set<std::string>* words) const {
+    std::ifstream file(filename);
+    if (file.is_open()) {
+      std::string line;
+      while (getline(file, line)) {
+        // Remove trailing line terminators from line.
+        while (!line.empty() && (line.back() == '\n' || line.back() == '\r')) {
+          line.resize(line.size() - 1);
+        }
+        // Add line to set.
+        words->insert(line.c_str());
+      }
+      file.close();
+    }
   }
-  string TestDataNameToPath(const string& name) const {
-    return file::JoinPath(FLAGS_test_srcdir, "testdata/" + name);
+  std::string TestDataNameToPath(const std::string& name) const {
+    return file::JoinPath(TESTDATA_DIR, name);
   }
-  string TessBinaryPath(const string& binary_name) const {
-    return file::JoinPath(FLAGS_test_srcdir,
+  std::string TessBinaryPath(const std::string& name) const {
+    return file::JoinPath(TESSBIN_DIR, "src/training/" + name);
   }
-  string OutputNameToPath(const string& name) const {
+  std::string OutputNameToPath(const std::string& name) const {
     return file::JoinPath(FLAGS_test_tmpdir, name);
   }
-  int RunCommand(const string& program, const string& arg1, const string& arg2,
-                 const string& arg3) const {
-    SubProcess p;
-    std::vector<string> argv;
-    argv.push_back(program);
-    argv.push_back(arg1);
-    argv.push_back(arg2);
-    argv.push_back(arg3);
-    p.SetProgram(TessBinaryPath(program), argv);
-    p.Start();
-    p.Wait();
-    return p.exit_code();
+  int RunCommand(const std::string& program, const std::string& arg1,
+                 const std::string& arg2, const std::string& arg3) const {
+    std::string cmdline =
+      TessBinaryPath(program) + " " + arg1 + " " + arg2 + " " + arg3;
+    return system(cmdline.c_str());
   }
   // Test that we are able to convert a wordlist file (one "word" per line) to
   // a dawg (a compressed format) and then extract the original wordlist back
   // out using the tools "wordlist2dawg" and "dawg2wordlist."
-  void TestDawgRoundTrip(const string& unicharset_filename,
-                         const string& wordlist_filename) const {
-    std::set<string> orig_words, roundtrip_words;
-    string unicharset = TestDataNameToPath(unicharset_filename);
-    string orig_wordlist = TestDataNameToPath(wordlist_filename);
-    string output_dawg = OutputNameToPath(wordlist_filename + ".dawg");
-    string output_wordlist = OutputNameToPath(wordlist_filename);
+  void TestDawgRoundTrip(const std::string& unicharset_filename,
+                         const std::string& wordlist_filename) const {
+    std::set<std::string> orig_words, roundtrip_words;
+    std::string unicharset = TestDataNameToPath(unicharset_filename);
+    std::string orig_wordlist = TestDataNameToPath(wordlist_filename);
+    std::string output_dawg = OutputNameToPath(wordlist_filename + ".dawg");
+    std::string output_wordlist = OutputNameToPath(wordlist_filename);
     LoadWordlist(orig_wordlist, &orig_words);
     EXPECT_EQ(
         RunCommand("wordlist2dawg", orig_wordlist, output_dawg, unicharset), 0);

--- a/unittest/layout_test.cc
+++ b/unittest/layout_test.cc
@@ -74,17 +74,17 @@ class LayoutTest : public testing::Test {
           strstr(block_text, strings[string_index]) != nullptr) {
         LOG(INFO) << "Found string " << strings[string_index]
           << " in block " << block_index
-          << " of type " << kPolyBlockNames[blocks[string_index]];
+          << " of type " << kPolyBlockNames[blocks[string_index]] << "\n";
         // Found this one.
         ++string_index;
       } else if (it->BlockType() == blocks[string_index] &&
                  block_text == nullptr && strings[string_index][0] == '\0') {
         LOG(INFO) << "Found block of type " << kPolyBlockNames[blocks[string_index]]
-           << " at block " << block_index;
+           << " at block " << block_index << "\n";
         // Found this one.
         ++string_index;
       } else {
-        LOG(INFO) << "No match found in block with text:\n%s" << block_text;
+        LOG(INFO) << "No match found in block with text:\n" << block_text;
       }
       delete[] block_text;
       ++block_index;

--- a/unittest/layout_test.cc
+++ b/unittest/layout_test.cc
@@ -1,14 +1,29 @@
+// (C) Copyright 2017, Google Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <string>
 #include <utility>
-#include "leptonica/include/allheaders.h"
-#include "tesseract/api/baseapi.h"
-#include "tesseract/ccmain/mutableiterator.h"
-#include "tesseract/ccmain/resultiterator.h"
-#include "tesseract/ccstruct/coutln.h"
-#include "tesseract/ccstruct/pageres.h"
-#include "tesseract/ccstruct/polyblk.h"
-#include "tesseract/ccstruct/stepblob.h"
+
+#include "include_gunit.h"
+
+#include "allheaders.h"
+#include "baseapi.h"
+#include "coutln.h"
+#include "log.h"                        // for LOG
+#include "mutableiterator.h"
+#include "ocrblock.h"                   // for class BLOCK
+#include "pageres.h"
+#include "polyblk.h"
+#include "resultiterator.h"
+#include "stepblob.h"
 
 namespace {
 
@@ -25,11 +40,11 @@ const PolyBlockType kBlocks8087_054[] = {PT_HEADING_TEXT, PT_FLOWING_TEXT,
 // The fixture for testing Tesseract.
 class LayoutTest : public testing::Test {
  protected:
-  string TestDataNameToPath(const string& name) {
-    return file::JoinPath(FLAGS_test_srcdir, "testdata/" + name);
+  std::string TestDataNameToPath(const std::string& name) {
+    return file::JoinPath(TESTING_DIR, "/" + name);
   }
-  string TessdataPath() {
-    return file::JoinPath(FLAGS_test_srcdir, "tessdata");
+  std::string TessdataPath() {
+    return file::JoinPath(TESSDATA_DIR, "");
   }
 
   LayoutTest() { src_pix_ = nullptr; }
@@ -57,21 +72,19 @@ class LayoutTest : public testing::Test {
       char* block_text = it->GetUTF8Text(tesseract::RIL_BLOCK);
       if (block_text != nullptr && it->BlockType() == blocks[string_index] &&
           strstr(block_text, strings[string_index]) != nullptr) {
-        VLOG(1) << StringPrintf("Found string %s in block %d of type %s",
-                                strings[string_index], block_index,
-                                kPolyBlockNames[blocks[string_index]]);
+        LOG(INFO) << "Found string " << strings[string_index]
+          << " in block " << block_index
+          << " of type " << kPolyBlockNames[blocks[string_index]];
         // Found this one.
         ++string_index;
       } else if (it->BlockType() == blocks[string_index] &&
                  block_text == nullptr && strings[string_index][0] == '\0') {
-        VLOG(1) << StringPrintf("Found block of type %s at block %d",
-                                kPolyBlockNames[blocks[string_index]],
-                                block_index);
+        LOG(INFO) << "Found block of type " << kPolyBlockNames[blocks[string_index]]
+           << " at block " << block_index;
         // Found this one.
         ++string_index;
       } else {
-        VLOG(1) << StringPrintf("No match found in block with text:\n%s",
-                                block_text);
+        LOG(INFO) << "No match found in block with text:\n%s" << block_text;
       }
       delete[] block_text;
       ++block_index;
@@ -87,7 +100,6 @@ class LayoutTest : public testing::Test {
   // be to the left of it if right_to_left is true, or to the right otherwise.
   void VerifyRoughBlockOrder(bool right_to_left, ResultIterator* it) {
     int prev_left = 0;
-    int prev_top = 0;
     int prev_right = 0;
     int prev_bottom = 0;
     it->Begin();
@@ -97,7 +109,7 @@ class LayoutTest : public testing::Test {
           PTIsTextType(it->BlockType()) && right - left > 800 &&
           bottom - top > 200) {
         if (prev_right > prev_left) {
-          if (min(right, prev_right) > max(left, prev_left)) {
+          if (std::min(right, prev_right) > std::max(left, prev_left)) {
             EXPECT_GE(top, prev_bottom) << "Overlapping block should be below";
           } else if (top < prev_bottom) {
             if (right_to_left) {
@@ -108,7 +120,6 @@ class LayoutTest : public testing::Test {
           }
         }
         prev_left = left;
-        prev_top = top;
         prev_right = right;
         prev_bottom = bottom;
       }
@@ -126,7 +137,7 @@ class LayoutTest : public testing::Test {
           PTIsTextType(it->BlockType()) && right - left > 800 &&
           bottom - top > 200) {
         const PAGE_RES_IT* pr_it = it->PageResIt();
-        POLY_BLOCK* pb = pr_it->block()->block->poly_block();
+        POLY_BLOCK* pb = pr_it->block()->block->pdblk.poly_block();
         CHECK(pb != nullptr);
         FCOORD skew = pr_it->block()->block->skew();
         EXPECT_GT(skew.x(), 0.0f);
@@ -156,7 +167,7 @@ class LayoutTest : public testing::Test {
   }
 
   Pix* src_pix_;
-  string ocr_text_;
+  std::string ocr_text_;
   tesseract::TessBaseAPI api_;
 };
 
@@ -173,9 +184,10 @@ TEST_F(LayoutTest, UNLV8087_054) {
 }
 
 // Tests that Tesseract gets the important blocks and in the right order
-// on a UNLV page numbered 8087_054.3B.tif. (Dubrovnik)
+// on GOOGLE:13510798882202548:74:84.sj-79.tif (Hebrew image)
+// TODO: replace hebrew.png by Google image referred above
 TEST_F(LayoutTest, HebrewOrderingAndSkew) {
-  SetImage("GOOGLE:13510798882202548:74:84.sj-79.tif", "eng");
+  SetImage("hebrew.png", "eng");
   // Just run recognition.
   EXPECT_EQ(api_.Recognize(nullptr), 0);
   tesseract::MutableIterator* it = api_.GetMutableIterator();
@@ -184,7 +196,7 @@ TEST_F(LayoutTest, HebrewOrderingAndSkew) {
   VerifyTotalContainment(1, it);
   delete it;
   // Now try again using Hebrew.
-  SetImage("GOOGLE:13510798882202548:74:84.sj-79.tif", "heb");
+  SetImage("hebrew.png", "heb");
   // Just run recognition.
   EXPECT_EQ(api_.Recognize(nullptr), 0);
   it = api_.GetMutableIterator();

--- a/unittest/mastertrainer_test.cc
+++ b/unittest/mastertrainer_test.cc
@@ -187,7 +187,7 @@ class MasterTrainerTest : public testing::Test {
     FLAGS_output_trainer = TmpNameToPath("tmp_trainer").c_str();
     FLAGS_F = file::JoinPath(LANGDATA_DIR, "font_properties").c_str();
     FLAGS_X = TestDataNameToPath("eng.xheights").c_str();
-    FLAGS_U = file::JoinPath(LANGDATA_DIR, "eng/eng.unicharset").c_str();
+    FLAGS_U = TestDataNameToPath("eng.unicharset").c_str();
     std::string tr_file_name(TestDataNameToPath("eng.Arial.exp0.tr"));
     const char* argv[] = {tr_file_name.c_str()};
     int argc = 1;


### PR DESCRIPTION
@stweil Please review. Still getting build errors.

layout_test.cc: In member function ‘void {anonymous}::LayoutTest::VerifyTotalContainment(int, tesseract::MutableIterator*)’:
layout_test.cc:132:47: error: invalid use of incomplete type ‘class BLOCK’
         POLY_BLOCK* pb = pr_it->block()->block->poly_block();
                                               ^~
In file included from ../src/ccstruct/blamer.h:26:0,
                 from ../src/ccstruct/pageres.h:27,
                 from layout_test.cc:12:
../src/ccstruct/boxword.h:26:7: note: forward declaration of ‘class BLOCK’
 class BLOCK;
       ^~~~~
layout_test.cc:134:44: error: invalid use of incomplete type ‘class BLOCK’
         FCOORD skew = pr_it->block()->block->skew();
                                            ^~
In file included from ../src/ccstruct/blamer.h:26:0,
                 from ../src/ccstruct/pageres.h:27,
                 from layout_test.cc:12:
../src/ccstruct/boxword.h:26:7: note: forward declaration of ‘class BLOCK’
 class BLOCK;
       ^~~~~
