### PR TITLE
Document that configfile can be a file path

### DIFF
--- a/doc/tesseract.1.asc
+++ b/doc/tesseract.1.asc
@@ -86,9 +86,10 @@ OPTIONS
 	3 = Default, based on what is available.
 
 'configfile'::
-	The name of a config to use. A config is a plain text file which
-	contains a list of parameters and their values, one per line,
-	with a space separating parameter from value. +
+	The name of a config to use. The name can be a file in tessdata/configs
+	or tessdata/tessconfigs, or an absolute or relative file path.
+	A config is a plain text file which contains a list of parameters and
+	their values, one per line, with a space separating parameter from value. +
 	Interesting config files include:
 
 	* `alto` - Output in ALTO format ('outputbase'`.xml`).


### PR DESCRIPTION
Useful for custom config or when pointing tessdata to alternate
traineddata.