### PR TITLE
Fix compiler warnings caused by ASSERT_HOST

### DIFF
--- a/src/ccmain/osdetect.cpp
+++ b/src/ccmain/osdetect.cpp
@@ -198,7 +198,7 @@ int orientation_and_script_detection(STRING& filename,
   if (lastdot != nullptr)
     name[lastdot-name.string()] = '\0';
 
-  ASSERT_HOST(tess->pix_binary() != nullptr)
+  ASSERT_HOST(tess->pix_binary() != nullptr);
   int width = pixGetWidth(tess->pix_binary());
   int height = pixGetHeight(tess->pix_binary());
 

--- a/src/ccmain/pgedit.cpp
+++ b/src/ccmain/pgedit.cpp
@@ -2,7 +2,6 @@
  * File:        pgedit.cpp (Formerly pgeditor.c)
  * Description: Page structure file editor
  * Author:      Phil Cheatle
- * Created:     Thu Oct 10 16:25:24 BST 1991
  *
  *(C) Copyright 1991, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0(the "License");
@@ -22,10 +21,10 @@
 #include "config_auto.h"
 #endif
 
-#include          "pgedit.h"
+#include "pgedit.h"
 
-#include          <cctype>
-#include          <cmath>
+#include <cctype>
+#include <cmath>
 
 #include "blread.h"
 #include "control.h"
@@ -879,7 +878,7 @@ bool Tesseract::word_display(PAGE_RES_IT* pr_it) {
     text += best_choice_str;
     IncorrectResultReason reason = (blamer_bundle == nullptr) ?
         IRR_PAGE_LAYOUT : blamer_bundle->incorrect_result_reason();
-    ASSERT_HOST(reason < IRR_NUM_REASONS)
+    ASSERT_HOST(reason < IRR_NUM_REASONS);
     blame += " [";
     blame += BlamerBundle::IncorrectReasonName(reason);
     blame += "]";

--- a/src/ccstruct/blobbox.cpp
+++ b/src/ccstruct/blobbox.cpp
@@ -2,7 +2,6 @@
  * File:        blobbox.cpp  (Formerly blobnbox.c)
  * Description: Code for the textord blob class.
  * Author:      Ray Smith
- * Created:     Thu Jul 30 09:08:51 BST 1992
  *
  * (C) Copyright 1992, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,7 +70,7 @@ void BLOBNBOX::reflect_box_in_y_axis() {
 // correction can be applied.
 void BLOBNBOX::rotate_box(FCOORD rotation) {
   if (IsDiacritic()) {
-    ASSERT_HOST(rotation.x() >= kCosSmallAngle)
+    ASSERT_HOST(rotation.x() >= kCosSmallAngle);
     ICOORD top_pt((box.left() + box.right()) / 2, base_char_top_);
     ICOORD bottom_pt(top_pt.x(), base_char_bottom_);
     top_pt.rotate(rotation);

--- a/src/ccutil/errcode.h
+++ b/src/ccutil/errcode.h
@@ -2,7 +2,6 @@
  * File:        errcode.h  (Formerly error.h)
  * Description: Header file for generic error handler class
  * Author:      Ray Smith
- * Created:     Tue May  1 16:23:36 BST 1990
  *
  * (C) Copyright 1990, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +16,10 @@
  *
  **********************************************************************/
 
-#ifndef           ERRCODE_H
-#define           ERRCODE_H
+#ifndef ERRCODE_H
+#define ERRCODE_H
 
-#include          "host.h"
+#include "host.h"
 
 /*Control parameters for error()*/
 enum TessErrorLogCode {
@@ -81,11 +80,15 @@ class TESS_API ERRCODE {           // error handler class
 
 const ERRCODE ASSERT_FAILED = "Assert failed";
 
-#define ASSERT_HOST(x) if (!(x))                                        \
-  {                                                                     \
-    ASSERT_FAILED.error(#x, ABORT, "in file %s, line %d",               \
-                        __FILE__, __LINE__);                            \
-  }
+#if defined __cplusplus
+# define DO_NOTHING static_cast<void>(0)
+#else
+# define DO_NOTHING (void)(0)
+#endif
+
+#define ASSERT_HOST(x) (x) \
+  ? DO_NOTHING \
+  : ASSERT_FAILED.error(#x, ABORT, "in file %s, line %d", __FILE__, __LINE__)
 
 #define ASSERT_HOST_MSG(x, ...)                                                \
   if (!(x)) {                                                                  \
@@ -100,4 +103,5 @@ void set_global_loc_code(int loc_code);
 void set_global_subloc_code(int loc_code);
 
 void set_global_subsubloc_code(int loc_code);
+
 #endif


### PR DESCRIPTION
The modified definition avoids warnings caused by redundant semicolons.
Now a semicolon is required when using the macro, so a few code locations
had to be updated.

Signed-off-by: Stefan Weil <sw@weilnetz.de>