### PR TITLE
Treat U_ARABIC_NUMBER as LTR

### DIFF
--- a/src/ccstruct/pageres.h
+++ b/src/ccstruct/pageres.h
@@ -398,8 +398,7 @@ class WERD_RES : public ELIST_LINK {
       UNICHARSET::Direction dir =
           uch_set->get_direction(unichar_id);
       if (dir == UNICHARSET::U_RIGHT_TO_LEFT ||
-          dir == UNICHARSET::U_RIGHT_TO_LEFT_ARABIC ||
-          dir == UNICHARSET::U_ARABIC_NUMBER)
+          dir == UNICHARSET::U_RIGHT_TO_LEFT_ARABIC)
         return true;
     }
     return false;
@@ -413,7 +412,8 @@ class WERD_RES : public ELIST_LINK {
       if (unichar_id < 0 || unichar_id >= uch_set->size())
         continue;  // Ignore illegal chars.
       UNICHARSET::Direction dir = uch_set->get_direction(unichar_id);
-      if (dir == UNICHARSET::U_LEFT_TO_RIGHT)
+      if (dir == UNICHARSET::U_LEFT_TO_RIGHT ||
+          dir == UNICHARSET::U_ARABIC_NUMBER)
         return true;
     }
     return false;

--- a/src/training/boxchar.cpp
+++ b/src/training/boxchar.cpp
@@ -63,9 +63,10 @@ void BoxChar::GetDirection(int* num_rtl, int* num_ltr) const {
   for (char32 ch : uni_vector) {
     UCharDirection dir = u_charDirection(ch);
     if (dir == U_RIGHT_TO_LEFT || dir == U_RIGHT_TO_LEFT_ARABIC ||
-        dir == U_ARABIC_NUMBER || dir == U_RIGHT_TO_LEFT_ISOLATE) {
+        dir == U_RIGHT_TO_LEFT_ISOLATE) {
       ++*num_rtl;
-    } else if (dir != U_DIR_NON_SPACING_MARK && dir != U_BOUNDARY_NEUTRAL) {
+    } else if ((dir == U_ARABIC_NUMBER) ||
+	          (dir != U_DIR_NON_SPACING_MARK && dir != U_BOUNDARY_NEUTRAL)) {
       ++*num_ltr;
     }
   }


### PR DESCRIPTION
https://www.w3.org/International/articles/inline-bidi-markup/uba-basics#numbers

> Numbers in RTL scripts run left-to-right within the right-to-left flow.

See earlier discussion in the closed PR - https://github.com/tesseract-ocr/tesseract/pull/2266

The change to ccutil/unicharset.cpp which was in earlier PR is NOT included, since U_ARABIC_NUMBER was being used there as part of condition to find if right_to_left scripts are significant in the unicharset.

https://github.com/tesseract-ocr/tesseract/blob/master/src/ccutil/unicharset.cpp#L956