### PR TITLE
Change message display for debug_level -1 during lstmtraining

### DIFF
--- a/src/lstm/lstmtrainer.cpp
+++ b/src/lstm/lstmtrainer.cpp
@@ -887,7 +887,7 @@ Trainability LSTMTrainer::PrepareForBackward(const ImageData* trainingdata,
   double word_error = ComputeWordError(&truth_text, &ocr_text);
   double delta_error = ComputeErrorRates(*targets, char_error, word_error);
   if (debug_interval_ != 0) {
-    tprintf("File %s page %d %s:\n", trainingdata->imagefilename().string(),
+    tprintf("File %s line %d %s:\n", trainingdata->imagefilename().string(),
             trainingdata->page_number(), delta_error == 0.0 ? "(Perfect)" : "");
   }
   if (delta_error == 0.0) return PERFECT;

--- a/src/lstm/lstmtrainer.cpp
+++ b/src/lstm/lstmtrainer.cpp
@@ -879,10 +879,8 @@ Trainability LSTMTrainer::PrepareForBackward(const ImageData* trainingdata,
   targets->SubtractAllFromFloat(*fwd_outputs);
   if (debug_interval_ != 0) {
       if (truth_text != ocr_text) {
-         tprintf("Iteration %d: GROUND  TRUTH : %s\n",
-            training_iteration(), truth_text.string());
-         tprintf("Iteration %d: BEST OCR TEXT : %s\n", training_iteration(),
-            ocr_text.string());
+         tprintf("Iteration %d: BEST OCR TEXT : %s\n", 
+            training_iteration(), ocr_text.string());
       }
   }
   double char_error = ComputeCharError(truth_labels, ocr_labels);
@@ -1046,8 +1044,12 @@ bool LSTMTrainer::DebugLSTMTraining(const NetworkIO& inputs,
     GenericVector<int> xcoords;
     LabelsFromOutputs(outputs, &labels, &xcoords);
     STRING text = DecodeLabels(labels);
-    tprintf("Iteration %d: ALIGNED TRUTH : %s\n",
+    tprintf("Iteration %d: GROUND  TRUTH : %s\n",
+        training_iteration(), truth_text.string());
+    if (truth_text != text) {
+        tprintf("Iteration %d: ALIGNED TRUTH : %s\n",
             training_iteration(), text.string());
+    }
     if (debug_interval_ > 0 && training_iteration() % debug_interval_ == 0) {
       tprintf("TRAINING activation path for truth string %s\n",
               truth_text.string());

--- a/src/lstm/lstmtrainer.cpp
+++ b/src/lstm/lstmtrainer.cpp
@@ -878,8 +878,12 @@ Trainability LSTMTrainer::PrepareForBackward(const ImageData* trainingdata,
   STRING truth_text = DecodeLabels(truth_labels);
   targets->SubtractAllFromFloat(*fwd_outputs);
   if (debug_interval_ != 0) {
-    tprintf("Iteration %d: BEST OCR TEXT : %s\n", training_iteration(),
+      if (truth_text != ocr_text) {
+         tprintf("Iteration %d: GROUND  TRUTH : %s\n",
+            training_iteration(), truth_text.string());
+         tprintf("Iteration %d: BEST OCR TEXT : %s\n", training_iteration(),
             ocr_text.string());
+      }
   }
   double char_error = ComputeCharError(truth_labels, ocr_labels);
   double word_error = ComputeWordError(&truth_text, &ocr_text);


### PR DESCRIPTION
```
Iteration 3282: ALIGNED TRUTH : including just place 18 service Articles as could these Community to link them Forum most 0
Iteration 3282: GROUND  TRUTH : including just place 18 service Articles as could these Community to link them Forum most 0
Iteration 3282: BEST OCR TEXT : including just place 18 service Articles as could these Community to 1ink them Forum most 0
File /tmp/eng-2019-03-30.Lcy/eng.Cousine.exp0.lstmf page 41 :
Mean rms=0.346%, delta=0.157%, train=0.512%(1.009%), skip ratio=0%
Iteration 3283: ALIGNED TRUTH : first 27 then 2.100 they FIG. 1 (GeneRIF) World and ABOUT time October the service through
File ./engrestrict/eng.Cutive_Mono.exp0.lstmf page 54 (Perfect):
Mean rms=0.346%, delta=0.157%, train=0.512%(1.009%), skip ratio=0%
Iteration 3284: ALIGNED TRUTH : for , Page CD AbstractPlus most Page , over Other reference 40 should a Posts my the search
File ./engrestrict/eng.DejaVu_Sans_Mono.exp0.lstmf page 54 (Perfect):
Mean rms=0.346%, delta=0.157%, train=0.512%(1.009%), skip ratio=0%
Iteration 3285: ALIGNED TRUTH : Music am search this Please time each How at Online (7) get quality Advanced can may such a
File /tmp/eng-2019-03-30.Lcy/eng.Fira_Mono.exp0.lstmf page 16 (Perfect):
```