### PR TITLE
configure: Remove header check for ICU

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -429,18 +429,15 @@ fi
 
 AM_CONDITIONAL([ENABLE_TRAINING], true)
 
-# Check location of icu headers
+# Check availability of ICU packages.
 PKG_CHECK_MODULES([ICU_UC], [icu-uc >= 52.1], [have_icu_uc=true], [have_icu_uc=false])
 PKG_CHECK_MODULES([ICU_I18N], [icu-i18n >= 52.1], [have_icu_i18n=true], [have_icu_i18n=false])
 if !($have_icu_uc && $have_icu_i18n); then
-  AC_CHECK_HEADERS([unicode/uchar.h], [have_icu=true], [have_icu=false])
   if !($have_icu); then
         AC_MSG_WARN([icu 52.1 or higher is required, but was not found.])
         AC_MSG_WARN([Training tools WILL NOT be built.])
         AC_MSG_WARN([Try to install libicu-devel package.])
         AM_CONDITIONAL([ENABLE_TRAINING], false)
-  else
-    ICU_UC_LIBS="-licui18n -licuuc"
   fi
 fi
 


### PR DESCRIPTION
It wrongly detects old versions of ICU as valid.
Checking with pkg-config is sufficient and also sets ICU_UC_LIBS.

Signed-off-by: Stefan Weil <sw@weilnetz.de>