### PR TITLE
 training: Don't terminate after processing 8 fonts or 8 images

### DIFF
--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -303,7 +303,7 @@ phase_I_generate_image() {
             sleep 1
             generate_font_image "${font}" &
             let counter=counter+1
-            let rem=counter%par_factor
+            let rem=counter%par_factor || true
             if [[ "${rem}" -eq 0 ]]; then
               wait
             fi
@@ -436,7 +436,7 @@ phase_E_extract_features() {
         run_command tesseract ${img_file} ${img_file%.*} \
             ${box_config} ${config} &
       let counter=counter+1
-      let rem=counter%par_factor
+      let rem=counter%par_factor || true
       if [[ "${rem}" -eq 0 ]]; then
         wait
       fi


### PR DESCRIPTION
tesstrain_utils.sh sets the shell flag -e, so it exits immediately
if a command exits with a non-zero status.

The following command returns a non-zero status as soon as counter is a
multiple of par_factor (par_factor=8, that means as soon as 8 fonts or
images are processed):

    let rem=counter%par_factor

The new code fixes this undesired exit.

Signed-off-by: Stefan Weil <sw@weilnetz.de>