### PR TITLE
Remove svpaint.cpp from libtesseract

### DIFF
--- a/src/viewer/Makefile.am
+++ b/src/viewer/Makefile.am
@@ -11,4 +11,6 @@ noinst_HEADERS = \
 noinst_LTLIBRARIES = libtesseract_viewer.la
 
 libtesseract_viewer_la_SOURCES = \
-    scrollview.cpp svmnode.cpp svutil.cpp svpaint.cpp
+    scrollview.cpp svmnode.cpp svutil.cpp
+
+# TODO: Add rule to generate svpaint from svpaint.cpp.


### PR DESCRIPTION
svpaint is a standalone application (it includes a main function)
and should not be part of the Tesseract library.

Signed-off-by: Stefan Weil <sw@weilnetz.de>