### PR TITLE
fix tesstrain_utils.sh

### DIFF
--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -18,7 +18,8 @@
 
 if [ -n "$BASH_VERSION" ];then
   set -u  # comment in case of "unbound variable" error or fix the code
-  set -eo pipefail;
+# set -e ## fixes https://groups.google.com/forum/#!topic/tesseract-ocr/N0Wh72kMqKc 
+  set -o pipefail;
 else
    echo "Warning: you aren't running script in bash - expect problems..."
  fi

--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -215,7 +215,7 @@ parse_flags() {
     # Take training text and wordlist from the langdata directory if not
     # specified in the command-line.
     TRAINING_TEXT=${TRAINING_TEXT:-${LANGDATA_ROOT}/${LANG_CODE}/${LANG_CODE}.training_text}
-    WORDLIST_FILE=${TRAINING_TEXT:-${LANGDATA_ROOT}/${LANG_CODE}/${LANG_CODE}.wordlist}
+    WORDLIST_FILE=${WORDLIST_FILE:-${LANGDATA_ROOT}/${LANG_CODE}/${LANG_CODE}.wordlist}
 
     WORD_BIGRAMS_FILE=${LANGDATA_ROOT}/${LANG_CODE}/${LANG_CODE}.word.bigrams
     NUMBERS_FILE=${LANGDATA_ROOT}/${LANG_CODE}/${LANG_CODE}.numbers


### PR DESCRIPTION
1. tesstrain_utils.sh was using training_text instead of wordlist. Error was introduced in commit 32c1e4f4339c758594d9d8b5239ecaf274749a27

2. https://groups.google.com/forum/#!topic/tesseract-ocr/N0Wh72kMqKc  reported error with tesstrain.sh process where if more than 8 files were used then process would hang/end unexpectedly.  Removing 'set -e' for bash in tesstrain_utils.sh gets rid of the problem and the training process completes successfully.