### PR TITLE
Remove test for Word started with a combiner

### DIFF
--- a/src/training/validate_grapheme.cpp
+++ b/src/training/validate_grapheme.cpp
@@ -15,11 +15,12 @@ bool ValidateGrapheme::ConsumeGraphemeIfValid() {
     char32 ch = codes_[codes_used_].second;
     const bool is_combiner =
         cc == CharClass::kCombiner || cc == CharClass::kVirama;
-    // Reject easily detected badly formed sequences.
-    if (prev_cc == CharClass::kWhitespace && is_combiner) {
-      if (report_errors_) tprintf("Word started with a combiner:0x%x\n", ch);
-      return false;
-    }
+    // TODO: Reject easily detected badly formed sequences.
+    // https://github.com/tesseract-ocr/tesseract/pull/2266#issuecomment-467114751
+    // if (prev_cc == CharClass::kWhitespace && is_combiner) {
+    //  if (report_errors_) tprintf("Word started with a combiner:0x%x\n", ch);
+    // return false;
+    //}
     if (prev_cc == CharClass::kVirama && cc == CharClass::kVirama) {
       if (report_errors_)
         tprintf("Two grapheme links in a row:0x%x 0x%x\n", prev_ch, ch);


### PR DESCRIPTION
Fixes errors such as:

Word started with a combiner:0x64b
Normalization failed for string 'ًا'

Encoding of string failed! Failure bytes: d9 8b d8 a7 d8 af d9 83 d8 a4 d9 85 db 94 d8 a9 d9 8a d8 b1 d8 a7 d8 af d8 a7 d9 84 d8 a7 20 d8 a9 d8 a6 d9 8a d9 87 d9 84 d8 a7 20 d8 a1 d8 a7 d8 b6 d8 b9 d8 a3 d8 a8 20 d8 a9 d9 82 d8 ab d9 84 d8 a7 20 d8 af d9 8a d8 af d8 ac d8 aa
Can't encode transcription: 'نا ًادكؤم۔ةيرادالا ةئيهلا ءاضعأب ةقثلا ديدجت' in language ''