### PR TITLE
tesstrain.sh was failing with line 81: ENABLE_SHAPE_CLUSTERING: unbound variable

### DIFF
--- a/src/training/tesstrain.sh
+++ b/src/training/tesstrain.sh
@@ -78,9 +78,7 @@ else
   phase_D_generate_dawg
   phase_E_extract_features "box.train" 8 "tr"
   phase_C_cluster_prototypes "${TRAINING_DIR}/${LANG_CODE}.normproto"
-  if [[ "${ENABLE_SHAPE_CLUSTERING}" == "y" ]]; then
-      phase_S_cluster_shapes
-  fi
+  phase_S_cluster_shapes
   phase_M_cluster_microfeatures
   phase_B_generate_ambiguities
   make__traineddata


### PR DESCRIPTION
It seems that to decide whether to run phase S or not, tesstrain.sh was checking if ENABLE_SHAPE_CLUSTERING variable was set to "y". However, this variable is unbound, and the script fails when it reaches this point.
It looks like whether to run shape clustering or not is decided with the --run_shape_clustering flag, which is checked in the tesstrain_utils.sh script instead.
Therefore, it seemed to me that removing this if statement from tesstrain.sh seemed appropriate to solve this bug.