### PR TITLE
Fix build rule for manpages

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -2,9 +2,6 @@
 
 if ASCIIDOC
 
-asciidoc=asciidoc -d manpage
-
-
 man_MANS = \
   combine_lang_model.1 \
   combine_tessdata.1  \
@@ -29,6 +26,8 @@ man_MANS += \
   unicharset.5
 endif
 
+man_xslt = http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
+
 EXTRA_DIST = $(man_MANS) Doxyfile
 
 .PHONY: html
@@ -36,7 +35,8 @@ EXTRA_DIST = $(man_MANS) Doxyfile
 html: $(patsubst %,%.html,$(man_MANS))
 
 %: %.asc
-	$(asciidoc) -o $@ $<
+	asciidoc -b docbook -d manpage -o - $< | \
+	xsltproc --nonet $(man_xslt) -
 
 %.html: %.asc
 	asciidoc -b html5 -o $@ $<


### PR DESCRIPTION
This is similar to commit 2106cba0a98a90451df835f3ab7b2aaf54826442
which fixed doc/generate_manpages.sh.

Signed-off-by: Stefan Weil <sw@weilnetz.de>