### PR TITLE
Fix memory leak for PNG images

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -613,9 +613,9 @@ void TessBaseAPI::SetImage(Pix* pix) {
   if (InternalSetImage()) {
     if (pixGetSpp(pix) == 4 && pixGetInputFormat(pix) == IFF_PNG) {
       // remove alpha channel from png
-      PIX* p1 = pixRemoveAlpha(pix);
+      Pix* p1 = pixRemoveAlpha(pix);
       pixSetSpp(p1, 3);
-      pix = pixCopy(nullptr, p1);
+      (void)pixCopy(pix, p1);
       pixDestroy(&p1);
     }
     thresholder_->SetImage(pix);


### PR DESCRIPTION
Commit 5fe1390748a15c0e445a5c57c834edff27ff2f4d used an implementation
which created a new Pix object. That object was never destroyed.

Signed-off-by: Stefan Weil <sw@weilnetz.de>