### PR TITLE
Avoid gmake-specific pattern substitution in Makefile.am.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -32,13 +32,15 @@ EXTRA_DIST = $(man_MANS) Doxyfile
 
 .PHONY: html
 
-html: $(patsubst %,%.html,$(man_MANS))
+html: ${man_MANS:%=%.html}
 
-%: %.asc
+SUFFIXES = .asc .html
+
+.asc:
 	asciidoc -b docbook -d manpage -o - $< | \
 	xsltproc --nonet $(man_xslt) -
 
-%.html: %.asc
+.asc.html:
 	asciidoc -b html5 -o $@ $<
 
 MAINTAINERCLEANFILES = $(man_MANS) Doxyfile


### PR DESCRIPTION
Resolves #2226