### PR TITLE
correct handling of 0BF0-0BFA Tamil numbers and symbols

### DIFF
--- a/src/training/validate_indic.cpp
+++ b/src/training/validate_indic.cpp
@@ -145,7 +145,7 @@ bool ValidateIndic::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
         // for consistency, we will always add ZWNJ if not present.
         output_.push_back(kZeroWidthNonJoiner);
       } else {
-	  CodeOnlyToOutput();
+        CodeOnlyToOutput();
       }
       // Explicit virama [H z]
       MultiCodePart(2);

--- a/src/training/validate_indic.cpp
+++ b/src/training/validate_indic.cpp
@@ -74,6 +74,12 @@ Validator::CharClass ValidateIndic::UnicodeToCharClass(char32 ch) const {
   if (off == 0x62 || off == 0x63) return CharClass::kMatra;
   // Danda and digits up to 6f are OK as other.
   // 70-7f are script-specific.
+  // 0BF0-0BF2 are Tamil numbers 10, 100 and 1000; treat as other.
+  if (script_ == ViramaScript::kTamil && (0x70 <= off && off <= 0x72))
+    return CharClass::kOther;
+  // 0BF3-0BFA are other Tamil symbols.
+  if (script_ == ViramaScript::kTamil && (0x73 <= off && off <= 0x7A))
+    return CharClass::kOther;
   if (script_ == ViramaScript::kBengali && (off == 0x70 || off == 0x71))
     return CharClass::kConsonant;
   if (script_ == ViramaScript::kGurmukhi && (off == 0x72 || off == 0x73))
@@ -139,7 +145,7 @@ bool ValidateIndic::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
         // for consistency, we will always add ZWNJ if not present.
         output_.push_back(kZeroWidthNonJoiner);
       } else {
-        CodeOnlyToOutput();
+	  CodeOnlyToOutput();
       }
       // Explicit virama [H z]
       MultiCodePart(2);


### PR DESCRIPTION
Fixes errors such as

Extracting unicharset from box file /tmp/tam-2019-03-01.pSD/tam.Noto_Sans_Tamil_Regular.exp0.box
Invalid start of grapheme sequence:D=0xbf0
Normalization failed for string '௰'
Invalid start of grapheme sequence:D=0xbf1
Normalization failed for string '௱'
Invalid start of grapheme sequence:D=0xbf2
Normalization failed for string '௲'
Invalid start of grapheme sequence:D=0xbf3
Normalization failed for string '௳'
Invalid start of grapheme sequence:D=0xbf0
Normalization failed for string '௰'
