### PR TITLE
DO NOT MERGE: Fix reversal of numerals in Arabic script

### DIFF
--- a/src/ccstruct/pageres.h
+++ b/src/ccstruct/pageres.h
@@ -398,8 +398,7 @@ class WERD_RES : public ELIST_LINK {
       UNICHARSET::Direction dir =
           uch_set->get_direction(unichar_id);
       if (dir == UNICHARSET::U_RIGHT_TO_LEFT ||
-          dir == UNICHARSET::U_RIGHT_TO_LEFT_ARABIC ||
-          dir == UNICHARSET::U_ARABIC_NUMBER)
+          dir == UNICHARSET::U_RIGHT_TO_LEFT_ARABIC)
         return true;
     }
     return false;
@@ -413,7 +412,8 @@ class WERD_RES : public ELIST_LINK {
       if (unichar_id < 0 || unichar_id >= uch_set->size())
         continue;  // Ignore illegal chars.
       UNICHARSET::Direction dir = uch_set->get_direction(unichar_id);
-      if (dir == UNICHARSET::U_LEFT_TO_RIGHT)
+      if (dir == UNICHARSET::U_LEFT_TO_RIGHT ||
+          dir == UNICHARSET::U_ARABIC_NUMBER)
         return true;
     }
     return false;

--- a/src/ccutil/unicharset.cpp
+++ b/src/ccutil/unicharset.cpp
@@ -962,10 +962,10 @@ bool UNICHARSET::major_right_to_left() const {
   int rtl_count = 0;
   for (int id = 0; id < size_used; ++id) {
     int dir = get_direction(id);
-    if (dir == UNICHARSET::U_LEFT_TO_RIGHT) ltr_count++;
+    if (dir == UNICHARSET::U_LEFT_TO_RIGHT ||
+        dir == UNICHARSET::U_ARABIC_NUMBER) ltr_count++;
     if (dir == UNICHARSET::U_RIGHT_TO_LEFT ||
-        dir == UNICHARSET::U_RIGHT_TO_LEFT_ARABIC ||
-        dir == UNICHARSET::U_ARABIC_NUMBER) rtl_count++;
+        dir == UNICHARSET::U_RIGHT_TO_LEFT_ARABIC) rtl_count++;
   }
   return rtl_count > ltr_count;
 }

--- a/src/training/boxchar.cpp
+++ b/src/training/boxchar.cpp
@@ -63,9 +63,10 @@ void BoxChar::GetDirection(int* num_rtl, int* num_ltr) const {
   for (char32 ch : uni_vector) {
     UCharDirection dir = u_charDirection(ch);
     if (dir == U_RIGHT_TO_LEFT || dir == U_RIGHT_TO_LEFT_ARABIC ||
-        dir == U_ARABIC_NUMBER || dir == U_RIGHT_TO_LEFT_ISOLATE) {
+       dir == U_RIGHT_TO_LEFT_ISOLATE) {
       ++*num_rtl;
-    } else if (dir != U_DIR_NON_SPACING_MARK && dir != U_BOUNDARY_NEUTRAL) {
+    } else if ((dir != U_DIR_NON_SPACING_MARK && dir != U_BOUNDARY_NEUTRAL) ||
+                dir == U_ARABIC_NUMBER) {
       ++*num_ltr;
     }
   }

--- a/src/training/validate_grapheme.cpp
+++ b/src/training/validate_grapheme.cpp
@@ -16,10 +16,10 @@ bool ValidateGrapheme::ConsumeGraphemeIfValid() {
     const bool is_combiner =
         cc == CharClass::kCombiner || cc == CharClass::kVirama;
     // Reject easily detected badly formed sequences.
-    if (prev_cc == CharClass::kWhitespace && is_combiner) {
-      if (report_errors_) tprintf("Word started with a combiner:0x%x\n", ch);
-      return false;
-    }
+//  if (prev_cc == CharClass::kWhitespace && is_combiner) {
+//    if (report_errors_) tprintf("Word started with a combiner:0x%x\n", ch);
+//    return false;
+//  }
     if (prev_cc == CharClass::kVirama && cc == CharClass::kVirama) {
       if (report_errors_)
         tprintf("Two grapheme links in a row:0x%x 0x%x\n", prev_ch, ch);


### PR DESCRIPTION
Fixes issue https://github.com/tesseract-ocr/tesseract/issues/2263

Also addresses related issues
Add Indic numerals and missing punctuation to Arabic tesseract-ocr/langdata#131
Arabic training data has room for improvement #2047

See https://github.com/Shreeshrii/tessdata_arabic
for the finetuned traineddata file and test image and OCR output.

The OCR output looks correct when seen in notepad++ in RTL view. However I am not able to copy it in github.

