### PR TITLE
Added an additional optional --tmp_dir parameter to specify the tempo…

### DIFF
--- a/src/training/tesstrain_utils.py
+++ b/src/training/tesstrain_utils.py
@@ -125,6 +125,7 @@ parser.add_argument(
     help="A list of fontnames to train on.",
 )
 parser.add_argument("--fonts_dir", help="Path to font files.")
+parser.add_argument("--tmp_dir", help="Path to temporary training directory.")
 parser.add_argument(
     "--lang", metavar="LANG_CODE", dest="lang_code", help="ISO 639 code."
 )
@@ -214,8 +215,11 @@ def parse_flags(argv=None):
         ctx.output_dir = mkdtemp(prefix=f"trained-{ctx.lang_code}-{ctx.timestamp}")
         log.info(f"Output directory set to: {ctx.output_dir}")
 
-    # Location where intermediate files will be created.
-    ctx.training_dir = mkdtemp(prefix=f"{ctx.lang_code}-{ctx.timestamp}")
+    # Location where intermediate files will be created.       
+    if not ctx.tmp_dir:
+        ctx.training_dir = mkdtemp(prefix=f"{ctx.lang_code}-{ctx.timestamp}")
+    else:
+        ctx.training_dir = mkdtemp(prefix=f"{ctx.lang_code}-{ctx.timestamp}", dir=ctx.tmp_dir)
     # Location of log file for the whole run.
     ctx.log_file = Path(ctx.training_dir) / "tesstrain.log"
     log.info(f"Log file location: {ctx.log_file}")

--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -149,6 +149,9 @@ parse_flags() {
             --fonts_dir)
                 parse_value "FONTS_DIR" ${ARGV[$j]:-}
                 i=$j ;;
+	    --tmp_dir)
+		parse_value "TMP_DIR"   ${ARGV[$j]:-}
+		i=$j ;;
             --lang)
                 parse_value "LANG_CODE" ${ARGV[$j]:-}
                 i=$j ;;
@@ -215,7 +218,11 @@ parse_flags() {
 
     # Location where intermediate files will be created.
     TIMESTAMP=$(date +%Y-%m-%d)
-    TMP_DIR=$(mktemp -d -t ${LANG_CODE}-${TIMESTAMP}.XXX)
+    if [[ -z ${TMP_DIR:-} ]]; then
+        TMP_DIR=$(mktemp -d -t ${LANG_CODE}-${TIMESTAMP}.XXX)
+    else
+	TMP_DIR=$(mktemp -d -p ${TMP_DIR} -t ${LANG_CODE}-${TIMESTAMP}.XXX)
+    fi
     TRAINING_DIR=${TMP_DIR}
     # Location of log file for the whole run.
     LOG_FILE=${TRAINING_DIR}/tesstrain.log


### PR DESCRIPTION
…rary directory in which tesstrain.py creates the training temporary files. The main reason is due to the slow R/W on HDD, if anyone wants to speed up this process can use as tmp_dir a directory on an SSDrive