### PR TITLE
PAGE_RES_IT: Optimize compare operators by using inline code

### DIFF
--- a/src/ccstruct/pageres.cpp
+++ b/src/ccstruct/pageres.cpp
@@ -1191,13 +1191,6 @@ void WERD_RES::ClearRatings() {
   }
 }
 
-
-bool PAGE_RES_IT::operator ==(const PAGE_RES_IT &other) const {
-  return word_res == other.word_res &&
-      row_res == other.row_res &&
-      block_res == other.block_res;
-}
-
 int PAGE_RES_IT::cmp(const PAGE_RES_IT &other) const {
   ASSERT_HOST(page_res == other.page_res);
   if (other.block_res == nullptr) {

--- a/src/ccstruct/pageres.h
+++ b/src/ccstruct/pageres.h
@@ -685,7 +685,10 @@ class PAGE_RES_IT {
 
   // Do two PAGE_RES_ITs point at the same word?
   // This is much cheaper than cmp().
-  bool operator ==(const PAGE_RES_IT &other) const;
+  bool operator ==(const PAGE_RES_IT &other) const {
+    return word_res == other.word_res && row_res == other.row_res &&
+           block_res == other.block_res;
+  }
 
   bool operator !=(const PAGE_RES_IT &other) const {return !(*this == other); }
 


### PR DESCRIPTION
Avoiding a function call will make both == and != operator faster.

Signed-off-by: Stefan Weil <sw@weilnetz.de>