### PR TITLE
automake: Add missing dependency for "check" target (fix parallel build)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,8 @@ training-uninstall:
 	@$(MAKE) -C src/training uninstall
 clean-local:
 	@$(MAKE) -C src/training clean
+# Some unit tests use code from training.
+check: training
 else
 training:
 	@echo "Need to reconfigure project, so there are no errors"


### PR DESCRIPTION
Some unit tests use code from training. Those tests are enabled
if training is enabled, so for that case the "check" target
depends on the "training" target.

Signed-off-by: Stefan Weil <sw@weilnetz.de>