### PR TITLE
Allow UTF-8 variant of C locale

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -208,11 +208,11 @@ TessBaseAPI::TessBaseAPI()
       image_height_(0) {
   const char *locale;
   locale = std::setlocale(LC_ALL, nullptr);
-  ASSERT_HOST(!strcmp(locale, "C"));
+  ASSERT_HOST(!strcmp(locale, "C") || !strcmp(locale, "C.UTF-8"));
   locale = std::setlocale(LC_CTYPE, nullptr);
-  ASSERT_HOST(!strcmp(locale, "C"));
+  ASSERT_HOST(!strcmp(locale, "C") || !strcmp(locale, "C.UTF-8"));
   locale = std::setlocale(LC_NUMERIC, nullptr);
-  ASSERT_HOST(!strcmp(locale, "C"));
+  ASSERT_HOST(!strcmp(locale, "C") || !strcmp(locale, "C.UTF-8"));
 }
 
 TessBaseAPI::~TessBaseAPI() {


### PR DESCRIPTION
It behaves same in scanf, but it allows proper handling of unicode
chars.