### PR TITLE
trying to add user words/patterns again:

### DIFF
--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -186,7 +186,7 @@ bool Tesseract::init_tesseract_lang_data(
     if (mgr->IsComponentAvailable(TESSDATA_LSTM)) {
       lstm_recognizer_ = new LSTMRecognizer;
       ASSERT_HOST(
-          lstm_recognizer_->Load(lstm_use_matrix ? language : nullptr, mgr));
+                  lstm_recognizer_->Load(this->params(), lstm_use_matrix ? language : nullptr, mgr));
     } else {
       tprintf("Error: LSTM requested, but not present!! Loading tesseract.\n");
       tessedit_ocr_engine_mode.set_value(OEM_TESSERACT_ONLY);

--- a/src/ccutil/params.h
+++ b/src/ccutil/params.h
@@ -155,7 +155,15 @@ class IntParam : public Param {
   void ResetToDefault() {
     value_ = default_;
   }
-
+  void ResetFrom(const ParamsVectors* vec) {
+    for (int i = 0; i < vec->int_params.size(); ++i) {
+      if (strcmp(vec->int_params[i]->name_str(), name_) == 0) {
+        //printf("overriding param %s=%d by =%d\n", name_, value_, *vec->int_params[i]);
+        value_ = *vec->int_params[i];
+      }
+    }
+  }
+  
  private:
   int32_t value_;
   int32_t default_;
@@ -178,6 +186,14 @@ class BoolParam : public Param {
   void set_value(BOOL8 value) { value_ = value; }
   void ResetToDefault() {
     value_ = default_;
+  }
+  void ResetFrom(const ParamsVectors* vec) {
+    for (int i = 0; i < vec->bool_params.size(); ++i) {
+      if (strcmp(vec->bool_params[i]->name_str(), name_) == 0) {
+        //printf("overriding param %s=%s by =%s\n", name_, value_ ? "true" : "false", *vec->bool_params[i] ? "true" : "false");
+        value_ = *vec->bool_params[i];
+      }
+    }
   }
 
  private:
@@ -208,6 +224,14 @@ class StringParam : public Param {
   void ResetToDefault() {
     value_ = default_;
   }
+  void ResetFrom(const ParamsVectors* vec) {
+    for (int i = 0; i < vec->string_params.size(); ++i) {
+      if (strcmp(vec->string_params[i]->name_str(), name_) == 0) {
+        //printf("overriding param %s=%s by =%s\n", name_, value_, vec->string_params[i]->c_str());
+        value_ = *vec->string_params[i];
+      }
+    }
+  }
 
  private:
   STRING value_;
@@ -231,6 +255,14 @@ class DoubleParam : public Param {
   void set_value(double value) { value_ = value; }
   void ResetToDefault() {
     value_ = default_;
+  }
+  void ResetFrom(const ParamsVectors* vec) {
+    for (int i = 0; i < vec->double_params.size(); ++i) {
+      if (strcmp(vec->double_params[i]->name_str(), name_) == 0) {
+        //printf("overriding param %s=%f by =%f\n", name_, value_, *vec->double_params[i]);
+        value_ = *vec->double_params[i];
+      }
+    }
   }
 
  private:

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -66,13 +66,13 @@ LSTMRecognizer::~LSTMRecognizer() {
 }
 
 // Loads a model from mgr, including the dictionary only if lang is not null.
-bool LSTMRecognizer::Load(const char* lang, TessdataManager* mgr) {
+bool LSTMRecognizer::Load(const ParamsVectors* params, const char* lang, TessdataManager* mgr) {
   TFile fp;
   if (!mgr->GetComponent(TESSDATA_LSTM, &fp)) return false;
   if (!DeSerialize(mgr, &fp)) return false;
   if (lang == nullptr) return true;
   // Allow it to run without a dictionary.
-  LoadDictionary(lang, mgr);
+  LoadDictionary(params, lang, mgr);
   return true;
 }
 
@@ -154,9 +154,14 @@ bool LSTMRecognizer::LoadRecoder(TFile* fp) {
 // on the unicharset matching. This enables training to deserialize a model
 // from checkpoint or restore without having to go back and reload the
 // dictionary.
-bool LSTMRecognizer::LoadDictionary(const char* lang, TessdataManager* mgr) {
+// Some parameters have to be passed in (from langdata/config/api via Tesseract)
+bool LSTMRecognizer::LoadDictionary(const ParamsVectors* params, const char* lang, TessdataManager* mgr) {
   delete dict_;
   dict_ = new Dict(&ccutil_);
+  dict_->user_words_file.ResetFrom(params);
+  dict_->user_words_suffix.ResetFrom(params);
+  dict_->user_patterns_file.ResetFrom(params);
+  dict_->user_patterns_suffix.ResetFrom(params);
   dict_->SetupForLoad(Dict::GlobalDawgCache());
   dict_->LoadLSTM(lang, mgr);
   if (dict_->FinishLoad()) return true;  // Success.

--- a/src/lstm/lstmrecognizer.h
+++ b/src/lstm/lstmrecognizer.h
@@ -25,6 +25,7 @@
 #include "matrix.h"
 #include "network.h"
 #include "networkscratch.h"
+#include "params.h"
 #include "recodebeam.h"
 #include "series.h"
 #include "strngs.h"
@@ -154,7 +155,7 @@ class LSTMRecognizer {
   int null_char() const { return null_char_; }
 
   // Loads a model from mgr, including the dictionary only if lang is not null.
-  bool Load(const char* lang, TessdataManager* mgr);
+  bool Load(const ParamsVectors* params, const char* lang, TessdataManager* mgr);
 
   // Writes to the given file. Returns false in case of error.
   // If mgr contains a unicharset and recoder, then they are not encoded to fp.
@@ -174,7 +175,7 @@ class LSTMRecognizer {
   // on the unicharset matching. This enables training to deserialize a model
   // from checkpoint or restore without having to go back and reload the
   // dictionary.
-  bool LoadDictionary(const char* lang, TessdataManager* mgr);
+  bool LoadDictionary(const ParamsVectors* params, const char* lang, TessdataManager* mgr);
 
   // Recognizes the line image, contained within image_data, returning the
   // recognized tesseract WERD_RES for the words.


### PR DESCRIPTION
- pass in `ParamsVectors` from `Tesseract`
  (carrying values from langdata/config/api)
  into `LSTMRecognizer::Load` and `LoadDictionary`
- after `LSTMRecognizer`'s `Dict` is initialised
  (with default values), reset the variables
  user_{words,patterns}_{suffix,file} from the
  corresponding entries in the passed vector