### PR TITLE
Modernize code by replacing C type casts

### DIFF
--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -577,7 +577,7 @@ bool TessPDFRenderer::BeginDocumentHandler() {
                "  /Length %lu /Filter /FlateDecode\n"
                ">>\n"
                "stream\n",
-               (unsigned long)len);
+               static_cast<unsigned long>(len));
   if (n >= sizeof(buf)) {
     lept_free(comp);
     return false;
@@ -624,7 +624,7 @@ bool TessPDFRenderer::BeginDocumentHandler() {
                "stream\n"
                "%s"
                "endstream\n"
-               "endobj\n", (unsigned long) strlen(stream), stream);
+               "endobj\n", static_cast<unsigned long>(strlen(stream)), stream);
   if (n >= sizeof(buf)) return false;
   AppendPDFObject(buf);
 
@@ -781,7 +781,7 @@ bool TessPDFRenderer::imageToPDFObj(Pix *pix,
                "<<\n"
                "  /Length %ld\n"
                "  /Subtype /Image\n",
-               objnum, (unsigned long) cid->nbytescomp);
+               objnum, static_cast<unsigned long>(cid->nbytescomp));
   if (n >= sizeof(b1)) {
     l_CIDataDestroy(&cid);
     return false;

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -1960,7 +1960,7 @@ static void find_modal_font(  // good chars in word
   int32_t count; //pile count
 
   if (fonts->get_total () > 0) {
-    font = (int16_t) fonts->mode ();
+    font = static_cast<int16_t>(fonts->mode ());
     *font_out = font;
     count = fonts->pile_count (font);
     *font_count = count < INT8_MAX ? count : INT8_MAX;

--- a/src/ccmain/docqual.cpp
+++ b/src/ccmain/docqual.cpp
@@ -177,7 +177,7 @@ void Tesseract::unrej_good_quality_words(  //unreject potential
     }
     else if ((page_res_it.row ()->char_count > 0) &&
       ((page_res_it.row ()->rej_count /
-      (float) page_res_it.row ()->char_count) <=
+      static_cast<float>(page_res_it.row ()->char_count)) <=
     quality_rowrej_pc)) {
       word = page_res_it.word ();
       if (word->reject_map.quality_recoverable_rejects() &&
@@ -863,7 +863,7 @@ GARBAGE_LEVEL Tesseract::garbage_word(WERD_RES *word, bool ok_dict_word) {
   if (len > 4) {
     dodgy_chars = 2 * tess_rejs + bad_char_count + isolated_digits +
         isolated_alphas;
-    if (dodgy_chars > 5 || (dodgy_chars / (float) len) > 0.5)
+    if (dodgy_chars > 5 || (dodgy_chars / static_cast<float>(len)) > 0.5)
       return G_DODGY;
     else
       return G_OK;

--- a/src/ccmain/fixspace.cpp
+++ b/src/ccmain/fixspace.cpp
@@ -509,7 +509,7 @@ void Tesseract::dump_words(WERD_RES_LIST &perm, int16_t score,
         if (!word_res_it.data()->part_of_combo) {
           tprintf("%s/%1d ",
                   word_res_it.data()->best_choice->unichar_string().string(),
-                  (int)word_res_it.data()->best_choice->permuter());
+                  static_cast<int>(word_res_it.data()->best_choice->permuter()));
         }
       }
       tprintf("\"\n");
@@ -520,7 +520,7 @@ void Tesseract::dump_words(WERD_RES_LIST &perm, int16_t score,
         if (!word_res_it.data()->part_of_combo) {
           tprintf("%s/%1d ",
                   word_res_it.data()->best_choice->unichar_string().string(),
-                  (int)word_res_it.data()->best_choice->permuter());
+                  static_cast<int>(word_res_it.data()->best_choice->permuter()));
         }
       }
       tprintf("\"\n");

--- a/src/ccmain/output.cpp
+++ b/src/ccmain/output.cpp
@@ -240,7 +240,7 @@ char determine_newline_type(                   //test line ends
   block_box = block->pdblk.bounding_box ();
                                  //gap to eol
   end_gap = block_box.right () - word_box.right ();
-  end_gap -= (int32_t) block->space ();
+  end_gap -= static_cast<int32_t>(block->space ());
   width = next_box.right () - next_box.left ();
   //      tprintf("end_gap=%d-%d=%d, width=%d-%d=%d, nl=%d\n",
   //              block_box.right(),word_box.right(),end_gap,

--- a/src/ccmain/paramsd.cpp
+++ b/src/ccmain/paramsd.cpp
@@ -2,7 +2,6 @@
 // File:        paramsd.cpp
 // Description: Tesseract parameter Editor
 // Author:      Joern Wanke
-// Created:     Wed Jul 18 10:05:01 PDT 2007
 //
 // (C) Copyright 2007, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -140,7 +139,7 @@ STRING ParamContent::GetValue() const {
   } else if (param_type_ == VT_DOUBLE) {
     result.add_str_double("", *dIt);
   } else if (param_type_ == VT_STRING) {
-    if (((STRING) * (sIt)).string() != nullptr) {
+    if (STRING(*(sIt)).string() != nullptr) {
       result = sIt->string();
     } else {
       result = "Null";

--- a/src/ccmain/pgedit.cpp
+++ b/src/ccmain/pgedit.cpp
@@ -426,7 +426,7 @@ bool Tesseract::process_cmd_win_event(                 // UI command semantics
     case RECOG_WERDS:
     case RECOG_PSEUDO:
     case SHOW_BLOB_FEATURES:
-      mode =(CMD_EVENTS) cmd_event;
+      mode =static_cast<CMD_EVENTS>(cmd_event);
       break;
     case DEBUG_WERD_CMD_EVENT:
       mode = DEBUG_WERD_CMD_EVENT;
@@ -822,13 +822,12 @@ bool Tesseract::word_display(PAGE_RES_IT* pr_it) {
                                  // display bounding box
   if (word->display_flag(DF_BOX)) {
     word->bounding_box().plot(image_win,
-     (ScrollView::Color)((int32_t)
+     static_cast<ScrollView::Color>((int32_t)
       editor_image_word_bb_color),
-     (ScrollView::Color)((int32_t)
+     static_cast<ScrollView::Color>((int32_t)
       editor_image_word_bb_color));
 
-    auto c = (ScrollView::Color)
-       ((int32_t) editor_image_blob_bb_color);
+    auto c = static_cast<ScrollView::Color>((int32_t) editor_image_blob_bb_color);
     image_win->Pen(c);
     // cblob iterator
     C_BLOB_IT c_it(word->cblob_list());
@@ -904,8 +903,8 @@ bool Tesseract::word_display(PAGE_RES_IT* pr_it) {
 
   if (!displayed_something)      // display BBox anyway
     word->bounding_box().plot(image_win,
-     (ScrollView::Color)((int32_t) editor_image_word_bb_color),
-     (ScrollView::Color)((int32_t)
+     static_cast<ScrollView::Color>((int32_t) editor_image_word_bb_color),
+     static_cast<ScrollView::Color>((int32_t)
       editor_image_word_bb_color));
   return true;
 }

--- a/src/ccmain/reject.cpp
+++ b/src/ccmain/reject.cpp
@@ -577,7 +577,7 @@ int16_t Tesseract::count_alphanums(WERD_RES *word_res) {
 void Tesseract::reject_mostly_rejects(WERD_RES *word) {
   /* Reject the whole of the word if the fraction of rejects exceeds a limit */
 
-  if ((float) word->reject_map.reject_count() / word->reject_map.length() >=
+  if (static_cast<float>(word->reject_map.reject_count()) / word->reject_map.length() >=
     rej_whole_of_mostly_reject_word_fract)
     word->reject_map.rej_word_mostly_rej();
 }
@@ -640,7 +640,7 @@ void Tesseract::flip_hyphens(WERD_RES *word_res) {
     // Don't touch small or touching blobs - it is too dangerous.
     if ((out_box.width() > 8 * word_res->denorm.x_scale()) &&
         (out_box.left() > prev_right) && (out_box.right() < next_left)) {
-      aspect_ratio = out_box.width() / (float) out_box.height();
+      aspect_ratio = out_box.width() / static_cast<float>(out_box.height());
       if (word_res->uch_set->eq(best_choice->unichar_id(i), ".")) {
         if (aspect_ratio >= tessedit_upper_flip_hyphen &&
             word_res->uch_set->contains_unichar_id(unichar_dash) &&

--- a/src/ccstruct/blobbox.cpp
+++ b/src/ccstruct/blobbox.cpp
@@ -136,14 +136,14 @@ void BLOBNBOX::chop(                        //chop blobs
   BLOBNBOX_IT blob_it;           //blob iterator
 
                                  //get no of chops
-  blobcount = (int16_t) floor (box.width () / xheight);
+  blobcount = static_cast<int16_t>(floor (box.width () / xheight));
   if (blobcount > 1 && cblob_ptr != nullptr) {
                                  //width of each
-    blobwidth = (float) (box.width () + 1) / blobcount;
+    blobwidth = static_cast<float>(box.width () + 1) / blobcount;
     for (blobindex = blobcount - 1, rightx = box.right ();
     blobindex >= 0; blobindex--, rightx -= blobwidth) {
-      ymin = (float) INT32_MAX;
-      ymax = (float) -INT32_MAX;
+      ymin = static_cast<float>(INT32_MAX);
+      ymax = static_cast<float>(-INT32_MAX);
       blob_it = *start_it;
       do {
         blob = blob_it.data ();
@@ -155,11 +155,11 @@ void BLOBNBOX::chop(                        //chop blobs
       }
       while (blob != end_it->data ());
       if (ymin < ymax) {
-        leftx = (int16_t) floor (rightx - blobwidth);
+        leftx = static_cast<int16_t>(floor (rightx - blobwidth));
         if (leftx < box.left ())
           leftx = box.left ();   //clip to real box
-        bl = ICOORD (leftx, (int16_t) floor (ymin));
-        tr = ICOORD ((int16_t) ceil (rightx), (int16_t) ceil (ymax));
+        bl = ICOORD (leftx, static_cast<int16_t>(floor (ymin)));
+        tr = ICOORD (static_cast<int16_t>(ceil (rightx)), static_cast<int16_t>(ceil (ymax)));
         if (blobindex == 0)
           box = TBOX (bl, tr);    //change box
         else {
@@ -510,8 +510,8 @@ void find_cblob_limits(                  //get y limits
                                  //outlines
   C_OUTLINE_IT out_it = blob->out_list ();
 
-  ymin = (float) INT32_MAX;
-  ymax = (float) -INT32_MAX;
+  ymin = static_cast<float>(INT32_MAX);
+  ymax = static_cast<float>(-INT32_MAX);
   for (out_it.mark_cycle_pt (); !out_it.cycled_list (); out_it.forward ()) {
     outline = out_it.data ();
     pos = outline->start_pos (); //get coords
@@ -549,8 +549,8 @@ void find_cblob_vlimits(               //get y limits
                                  //outlines
   C_OUTLINE_IT out_it = blob->out_list ();
 
-  ymin = (float) INT32_MAX;
-  ymax = (float) -INT32_MAX;
+  ymin = static_cast<float>(INT32_MAX);
+  ymax = static_cast<float>(-INT32_MAX);
   for (out_it.mark_cycle_pt (); !out_it.cycled_list (); out_it.forward ()) {
     outline = out_it.data ();
     pos = outline->start_pos (); //get coords
@@ -586,8 +586,8 @@ void find_cblob_hlimits(                //get x limits
                                  //outlines
   C_OUTLINE_IT out_it = blob->out_list ();
 
-  xmin = (float) INT32_MAX;
-  xmax = (float) -INT32_MAX;
+  xmin = static_cast<float>(INT32_MAX);
+  xmax = static_cast<float>(-INT32_MAX);
   for (out_it.mark_cycle_pt (); !out_it.cycled_list (); out_it.forward ()) {
     outline = out_it.data ();
     pos = outline->start_pos (); //get coords

--- a/src/ccstruct/blread.cpp
+++ b/src/ccstruct/blread.cpp
@@ -50,8 +50,8 @@ bool read_unlv_file(                    //print list of sides
     while (tfscanf(pdfp, "%d %d %d %d %*s", &x, &y, &width, &height) >= 4) {
                                  //make rect block
       block = new BLOCK (name.string (), true, 0, 0,
-                         (int16_t) x, (int16_t) (ysize - y - height),
-                         (int16_t) (x + width), (int16_t) (ysize - y));
+                         static_cast<int16_t>(x), static_cast<int16_t>(ysize - y - height),
+                         static_cast<int16_t>(x + width), static_cast<int16_t>(ysize - y));
                                  //on end of list
       block_it.add_to_end (block);
     }

--- a/src/ccstruct/coutln.cpp
+++ b/src/ccstruct/coutln.cpp
@@ -63,7 +63,7 @@ C_OUTLINE::C_OUTLINE(CRACKEDGE* startpt, ICOORD bot_left, ICOORD top_right,
     return;
   }
                                  //get memory
-  steps = (uint8_t *)calloc(step_mem(), 1);
+  steps = static_cast<uint8_t *>(calloc(step_mem(), 1));
   edgept = startpt;
 
   for (stepindex = 0; stepindex < length; stepindex++) {
@@ -159,7 +159,7 @@ C_OUTLINE::C_OUTLINE(C_OUTLINE* srcline, FCOORD rotation) : offsets(nullptr) {
     return;
   }
                                  //get memory
-  steps = (uint8_t *)calloc(step_mem(), 1);
+  steps = static_cast<uint8_t *>(calloc(step_mem(), 1));
 
   for (int iteration = 0; iteration < 2; ++iteration) {
     DIR128 round1 = iteration == 0 ? 32 : 0;
@@ -1012,7 +1012,7 @@ C_OUTLINE& C_OUTLINE::operator=(const C_OUTLINE& source) {
   start = source.start;
   free(steps);
   stepcount = source.stepcount;
-  steps = (uint8_t *)malloc(step_mem());
+  steps = static_cast<uint8_t *>(malloc(step_mem()));
   memmove (steps, source.steps, step_mem());
   if (!children.empty ())
     children.clear ();

--- a/src/ccstruct/coutln.h
+++ b/src/ccstruct/coutln.h
@@ -137,7 +137,7 @@ class DLLSYM C_OUTLINE:public ELIST_LINK {
     }
     // Return step at a given index as a DIR128.
     DIR128 step_dir(int index) const {
-      return DIR128((int16_t)(((steps[index/4] >> (index%4 * 2)) & STEP_MASK) <<
+      return DIR128(static_cast<int16_t>(((steps[index/4] >> (index%4 * 2)) & STEP_MASK) <<
                       (DIRBITS - 2)));
     }
     // Return the step vector for the given outline position.

--- a/src/ccstruct/fontinfo.cpp
+++ b/src/ccstruct/fontinfo.cpp
@@ -93,7 +93,7 @@ void FontInfoTable::MoveSpacingInfoFrom(FontInfoTable* other) {
         push_back(other->get(i));
         other->get(i).name = nullptr;
       } else {
-        delete [] get(target_index).spacing_vec;
+        delete get(target_index).spacing_vec;
         get(target_index).spacing_vec = other->get(i).spacing_vec;
       }
       other->get(i).spacing_vec = nullptr;

--- a/src/ccstruct/mod128.h
+++ b/src/ccstruct/mod128.h
@@ -36,7 +36,7 @@ class DLLSYM DIR128
       value %= MODULUS;          //modulo arithmetic
       if (value < 0)
         value += MODULUS;        //done properly
-      dir = (int8_t) value;
+      dir = static_cast<int8_t>(value);
     }
     DIR128(const FCOORD fc);  //quantize vector
 
@@ -45,7 +45,7 @@ class DLLSYM DIR128
       value %= MODULUS;          //modulo arithmetic
       if (value < 0)
         value += MODULUS;        //done properly
-      dir = (int8_t) value;
+      dir = static_cast<int8_t>(value);
       return *this;
     }
     int8_t operator- (             //subtraction
@@ -58,7 +58,7 @@ class DLLSYM DIR128
         result -= MODULUS;       //get in range
       else if (result < -MODULUS / 2)
         result += MODULUS;
-      return (int8_t) result;
+      return static_cast<int8_t>(result);
     }
     DIR128 operator+ (           //addition
       const DIR128 & add) const  //of itself

--- a/src/ccstruct/ocrblock.h
+++ b/src/ccstruct/ocrblock.h
@@ -61,7 +61,7 @@ class BLOCK:public ELIST_LINK
                  int16_t space,
                  int16_t ch_pitch) {
     proportional = prop;
-    kerning = (int8_t) kern;
+    kerning = static_cast<int8_t>(kern);
     spacing = space;
     pitch = ch_pitch;
   }

--- a/src/ccstruct/ocrrow.h
+++ b/src/ccstruct/ocrrow.h
@@ -59,7 +59,7 @@ class ROW:public ELIST_LINK
     float base_line(                     //compute baseline
                     float xpos) const {  //at the position
                                  //get spline value
-      return (float) baseline.y (xpos);
+      return static_cast<float>(baseline.y (xpos));
     }
     float x_height() const {  //return x height
       return xheight;

--- a/src/ccstruct/quadratc.h
+++ b/src/ccstruct/quadratc.h
@@ -37,7 +37,7 @@ class QUAD_COEFFS
 
     float y(                  //evaluate
             float x) const {  //at x
-      return (float) ((a * x + b) * x + c);
+      return static_cast<float>((a * x + b) * x + c);
     }
 
     void move(               // reposition word
@@ -50,8 +50,8 @@ class QUAD_COEFFS
       int16_t p = vec.x ();
       int16_t q = vec.y ();
 
-      c = (float) (c - b * p + a * p * p + q);
-      b = (float) (b - 2 * a * p);
+      c = static_cast<float>(c - b * p + a * p * p + q);
+      b = static_cast<float>(b - 2 * a * p);
     }
 
     double a;                    //x squared

--- a/src/ccstruct/quspline.cpp
+++ b/src/ccstruct/quspline.cpp
@@ -192,8 +192,8 @@ double QSPLINE::step(            //find step functions
   total = 0;
   while (index1 < index2) {
     total +=
-      (double) quadratics[index1 + 1].y ((float) xcoords[index1 + 1]);
-    total -= (double) quadratics[index1].y ((float) xcoords[index1 + 1]);
+      static_cast<double>(quadratics[index1 + 1].y (static_cast<float>(xcoords[index1 + 1])));
+    total -= static_cast<double>(quadratics[index1].y (static_cast<float>(xcoords[index1 + 1])));
     index1++;                    /*next segment */
   }
   return total;                  /*total steps */
@@ -356,7 +356,7 @@ void QSPLINE::plot(                //draw it
   window->Pen(colour);
   for (segment = 0; segment < segments; segment++) {
     increment =
-      (double) (xcoords[segment + 1] -
+      static_cast<double>(xcoords[segment + 1] -
       xcoords[segment]) / QSPLINE_PRECISION;
     x = xcoords[segment];
     for (step = 0; step <= QSPLINE_PRECISION; step++) {

--- a/src/ccstruct/statistc.cpp
+++ b/src/ccstruct/statistc.cpp
@@ -656,7 +656,7 @@ int32_t choose_nth_item(int32_t index, float *array, int32_t count) {
       index = 0;                 // ensure legal
     else if (index >= count)
       index = count - 1;
-    equal_count = (int32_t) (rand() % count);
+    equal_count = static_cast<int32_t>(rand() % count);
     pivot = array[equal_count];
                                  // fill gap
     array[equal_count] = array[0];
@@ -712,7 +712,7 @@ int32_t choose_nth_item(int32_t index, void *array, int32_t count, size_t size,
   if (count <= 1)
     return 0;
   if (count == 2) {
-    if (compar (array, (char *) array + size) < 0) {
+    if (compar (array, static_cast<char *>(array) + size) < 0) {
       return index >= 1 ? 1 : 0;
     }
     else {
@@ -723,15 +723,15 @@ int32_t choose_nth_item(int32_t index, void *array, int32_t count, size_t size,
     index = 0;                   // ensure legal
   else if (index >= count)
     index = count - 1;
-  pivot = (int32_t) (rand () % count);
+  pivot = static_cast<int32_t>(rand () % count);
   swap_entries (array, size, pivot, 0);
   next_lesser = 0;
   prev_greater = count;
   equal_count = 1;
   for (next_sample = 1; next_sample < prev_greater;) {
     result =
-      compar ((char *) array + size * next_sample,
-      (char *) array + size * next_lesser);
+      compar (static_cast<char *>(array) + size * next_sample,
+      static_cast<char *>(array) + size * next_lesser);
     if (result < 0) {
       swap_entries (array, size, next_lesser++, next_sample++);
       // shuffle
@@ -751,7 +751,7 @@ int32_t choose_nth_item(int32_t index, void *array, int32_t count, size_t size,
     return next_lesser;          // in equal bracket
   else
     return choose_nth_item (index - prev_greater,
-      (char *) array + size * prev_greater,
+      static_cast<char *>(array) + size * prev_greater,
       count - prev_greater, size,
       compar) + prev_greater;
 }

--- a/src/ccutil/clst.cpp
+++ b/src/ccutil/clst.cpp
@@ -138,7 +138,7 @@ const void *, const void *)) {
 
   /* Allocate an array of pointers, one per list element */
   count = length ();
-  base = (void **) malloc (count * sizeof (void *));
+  base = static_cast<void **>(malloc (count * sizeof (void *)));
 
   /* Extract all elements, putting the pointers in the array */
   current = base;

--- a/src/ccutil/elst.cpp
+++ b/src/ccutil/elst.cpp
@@ -115,7 +115,7 @@ const void *, const void *)) {
 
   /* Allocate an array of pointers, one per list element */
   count = length ();
-  base = (ELIST_LINK **) malloc (count * sizeof (ELIST_LINK *));
+  base = static_cast<ELIST_LINK **>(malloc (count * sizeof (ELIST_LINK *)));
 
   /* Extract all elements, putting the pointers in the array */
   current = base;

--- a/src/ccutil/elst2.cpp
+++ b/src/ccutil/elst2.cpp
@@ -115,7 +115,7 @@ const void *, const void *)) {
 
   /* Allocate an array of pointers, one per list element */
   count = length ();
-  base = (ELIST2_LINK **) malloc (count * sizeof (ELIST2_LINK *));
+  base = static_cast<ELIST2_LINK **>(malloc (count * sizeof (ELIST2_LINK *)));
 
   /* Extract all elements, putting the pointers in the array */
   current = base;

--- a/src/ccutil/strngs.cpp
+++ b/src/ccutil/strngs.cpp
@@ -51,7 +51,7 @@ const int kMaxDoubleSize = 16;
 const int kMinCapacity = 16;
 
 char* STRING::AllocData(int used, int capacity) {
-  data_ = (STRING_HEADER *)malloc(capacity + sizeof(STRING_HEADER));
+  data_ = static_cast<STRING_HEADER *>(malloc(capacity + sizeof(STRING_HEADER)));
 
   // header is the metadata for this memory block
   STRING_HEADER* header = GetHeader();
@@ -70,7 +70,7 @@ void STRING::DiscardData() {
 char* STRING::ensure_cstr(int32_t min_capacity) {
   STRING_HEADER* orig_header = GetHeader();
   if (min_capacity <= orig_header->capacity_)
-    return ((char *)this->data_) + sizeof(STRING_HEADER);
+    return (reinterpret_cast<char *>(this->data_)) + sizeof(STRING_HEADER);
 
   // if we are going to grow bigger, than double our existing
   // size, but if that still is not big enough then keep the
@@ -79,7 +79,7 @@ char* STRING::ensure_cstr(int32_t min_capacity) {
     min_capacity = 2 * orig_header->capacity_;
 
   int alloc = sizeof(STRING_HEADER) + min_capacity;
-  auto* new_header = (STRING_HEADER*)(malloc(alloc));
+  auto* new_header = static_cast<STRING_HEADER*>(malloc(alloc));
 
   memcpy(&new_header[1], GetCStr(), orig_header->used_);
   new_header->capacity_ = min_capacity;
@@ -90,7 +90,7 @@ char* STRING::ensure_cstr(int32_t min_capacity) {
   data_ = new_header;
 
   assert(InvariantOk());
-  return ((char *)data_) + sizeof(STRING_HEADER);
+  return (reinterpret_cast<char *>(data_)) + sizeof(STRING_HEADER);
 }
 
 // This is const, but is modifying a mutable field
@@ -277,7 +277,7 @@ char& STRING::operator[](int32_t index) const {
   // Code is casting away this const and mutating the string,
   // so mark used_ as -1 to flag it unreliable.
   GetHeader()->used_ = -1;
-  return ((char *)GetCStr())[index];
+  return (const_cast<char *>(GetCStr()))[index];
 }
 #endif
 

--- a/src/classify/adaptive.cpp
+++ b/src/classify/adaptive.cpp
@@ -79,7 +79,7 @@ void FreeTempConfig(TEMP_CONFIG Config) {
 
 /*---------------------------------------------------------------------------*/
 void FreeTempProto(void *arg) {
-  auto proto = (PROTO) arg;
+  auto proto = static_cast<PROTO>(arg);
 
   free(proto);
 }
@@ -102,7 +102,7 @@ static void FreePermConfig(PERM_CONFIG Config) {
 ADAPT_CLASS NewAdaptedClass() {
   ADAPT_CLASS Class;
 
-  Class = (ADAPT_CLASS) Emalloc (sizeof (ADAPT_CLASS_STRUCT));
+  Class = static_cast<ADAPT_CLASS>(Emalloc (sizeof (ADAPT_CLASS_STRUCT)));
   Class->NumPermConfigs = 0;
   Class->MaxNumTimesSeen = 0;
   Class->TempProtos = NIL_LIST;
@@ -151,7 +151,7 @@ namespace tesseract {
 ADAPT_TEMPLATES Classify::NewAdaptedTemplates(bool InitFromUnicharset) {
   ADAPT_TEMPLATES Templates;
 
-  Templates = (ADAPT_TEMPLATES) Emalloc (sizeof (ADAPT_TEMPLATES_STRUCT));
+  Templates = static_cast<ADAPT_TEMPLATES>(Emalloc (sizeof (ADAPT_TEMPLATES_STRUCT)));
 
   Templates->Templates = NewIntTemplates ();
   Templates->NumPermClasses = 0;
@@ -203,7 +203,7 @@ void free_adapted_templates(ADAPT_TEMPLATES templates) {
 TEMP_CONFIG NewTempConfig(int MaxProtoId, int FontinfoId) {
   int NumProtos = MaxProtoId + 1;
 
-  auto Config = (TEMP_CONFIG)malloc(sizeof(TEMP_CONFIG_STRUCT));
+  auto Config = static_cast<TEMP_CONFIG>(malloc(sizeof(TEMP_CONFIG_STRUCT)));
   Config->Protos = NewBitVector (NumProtos);
 
   Config->NumTimesSeen = 1;
@@ -226,7 +226,7 @@ TEMP_CONFIG NewTempConfig(int MaxProtoId, int FontinfoId) {
  * @note Globals: none
  */
 TEMP_PROTO NewTempProto() {
-  return (TEMP_PROTO)malloc(sizeof(TEMP_PROTO_STRUCT));
+  return static_cast<TEMP_PROTO>(malloc(sizeof(TEMP_PROTO_STRUCT)));
 }                                /* NewTempProto */
 
 
@@ -285,7 +285,7 @@ ADAPT_CLASS ReadAdaptedClass(TFile *fp) {
   ADAPT_CLASS Class;
 
   /* first read high level adapted class structure */
-  Class = (ADAPT_CLASS) Emalloc (sizeof (ADAPT_CLASS_STRUCT));
+  Class = static_cast<ADAPT_CLASS>(Emalloc (sizeof (ADAPT_CLASS_STRUCT)));
   fp->FRead(Class, sizeof(ADAPT_CLASS_STRUCT), 1);
 
   /* then read in the definitions of the permanent protos and configs */
@@ -300,7 +300,7 @@ ADAPT_CLASS ReadAdaptedClass(TFile *fp) {
   fp->FRead(&NumTempProtos, sizeof(int), 1);
   Class->TempProtos = NIL_LIST;
   for (i = 0; i < NumTempProtos; i++) {
-    auto TempProto = (TEMP_PROTO)malloc(sizeof(TEMP_PROTO_STRUCT));
+    auto TempProto = static_cast<TEMP_PROTO>(malloc(sizeof(TEMP_PROTO_STRUCT)));
     fp->FRead(TempProto, sizeof(TEMP_PROTO_STRUCT), 1);
     Class->TempProtos = push_last (Class->TempProtos, TempProto);
   }
@@ -333,7 +333,7 @@ ADAPT_TEMPLATES Classify::ReadAdaptedTemplates(TFile *fp) {
   ADAPT_TEMPLATES Templates;
 
   /* first read the high level adaptive template struct */
-  Templates = (ADAPT_TEMPLATES) Emalloc (sizeof (ADAPT_TEMPLATES_STRUCT));
+  Templates = static_cast<ADAPT_TEMPLATES>(Emalloc (sizeof (ADAPT_TEMPLATES_STRUCT)));
   fp->FRead(Templates, sizeof(ADAPT_TEMPLATES_STRUCT), 1);
 
   /* then read in the basic integer templates */
@@ -360,7 +360,7 @@ ADAPT_TEMPLATES Classify::ReadAdaptedTemplates(TFile *fp) {
  * @note Globals: none
  */
 PERM_CONFIG ReadPermConfig(TFile *fp) {
-  auto Config = (PERM_CONFIG)malloc(sizeof(PERM_CONFIG_STRUCT));
+  auto Config = static_cast<PERM_CONFIG>(malloc(sizeof(PERM_CONFIG_STRUCT)));
   uint8_t NumAmbigs;
   fp->FRead(&NumAmbigs, sizeof(NumAmbigs), 1);
   Config->Ambigs = new UNICHAR_ID[NumAmbigs + 1];
@@ -384,7 +384,7 @@ PERM_CONFIG ReadPermConfig(TFile *fp) {
  * @note Globals: none
  */
 TEMP_CONFIG ReadTempConfig(TFile *fp) {
-  auto Config = (TEMP_CONFIG)malloc(sizeof(TEMP_CONFIG_STRUCT));
+  auto Config = static_cast<TEMP_CONFIG>(malloc(sizeof(TEMP_CONFIG_STRUCT)));
   fp->FRead(Config, sizeof(TEMP_CONFIG_STRUCT), 1);
 
   Config->Protos = NewBitVector (Config->ProtoVectorSize * BITSINLONG);

--- a/src/classify/adaptmatch.cpp
+++ b/src/classify/adaptmatch.cpp
@@ -965,7 +965,7 @@ void Classify::DisplayAdaptedChar(TBLOB* blob, INT_CLASS_STRUCT* int_class) {
     uint32_t ConfigMask;
     ConfigMask = 1 << int_result.config;
     ShowMatchDisplay();
-    im_.Match(int_class, AllProtosOn, (BIT_VECTOR)&ConfigMask,
+    im_.Match(int_class, AllProtosOn, static_cast<BIT_VECTOR>(&ConfigMask),
               bl_features.size(), &bl_features[0],
               &int_result, classify_adapt_feature_threshold,
               6 | 0x19, matcher_debug_separate_windows);
@@ -1938,7 +1938,7 @@ void Classify::MakePermanent(ADAPT_TEMPLATES Templates,
 
   // Initialize permanent config.
   Ambigs = GetAmbiguities(Blob, ClassId);
-  auto Perm = (PERM_CONFIG)malloc(sizeof(PERM_CONFIG_STRUCT));
+  auto Perm = static_cast<PERM_CONFIG>(malloc(sizeof(PERM_CONFIG_STRUCT)));
   Perm->Ambigs = Ambigs;
   Perm->FontinfoId = Config->FontinfoId;
 
@@ -1985,8 +1985,8 @@ int MakeTempProtoPerm(void *item1, void *item2) {
   TEMP_PROTO TempProto;
   PROTO_KEY *ProtoKey;
 
-  TempProto = (TEMP_PROTO) item1;
-  ProtoKey = (PROTO_KEY *) item2;
+  TempProto = static_cast<TEMP_PROTO>(item1);
+  ProtoKey = static_cast<PROTO_KEY *>(item2);
 
   Class = ProtoKey->Templates->Class[ProtoKey->ClassId];
   Config = TempConfigFor(Class, ProtoKey->ConfigId);

--- a/src/classify/cluster.cpp
+++ b/src/classify/cluster.cpp
@@ -1829,12 +1829,13 @@ static double NormalDensity(int32_t x) {
  * @return The value of the uniform distribution at x.
  */
 static double UniformDensity(int32_t x) {
-  static double UniformDistributionDensity = 1.0 / BUCKETTABLESIZE;
+  constexpr auto UniformDistributionDensity = 1.0 / BUCKETTABLESIZE;
 
-  if ((x >= 0.0) && (x <= BUCKETTABLESIZE))
+  if ((x >= 0) && (x <= BUCKETTABLESIZE)) {
     return UniformDistributionDensity;
-  else
+  } else {
     return 0.0;
+  }
 }                                // UniformDensity
 
 /**

--- a/src/classify/cluster.cpp
+++ b/src/classify/cluster.cpp
@@ -377,7 +377,7 @@ MakeClusterer (int16_t SampleSize, const PARAM_DESC ParamDesc[]) {
   int i;
 
   // allocate main clusterer data structure and init simple fields
-  Clusterer = (CLUSTERER *) Emalloc (sizeof (CLUSTERER));
+  Clusterer = static_cast<CLUSTERER *>(Emalloc (sizeof (CLUSTERER)));
   Clusterer->SampleSize = SampleSize;
   Clusterer->NumberOfSamples = 0;
   Clusterer->NumChar = 0;
@@ -388,7 +388,7 @@ MakeClusterer (int16_t SampleSize, const PARAM_DESC ParamDesc[]) {
 
   // maintain a copy of param descriptors in the clusterer data structure
   Clusterer->ParamDesc =
-    (PARAM_DESC *) Emalloc (SampleSize * sizeof (PARAM_DESC));
+    static_cast<PARAM_DESC *>(Emalloc (SampleSize * sizeof (PARAM_DESC)));
   for (i = 0; i < SampleSize; i++) {
     Clusterer->ParamDesc[i].Circular = ParamDesc[i].Circular;
     Clusterer->ParamDesc[i].NonEssential = ParamDesc[i].NonEssential;
@@ -435,9 +435,9 @@ SAMPLE* MakeSample(CLUSTERER * Clusterer, const float* Feature,
   ASSERT_HOST(Clusterer->Root == nullptr);
 
   // allocate the new sample and initialize it
-  Sample = (SAMPLE *) Emalloc (sizeof (SAMPLE) +
+  Sample = static_cast<SAMPLE *>(Emalloc (sizeof (SAMPLE) +
     (Clusterer->SampleSize -
-    1) * sizeof (float));
+    1) * sizeof (float)));
   Sample->Clustered = false;
   Sample->Prototype = false;
   Sample->SampleCount = 1;
@@ -549,7 +549,7 @@ void FreeProtoList(LIST *ProtoList) {
  * @return None
  */
 void FreePrototype(void *arg) {  //PROTOTYPE     *Prototype)
-  auto *Prototype = (PROTOTYPE *) arg;
+  auto *Prototype = static_cast<PROTOTYPE *>(arg);
 
   // unmark the corresponding cluster (if there is one
   if (Prototype->Cluster != nullptr)
@@ -584,7 +584,7 @@ CLUSTER *NextSample(LIST *SearchState) {
 
   if (*SearchState == NIL_LIST)
     return (nullptr);
-  Cluster = (CLUSTER *) first_node (*SearchState);
+  Cluster = reinterpret_cast<CLUSTER *>first_node (*SearchState);
   *SearchState = pop (*SearchState);
   for (;;) {
     if (Cluster->Left == nullptr)
@@ -615,15 +615,13 @@ float Mean(PROTOTYPE *Proto, uint16_t Dimension) {
 float StandardDeviation(PROTOTYPE *Proto, uint16_t Dimension) {
   switch (Proto->Style) {
     case spherical:
-      return ((float) sqrt ((double) Proto->Variance.Spherical));
+      return (static_cast<float>(sqrt (static_cast<double>(Proto->Variance.Spherical))));
     case elliptical:
-      return ((float)
-        sqrt ((double) Proto->Variance.Elliptical[Dimension]));
+      return (static_cast<float>(sqrt (static_cast<double>(Proto->Variance.Elliptical[Dimension]))));
     case mixed:
       switch (Proto->Distrib[Dimension]) {
         case normal:
-          return ((float)
-            sqrt ((double) Proto->Variance.Elliptical[Dimension]));
+          return (static_cast<float>(sqrt (static_cast<double>(Proto->Variance.Elliptical[Dimension]))));
         case uniform:
         case D_random:
           return (Proto->Variance.Elliptical[Dimension]);
@@ -659,11 +657,10 @@ static void CreateClusterTree(CLUSTERER *Clusterer) {
   // each sample and its nearest neighbor form a "potential" cluster
   // save these in a heap with the "best" potential clusters on top
   context.tree = Clusterer->KDTree;
-  context.candidates = (TEMPCLUSTER *)
-    Emalloc(Clusterer->NumberOfSamples * sizeof(TEMPCLUSTER));
+  context.candidates = static_cast<TEMPCLUSTER *>(Emalloc(Clusterer->NumberOfSamples * sizeof(TEMPCLUSTER)));
   context.next = 0;
   context.heap = new ClusterHeap(Clusterer->NumberOfSamples);
-  KDWalk(context.tree, (void_proc)MakePotentialClusters, &context);
+  KDWalk(context.tree, reinterpret_cast<void_proc>(MakePotentialClusters), &context);
 
   // form potential clusters into actual clusters - always do "best" first
   while (context.heap->Pop(&HeapEntry)) {
@@ -700,7 +697,7 @@ static void CreateClusterTree(CLUSTERER *Clusterer) {
   }
 
   // the root node in the cluster tree is now the only node in the kd-tree
-  Clusterer->Root = (CLUSTER *) RootOf(Clusterer->KDTree);
+  Clusterer->Root = static_cast<CLUSTER *>RootOf(Clusterer->KDTree);
 
   // free up the memory used by the K-D tree, heap, and temp clusters
   FreeKDTree(context.tree);
@@ -760,7 +757,7 @@ FindNearestNeighbor(KDTREE* Tree, CLUSTER* Cluster, float* Distance)
 
   // find the 2 nearest neighbors of the cluster
   KDNearestNeighborSearch(Tree, Cluster->Mean, MAXNEIGHBORS, MAXDISTANCE,
-                          &NumberOfNeighbors, (void **)Neighbor, Dist);
+                          &NumberOfNeighbors, reinterpret_cast<void **>(Neighbor), Dist);
 
   // search for the nearest neighbor that is not the cluster itself
   *Distance = MAXDISTANCE;
@@ -788,8 +785,8 @@ static CLUSTER* MakeNewCluster(CLUSTERER* Clusterer,
   CLUSTER *Cluster;
 
   // allocate the new cluster and initialize it
-  Cluster = (CLUSTER *) Emalloc(
-      sizeof(CLUSTER) + (Clusterer->SampleSize - 1) * sizeof(float));
+  Cluster = static_cast<CLUSTER *>(Emalloc(
+      sizeof(CLUSTER) + (Clusterer->SampleSize - 1) * sizeof(float)));
   Cluster->Clustered = false;
   Cluster->Prototype = false;
   Cluster->Left = TempCluster->Cluster;
@@ -883,7 +880,7 @@ static void ComputePrototypes(CLUSTERER* Clusterer, CLUSTERCONFIG* Config) {
     // remove the next cluster to be analyzed from the stack
     // try to make a prototype from the cluster
     // if successful, put it on the proto list, else split the cluster
-    Cluster = (CLUSTER *) first_node (ClusterStack);
+    Cluster = reinterpret_cast<CLUSTER *>first_node (ClusterStack);
     ClusterStack = pop (ClusterStack);
     Prototype = MakePrototype(Clusterer, Config, Cluster);
     if (Prototype != nullptr) {
@@ -930,7 +927,7 @@ static PROTOTYPE* MakePrototype(CLUSTERER* Clusterer, CLUSTERCONFIG* Config,
   // character samples have been removed (as above)
   Proto = MakeDegenerateProto(
       Clusterer->SampleSize, Cluster, Statistics, Config->ProtoStyle,
-      (int32_t) (Config->MinSamples * Clusterer->NumChar));
+      static_cast<int32_t>(Config->MinSamples * Clusterer->NumChar));
   if (Proto != nullptr) {
     FreeStatistics(Statistics);
     return Proto;
@@ -1155,7 +1152,7 @@ static PROTOTYPE* MakeSphericalProto(CLUSTERER* Clusterer,
 
     FillBuckets (Buckets, Cluster, i, &(Clusterer->ParamDesc[i]),
       Cluster->Mean[i],
-      sqrt ((double) (Statistics->AvgVariance)));
+      sqrt (static_cast<double>(Statistics->AvgVariance)));
     if (!DistributionOK (Buckets))
       break;
   }
@@ -1189,8 +1186,8 @@ static PROTOTYPE* MakeEllipticalProto(CLUSTERER* Clusterer,
 
     FillBuckets (Buckets, Cluster, i, &(Clusterer->ParamDesc[i]),
       Cluster->Mean[i],
-      sqrt ((double) Statistics->
-      CoVariance[i * (Clusterer->SampleSize + 1)]));
+      sqrt (static_cast<double>(Statistics->
+      CoVariance[i * (Clusterer->SampleSize + 1)])));
     if (!DistributionOK (Buckets))
       break;
   }
@@ -1233,7 +1230,7 @@ static PROTOTYPE* MakeMixedProto(CLUSTERER* Clusterer,
 
     FillBuckets (NormalBuckets, Cluster, i, &(Clusterer->ParamDesc[i]),
       Proto->Mean[i],
-      sqrt ((double) Proto->Variance.Elliptical[i]));
+      sqrt (static_cast<double>(Proto->Variance.Elliptical[i])));
     if (DistributionOK (NormalBuckets))
       continue;
 
@@ -1281,7 +1278,7 @@ static void MakeDimRandom(uint16_t i, PROTOTYPE* Proto, PARAM_DESC* ParamDesc) {
   Proto->TotalMagnitude /= Proto->Magnitude.Elliptical[i];
   Proto->Magnitude.Elliptical[i] = 1.0 / ParamDesc->Range;
   Proto->TotalMagnitude *= Proto->Magnitude.Elliptical[i];
-  Proto->LogMagnitude = log ((double) Proto->TotalMagnitude);
+  Proto->LogMagnitude = log (static_cast<double>(Proto->TotalMagnitude));
 
   // note that the proto Weight is irrelevant for D_random protos
 }                                // MakeDimRandom
@@ -1308,7 +1305,7 @@ static void MakeDimUniform(uint16_t i, PROTOTYPE* Proto, STATISTICS* Statistics)
   Proto->Magnitude.Elliptical[i] =
     1.0 / (2.0 * Proto->Variance.Elliptical[i]);
   Proto->TotalMagnitude *= Proto->Magnitude.Elliptical[i];
-  Proto->LogMagnitude = log ((double) Proto->TotalMagnitude);
+  Proto->LogMagnitude = log (static_cast<double>(Proto->TotalMagnitude));
 
   // note that the proto Weight is irrelevant for uniform protos
 }                                // MakeDimUniform
@@ -1338,13 +1335,13 @@ ComputeStatistics (int16_t N, PARAM_DESC ParamDesc[], CLUSTER * Cluster) {
   uint32_t SampleCountAdjustedForBias;
 
   // allocate memory to hold the statistics results
-  Statistics = (STATISTICS *) Emalloc (sizeof (STATISTICS));
-  Statistics->CoVariance = (float *)Emalloc(sizeof(float) * N * N);
-  Statistics->Min = (float *) Emalloc (N * sizeof (float));
-  Statistics->Max = (float *) Emalloc (N * sizeof (float));
+  Statistics = static_cast<STATISTICS *>(Emalloc (sizeof (STATISTICS)));
+  Statistics->CoVariance = static_cast<float *>(Emalloc(sizeof(float) * N * N));
+  Statistics->Min = static_cast<float *>(Emalloc (N * sizeof (float)));
+  Statistics->Max = static_cast<float *>(Emalloc (N * sizeof (float)));
 
   // allocate temporary memory to hold the sample to mean distances
-  Distance = (float *) Emalloc (N * sizeof (float));
+  Distance = static_cast<float *>(Emalloc (N * sizeof (float)));
 
   // initialize the statistics
   Statistics->AvgVariance = 1.0;
@@ -1394,8 +1391,8 @@ ComputeStatistics (int16_t N, PARAM_DESC ParamDesc[], CLUSTER * Cluster) {
       Statistics->AvgVariance *= *CoVariance;
     }
   }
-  Statistics->AvgVariance = (float)pow((double)Statistics->AvgVariance,
-                                       1.0 / N);
+  Statistics->AvgVariance = static_cast<float>(pow(static_cast<double>(Statistics->AvgVariance),
+                                       1.0 / N));
 
   // release temporary memory and return
   free(Distance);
@@ -1425,10 +1422,10 @@ static PROTOTYPE* NewSphericalProto(uint16_t N, CLUSTER* Cluster,
 
   Proto->Magnitude.Spherical =
     1.0 / sqrt(2.0 * M_PI * Proto->Variance.Spherical);
-  Proto->TotalMagnitude = (float)pow((double)Proto->Magnitude.Spherical,
-                                     (double) N);
+  Proto->TotalMagnitude = static_cast<float>(pow(static_cast<double>(Proto->Magnitude.Spherical),
+                                     static_cast<double>(N)));
   Proto->Weight.Spherical = 1.0 / Proto->Variance.Spherical;
-  Proto->LogMagnitude = log ((double) Proto->TotalMagnitude);
+  Proto->LogMagnitude = log (static_cast<double>(Proto->TotalMagnitude));
 
   return (Proto);
 }                                // NewSphericalProto
@@ -1450,9 +1447,9 @@ static PROTOTYPE* NewEllipticalProto(int16_t N, CLUSTER* Cluster,
   int i;
 
   Proto = NewSimpleProto (N, Cluster);
-  Proto->Variance.Elliptical = (float *) Emalloc (N * sizeof (float));
-  Proto->Magnitude.Elliptical = (float *) Emalloc (N * sizeof (float));
-  Proto->Weight.Elliptical = (float *) Emalloc (N * sizeof (float));
+  Proto->Variance.Elliptical = static_cast<float *>(Emalloc (N * sizeof (float)));
+  Proto->Magnitude.Elliptical = static_cast<float *>(Emalloc (N * sizeof (float)));
+  Proto->Weight.Elliptical = static_cast<float *>(Emalloc (N * sizeof (float)));
 
   CoVariance = Statistics->CoVariance;
   Proto->TotalMagnitude = 1.0;
@@ -1466,7 +1463,7 @@ static PROTOTYPE* NewEllipticalProto(int16_t N, CLUSTER* Cluster,
     Proto->Weight.Elliptical[i] = 1.0 / Proto->Variance.Elliptical[i];
     Proto->TotalMagnitude *= Proto->Magnitude.Elliptical[i];
   }
-  Proto->LogMagnitude = log ((double) Proto->TotalMagnitude);
+  Proto->LogMagnitude = log (static_cast<double>(Proto->TotalMagnitude));
   Proto->Style = elliptical;
   return (Proto);
 }                                // NewEllipticalProto
@@ -1490,7 +1487,7 @@ static PROTOTYPE* NewMixedProto(int16_t N, CLUSTER* Cluster,
   int i;
 
   Proto = NewEllipticalProto (N, Cluster, Statistics);
-  Proto->Distrib = (DISTRIBUTION *) Emalloc (N * sizeof (DISTRIBUTION));
+  Proto->Distrib = static_cast<DISTRIBUTION *>(Emalloc (N * sizeof (DISTRIBUTION)));
 
   for (i = 0; i < N; i++) {
     Proto->Distrib[i] = normal;
@@ -1511,8 +1508,8 @@ static PROTOTYPE *NewSimpleProto(int16_t N, CLUSTER *Cluster) {
   PROTOTYPE *Proto;
   int i;
 
-  Proto = (PROTOTYPE *) Emalloc (sizeof (PROTOTYPE));
-  Proto->Mean = (float *) Emalloc (N * sizeof (float));
+  Proto = static_cast<PROTOTYPE *>(Emalloc (sizeof (PROTOTYPE)));
+  Proto->Mean = static_cast<float *>(Emalloc (N * sizeof (float)));
 
   for (i = 0; i < N; i++)
     Proto->Mean[i] = Cluster->Mean[i];
@@ -1676,7 +1673,7 @@ static BUCKETS *MakeBuckets(DISTRIBUTION Distribution,
 
   if (Symmetrical) {
     // allocate buckets so that all have approx. equal probability
-    BucketProbability = 1.0 / (double) (Buckets->NumberOfBuckets);
+    BucketProbability = 1.0 / static_cast<double>(Buckets->NumberOfBuckets);
 
     // distribution is symmetric so fill in upper half then copy
     CurrentBucket = Buckets->NumberOfBuckets / 2;
@@ -1687,9 +1684,9 @@ static BUCKETS *MakeBuckets(DISTRIBUTION Distribution,
 
     Probability = 0.0;
     LastProbDensity =
-      (*DensityFunction[(int) Distribution]) (BUCKETTABLESIZE / 2);
+      (*DensityFunction[static_cast<int>(Distribution)]) (BUCKETTABLESIZE / 2);
     for (i = BUCKETTABLESIZE / 2; i < BUCKETTABLESIZE; i++) {
-      ProbDensity = (*DensityFunction[(int) Distribution]) (i + 1);
+      ProbDensity = (*DensityFunction[static_cast<int>(Distribution)]) (i + 1);
       ProbabilityDelta = Integral (LastProbDensity, ProbDensity, 1.0);
       Probability += ProbabilityDelta;
       if (Probability > NextBucketBoundary) {
@@ -1699,12 +1696,12 @@ static BUCKETS *MakeBuckets(DISTRIBUTION Distribution,
       }
       Buckets->Bucket[i] = CurrentBucket;
       Buckets->ExpectedCount[CurrentBucket] +=
-        (float) (ProbabilityDelta * SampleCount);
+        static_cast<float>(ProbabilityDelta * SampleCount);
       LastProbDensity = ProbDensity;
     }
     // place any leftover probability into the last bucket
     Buckets->ExpectedCount[CurrentBucket] +=
-      (float) ((0.5 - Probability) * SampleCount);
+      static_cast<float>((0.5 - Probability) * SampleCount);
 
     // copy upper half of distribution to lower half
     for (i = 0, j = BUCKETTABLESIZE - 1; i < j; i++, j--)
@@ -1740,9 +1737,9 @@ static uint16_t OptimumNumberOfBuckets(uint32_t SampleCount) {
 
   for (Last = 0, Next = 1; Next < LOOKUPTABLESIZE; Last++, Next++) {
     if (SampleCount <= kCountTable[Next]) {
-      Slope = (float) (kBucketsTable[Next] - kBucketsTable[Last]) /
-          (float) (kCountTable[Next] - kCountTable[Last]);
-      return ((uint16_t) (kBucketsTable[Last] +
+      Slope = static_cast<float>(kBucketsTable[Next] - kBucketsTable[Last]) /
+          static_cast<float>(kCountTable[Next] - kCountTable[Last]);
+      return (static_cast<uint16_t>(kBucketsTable[Last] +
           Slope * (SampleCount - kCountTable[Last])));
     }
   }
@@ -1785,14 +1782,14 @@ ComputeChiSquared (uint16_t DegreesOfFreedom, double Alpha)
      for the specified number of degrees of freedom.  Search the list for
      the desired chi-squared. */
   SearchKey.Alpha = Alpha;
-  OldChiSquared = (CHISTRUCT *) first_node (search (ChiWith[DegreesOfFreedom],
+  OldChiSquared = reinterpret_cast<CHISTRUCT *>first_node (search (ChiWith[DegreesOfFreedom],
     &SearchKey, AlphaMatch));
 
   if (OldChiSquared == nullptr) {
     OldChiSquared = NewChiStruct (DegreesOfFreedom, Alpha);
     OldChiSquared->ChiSquared = Solve (ChiArea, OldChiSquared,
-      (double) DegreesOfFreedom,
-      (double) CHIACCURACY);
+      static_cast<double>(DegreesOfFreedom),
+      CHIACCURACY);
     ChiWith[DegreesOfFreedom] = push (ChiWith[DegreesOfFreedom],
       OldChiSquared);
   }
@@ -1832,7 +1829,7 @@ static double NormalDensity(int32_t x) {
  * @return The value of the uniform distribution at x.
  */
 static double UniformDensity(int32_t x) {
-  static double UniformDistributionDensity = (double) 1.0 / BUCKETTABLESIZE;
+  static double UniformDistributionDensity = 1.0 / BUCKETTABLESIZE;
 
   if ((x >= 0.0) && (x <= BUCKETTABLESIZE))
     return UniformDistributionDensity;
@@ -1960,8 +1957,8 @@ static uint16_t NormalBucket(PARAM_DESC *ParamDesc,
   if (X < 0)
     return 0;
   if (X > BUCKETTABLESIZE - 1)
-    return ((uint16_t) (BUCKETTABLESIZE - 1));
-  return (uint16_t) floor((double) X);
+    return (static_cast<uint16_t>(BUCKETTABLESIZE - 1));
+  return static_cast<uint16_t>(floor(static_cast<double>(X)));
 }                                // NormalBucket
 
 /**
@@ -1993,8 +1990,8 @@ static uint16_t UniformBucket(PARAM_DESC *ParamDesc,
   if (X < 0)
     return 0;
   if (X > BUCKETTABLESIZE - 1)
-    return (uint16_t) (BUCKETTABLESIZE - 1);
-  return (uint16_t) floor((double) X);
+    return static_cast<uint16_t>(BUCKETTABLESIZE - 1);
+  return static_cast<uint16_t>(floor(static_cast<double>(X)));
 }                                // UniformBucket
 
 /**
@@ -2085,7 +2082,7 @@ static uint16_t DegreesOfFreedom(DISTRIBUTION Distribution, uint16_t HistogramBu
 
   uint16_t AdjustedNumBuckets;
 
-  AdjustedNumBuckets = HistogramBuckets - DegreeOffsets[(int) Distribution];
+  AdjustedNumBuckets = HistogramBuckets - DegreeOffsets[static_cast<int>(Distribution)];
   if (Odd (AdjustedNumBuckets))
     AdjustedNumBuckets++;
   return (AdjustedNumBuckets);
@@ -2104,8 +2101,8 @@ static void AdjustBuckets(BUCKETS *Buckets, uint32_t NewSampleCount) {
   int i;
   double AdjustFactor;
 
-  AdjustFactor = (((double) NewSampleCount) /
-    ((double) Buckets->SampleCount));
+  AdjustFactor = ((static_cast<double>(NewSampleCount)) /
+    (static_cast<double>(Buckets->SampleCount)));
 
   for (i = 0; i < Buckets->NumberOfBuckets; i++) {
     Buckets->ExpectedCount[i] *= AdjustFactor;
@@ -2144,8 +2141,8 @@ static void InitBuckets(BUCKETS *Buckets) {
  */
 static int AlphaMatch(void *arg1,    //CHISTRUCT                             *ChiStruct,
                void *arg2) {  //CHISTRUCT                             *SearchKey)
-  auto *ChiStruct = (CHISTRUCT *) arg1;
-  auto *SearchKey = (CHISTRUCT *) arg2;
+  auto *ChiStruct = static_cast<CHISTRUCT *>(arg1);
+  auto *SearchKey = static_cast<CHISTRUCT *>(arg2);
 
   return (ChiStruct->Alpha == SearchKey->Alpha);
 
@@ -2163,7 +2160,7 @@ static int AlphaMatch(void *arg1,    //CHISTRUCT                             *Ch
 static CHISTRUCT *NewChiStruct(uint16_t DegreesOfFreedom, double Alpha) {
   CHISTRUCT *NewChiStruct;
 
-  NewChiStruct = (CHISTRUCT *) Emalloc (sizeof (CHISTRUCT));
+  NewChiStruct = static_cast<CHISTRUCT *>(Emalloc (sizeof (CHISTRUCT)));
   NewChiStruct->DegreesOfFreedom = DegreesOfFreedom;
   NewChiStruct->Alpha = Alpha;
   return (NewChiStruct);
@@ -2201,7 +2198,7 @@ void *FunctionParams, double InitialGuess, double Accuracy)
   Delta = INITIALDELTA;
   LastPosX = FLT_MAX;
   LastNegX = -FLT_MAX;
-  f = (*Function) ((CHISTRUCT *) FunctionParams, x);
+  f = (*Function) (static_cast<CHISTRUCT *>(FunctionParams), x);
   while (Abs (LastPosX - LastNegX) > Accuracy) {
     // keep track of outer bounds of current estimate
     if (f < 0)
@@ -2211,7 +2208,7 @@ void *FunctionParams, double InitialGuess, double Accuracy)
 
     // compute the approx. slope of f(x) at the current point
     Slope =
-      ((*Function) ((CHISTRUCT *) FunctionParams, x + Delta) - f) / Delta;
+      ((*Function) (static_cast<CHISTRUCT *>(FunctionParams), x + Delta) - f) / Delta;
 
     // compute the next solution guess */
     xDelta = f / Slope;
@@ -2224,7 +2221,7 @@ void *FunctionParams, double InitialGuess, double Accuracy)
       Delta = NewDelta;
 
     // compute the value of the function at the new guess
-    f = (*Function) ((CHISTRUCT *) FunctionParams, x);
+    f = (*Function) (static_cast<CHISTRUCT *>(FunctionParams), x);
   }
   return (x);
 
@@ -2327,7 +2324,7 @@ MultipleCharSamples(CLUSTERER* Clusterer,
         CharFlags[CharID] = ILLEGAL_CHAR;
       }
       NumCharInCluster--;
-      PercentIllegal = (float) NumIllegalInCluster / NumCharInCluster;
+      PercentIllegal = static_cast<float>(NumIllegalInCluster) / NumCharInCluster;
       if (PercentIllegal > MaxIllegal) {
         destroy(SearchState);
         return true;

--- a/src/classify/clusttool.cpp
+++ b/src/classify/clusttool.cpp
@@ -60,7 +60,7 @@ PARAM_DESC *ReadParamDesc(TFile *fp, uint16_t N) {
   PARAM_DESC *ParamDesc;
   char linear_token[TOKENSIZE], essential_token[TOKENSIZE];
 
-  ParamDesc = (PARAM_DESC *) Emalloc (N * sizeof (PARAM_DESC));
+  ParamDesc = static_cast<PARAM_DESC *>(Emalloc (N * sizeof (PARAM_DESC)));
   for (int i = 0; i < N; i++) {
     const int kMaxLineSize = TOKENSIZE * 4;
     char line[kMaxLineSize];
@@ -101,7 +101,7 @@ PROTOTYPE *ReadPrototype(TFile *fp, uint16_t N) {
     tprintf("Invalid prototype: %s\n", line);
     return nullptr;
   }
-  Proto = (PROTOTYPE *)Emalloc(sizeof(PROTOTYPE));
+  Proto = static_cast<PROTOTYPE *>(Emalloc(sizeof(PROTOTYPE)));
   Proto->Cluster = nullptr;
   Proto->Significant = (sig_token[0] == 's');
 
@@ -131,16 +131,16 @@ PROTOTYPE *ReadPrototype(TFile *fp, uint16_t N) {
       ASSERT_HOST(ReadNFloats(fp, 1, &(Proto->Variance.Spherical)) != nullptr);
       Proto->Magnitude.Spherical =
           1.0 / sqrt(2.0 * M_PI * Proto->Variance.Spherical);
-      Proto->TotalMagnitude = pow(Proto->Magnitude.Spherical, (float)N);
-      Proto->LogMagnitude = log((double)Proto->TotalMagnitude);
+      Proto->TotalMagnitude = pow(Proto->Magnitude.Spherical, static_cast<float>(N));
+      Proto->LogMagnitude = log(static_cast<double>(Proto->TotalMagnitude));
       Proto->Weight.Spherical = 1.0 / Proto->Variance.Spherical;
       Proto->Distrib = nullptr;
       break;
     case elliptical:
       Proto->Variance.Elliptical = ReadNFloats(fp, N, nullptr);
       ASSERT_HOST(Proto->Variance.Elliptical != nullptr);
-      Proto->Magnitude.Elliptical = (float *)Emalloc(N * sizeof(float));
-      Proto->Weight.Elliptical = (float *)Emalloc(N * sizeof(float));
+      Proto->Magnitude.Elliptical = static_cast<float *>(Emalloc(N * sizeof(float)));
+      Proto->Weight.Elliptical = static_cast<float *>(Emalloc(N * sizeof(float)));
       Proto->TotalMagnitude = 1.0;
       for (i = 0; i < N; i++) {
         Proto->Magnitude.Elliptical[i] =
@@ -148,7 +148,7 @@ PROTOTYPE *ReadPrototype(TFile *fp, uint16_t N) {
         Proto->Weight.Elliptical[i] = 1.0 / Proto->Variance.Elliptical[i];
         Proto->TotalMagnitude *= Proto->Magnitude.Elliptical[i];
       }
-      Proto->LogMagnitude = log((double)Proto->TotalMagnitude);
+      Proto->LogMagnitude = log(static_cast<double>(Proto->TotalMagnitude));
       Proto->Distrib = nullptr;
       break;
     default:
@@ -242,7 +242,7 @@ void WritePrototype(FILE *File, uint16_t N, PROTOTYPE *Proto) {
     fprintf (File, "significant   ");
   else
     fprintf (File, "insignificant ");
-  WriteProtoStyle (File, (PROTOSTYLE) Proto->Style);
+  WriteProtoStyle (File, static_cast<PROTOSTYLE>(Proto->Style));
   fprintf (File, "%6d\n\t", Proto->NumSamples);
   WriteNFloats (File, N, Proto->Mean);
   fprintf (File, "\t");
@@ -342,7 +342,7 @@ void WriteProtoList(FILE* File, uint16_t N, PARAM_DESC* ParamDesc,
   /* write prototypes */
   iterate(ProtoList)
     {
-      Proto = (PROTOTYPE *) first_node (ProtoList);
+      Proto = reinterpret_cast<PROTOTYPE *>first_node (ProtoList);
       if ((Proto->Significant && WriteSigProtos) ||
           (!Proto->Significant && WriteInsigProtos))
         WritePrototype(File, N, Proto);

--- a/src/classify/featdefs.cpp
+++ b/src/classify/featdefs.cpp
@@ -147,7 +147,7 @@ void FreeCharDescription(CHAR_DESC CharDesc) {
  */
 CHAR_DESC NewCharDescription(const FEATURE_DEFS_STRUCT &FeatureDefs) {
   CHAR_DESC CharDesc;
-  CharDesc = (CHAR_DESC) Emalloc (sizeof (CHAR_DESC_STRUCT));
+  CharDesc = static_cast<CHAR_DESC>(Emalloc (sizeof (CHAR_DESC_STRUCT)));
   CharDesc->NumFeatureSets = FeatureDefs.NumFeatureTypes;
 
   for (size_t i = 0; i < CharDesc->NumFeatureSets; i++)

--- a/src/classify/intmatcher.cpp
+++ b/src/classify/intmatcher.cpp
@@ -714,17 +714,17 @@ IntegerMatcher::IntegerMatcher(tesseract::IntParam *classify_debug_level)
   /* Initialize table for evidence to similarity lookup */
   for (int i = 0; i < SE_TABLE_SIZE; i++) {
     uint32_t IntSimilarity = i << (27 - SE_TABLE_BITS);
-    double Similarity = ((double) IntSimilarity) / 65536.0 / 65536.0;
+    double Similarity = (static_cast<double>(IntSimilarity)) / 65536.0 / 65536.0;
     double evidence = Similarity / kSimilarityCenter;
     evidence = 255.0 / (evidence * evidence + 1.0);
 
     if (kSEExponentialMultiplier > 0.0) {
       double scale = 1.0 - exp(-kSEExponentialMultiplier) *
-        exp(kSEExponentialMultiplier * ((double) i / SE_TABLE_SIZE));
+        exp(kSEExponentialMultiplier * (static_cast<double>(i) / SE_TABLE_SIZE));
       evidence *= ClipToRange(scale, 0.0, 1.0);
     }
 
-    similarity_evidence_table_[i] = (uint8_t) (evidence + 0.5);
+    similarity_evidence_table_[i] = static_cast<uint8_t>(evidence + 0.5);
   }
 
   /* Initialize evidence computation variables */
@@ -757,7 +757,7 @@ void ScratchEvidence::ClearFeatureEvidence(const INT_CLASS class_template) {
 static void IMDebugConfiguration(int FeatureNum, uint16_t ActualProtoNum,
                                  uint8_t Evidence, uint32_t ConfigWord) {
   cprintf ("F = %3d, P = %3d, E = %3d, Configs = ",
-    FeatureNum, (int) ActualProtoNum, (int) Evidence);
+    FeatureNum, static_cast<int>(ActualProtoNum), static_cast<int>(Evidence));
   while (ConfigWord) {
     if (ConfigWord & 1)
       cprintf ("1");
@@ -826,7 +826,7 @@ int IntegerMatcher::UpdateTablesForFeature(
   for (ProtoSetIndex = 0, ActualProtoNum = 0;
   ProtoSetIndex < ClassTemplate->NumProtoSets; ProtoSetIndex++) {
     ProtoSet = ClassTemplate->ProtoSets[ProtoSetIndex];
-    ProtoPrunerPtr = (uint32_t *) ((*ProtoSet).ProtoPruner);
+    ProtoPrunerPtr = reinterpret_cast<uint32_t *>((*ProtoSet).ProtoPruner);
     for (ProtoNum = 0; ProtoNum < PROTOS_PER_PROTO_SET;
       ProtoNum += (PROTOS_PER_PROTO_SET >> 1), ActualProtoNum +=
     (PROTOS_PER_PROTO_SET >> 1), ProtoMask++, ProtoPrunerPtr++) {
@@ -960,7 +960,7 @@ void IntegerMatcher::DebugFeatureProtoError(
     for (ConfigNum = 0; ConfigNum < ClassTemplate->NumConfigs; ConfigNum++) {
       cprintf(
           " %5.1f",
-          100.0 * (1.0 - (float)tables.sum_feature_evidence_[ConfigNum]
+          100.0 * (1.0 - static_cast<float>(tables.sum_feature_evidence_[ConfigNum])
           / NumFeatures / 256.0));
     }
     cprintf("\n\n\n");
@@ -1042,7 +1042,7 @@ void IntegerMatcher::DebugFeatureProtoError(
     cprintf ("Proto Length for Configurations:\n");
     for (ConfigNum = 0; ConfigNum < ClassTemplate->NumConfigs; ConfigNum++)
       cprintf (" %4.1f",
-        (float) ClassTemplate->ConfigLengths[ConfigNum]);
+        static_cast<float>(ClassTemplate->ConfigLengths[ConfigNum]));
     cprintf ("\n\n");
   }
 

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -293,14 +293,14 @@ int AddIntProto(INT_CLASS Class) {
   if (Class->NumProtos > MaxNumIntProtosIn(Class)) {
     ProtoSetId = Class->NumProtoSets++;
 
-    ProtoSet = (PROTO_SET) Emalloc(sizeof(PROTO_SET_STRUCT));
+    ProtoSet = static_cast<PROTO_SET>(Emalloc(sizeof(PROTO_SET_STRUCT)));
     Class->ProtoSets[ProtoSetId] = ProtoSet;
     memset(ProtoSet, 0, sizeof(*ProtoSet));
 
     /* reallocate space for the proto lengths and install in class */
     Class->ProtoLengths =
-      (uint8_t *)Erealloc(Class->ProtoLengths,
-                        MaxNumIntProtosIn(Class) * sizeof(uint8_t));
+      static_cast<uint8_t *>(Erealloc(Class->ProtoLengths,
+                        MaxNumIntProtosIn(Class) * sizeof(uint8_t)));
     memset(&Class->ProtoLengths[Index], 0,
            sizeof(*Class->ProtoLengths) * (MaxNumIntProtosIn(Class) - Index));
   }
@@ -512,7 +512,7 @@ void Classify::ConvertProto(PROTO Proto, int ProtoId, INT_CLASS Class) {
   if (Param < 0 || Param >= 256)
     P->Angle = 0;
   else
-    P->Angle = (uint8_t) Param;
+    P->Angle = static_cast<uint8_t>(Param);
 
   /* round proto length to nearest integer number of pico-features */
   Param = (Proto->Length / GetPicoFeatureLength()) + 0.5;
@@ -638,7 +638,7 @@ INT_CLASS NewIntClass(int MaxNumProtos, int MaxNumConfigs) {
 
   assert(MaxNumConfigs <= MAX_NUM_CONFIGS);
 
-  Class = (INT_CLASS) Emalloc(sizeof(INT_CLASS_STRUCT));
+  Class = static_cast<INT_CLASS>(Emalloc(sizeof(INT_CLASS_STRUCT)));
   Class->NumProtoSets = ((MaxNumProtos + PROTOS_PER_PROTO_SET - 1) /
                             PROTOS_PER_PROTO_SET);
 
@@ -649,7 +649,7 @@ INT_CLASS NewIntClass(int MaxNumProtos, int MaxNumConfigs) {
 
   for (i = 0; i < Class->NumProtoSets; i++) {
     /* allocate space for a proto set, install in class, and initialize */
-    ProtoSet = (PROTO_SET) Emalloc(sizeof(PROTO_SET_STRUCT));
+    ProtoSet = static_cast<PROTO_SET>(Emalloc(sizeof(PROTO_SET_STRUCT)));
     memset(ProtoSet, 0, sizeof(*ProtoSet));
     Class->ProtoSets[i] = ProtoSet;
 
@@ -657,7 +657,7 @@ INT_CLASS NewIntClass(int MaxNumProtos, int MaxNumConfigs) {
   }
   if (MaxNumIntProtosIn (Class) > 0) {
     Class->ProtoLengths =
-      (uint8_t *)Emalloc(MaxNumIntProtosIn (Class) * sizeof (uint8_t));
+      static_cast<uint8_t *>(Emalloc(MaxNumIntProtosIn (Class) * sizeof (uint8_t)));
     memset(Class->ProtoLengths, 0,
            MaxNumIntProtosIn(Class) * sizeof(*Class->ProtoLengths));
   } else {
@@ -691,7 +691,7 @@ INT_TEMPLATES NewIntTemplates() {
   INT_TEMPLATES T;
   int i;
 
-  T = (INT_TEMPLATES) Emalloc (sizeof (INT_TEMPLATES_STRUCT));
+  T = static_cast<INT_TEMPLATES>(Emalloc (sizeof (INT_TEMPLATES_STRUCT)));
   T->NumClasses = 0;
   T->NumClassPruners = 0;
 
@@ -851,7 +851,7 @@ INT_TEMPLATES Classify::ReadIntTemplates(TFile *fp) {
   /* then read in each class */
   for (i = 0; i < Templates->NumClasses; i++) {
     /* first read in the high level struct for the class */
-    Class = (INT_CLASS) Emalloc (sizeof (INT_CLASS_STRUCT));
+    Class = static_cast<INT_CLASS>(Emalloc (sizeof (INT_CLASS_STRUCT)));
     if (fp->FReadEndian(&Class->NumProtos, sizeof(Class->NumProtos), 1) != 1 ||
         fp->FRead(&Class->NumProtoSets, sizeof(Class->NumProtoSets), 1) != 1 ||
         fp->FRead(&Class->NumConfigs, sizeof(Class->NumConfigs), 1) != 1)
@@ -879,7 +879,7 @@ INT_TEMPLATES Classify::ReadIntTemplates(TFile *fp) {
     /* then read in the proto lengths */
     Lengths = nullptr;
     if (MaxNumIntProtosIn (Class) > 0) {
-      Lengths = (uint8_t *)Emalloc(sizeof(uint8_t) * MaxNumIntProtosIn(Class));
+      Lengths = static_cast<uint8_t *>(Emalloc(sizeof(uint8_t) * MaxNumIntProtosIn(Class)));
       if (fp->FRead(Lengths, sizeof(uint8_t), MaxNumIntProtosIn(Class)) !=
           MaxNumIntProtosIn(Class))
         tprintf("Bad read of inttemp!\n");
@@ -888,7 +888,7 @@ INT_TEMPLATES Classify::ReadIntTemplates(TFile *fp) {
 
     /* then read in the proto sets */
     for (j = 0; j < Class->NumProtoSets; j++) {
-      ProtoSet = (PROTO_SET)Emalloc(sizeof(PROTO_SET_STRUCT));
+      ProtoSet = static_cast<PROTO_SET>(Emalloc(sizeof(PROTO_SET_STRUCT)));
       int num_buckets = NUM_PP_PARAMS * NUM_PP_BUCKETS * WERDS_PER_PP_VECTOR;
       if (fp->FReadEndian(&ProtoSet->ProtoPruner,
                           sizeof(ProtoSet->ProtoPruner[0][0][0]),
@@ -1101,7 +1101,7 @@ void Classify::WriteIntTemplates(FILE *File, INT_TEMPLATES Templates,
  * @note Globals: none
  */
 float BucketStart(int Bucket, float Offset, int NumBuckets) {
-  return (((float) Bucket / NumBuckets) - Offset);
+  return ((static_cast<float>(Bucket) / NumBuckets) - Offset);
 
 }                                /* BucketStart */
 
@@ -1117,7 +1117,7 @@ float BucketStart(int Bucket, float Offset, int NumBuckets) {
  * @note Globals: none
  */
 float BucketEnd(int Bucket, float Offset, int NumBuckets) {
-  return (((float) (Bucket + 1) / NumBuckets) - Offset);
+  return ((static_cast<float>(Bucket + 1) / NumBuckets) - Offset);
 }                                /* BucketEnd */
 
 /**
@@ -1529,8 +1529,8 @@ void InitTableFiller (float EndPad, float SidePad,
 
       /* translate into bucket positions and deltas */
       Filler->X = Bucket8For(Start.x, XS, NB);
-      Filler->StartDelta = -(int16_t) ((Cos / Sin) * 256);
-      Filler->EndDelta = (int16_t) ((Sin / Cos) * 256);
+      Filler->StartDelta = -static_cast<int16_t>((Cos / Sin) * 256);
+      Filler->EndDelta = static_cast<int16_t>((Sin / Cos) * 256);
 
       XAdjust = BucketEnd(Filler->X, XS, NB) - Start.x;
       YAdjust = XAdjust * Cos / Sin;

--- a/src/classify/kdtree.cpp
+++ b/src/classify/kdtree.cpp
@@ -165,7 +165,7 @@ void KDTreeSearch::Search(int *result_count,
     for (int j = 0; j < count; j++) {
       // Pre-cast to float64 as key is a template type and we have no control
       // over its actual type.
-      distances[j] = (float)sqrt((double)results_.elements()[j].key);
+      distances[j] = static_cast<float>(sqrt(static_cast<double>(results_.elements()[j].key)));
       results[j] = results_.elements()[j].value;
     }
   }
@@ -178,8 +178,8 @@ void KDTreeSearch::Search(int *result_count,
 /// @param KeySize  # of dimensions in the K-D tree
 /// @param KeyDesc  array of params to describe key dimensions
 KDTREE *MakeKDTree(int16_t KeySize, const PARAM_DESC KeyDesc[]) {
-  auto *KDTree = (KDTREE *) Emalloc(
-      sizeof(KDTREE) + (KeySize - 1) * sizeof(PARAM_DESC));
+  auto *KDTree = static_cast<KDTREE *>(Emalloc(
+      sizeof(KDTREE) + (KeySize - 1) * sizeof(PARAM_DESC)));
   for (int i = 0; i < KeySize; i++) {
     KDTree->KeyDesc[i].NonEssential = KeyDesc[i].NonEssential;
     KDTree->KeyDesc[i].Circular = KeyDesc[i].Circular;
@@ -232,7 +232,7 @@ void KDStore(KDTREE *Tree, float *Key, void *Data) {
     Node = *PtrToNode;
   }
 
-  *PtrToNode = MakeKDNode(Tree, Key, (void *) Data, Level);
+  *PtrToNode = MakeKDNode(Tree, Key, Data, Level);
 }                                /* KDStore */
 
 /**
@@ -353,7 +353,7 @@ void FreeKDTree(KDTREE *Tree) {
 KDNODE *MakeKDNode(KDTREE *tree, float Key[], void *Data, int Index) {
   KDNODE *NewNode;
 
-  NewNode = (KDNODE *) Emalloc (sizeof (KDNODE));
+  NewNode = static_cast<KDNODE *>(Emalloc (sizeof (KDNODE)));
 
   NewNode->Key = Key;
   NewNode->Data = Data;

--- a/src/classify/mf.cpp
+++ b/src/classify/mf.cpp
@@ -55,7 +55,7 @@ FEATURE_SET ExtractMicros(TBLOB* Blob, const DENORM& cn_denorm) {
 
   Features = OldFeatures;
   iterate(Features) {
-    OldFeature = (MICROFEATURE) first_node (Features);
+    OldFeature = reinterpret_cast<MICROFEATURE>first_node (Features);
     Feature = NewFeature (&MicroFeatureDesc);
     Feature->Params[MFDirection] = OldFeature[ORIENTATION];
     Feature->Params[MFXPosition] = OldFeature[XPOSITION];

--- a/src/classify/mfdefs.cpp
+++ b/src/classify/mfdefs.cpp
@@ -32,7 +32,7 @@
  * @return New MICROFEATURE
  */
 MICROFEATURE NewMicroFeature() {
-  return ((MICROFEATURE) Emalloc (sizeof (MFBLOCK)));
+  return (static_cast<MICROFEATURE>(Emalloc (sizeof (MFBLOCK))));
 }                                /* NewMicroFeature */
 
 

--- a/src/classify/mfoutline.cpp
+++ b/src/classify/mfoutline.cpp
@@ -148,7 +148,7 @@ void FindDirectionChanges(MFOUTLINE Outline,
  */
 void FreeMFOutline(void *arg) {  //MFOUTLINE                             Outline)
   MFOUTLINE Start;
-  auto Outline = (MFOUTLINE) arg;
+  auto Outline = static_cast<MFOUTLINE>(arg);
 
   /* break the circular outline so we can use std. techniques to deallocate */
   Start = list_rest (Outline);
@@ -293,7 +293,7 @@ void Classify::NormalizeOutlines(LIST Outlines,
 
     case baseline:
       iterate(Outlines) {
-        Outline = (MFOUTLINE) first_node(Outlines);
+        Outline = static_cast<MFOUTLINE>first_node(Outlines);
         NormalizeOutline(Outline, 0.0);
       }
       *XScale = *YScale = MF_SCALE_FACTOR;

--- a/src/classify/mfx.cpp
+++ b/src/classify/mfx.cpp
@@ -76,13 +76,13 @@ MICROFEATURES BlobMicroFeatures(TBLOB* Blob, const DENORM& cn_denorm) {
 
     RemainingOutlines = Outlines;
     iterate(RemainingOutlines) {
-      Outline = (MFOUTLINE) first_node (RemainingOutlines);
+      Outline = static_cast<MFOUTLINE>first_node (RemainingOutlines);
       CharNormalizeOutline(Outline, cn_denorm);
     }
 
     RemainingOutlines = Outlines;
     iterate(RemainingOutlines) {
-      Outline = (MFOUTLINE) first_node(RemainingOutlines);
+      Outline = static_cast<MFOUTLINE>first_node(RemainingOutlines);
       FindDirectionChanges(Outline, classify_min_slope, classify_max_slope);
       MarkDirectionChanges(Outline);
       MicroFeatures = ConvertToMicroFeatures(Outline, MicroFeatures);

--- a/src/classify/normmatch.cpp
+++ b/src/classify/normmatch.cpp
@@ -114,7 +114,7 @@ float Classify::ComputeNormMatch(CLASS_ID ClassId,
 
   ProtoId = 0;
   iterate(Protos) {
-    Proto = (PROTOTYPE *) first_node (Protos);
+    Proto = reinterpret_cast<PROTOTYPE *>first_node (Protos);
     Delta = feature.Params[CharNormY] - Proto->Mean[CharNormY];
     Match = Delta * Delta * Proto->Weight.Elliptical[CharNormY];
     if (DebugMatch) {
@@ -240,9 +240,9 @@ NORM_PROTOS *Classify::ReadNormProtos(TFile *fp) {
   int NumProtos;
 
   /* allocate and initialization data structure */
-  NormProtos = (NORM_PROTOS *) Emalloc (sizeof (NORM_PROTOS));
+  NormProtos = static_cast<NORM_PROTOS *>(Emalloc (sizeof (NORM_PROTOS)));
   NormProtos->NumProtos = unicharset.size();
-  NormProtos->Protos = (LIST *) Emalloc (NormProtos->NumProtos * sizeof(LIST));
+  NormProtos->Protos = static_cast<LIST *>(Emalloc (NormProtos->NumProtos * sizeof(LIST)));
   for (i = 0; i < NormProtos->NumProtos; i++)
     NormProtos->Protos[i] = NIL_LIST;
 

--- a/src/classify/ocrfeatures.cpp
+++ b/src/classify/ocrfeatures.cpp
@@ -80,8 +80,8 @@ void FreeFeatureSet(FEATURE_SET FeatureSet) {
 FEATURE NewFeature(const FEATURE_DESC_STRUCT* FeatureDesc) {
   FEATURE Feature;
 
-  Feature = (FEATURE)malloc(sizeof(FEATURE_STRUCT) +
-                            (FeatureDesc->NumParams - 1) * sizeof(float));
+  Feature = static_cast<FEATURE>(malloc(sizeof(FEATURE_STRUCT) +
+                            (FeatureDesc->NumParams - 1) * sizeof(float)));
   Feature->Type = FeatureDesc;
   return (Feature);
 
@@ -96,8 +96,8 @@ FEATURE NewFeature(const FEATURE_DESC_STRUCT* FeatureDesc) {
 FEATURE_SET NewFeatureSet(int NumFeatures) {
   FEATURE_SET FeatureSet;
 
-  FeatureSet = (FEATURE_SET) Emalloc (sizeof (FEATURE_SET_STRUCT) +
-    (NumFeatures - 1) * sizeof (FEATURE));
+  FeatureSet = static_cast<FEATURE_SET>(Emalloc (sizeof (FEATURE_SET_STRUCT) +
+    (NumFeatures - 1) * sizeof (FEATURE)));
   FeatureSet->MaxNumFeatures = NumFeatures;
   FeatureSet->NumFeatures = 0;
   return (FeatureSet);

--- a/src/classify/outfeat.cpp
+++ b/src/classify/outfeat.cpp
@@ -55,7 +55,7 @@ FEATURE_SET Classify::ExtractOutlineFeatures(TBLOB *Blob) {
   NormalizeOutlines(Outlines, &XScale, &YScale);
   RemainingOutlines = Outlines;
   iterate(RemainingOutlines) {
-    Outline = (MFOUTLINE) first_node (RemainingOutlines);
+    Outline = static_cast<MFOUTLINE>first_node (RemainingOutlines);
     ConvertToOutlineFeatures(Outline, FeatureSet);
   }
   if (classify_norm_method == baseline)

--- a/src/classify/picofeat.cpp
+++ b/src/classify/picofeat.cpp
@@ -73,7 +73,7 @@ FEATURE_SET Classify::ExtractPicoFeatures(TBLOB *Blob) {
   NormalizeOutlines(Outlines, &XScale, &YScale);
   RemainingOutlines = Outlines;
   iterate(RemainingOutlines) {
-    Outline = (MFOUTLINE) first_node (RemainingOutlines);
+    Outline = static_cast<MFOUTLINE>first_node (RemainingOutlines);
     ConvertToPicoFeatures2(Outline, FeatureSet);
   }
   if (classify_norm_method == baseline)
@@ -114,7 +114,7 @@ void ConvertSegmentToPicoFeat(FPOINT *Start,
 
   Angle = NormalizedAngleFrom (Start, End, 1.0);
   Length = DistanceBetween (*Start, *End);
-  NumFeatures = (int) floor (Length / classify_pico_feature_length + 0.5);
+  NumFeatures = static_cast<int>(floor (Length / classify_pico_feature_length + 0.5));
   if (NumFeatures < 1)
     NumFeatures = 1;
 

--- a/src/classify/protos.cpp
+++ b/src/classify/protos.cpp
@@ -58,8 +58,8 @@ int AddConfigToClass(CLASS_TYPE Class) {
       CONFIG_INCREMENT) * CONFIG_INCREMENT);
 
     Class->Configurations =
-      (CONFIGS) Erealloc (Class->Configurations,
-      sizeof (BIT_VECTOR) * NewNumConfigs);
+      static_cast<CONFIGS>(Erealloc (Class->Configurations,
+      sizeof (BIT_VECTOR) * NewNumConfigs));
 
     Class->MaxNumConfigs = NewNumConfigs;
   }
@@ -92,9 +92,9 @@ int AddProtoToClass(CLASS_TYPE Class) {
     NewNumProtos = (((Class->MaxNumProtos + PROTO_INCREMENT) /
       PROTO_INCREMENT) * PROTO_INCREMENT);
 
-    Class->Prototypes = (PROTO) Erealloc (Class->Prototypes,
+    Class->Prototypes = static_cast<PROTO>(Erealloc (Class->Prototypes,
       sizeof (PROTO_STRUCT) *
-      NewNumProtos);
+      NewNumProtos));
 
     Class->MaxNumProtos = NewNumProtos;
 
@@ -175,11 +175,11 @@ CLASS_TYPE NewClass(int NumProtos, int NumConfigs) {
   Class = new CLASS_STRUCT;
 
   if (NumProtos > 0)
-    Class->Prototypes = (PROTO) Emalloc (NumProtos * sizeof (PROTO_STRUCT));
+    Class->Prototypes = static_cast<PROTO>(Emalloc (NumProtos * sizeof (PROTO_STRUCT)));
 
   if (NumConfigs > 0)
-    Class->Configurations = (CONFIGS) Emalloc (NumConfigs *
-      sizeof (BIT_VECTOR));
+    Class->Configurations = static_cast<CONFIGS>(Emalloc (NumConfigs *
+      sizeof (BIT_VECTOR)));
   Class->MaxNumProtos = NumProtos;
   Class->MaxNumConfigs = NumConfigs;
   Class->NumProtos = 0;

--- a/src/cutil/bitvec.cpp
+++ b/src/cutil/bitvec.cpp
@@ -41,8 +41,8 @@
  * @return New expanded bit vector.
  */
 BIT_VECTOR ExpandBitVector(BIT_VECTOR Vector, int NewNumBits) {
-  return ((BIT_VECTOR) Erealloc(Vector,
-    sizeof(Vector[0]) * WordsInVectorOfSize(NewNumBits)));
+  return (static_cast<BIT_VECTOR>(Erealloc(Vector,
+    sizeof(Vector[0]) * WordsInVectorOfSize(NewNumBits))));
 }                                /* ExpandBitVector */
 
 
@@ -79,6 +79,6 @@ void FreeBitVector(BIT_VECTOR BitVector) {
  * @return New bit vector.
  */
 BIT_VECTOR NewBitVector(int NumBits) {
-  return ((BIT_VECTOR) Emalloc(sizeof(uint32_t) *
-    WordsInVectorOfSize(NumBits)));
+  return (static_cast<BIT_VECTOR>(Emalloc(sizeof(uint32_t) *
+    WordsInVectorOfSize(NumBits))));
 }                                /* NewBitVector */

--- a/src/cutil/callcpp.cpp
+++ b/src/cutil/callcpp.cpp
@@ -63,8 +63,8 @@ void c_line_color_index(  /*set color */
                         void *win,
                         C_COL index) {
  // The colors are the same as the SV ones except that SV has COLOR:NONE --> offset of 1
- auto* window = (ScrollView*) win;
- window->Pen((ScrollView::Color) (index + 1));
+ auto* window = static_cast<ScrollView*>(win);
+ window->Pen(static_cast<ScrollView::Color>(index + 1));
 }
 
 
@@ -72,8 +72,8 @@ void c_move(  /*move pen */
             void *win,
             double x,
             double y) {
-  auto* window = (ScrollView*) win;
-  window->SetCursor((int) x, (int) y);
+  auto* window = static_cast<ScrollView*>(win);
+  window->SetCursor(static_cast<int>(x), static_cast<int>(y));
 }
 
 
@@ -81,21 +81,21 @@ void c_draw(  /*move pen */
             void *win,
             double x,
             double y) {
-  auto* window = (ScrollView*) win;
-  window->DrawTo((int) x, (int) y);
+  auto* window = static_cast<ScrollView*>(win);
+  window->DrawTo(static_cast<int>(x), static_cast<int>(y));
 }
 
 
 void c_make_current(  /*move pen */
                     void *win) {
-  auto* window = (ScrollView*) win;
+  auto* window = static_cast<ScrollView*>(win);
   window->Update();
 }
 
 
 void c_clear_window(  /*move pen */
                     void *win) {
-  auto* window = (ScrollView*) win;
+  auto* window = static_cast<ScrollView*>(win);
   window->Clear();
 }
 
@@ -116,7 +116,7 @@ char window_wait(ScrollView* win) {
 
 void reverse32(void *ptr) {
   char tmp;
-  char *cptr = (char *) ptr;
+  char *cptr = static_cast<char *>(ptr);
 
   tmp = *cptr;
   *cptr = *(cptr + 3);
@@ -129,7 +129,7 @@ void reverse32(void *ptr) {
 
 void reverse16(void *ptr) {
   char tmp;
-  char *cptr = (char *) ptr;
+  char *cptr = static_cast<char *>(ptr);
 
   tmp = *cptr;
   *cptr = *(cptr + 1);

--- a/src/cutil/oldlist.cpp
+++ b/src/cutil/oldlist.cpp
@@ -89,7 +89,7 @@
  *  if they are equivalent strings.  (Return false if not)
  **********************************************************************/
 static int is_same(void *item1, void *item2) {
-  return strcmp((char *)item1, (char *)item2) == 0;
+  return strcmp(static_cast<char *>(item1), static_cast<char *>(item2)) == 0;
 }
 
 /**********************************************************************
@@ -205,7 +205,7 @@ LIST push(LIST list, void *element) {
   LIST t;
 
   t = new_cell();
-  t->node = (LIST)element;
+  t->node = static_cast<LIST>(element);
   set_rest(t, list);
   return (t);
 }

--- a/src/textord/cjkpitch.cpp
+++ b/src/textord/cjkpitch.cpp
@@ -384,7 +384,7 @@ class FPRow {
  private:
   static float x_overlap_fraction(const TBOX& box1, const TBOX& box2) {
     if (std::min(box1.width(), box2.width()) == 0) return 0.0;
-    return -box1.x_gap(box2) / (float)std::min(box1.width(), box2.width());
+    return -box1.x_gap(box2) / static_cast<float>(std::min(box1.width(), box2.width()));
   }
 
   static bool mostly_overlap(const TBOX& box1, const TBOX& box2) {
@@ -531,7 +531,7 @@ void FPRow::OutputEstimations() {
   // Don't consider a quarter space as a real space, because it's used
   // for line justification in traditional Japanese books.
   real_row_->max_nonspace = std::max(pitch_ * 0.25 + good_gaps_.minimum(),
-                                (double)good_gaps_.ile(0.875));
+                                static_cast<double>(good_gaps_.ile(0.875)));
 
   int space_threshold =
           std::min((real_row_->max_nonspace + real_row_->min_space) / 2,
@@ -658,7 +658,7 @@ void FPRow::DebugOutputResult(int row_index) {
   if (num_chars() > 0) {
     tprintf("Row %d: pitch_decision=%d, fixed_pitch=%f, max_nonspace=%d, "
             "space_size=%f, space_threshold=%d, xheight=%f\n",
-            row_index, (int)(real_row_->pitch_decision),
+            row_index, static_cast<int>(real_row_->pitch_decision),
             real_row_->fixed_pitch, real_row_->max_nonspace,
             real_row_->space_size, real_row_->space_threshold,
             real_row_->xheight);

--- a/src/textord/drawtord.cpp
+++ b/src/textord/drawtord.cpp
@@ -131,7 +131,7 @@ void plot_parallel_row(                 //draw a row
   FCOORD plot_pt;                //point to plot
                                  //blobs
   BLOBNBOX_IT it = row->blob_list ();
-  auto fleft = (float) left;    //floating version
+  auto fleft = static_cast<float>(left);    //floating version
   float right;                   //end of row
 
   //      left=it.data()->bounding_box().left();
@@ -171,11 +171,11 @@ int32_t thresholds[]               //for drop out
 ) {
   int32_t line_index;              //pixel coord
   ScrollView::Color colour;                 //of histogram
-  auto fleft = (float) xleft;   //float version
+  auto fleft = static_cast<float>(xleft);   //float version
 
   colour = ScrollView::WHITE;
   to_win->Pen(colour);
-  to_win->SetCursor(fleft, (float) ybottom);
+  to_win->SetCursor(fleft, static_cast<float>(ybottom));
   for (line_index = min_y; line_index <= max_y; line_index++) {
     if (occupation[line_index - min_y] < thresholds[line_index - min_y]) {
       if (colour != ScrollView::BLUE) {
@@ -189,13 +189,13 @@ int32_t thresholds[]               //for drop out
         to_win->Pen(colour);
       }
     }
-  to_win->DrawTo(fleft + occupation[line_index - min_y] / 10.0,      (float) line_index);
+  to_win->DrawTo(fleft + occupation[line_index - min_y] / 10.0,      static_cast<float>(line_index));
   }
   colour=ScrollView::STEEL_BLUE;
   to_win->Pen(colour);
-  to_win->SetCursor(fleft, (float) ybottom);
+  to_win->SetCursor(fleft, static_cast<float>(ybottom));
   for (line_index = min_y; line_index <= max_y; line_index++) {
-     to_win->DrawTo(fleft + thresholds[line_index - min_y] / 10.0,      (float) line_index);
+     to_win->DrawTo(fleft + thresholds[line_index - min_y] / 10.0,      static_cast<float>(line_index));
   }
 }
 
@@ -226,12 +226,12 @@ void draw_meanlines(                  //draw a block
     blob_it.move_to_last ();
     right = blob_it.data ()->bounding_box ().right ();
     plot_pt =
-      FCOORD ((float) left,
+      FCOORD (static_cast<float>(left),
       gradient * left + row->parallel_c () + row->xheight);
     plot_pt.rotate (rotation);
   to_win->SetCursor(plot_pt.x (), plot_pt.y ());
     plot_pt =
-      FCOORD ((float) right,
+      FCOORD (right,
       gradient * right + row->parallel_c () + row->xheight);
     plot_pt.rotate (rotation);
     to_win->DrawTo (plot_pt.x (), plot_pt.y ());
@@ -283,7 +283,7 @@ void plot_word_decisions(              //draw words
       if (colour == ScrollView::MAGENTA)
         colour = ScrollView::RED;
       else
-        colour = (ScrollView::Color) (colour + 1);
+        colour = static_cast<ScrollView::Color>(colour + 1);
       if (blob_box.left () - prev_x < row->min_space) {
         if (blob_box.left () - prev_x > row->space_threshold)
           rect_colour = ScrollView::GOLDENROD;

--- a/src/textord/fpchop.cpp
+++ b/src/textord/fpchop.cpp
@@ -132,15 +132,15 @@ ROW *fixed_pitch_words(                 //find lines
     } else {
       if (rep_left < chop_coord) {
         if (rep_left > prev_chop_coord)
-          new_blanks = (uint8_t) floor ((rep_left - prev_chop_coord)
-            / row->fixed_pitch + 0.5);
+          new_blanks = static_cast<uint8_t>(floor ((rep_left - prev_chop_coord)
+            / row->fixed_pitch + 0.5));
         else
           new_blanks = 0;
       }
       else {
         if (chop_coord > prev_chop_coord)
-          new_blanks = (uint8_t) floor ((chop_coord - prev_chop_coord)
-            / row->fixed_pitch + 0.5);
+          new_blanks = static_cast<uint8_t>(floor ((chop_coord - prev_chop_coord)
+            / row->fixed_pitch + 0.5));
         else
           new_blanks = 0;
       }
@@ -184,7 +184,7 @@ ROW *fixed_pitch_words(                 //find lines
   if (prev_chop_coord > prev_x)
     prev_x = prev_chop_coord;
   xstarts[1] = prev_x + 1;
-  real_row = new ROW (row, (int16_t) row->kern_size, (int16_t) row->space_size);
+  real_row = new ROW (row, static_cast<int16_t>(row->kern_size), static_cast<int16_t>(row->space_size));
   word_it.set_to_list (real_row->word_list ());
                                  //put words in row
   word_it.add_list_after (&words);
@@ -211,7 +211,7 @@ WERD *add_repeated_word(                         //move repeated word
   int16_t new_blanks;              //extra blanks
 
   if (rep_left > prev_chop_coord) {
-    new_blanks = (uint8_t) floor ((rep_left - prev_chop_coord) / pitch + 0.5);
+    new_blanks = static_cast<uint8_t>(floor ((rep_left - prev_chop_coord) / pitch + 0.5));
     blanks += new_blanks;
   }
   word = rep_it->extract ();

--- a/src/textord/gap_map.cpp
+++ b/src/textord/gap_map.cpp
@@ -61,7 +61,7 @@ GAPMAP::GAPMAP(                 //Constructor
     row = row_it.data ();
     if (!row->blob_list ()->empty ()) {
       total_rows++;
-      xht_stats.add ((int16_t) floor (row->xheight + 0.5), 1);
+      xht_stats.add (static_cast<int16_t>(floor (row->xheight + 0.5)), 1);
       blob_it.set_to_list (row->blob_list ());
       start_of_row = blob_it.data ()->bounding_box ().left ();
       end_of_row = blob_it.data_relative (-1)->bounding_box ().right ();
@@ -78,7 +78,7 @@ GAPMAP::GAPMAP(                 //Constructor
     min_left = max_right = 0;
     return;
   }
-  bucket_size = (int16_t) floor (xht_stats.median () + 0.5) / 2;
+  bucket_size = static_cast<int16_t>(floor (xht_stats.median () + 0.5)) / 2;
   map_max = (max_right - min_left) / bucket_size;
   map = new int16_t[map_max + 1];
   for (i = 0; i <= map_max; i++)

--- a/src/textord/makerow.cpp
+++ b/src/textord/makerow.cpp
@@ -249,7 +249,7 @@ void make_initial_textrows(                  //find lines
     colour = ScrollView::RED;
     for (row_it.mark_cycle_pt (); !row_it.cycled_list (); row_it.forward ()) {
       plot_to_row (row_it.data (), colour, rotation);
-      colour = (ScrollView::Color) (colour + 1);
+      colour = static_cast<ScrollView::Color>(colour + 1);
       if (colour > ScrollView::MAGENTA)
         colour = ScrollView::RED;
     }
@@ -328,7 +328,7 @@ void compute_page_skew(                        //get average gradient
     for (row_it.mark_cycle_pt (); !row_it.cycled_list (); row_it.forward ()) {
       row = row_it.data ();
       blob_count = row->blob_list ()->length ();
-      row_err = (int32_t) ceil (row->line_error ());
+      row_err = static_cast<int32_t>(ceil (row->line_error ()));
       if (row_err <= 0)
         row_err = 1;
       if (textord_biased_skewcalc) {
@@ -365,10 +365,10 @@ void compute_page_skew(                        //get average gradient
     }
   }
   row_count = row_index;
-  row_index = choose_nth_item ((int32_t) (row_count * textord_skew_ile),
+  row_index = choose_nth_item (static_cast<int32_t>(row_count * textord_skew_ile),
     &gradients[0], row_count);
   page_m = gradients[row_index];
-  row_index = choose_nth_item ((int32_t) (row_count * textord_skew_ile),
+  row_index = choose_nth_item (static_cast<int32_t>(row_count * textord_skew_ile),
     &errors[0], row_count);
   page_err = errors[row_index];
 }
@@ -594,7 +594,7 @@ void delete_non_dropout_rows(                   //find lines
   min_y = block_box.bottom () - 1;
   max_y = block_box.top () + 1;
   for (row_it.mark_cycle_pt (); !row_it.cycled_list (); row_it.forward ()) {
-    line_index = (int32_t) floor (row_it.data ()->intercept ());
+    line_index = static_cast<int32_t>(floor (row_it.data ()->intercept ()));
     if (line_index <= min_y)
       min_y = line_index - 1;
     if (line_index >= max_y)
@@ -609,13 +609,12 @@ void delete_non_dropout_rows(                   //find lines
   std::vector<int32_t> occupation(line_count);
 
   compute_line_occupation(block, gradient, min_y, max_y, &occupation[0], &deltas[0]);
-  compute_occupation_threshold ((int32_t)
-    ceil (block->line_spacing *
+  compute_occupation_threshold (static_cast<int32_t>(ceil (block->line_spacing *
     (tesseract::CCStruct::kDescenderFraction +
-    tesseract::CCStruct::kAscenderFraction)),
-    (int32_t) ceil (block->line_spacing *
+    tesseract::CCStruct::kAscenderFraction))),
+    static_cast<int32_t>(ceil (block->line_spacing *
     (tesseract::CCStruct::kXHeightFraction +
-    tesseract::CCStruct::kAscenderFraction)),
+    tesseract::CCStruct::kAscenderFraction))),
     max_y - min_y + 1, &occupation[0], &deltas[0]);
 #ifndef GRAPHICS_DISABLED
   if (testing_on) {
@@ -625,7 +624,7 @@ void delete_non_dropout_rows(                   //find lines
   compute_dropout_distances(&occupation[0], &deltas[0], line_count);
   for (row_it.mark_cycle_pt (); !row_it.cycled_list (); row_it.forward ()) {
     row = row_it.data ();
-    line_index = (int32_t) floor (row->intercept ());
+    line_index = static_cast<int32_t>(floor (row->intercept ()));
     distance = deltas[line_index - min_y];
     if (find_best_dropout_row (row, distance, block->line_spacing / 2,
     line_index, &row_it, testing_on)) {
@@ -686,7 +685,7 @@ bool find_best_dropout_row(                    //find neighbours
     row_offset = row_inc;
     do {
       next_row = row_it->data_relative (row_offset);
-      next_index = (int32_t) floor (next_row->intercept ());
+      next_index = static_cast<int32_t>(floor (next_row->intercept ()));
       if ((distance < 0
         && next_index < line_index
         && next_index > line_index + distance + distance)
@@ -836,7 +835,7 @@ void compute_occupation_threshold(                    //project blobs
   int32_t test_index;              //for finding min
 
   divisor =
-    (int32_t) ceil ((low_window + high_window) / textord_occupancy_threshold);
+    static_cast<int32_t>(ceil ((low_window + high_window) / textord_occupancy_threshold));
   if (low_window + high_window < line_count) {
     for (sum = 0, high_index = 0; high_index < low_window; high_index++)
       sum += occupation[high_index];
@@ -1915,7 +1914,7 @@ void pre_associate_blobs(                  //make rough chars
             blob_box.right (), blob_box.top ());
         }
       }
-      colour = (ScrollView::Color) (colour + 1);
+      colour = static_cast<ScrollView::Color>(colour + 1);
       if (colour > ScrollView::MAGENTA)
         colour = ScrollView::RED;
     }
@@ -1954,7 +1953,7 @@ void fit_parallel_rows(                   //find lines
     for (row_it.mark_cycle_pt (); !row_it.cycled_list (); row_it.forward ()) {
       plot_parallel_row (row_it.data (), gradient,
         block_edge, colour, rotation);
-      colour = (ScrollView::Color) (colour + 1);
+      colour = static_cast<ScrollView::Color>(colour + 1);
       if (colour > ScrollView::MAGENTA)
         colour = ScrollView::RED;
     }
@@ -2023,7 +2022,7 @@ void Textord::make_spline_rows(TO_BLOCK* block,   // block to do
       for (row_it.mark_cycle_pt (); !row_it.cycled_list ();
       row_it.forward ()) {
         row_it.data ()->baseline.plot (to_win, colour);
-        colour = (ScrollView::Color) (colour + 1);
+        colour = static_cast<ScrollView::Color>(colour + 1);
         if (colour > ScrollView::MAGENTA)
           colour = ScrollView::RED;
       }
@@ -2036,7 +2035,7 @@ void Textord::make_spline_rows(TO_BLOCK* block,   // block to do
     colour = ScrollView::RED;
     for (row_it.mark_cycle_pt (); !row_it.cycled_list (); row_it.forward ()) {
       row_it.data ()->baseline.plot (to_win, colour);
-      colour = (ScrollView::Color) (colour + 1);
+      colour = static_cast<ScrollView::Color>(colour + 1);
       if (colour > ScrollView::MAGENTA)
         colour = ScrollView::RED;
     }
@@ -2333,7 +2332,7 @@ void assign_blobs_to_rows(                      //find lines
       && last_x - left_x > block->line_size * 2
     && textord_interpolating_skew) {
       //                      tprintf("Interpolating skew from %g",block_skew);
-      block_skew *= (float) (blob->bounding_box ().left () - left_x)
+      block_skew *= static_cast<float>(blob->bounding_box ().left () - left_x)
         / (last_x - left_x);
       //                      tprintf("to %g\n",block_skew);
     }

--- a/src/textord/oldbasel.cpp
+++ b/src/textord/oldbasel.cpp
@@ -143,7 +143,7 @@ void Textord::correlate_lines(TO_BLOCK *block, float gradient) {
   correlate_neighbours(block, &rows[0], rowcount);
 
   if (textord_really_old_xheight || textord_old_xheight) {
-    block->xheight = (float) correlate_with_stats(&rows[0], rowcount, block);
+    block->xheight = static_cast<float>(correlate_with_stats(&rows[0], rowcount, block));
     if (block->xheight <= 0)
       block->xheight = block->line_size * tesseract::CCStruct::kXHeightFraction;
     if (block->xheight < textord_min_xheight)
@@ -315,7 +315,7 @@ int Textord::correlate_with_stats(TO_ROW **rows,  // rows of block.
         row->descdrop = -row->xheight * DESCENDER_FRACTION;
     }
   }
-  return (int) lineheight;       //block xheight
+  return static_cast<int>(lineheight);       //block xheight
 }
 
 
@@ -353,7 +353,7 @@ void Textord::find_textlines(TO_BLOCK *block,  // block row is in
   // diffs from 1st approx
   std::vector<float> ydiffs(blobcount);
 
-  lineheight = get_blob_coords(row, (int)block->line_size, &blobcoords[0],
+  lineheight = get_blob_coords(row, static_cast<int>(block->line_size), &blobcoords[0],
     holed_line, blobcount);
                                  /*limit for line change */
   jumplimit = lineheight * textord_oldbl_jumplimit;
@@ -409,7 +409,7 @@ void Textord::find_textlines(TO_BLOCK *block,  // block row is in
     old_first_xheight (row, &blobcoords[0], lineheight,
       blobcount, &row->baseline, jumplimit);
   } else if (textord_old_xheight) {
-    make_first_xheight (row, &blobcoords[0], lineheight, (int)block->line_size,
+    make_first_xheight (row, &blobcoords[0], lineheight, static_cast<int>(block->line_size),
                         blobcount, &row->baseline, jumplimit);
   } else {
     compute_row_xheight(row, block->block->classify_rotation(),
@@ -482,7 +482,7 @@ int get_blob_coords(                    //get boxes
 
   if (heightstat.get_total () > 1)
                                  /*guess x-height */
-    return (int) heightstat.ile (0.25);
+    return static_cast<int>(heightstat.ile (0.25));
   else
     return blobcoords[0].height ();
 }
@@ -624,7 +624,7 @@ float jumplimit                  /*guess half descenders */
   }
   else {
     *baseline = *spline;         /*copy it */
-    shift = ICOORD (0, (int16_t) (blobcoords[0].bottom ()
+    shift = ICOORD (0, static_cast<int16_t>(blobcoords[0].bottom ()
       - spline->y (blobcoords[0].right ())));
     baseline->move (shift);
   }
@@ -682,7 +682,7 @@ float gradient                   //of line
   - MAXOVERLAP * (rightedge - leftedge)) {
     *baseline = *spline;         /*copy it */
     x = (leftedge + rightedge) / 2.0;
-    shift = ICOORD (0, (int16_t) (gradient * x + c - spline->y (x)));
+    shift = ICOORD (0, static_cast<int16_t>(gradient * x + c - spline->y (x)));
     baseline->move (shift);
   }
 }
@@ -909,7 +909,7 @@ float ydiffs[]                   /*output */
 
   diffsum = 0.0f;
   bestindex = 0;
-  bestsum = (float) INT32_MAX;
+  bestsum = static_cast<float>(INT32_MAX);
   drift = 0.0f;
   lastx = blobcoords[0].left ();
                                  /*do each blob in row */
@@ -1408,21 +1408,21 @@ float jumplimit                  /*min ascender height */
       xcentre = (blobcoords[blobindex].left ()
         + blobcoords[blobindex].right ()) / 2;
                                  /*height of blob */
-      height = (int) (blobcoords[blobindex].top () - baseline->y (xcentre) + 0.5);
+      height = static_cast<int>(blobcoords[blobindex].top () - baseline->y (xcentre) + 0.5);
       if (height > initialheight * oldbl_xhfract
         && height > textord_min_xheight)
         heightstat.add (height, 1);
     }
     if (heightstat.get_total () > 3) {
-      lineheight = (int) heightstat.ile (0.25);
+      lineheight = static_cast<int>(heightstat.ile (0.25));
       if (lineheight <= 0)
-        lineheight = (int) heightstat.ile (0.5);
+        lineheight = static_cast<int>(heightstat.ile (0.5));
     }
     else
       lineheight = initialheight;
   }
   else {
-    lineheight = (int) (blobcoords[0].top ()
+    lineheight = static_cast<int>(blobcoords[0].top ()
       - baseline->y ((blobcoords[0].left ()
       + blobcoords[0].right ()) / 2) +
       0.5);
@@ -1448,7 +1448,7 @@ float jumplimit                  /*min ascender height */
   if (xcount > 0)
     xsum /= xcount;              /*average xheight */
   else
-    xsum = (float) lineheight;   /*guess it */
+    xsum = static_cast<float>(lineheight);   /*guess it */
   row->xheight *= xsum;
   if (asccount > 0)
     row->ascrise = ascenders / asccount - xsum;
@@ -1517,9 +1517,9 @@ float jumplimit                  /*min ascender height */
     }
   }
 
-  mode_threshold = (int) (blobcount * 0.1);
+  mode_threshold = static_cast<int>(blobcount * 0.1);
   if (oldbl_dot_error_size > 1 || oldbl_xhfix)
-    mode_threshold = (int) (mode_count * 0.1);
+    mode_threshold = static_cast<int>(mode_count * 0.1);
 
   if (textord_oldbl_debug) {
     tprintf ("blobcount=%d, mode_count=%d, mode_t=%d\n",
@@ -1615,7 +1615,7 @@ void pick_x_height(TO_ROW * row,                    //row to do
           (!textord_ocropus_mode ||
                   std::min(rights[modelist[x]], rights[modelist[y]]) >
                    std::max(lefts[modelist[x]], lefts[modelist[y]]))) {
-        ratio = (float) modelist[y] / (float) modelist[x];
+        ratio = static_cast<float>(modelist[y]) / static_cast<float>(modelist[x]);
         if (1.2 < ratio && ratio < 1.8) {
           /* Two modes found */
           best_x_height = modelist[x];
@@ -1629,7 +1629,7 @@ void pick_x_height(TO_ROW * row,                    //row to do
                   (!textord_ocropus_mode ||
                           std::min(rights[modelist[x]], rights[modelist[y]]) >
                             std::max(lefts[modelist[x]], lefts[modelist[y]]))) {
-                ratio = (float) modelist[y] / (float) modelist[z];
+                ratio = static_cast<float>(modelist[y]) / static_cast<float>(modelist[z]);
                 if ((1.2 < ratio && ratio < 1.8) &&
                                /* Should be half of best */
                     heightstat->pile_count (modelist[z]) >
@@ -1656,7 +1656,7 @@ void pick_x_height(TO_ROW * row,                    //row to do
                   (!textord_ocropus_mode ||
                           std::min(rights[modelist[x]], rights[modelist[y]]) >
                             std::max(lefts[modelist[x]], lefts[modelist[y]]))) {
-                ratio = (float) modelist[z] / (float) best_x_height;
+                ratio = static_cast<float>(modelist[z]) / static_cast<float>(best_x_height);
                 if ((1.2 < ratio && ratio < 1.8) &&
                                /* Should be half of best */
                     heightstat->pile_count (modelist[z]) >
@@ -1670,8 +1670,8 @@ void pick_x_height(TO_ROW * row,                    //row to do
           }
           while (found_one_bigger);
 
-          row->xheight = (float) best_x_height;
-          row->ascrise = (float) best_asc - best_x_height;
+          row->xheight = static_cast<float>(best_x_height);
+          row->ascrise = static_cast<float>(best_asc) - best_x_height;
           return;
         }
       }
@@ -1696,7 +1696,7 @@ void pick_x_height(TO_ROW * row,                    //row to do
   while (found_one_bigger);
 
   row->ascrise = 0.0f;
-  row->xheight = (float) best_x_height;
+  row->xheight = static_cast<float>(best_x_height);
   if (row->xheight == 0)
     row->xheight = -1.0f;
 }

--- a/src/textord/pithsync.cpp
+++ b/src/textord/pithsync.cpp
@@ -165,7 +165,7 @@ void FPCUTPT::assign(                         //constructor
                 <= zero_count);
           }
           balance_count =
-            (int16_t) (balance_count * textord_balance_factor /
+            static_cast<int16_t>(balance_count * textord_balance_factor /
             projection_scale);
         }
         r_index = segpt->region_index + 1;
@@ -258,7 +258,7 @@ void FPCUTPT::assign_cheap(                         //constructor
           balance_count++;
           lead_flag &= lead_flag - 1;
         }
-        balance_count = (int16_t) (balance_count * textord_balance_factor
+        balance_count = static_cast<int16_t>(balance_count * textord_balance_factor
           / projection_scale);
       }
       r_index = segpt->region_index + 1;
@@ -529,7 +529,7 @@ double check_pitch_sync3(                          //find segmentation
   if ((pitch - 3) / 2 < pitch_error)
     pitch_error = (pitch - 3) / 2;
                                  //min dist of zero
-  zero_offset = (int16_t) (pitch * pitsync_joined_edge);
+  zero_offset = static_cast<int16_t>(pitch * pitsync_joined_edge);
   for (left_edge = projection_left; projection->pile_count (left_edge) == 0
     && left_edge < projection_right; left_edge++);
   for (right_edge = projection_right; projection->pile_count (right_edge) == 0
@@ -599,7 +599,7 @@ double check_pitch_sync3(                          //find segmentation
       }
       else {
         projection_offset =
-          (int16_t) (projection->pile_count (x) / projection_scale);
+          static_cast<int16_t>(projection->pile_count (x) / projection_scale);
         if (projection_offset > offset)
           offset = projection_offset;
         mid_cut = true;

--- a/src/textord/topitch.cpp
+++ b/src/textord/topitch.cpp
@@ -169,7 +169,7 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
   STATS like_stats;              //pitches in page
 
   block_votes = like_votes = other_votes = 0;
-  maxwidth = (int32_t) ceil (bad_row->xheight * textord_words_maxspace);
+  maxwidth = static_cast<int32_t>(ceil (bad_row->xheight * textord_words_maxspace));
   if (bad_row->pitch_decision != PITCH_DEF_FIXED
   && bad_row->pitch_decision != PITCH_DEF_PROP) {
     block_stats.set_range (0, maxwidth);
@@ -201,13 +201,13 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
           if (block_index == block_target) {
             if (row->pitch_decision == PITCH_DEF_FIXED) {
               block_votes += textord_words_veto_power;
-              block_stats.add ((int32_t) row->fixed_pitch,
+              block_stats.add (static_cast<int32_t>(row->fixed_pitch),
                 textord_words_veto_power);
             }
             else if (row->pitch_decision == PITCH_MAYBE_FIXED
             || row->pitch_decision == PITCH_CORR_FIXED) {
               block_votes++;
-              block_stats.add ((int32_t) row->fixed_pitch, 1);
+              block_stats.add (static_cast<int32_t>(row->fixed_pitch), 1);
             }
             else if (row->pitch_decision == PITCH_DEF_PROP)
               block_votes -= textord_words_veto_power;
@@ -218,13 +218,13 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
           else {
             if (row->pitch_decision == PITCH_DEF_FIXED) {
               like_votes += textord_words_veto_power;
-              like_stats.add ((int32_t) row->fixed_pitch,
+              like_stats.add (static_cast<int32_t>(row->fixed_pitch),
                 textord_words_veto_power);
             }
             else if (row->pitch_decision == PITCH_MAYBE_FIXED
             || row->pitch_decision == PITCH_CORR_FIXED) {
               like_votes++;
-              like_stats.add ((int32_t) row->fixed_pitch, 1);
+              like_stats.add (static_cast<int32_t>(row->fixed_pitch), 1);
             }
             else if (row->pitch_decision == PITCH_DEF_PROP)
               like_votes -= textord_words_veto_power;
@@ -287,8 +287,8 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
     if (bad_row->fixed_pitch < textord_min_xheight)
       bad_row->fixed_pitch = (float) textord_min_xheight;
     bad_row->kern_size = bad_row->fixed_pitch / 4;
-    bad_row->min_space = (int32_t) (bad_row->fixed_pitch * 0.6);
-    bad_row->max_nonspace = (int32_t) (bad_row->fixed_pitch * 0.4);
+    bad_row->min_space = static_cast<int32_t>(bad_row->fixed_pitch * 0.6);
+    bad_row->max_nonspace = static_cast<int32_t>(bad_row->fixed_pitch * 0.4);
     bad_row->space_threshold =
       (bad_row->min_space + bad_row->max_nonspace) / 2;
     bad_row->space_size = bad_row->fixed_pitch;
@@ -327,13 +327,13 @@ void compute_block_pitch(TO_BLOCK* block,     // input list
       block_box.left (), block_box.bottom (),
       block_box.right (), block_box.top ());
   }
-  block->min_space = (int32_t) floor (block->xheight
-    * textord_words_default_minspace);
-  block->max_nonspace = (int32_t) ceil (block->xheight
-    * textord_words_default_nonspace);
+  block->min_space = static_cast<int32_t>(floor (block->xheight
+    * textord_words_default_minspace));
+  block->max_nonspace = static_cast<int32_t>(ceil (block->xheight
+    * textord_words_default_nonspace));
   block->fixed_pitch = 0.0f;
-  block->space_size = (float) block->min_space;
-  block->kern_size = (float) block->max_nonspace;
+  block->space_size = static_cast<float>(block->min_space);
+  block->kern_size = static_cast<float>(block->max_nonspace);
   block->pr_nonsp = block->xheight * words_default_prop_nonspace;
   block->pr_space = block->pr_nonsp * textord_spacesize_ratioprop;
   if (!block->get_rows ()->empty ()) {
@@ -373,7 +373,7 @@ bool compute_rows_pitch(                    //find line stats
     row = row_it.data ();
     ASSERT_HOST (row->xheight > 0);
     row->compute_vertical_projection ();
-    maxwidth = (int32_t) ceil (row->xheight * textord_words_maxspace);
+    maxwidth = static_cast<int32_t>(ceil (row->xheight * textord_words_maxspace));
     if (row_pitch_stats (row, maxwidth, testing_on)
       && find_row_pitch (row, maxwidth,
       textord_dotmatrix_gap + 1, block, block_index,
@@ -456,14 +456,14 @@ bool try_doc_fixed(                             //determine pitch
       row = row_it.data ();
       total_row_count++;
       if (row->fixed_pitch > 0)
-        pitches.add ((int32_t) (row->fixed_pitch), 1);
+        pitches.add (static_cast<int32_t>(row->fixed_pitch), 1);
       //find median
       row_y = row->baseline.y (master_x);
       row_left =
-        (int16_t) (row->projection_left -
+        static_cast<int16_t>(row->projection_left -
         shift_factor * (master_y - row_y));
       row_right =
-        (int16_t) (row->projection_right -
+        static_cast<int16_t>(row->projection_right -
         shift_factor * (master_y - row_y));
       if (row_left < projection_left)
         projection_left = row_left;
@@ -483,7 +483,7 @@ bool try_doc_fixed(                             //determine pitch
       row = row_it.data ();
       row_y = row->baseline.y (master_x);
       row_left =
-        (int16_t) (row->projection_left -
+        static_cast<int16_t>(row->projection_left -
         shift_factor * (master_y - row_y));
       for (x = row->projection_left; x < row->projection_right;
       x++, row_left++) {
@@ -500,7 +500,7 @@ bool try_doc_fixed(                             //determine pitch
       row->intercept (), 1.0f, -1.0f, ScrollView::CORAL);
 #endif
   final_pitch = pitches.ile (0.5);
-  pitch = (int16_t) final_pitch;
+  pitch = static_cast<int16_t>(final_pitch);
   pitch_sd =
     tune_row_pitch (row, &projection, projection_left, projection_right,
     pitch * 0.75, final_pitch, sp_sd, mid_cuts,
@@ -729,7 +729,7 @@ bool row_pitch_stats(                  //find line stats
   //clusters
 
   smooth_factor =
-    (int32_t) (row->xheight * textord_wordstats_smooth_factor + 1.5);
+    static_cast<int32_t>(row->xheight * textord_wordstats_smooth_factor + 1.5);
   if (!blob_it.empty ()) {
     prev_x = blob_it.data ()->bounding_box ().right ();
     blob_it.forward ();
@@ -961,9 +961,9 @@ bool find_row_pitch(                    //find lines
     row->pitch_decision = PITCH_MAYBE_PROP;
   row->fixed_pitch = pitch;
   row->kern_size = gap_stats.ile (0.5);
-  row->min_space = (int32_t) (row->fixed_pitch + non_space) / 2;
+  row->min_space = static_cast<int32_t>(row->fixed_pitch + non_space) / 2;
   if (row->min_space > row->fixed_pitch)
-    row->min_space = (int32_t) row->fixed_pitch;
+    row->min_space = static_cast<int32_t>(row->fixed_pitch);
   row->max_nonspace = row->min_space;
   row->space_size = row->fixed_pitch;
   row->space_threshold = (row->max_nonspace + row->min_space) / 2;
@@ -1108,19 +1108,19 @@ bool count_pitch_stats(                       //find lines
         blob_width = joined_box.width ();
         if (split_outsize) {
           width_units =
-            (int32_t) floor ((float) blob_width / initial_pitch + 0.5);
+            static_cast<int32_t>(floor (static_cast<float>(blob_width) / initial_pitch + 0.5));
           if (width_units < 1)
             width_units = 1;
           width_units--;
         }
         else if (ignore_outsize) {
-          width = (float) blob_width / initial_pitch;
+          width = static_cast<float>(blob_width) / initial_pitch;
           width_units = width < 1 + words_default_fixed_limit
             && width > 1 - words_default_fixed_limit ? 0 : -1;
         }
         else
           width_units = 0;       //everything in
-        x_centre = (int32_t) (joined_box.left ()
+        x_centre = static_cast<int32_t>(joined_box.left ()
           + (blob_width -
           width_units * initial_pitch) / 2);
         if (prev_valid && width_units >= 0) {
@@ -1132,7 +1132,7 @@ bool count_pitch_stats(                       //find lines
           gap_stats->add (joined_box.left () - prev_right, 1);
           pitch_stats->add (x_centre - prev_centre, 1);
         }
-        prev_centre = (int32_t) (x_centre + width_units * initial_pitch);
+        prev_centre = static_cast<int32_t>(x_centre + width_units * initial_pitch);
         prev_right = joined_box.right ();
         prev_valid = blob_box.left () - joined_box.right () < min_space;
         prev_valid = prev_valid && width_units >= 0;
@@ -1455,13 +1455,13 @@ float compute_pitch_sd(                            //find fp cells
     plot_it = start_it;
     if (pitsync_linear_version & 3)
       word_sync =
-        check_pitch_sync2 (&start_it, blob_count, (int16_t) initial_pitch, 2,
+        check_pitch_sync2 (&start_it, blob_count, static_cast<int16_t>(initial_pitch), 2,
         projection, projection_left, projection_right,
         row->xheight * textord_projection_scale,
         occupation, &seg_list, start, end);
     else
       word_sync =
-        check_pitch_sync (&start_it, blob_count, (int16_t) initial_pitch, 2,
+        check_pitch_sync (&start_it, blob_count, static_cast<int16_t>(initial_pitch), 2,
         projection, &seg_list);
     if (testing_on) {
       tprintf ("Word ending at (%d,%d), len=%d, sync rating=%g, ",
@@ -1497,9 +1497,9 @@ float compute_pitch_sd(                            //find fp cells
       if (cell_it.empty () || segpos > cellpos + initial_pitch / 2) {
                                  //big gap
         while (!cell_it.empty () && segpos > cellpos + initial_pitch * 3 / 2) {
-          cell = new ICOORDELT (cellpos + (int16_t) initial_pitch, 0);
+          cell = new ICOORDELT (cellpos + static_cast<int16_t>(initial_pitch), 0);
           cell_it.add_after_then_move (cell);
-          cellpos += (int16_t) initial_pitch;
+          cellpos += static_cast<int16_t>(initial_pitch);
         }
                                  //make new one
         cell = new ICOORDELT (segpos, 0);
@@ -1585,7 +1585,7 @@ float compute_pitch_sd2(                            //find fp cells
   }
   while (!blob_it.cycled_list ());
   plot_it = blob_it;
-  word_sync = check_pitch_sync2 (&blob_it, blob_count, (int16_t) initial_pitch,
+  word_sync = check_pitch_sync2 (&blob_it, blob_count, static_cast<int16_t>(initial_pitch),
     2, projection, projection_left,
     projection_right,
     row->xheight * textord_projection_scale,
@@ -1687,7 +1687,7 @@ void print_pitch_sd(                        //find fp cells
     while (!blob_it.cycled_list ()
       && blob_box.left () - prev_box.right () < space_size);
     word_sync =
-      check_pitch_sync2 (&start_it, blob_count, (int16_t) initial_pitch, 2,
+      check_pitch_sync2 (&start_it, blob_count, static_cast<int16_t>(initial_pitch), 2,
       projection, projection_left, projection_right,
       row->xheight * textord_projection_scale,
       occupation, &seg_list, 0, 0);
@@ -1724,7 +1724,7 @@ void print_pitch_sd(                        //find fp cells
   start_it = row_start;
   blob_it = row_start;
   word_sync =
-    check_pitch_sync2 (&blob_it, total_blob_count, (int16_t) initial_pitch, 2,
+    check_pitch_sync2 (&blob_it, total_blob_count, static_cast<int16_t>(initial_pitch), 2,
     projection, projection_left, projection_right,
     row->xheight * textord_projection_scale, occupation,
     &seg_list, 0, 0);
@@ -1835,10 +1835,10 @@ void plot_fp_word(                  //draw block of words
 
   for (row_it.mark_cycle_pt (); !row_it.cycled_list (); row_it.forward ()) {
     row = row_it.data ();
-    row->min_space = (int32_t) ((pitch + nonspace) / 2);
+    row->min_space = static_cast<int32_t>((pitch + nonspace) / 2);
     row->max_nonspace = row->min_space;
     row->space_threshold = row->min_space;
-    plot_word_decisions (to_win, (int16_t) pitch, row);
+    plot_word_decisions (to_win, static_cast<int16_t>(pitch), row);
   }
 }
 #endif

--- a/src/textord/tordmain.cpp
+++ b/src/textord/tordmain.cpp
@@ -558,7 +558,7 @@ bool Textord::clean_noise_from_row(          //remove empties
     tprintf ("Row ending at (%d,%g):",
       blob_box.right (), row->base_line (blob_box.right ()));
     tprintf (" R=%g, dc=%d, nc=%d, %s\n",
-      norm_count > 0 ? (float) dot_count / norm_count : 9999,
+      norm_count > 0 ? static_cast<float>(dot_count) / norm_count : 9999,
       dot_count, norm_count,
       dot_count > norm_count * textord_noise_normratio
       && dot_count > 2 ? "REJECTED" : "ACCEPTED");

--- a/src/textord/tospace.cpp
+++ b/src/textord/tospace.cpp
@@ -74,8 +74,8 @@ void Textord::to_spacing(
     // often over-estimated and should not be trusted. A similar ratio
     // is found in block_spacing_stats.
     if (tosp_old_to_method && tosp_old_to_constrain_sp_kn &&
-        (float) block_space_gap_width / block_non_space_gap_width < 3.0) {
-      block_non_space_gap_width = (int16_t) floor (block_space_gap_width / 3.0);
+        static_cast<float>(block_space_gap_width) / block_non_space_gap_width < 3.0) {
+      block_non_space_gap_width = static_cast<int16_t>(floor (block_space_gap_width / 3.0));
     }
     // row iterator
     TO_ROW_IT row_it(block->get_rows());
@@ -103,7 +103,7 @@ void Textord::to_spacing(
       }
 #ifndef GRAPHICS_DISABLED
       if (textord_show_initial_words)
-        plot_word_decisions (to_win, (int16_t) row->fixed_pitch, row);
+        plot_word_decisions (to_win, static_cast<int16_t>(row->fixed_pitch), row);
 #endif
       row_index++;
     }
@@ -213,7 +213,7 @@ void Textord::block_spacing_stats(
     block. Do this by using a crude threshold to ignore "narrow" gaps, then
     find the median of the "wide" gaps and use this.
     */
-    block_non_space_gap_width = (int16_t) floor (all_gap_stats.median ());
+    block_non_space_gap_width = static_cast<int16_t>(floor (all_gap_stats.median ()));
     // median gap
 
     row_it.set_to_list (block->get_rows ());
@@ -432,7 +432,7 @@ void Textord::row_spacing_stats(
         tprintf("B:%d R:%d -- DON'T BELIEVE SPACE %3.2f %d %3.2f.\n", block_idx,
                 row_idx, row->kern_size, row->space_threshold, row->space_size);
       row->space_threshold =
-        (int32_t) (tosp_table_kn_sp_ratio * row->kern_size);
+        static_cast<int32_t>(tosp_table_kn_sp_ratio * row->kern_size);
       row->space_size = std::max(row->space_threshold + 1.0f, row->xheight);
     }
   }
@@ -484,7 +484,7 @@ void Textord::row_spacing_stats(
             row->kern_size,
             row->space_threshold, row->space_size);
                                  //the minimum sane value
-        row->space_threshold = (int32_t) sane_space;
+        row->space_threshold = static_cast<int32_t>(sane_space);
         row->space_size = std::max(row->space_threshold + 1.0f, row->xheight);
       }
     }
@@ -541,10 +541,10 @@ void Textord::row_spacing_stats(
   if ((tosp_fuzzy_sp_fraction > 0) &&
     (row->space_size > row->space_threshold))
     row->min_space = std::max(row->min_space,
-      (int32_t) ceil (row->space_threshold +
+      static_cast<int32_t>(ceil (row->space_threshold +
       tosp_fuzzy_sp_fraction *
       (row->space_size -
-      row->space_threshold)));
+      row->space_threshold))));
 
   /* Ensure that ANY space less than some multiplier times the kern size is
   fuzzy.  In tables there is a risk of erroneously setting a small space size
@@ -556,14 +556,14 @@ void Textord::row_spacing_stats(
   if ((tosp_table_fuzzy_kn_sp_ratio > 0) &&
     (suspected_table || tosp_fuzzy_limit_all))
     row->min_space = std::max(row->min_space,
-      (int32_t) ceil (tosp_table_fuzzy_kn_sp_ratio *
-      row->kern_size));
+      static_cast<int32_t>(ceil (tosp_table_fuzzy_kn_sp_ratio *
+      row->kern_size)));
 
   if ((tosp_fuzzy_kn_fraction > 0) && (row->kern_size < row->space_threshold)) {
-    row->max_nonspace = (int32_t) floor (0.5 + row->kern_size +
+    row->max_nonspace = static_cast<int32_t>(floor (0.5 + row->kern_size +
       tosp_fuzzy_kn_fraction *
       (row->space_threshold -
-      row->kern_size));
+      row->kern_size)));
   }
   if (row->max_nonspace > row->space_threshold) {
     // Don't be silly
@@ -699,12 +699,11 @@ bool Textord::isolated_row_stats(TO_ROW* row,
   crude_threshold_estimate = std::max(tosp_init_guess_kn_mult * kern_estimate,
     tosp_init_guess_xht_mult * row->xheight);
   small_gaps_count = stats_count_under (all_gap_stats,
-    (int16_t)
-    ceil (crude_threshold_estimate));
+    static_cast<int16_t>(ceil (crude_threshold_estimate)));
   total = all_gap_stats->get_total ();
 
   if ((total <= tosp_redo_kern_limit) ||
-    ((small_gaps_count / (float) total) < tosp_enough_small_gaps) ||
+    ((small_gaps_count / static_cast<float>(total)) < tosp_enough_small_gaps) ||
   (total - small_gaps_count < 1)) {
     if (tosp_debug_level > 5)
       tprintf("B:%d R:%d -- Can't do isolated row stats.\n", block_idx,
@@ -829,7 +828,7 @@ void Textord::improve_row_threshold(TO_ROW *row, STATS *all_gap_stats) {
     (sp <= 10) ||
     (sp <= 3 * kn) ||
     (stats_count_under (all_gap_stats,
-    (int16_t) ceil (kn + (sp - kn) / 3 + 0.5)) <
+    static_cast<int16_t>(ceil (kn + (sp - kn) / 3 + 0.5))) <
     (0.75 * all_gap_stats->get_total ())))
     return;
   if (tosp_debug_level > 10)
@@ -839,7 +838,7 @@ void Textord::improve_row_threshold(TO_ROW *row, STATS *all_gap_stats) {
   max(3, (sp - kn) / 3) and starts between kn and sp. If found, and current
   threshold is not within it, move the threshold so that is is just inside it.
   */
-  reqd_zero_width = (int16_t) floor ((sp - kn) / 3 + 0.5);
+  reqd_zero_width = static_cast<int16_t>(floor ((sp - kn) / 3 + 0.5));
   if (reqd_zero_width < 3)
     reqd_zero_width = 3;
 
@@ -963,7 +962,7 @@ ROW *Textord::make_prop_words(
         next_rep_char_word_right;
       current_within_xht_gap = current_gap;
       if (current_gap > tosp_rep_space * repetition_spacing) {
-        prev_blanks = (uint8_t) floor (current_gap / row->space_size);
+        prev_blanks = static_cast<uint8_t>(floor (current_gap / row->space_size));
         if (prev_blanks < 1)
           prev_blanks = 1;
       }
@@ -1064,7 +1063,7 @@ ROW *Textord::make_prop_words(
             current_within_xht_gap = current_gap;
             if (current_gap > tosp_rep_space * repetition_spacing) {
               blanks =
-                (uint8_t) floor (current_gap / row->space_size);
+                static_cast<uint8_t>(floor (current_gap / row->space_size));
               if (blanks < 1)
                 blanks = 1;
             }
@@ -1085,7 +1084,7 @@ ROW *Textord::make_prop_words(
             current_gap =
               blob_box.left () - next_rep_char_word_right;
             if (current_gap > tosp_rep_space * repetition_spacing) {
-              blanks = (uint8_t) (current_gap / row->space_size);
+              blanks = static_cast<uint8_t>(current_gap / row->space_size);
               if (blanks < 1)
                 blanks = 1;
             }
@@ -1131,7 +1130,7 @@ ROW *Textord::make_prop_words(
       repetition_spacing = find_mean_blob_spacing (word);
       current_gap = word->bounding_box ().left () - prev_x;
       if (current_gap > tosp_rep_space * repetition_spacing) {
-        blanks = (uint8_t) floor (current_gap / row->space_size);
+        blanks = static_cast<uint8_t>(floor (current_gap / row->space_size));
         if (blanks < 1)
           blanks = 1;
       }
@@ -1157,7 +1156,7 @@ ROW *Textord::make_prop_words(
       }
     }
     real_row = new ROW (row,
-      (int16_t) row->kern_size, (int16_t) row->space_size);
+      static_cast<int16_t>(row->kern_size), static_cast<int16_t>(row->space_size));
     word_it.set_to_list (real_row->word_list ());
                                  //put words in row
     word_it.add_list_after (&words);
@@ -1238,7 +1237,7 @@ ROW *Textord::make_blob_words(
     }
     while (!box_it.at_first()); // until back at start
     /* Setup the row with created words. */
-    real_row = new ROW(row, (int16_t) row->kern_size, (int16_t) row->space_size);
+    real_row = new ROW(row, static_cast<int16_t>(row->kern_size), static_cast<int16_t>(row->space_size));
     word_it.set_to_list(real_row->word_list());
                                  //put words in row
     word_it.add_list_after(&words);
@@ -1312,7 +1311,7 @@ bool Textord::make_a_word_break(
         }
       }
       else {
-        blanks = (uint8_t) (current_gap / row->space_size);
+        blanks = static_cast<uint8_t>(current_gap / row->space_size);
         if (blanks < 1)
           blanks = 1;
         fuzzy_sp = false;
@@ -1567,7 +1566,7 @@ bool Textord::make_a_word_break(
 bool Textord::narrow_blob(TO_ROW* row, TBOX blob_box) {
   bool result;
   result = ((blob_box.width () <= tosp_narrow_fraction * row->xheight) ||
-    (((float) blob_box.width () / blob_box.height ()) <=
+    ((static_cast<float>(blob_box.width ()) / blob_box.height ()) <=
     tosp_narrow_aspect_ratio));
   return result;
 }
@@ -1577,7 +1576,7 @@ bool Textord::wide_blob(TO_ROW* row, TBOX blob_box) {
   if (tosp_wide_fraction > 0) {
     if (tosp_wide_aspect_ratio > 0)
       result = ((blob_box.width () >= tosp_wide_fraction * row->xheight) &&
-        (((float) blob_box.width () / blob_box.height ()) >
+        ((static_cast<float>(blob_box.width ()) / blob_box.height ()) >
         tosp_wide_aspect_ratio));
     else
       result = (blob_box.width () >= tosp_wide_fraction * row->xheight);
@@ -1722,7 +1721,7 @@ float Textord::find_mean_blob_spacing(WERD *word) {
     }
   }
   if (gap_count > 0)
-    return (gap_sum / (float) gap_count);
+    return (gap_sum / static_cast<float>(gap_count));
   else
     return 0.0f;
 }
@@ -1860,20 +1859,20 @@ TBOX Textord::reduced_box_for_blob(
   Find LH limit of blob ABOVE the xht. This is so that we can detect certain
   caps ht chars which should NOT have their box reduced: T, Y, V, W etc
   */
-  left_limit = (float) INT32_MAX;
-  junk = (float) -INT32_MAX;
+  left_limit = static_cast<float>(INT32_MAX);
+  junk = static_cast<float>(-INT32_MAX);
   find_cblob_hlimits(blob->cblob(), (baseline + 1.1 * row->xheight),
                      static_cast<float>(INT16_MAX), left_limit, junk);
   if (left_limit > junk)
     *left_above_xht = INT16_MAX; //No area above xht
   else
-    *left_above_xht = (int16_t) floor (left_limit);
+    *left_above_xht = static_cast<int16_t>(floor (left_limit));
   /*
   Find reduced LH limit of blob - the left extent of the region ABOVE the
   baseline.
   */
-  left_limit = (float) INT32_MAX;
-  junk = (float) -INT32_MAX;
+  left_limit = static_cast<float>(INT32_MAX);
+  junk = static_cast<float>(-INT32_MAX);
   find_cblob_hlimits(blob->cblob(), baseline, static_cast<float>(INT16_MAX),
                      left_limit, junk);
 
@@ -1882,14 +1881,14 @@ TBOX Textord::reduced_box_for_blob(
   /*
   Find reduced RH limit of blob - the right extent of the region BELOW the xht.
   */
-  junk = (float) INT32_MAX;
-  right_limit = (float) -INT32_MAX;
+  junk = static_cast<float>(INT32_MAX);
+  right_limit = static_cast<float>(-INT32_MAX);
   find_cblob_hlimits(blob->cblob(), static_cast<float>(-INT16_MAX),
                      (baseline + row->xheight), junk, right_limit);
   if (junk > right_limit)
     return TBOX ();               //no area within xht so return empty box
 
-  return TBOX (ICOORD ((int16_t) floor (left_limit), blob_box.bottom ()),
-    ICOORD ((int16_t) ceil (right_limit), blob_box.top ()));
+  return TBOX (ICOORD (static_cast<int16_t>(floor (left_limit)), blob_box.bottom ()),
+    ICOORD (static_cast<int16_t>(ceil (right_limit)), blob_box.top ()));
 }
 }  // namespace tesseract

--- a/src/textord/underlin.cpp
+++ b/src/textord/underlin.cpp
@@ -121,7 +121,7 @@ TO_ROW *most_overlapping_row(                    //find best row
   float bestover;                //best overlap
 
   best_row = nullptr;
-  bestover = (float) -INT32_MAX;
+  bestover = static_cast<float>(-INT32_MAX);
   if (row_it.empty ())
     return nullptr;
   row = row_it.data ();
@@ -232,10 +232,10 @@ void vertical_cunderline_projection(                        //project outlines
     step = outline->step (stepindex);
     if (step.x () > 0) {
       lower_y =
-        (int16_t) floor (baseline->y (pos.x ()) + baseline_offset + 0.5);
+        static_cast<int16_t>(floor (baseline->y (pos.x ()) + baseline_offset + 0.5));
       upper_y =
-        (int16_t) floor (baseline->y (pos.x ()) + baseline_offset +
-        xheight + 0.5);
+        static_cast<int16_t>(floor (baseline->y (pos.x ()) + baseline_offset +
+        xheight + 0.5));
       if (pos.y () >= lower_y) {
         lower_proj->add (pos.x (), -lower_y);
         if (pos.y () >= upper_y) {
@@ -250,11 +250,11 @@ void vertical_cunderline_projection(                        //project outlines
     }
     else if (step.x () < 0) {
       lower_y =
-        (int16_t) floor (baseline->y (pos.x () - 1) + baseline_offset +
-        0.5);
+        static_cast<int16_t>(floor (baseline->y (pos.x () - 1) + baseline_offset +
+        0.5));
       upper_y =
-        (int16_t) floor (baseline->y (pos.x () - 1) + baseline_offset +
-        xheight + 0.5);
+        static_cast<int16_t>(floor (baseline->y (pos.x () - 1) + baseline_offset +
+        xheight + 0.5));
       if (pos.y () >= lower_y) {
         lower_proj->add (pos.x () - 1, lower_y);
         if (pos.y () >= upper_y) {

--- a/src/textord/wordseg.cpp
+++ b/src/textord/wordseg.cpp
@@ -140,13 +140,13 @@ void set_row_spaces(                  //find space sizes
     row = row_it.data ();
     if (row->fixed_pitch == 0) {
       row->min_space =
-        (int32_t) ceil (row->pr_space -
+        static_cast<int32_t>(ceil (row->pr_space -
         (row->pr_space -
-        row->pr_nonsp) * textord_words_definite_spread);
+        row->pr_nonsp) * textord_words_definite_spread));
       row->max_nonspace =
-        (int32_t) floor (row->pr_nonsp +
+        static_cast<int32_t>(floor (row->pr_nonsp +
         (row->pr_space -
-        row->pr_nonsp) * textord_words_definite_spread);
+        row->pr_nonsp) * textord_words_definite_spread));
       if (testing_on && textord_show_initial_words) {
         tprintf ("Assigning defaults %d non, %d space to row at %g\n",
           row->max_nonspace, row->min_space, row->intercept ());
@@ -157,7 +157,7 @@ void set_row_spaces(                  //find space sizes
     }
 #ifndef GRAPHICS_DISABLED
     if (textord_show_initial_words && testing_on) {
-      plot_word_decisions (to_win, (int16_t) row->fixed_pitch, row);
+      plot_word_decisions (to_win, static_cast<int16_t>(row->fixed_pitch), row);
     }
 #endif
   }
@@ -195,7 +195,7 @@ int32_t row_words(                  //compute space size
 
   testpt = ICOORD (textord_test_x, textord_test_y);
   smooth_factor =
-    (int32_t) (block->xheight * textord_wordstats_smooth_factor + 1.5);
+    static_cast<int32_t>(block->xheight * textord_wordstats_smooth_factor + 1.5);
   //      if (testing_on)
   //              tprintf("Row smooth factor=%d\n",smooth_factor);
   prev_valid = false;
@@ -308,9 +308,9 @@ int32_t row_words(                  //compute space size
     }
   }
   row->min_space =
-    (int32_t) ceil (upper - (upper - lower) * textord_words_definite_spread);
+    static_cast<int32_t>(ceil (upper - (upper - lower) * textord_words_definite_spread));
   row->max_nonspace =
-    (int32_t) floor (lower + (upper - lower) * textord_words_definite_spread);
+    static_cast<int32_t>(floor (lower + (upper - lower) * textord_words_definite_spread));
   row->space_threshold = (row->max_nonspace + row->min_space) / 2;
   row->space_size = upper;
   row->kern_size = lower;
@@ -368,14 +368,14 @@ int32_t row_words2(                  //compute space size
 
   testpt = ICOORD (textord_test_x, textord_test_y);
   smooth_factor =
-    (int32_t) (block->xheight * textord_wordstats_smooth_factor + 1.5);
+    static_cast<int32_t>(block->xheight * textord_wordstats_smooth_factor + 1.5);
   //      if (testing_on)
   //              tprintf("Row smooth factor=%d\n",smooth_factor);
   prev_valid = false;
   prev_x = -INT16_MAX;
   const bool testing_row = false;
                                  //min blob size
-  min_width = (int32_t) block->pr_space;
+  min_width = static_cast<int32_t>(block->pr_space);
   total_count = 0;
   for (blob_it.mark_cycle_pt (); !blob_it.cycled_list (); blob_it.forward ()) {
     blob = blob_it.data ();
@@ -462,9 +462,9 @@ int32_t row_words2(                  //compute space size
     upper = block->pr_space;
   }
   row->min_space =
-    (int32_t) ceil (upper - (upper - lower) * textord_words_definite_spread);
+    static_cast<int32_t>(ceil (upper - (upper - lower) * textord_words_definite_spread));
   row->max_nonspace =
-    (int32_t) floor (lower + (upper - lower) * textord_words_definite_spread);
+    static_cast<int32_t>(floor (lower + (upper - lower) * textord_words_definite_spread));
   row->space_threshold = (row->max_nonspace + row->min_space) / 2;
   row->space_size = upper;
   row->kern_size = lower;
@@ -533,9 +533,9 @@ void make_real_words(
       real_row_it.add_after_then_move (real_row);
     }
   }
-  block->block->set_stats (block->fixed_pitch == 0, (int16_t) block->kern_size,
-    (int16_t) block->space_size,
-    (int16_t) block->fixed_pitch);
+  block->block->set_stats (block->fixed_pitch == 0, static_cast<int16_t>(block->kern_size),
+    static_cast<int16_t>(block->space_size),
+    static_cast<int16_t>(block->fixed_pitch));
   block->block->check_pitch ();
 }
 
@@ -563,7 +563,7 @@ ROW *make_rep_words(                 //make a row
     word_box += word_it.data ()->bounding_box ();
   row->xheight = block->xheight;
   real_row = new ROW(row,
-    (int16_t) block->kern_size, (int16_t) block->space_size);
+    static_cast<int16_t>(block->kern_size), static_cast<int16_t>(block->space_size));
   word_it.set_to_list (real_row->word_list ());
                                  //put words in row
   word_it.add_list_after (&row->rep_words);

--- a/src/training/cntraining.cpp
+++ b/src/training/cntraining.cpp
@@ -148,7 +148,7 @@ int main(int argc, char *argv[]) {
   GenericVector<LIST> freeable_protos;
   iterate(pCharList) {
     //Cluster
-    CharSample = (LABELEDLIST)first_node(pCharList);
+    CharSample = reinterpret_cast<LABELEDLIST>first_node(pCharList);
     Clusterer =
       SetUpForClustering(FeatureDefs, CharSample, PROGRAM_FEATURE_TYPE);
     if (Clusterer == nullptr) {  // To avoid a SIGSEGV
@@ -222,7 +222,7 @@ static void WriteNormProtos(const char *Directory, LIST LabeledProtoList,
   WriteParamDesc(File, feature_desc->NumParams, feature_desc->ParamDesc);
   iterate(LabeledProtoList)
   {
-    LabeledProto = (LABELEDLIST) first_node (LabeledProtoList);
+    LabeledProto = reinterpret_cast<LABELEDLIST>first_node (LabeledProtoList);
     N = NumberOfProtos(LabeledProto->List, true, false);
     if (N < 1) {
       printf ("\nError! Not enough protos for %s: %d protos"
@@ -250,7 +250,7 @@ static void WriteProtos(FILE* File, uint16_t N, LIST ProtoList,
   // write prototypes
   iterate(ProtoList)
   {
-    Proto = (PROTOTYPE*)first_node(ProtoList);
+    Proto = reinterpret_cast<PROTOTYPE*>first_node(ProtoList);
     if ((Proto->Significant && WriteSigProtos)  ||
       (! Proto->Significant && WriteInsigProtos))
       WritePrototype(File, N, Proto);

--- a/src/training/commontraining.cpp
+++ b/src/training/commontraining.cpp
@@ -349,7 +349,7 @@ LABELEDLIST FindList(LIST List, char* Label) {
 
   iterate (List)
   {
-    LabeledList = (LABELEDLIST) first_node (List);
+    LabeledList = reinterpret_cast<LABELEDLIST>first_node (List);
     if (strcmp (LabeledList->Label, Label) == 0)
       return (LabeledList);
   }
@@ -368,8 +368,8 @@ LABELEDLIST FindList(LIST List, char* Label) {
 LABELEDLIST NewLabeledList(const char* Label) {
   LABELEDLIST LabeledList;
 
-  LabeledList = (LABELEDLIST) Emalloc (sizeof (LABELEDLISTNODE));
-  LabeledList->Label = (char*)Emalloc (strlen (Label)+1);
+  LabeledList = static_cast<LABELEDLIST>(Emalloc (sizeof (LABELEDLISTNODE)));
+  LabeledList->Label = static_cast<char*>(Emalloc (strlen (Label)+1));
   strcpy (LabeledList->Label, Label);
   LabeledList->List = NIL_LIST;
   LabeledList->SampleCount = 0;
@@ -465,10 +465,10 @@ void FreeTrainingSamples(LIST CharList) {
 
   LIST nodes = CharList;
   iterate(CharList) { /* iterate through all of the fonts */
-    char_sample = (LABELEDLIST) first_node(CharList);
+    char_sample = reinterpret_cast<LABELEDLIST>first_node(CharList);
     FeatureList = char_sample->List;
     iterate(FeatureList) { /* iterate through all of the classes */
-      FeatureSet = (FEATURE_SET) first_node(FeatureList);
+      FeatureSet = reinterpret_cast<FEATURE_SET>first_node(FeatureList);
       FreeFeatureSet(FeatureSet);
     }
     FreeLabeledList(char_sample);
@@ -522,9 +522,9 @@ CLUSTERER *SetUpForClustering(const FEATURE_DEFS_STRUCT &FeatureDefs,
   FeatureList = char_sample->List;
   CharID = 0;
   iterate(FeatureList) {
-    FeatureSet = (FEATURE_SET) first_node(FeatureList);
+    FeatureSet = reinterpret_cast<FEATURE_SET>first_node(FeatureList);
     for (i = 0; i < FeatureSet->MaxNumFeatures; i++) {
-      if (Sample == nullptr) Sample = (float*)Emalloc(N * sizeof(float));
+      if (Sample == nullptr) Sample = static_cast<float*>(Emalloc(N * sizeof(float)));
       for (j = 0; j < N; j++)
         Sample[j] = FeatureSet->Features[i]->Params[j];
       MakeSample (Clusterer, Sample, CharID);
@@ -545,7 +545,7 @@ void MergeInsignificantProtos(LIST ProtoList, const char* label,
 
   LIST pProtoList = ProtoList;
   iterate(pProtoList) {
-    Prototype = (PROTOTYPE *) first_node (pProtoList);
+    Prototype = reinterpret_cast<PROTOTYPE *>first_node (pProtoList);
     if (Prototype->Significant || Prototype->Merged)
       continue;
     float best_dist = 0.125;
@@ -553,7 +553,7 @@ void MergeInsignificantProtos(LIST ProtoList, const char* label,
     // Find the nearest alive prototype.
     LIST list_it = ProtoList;
     iterate(list_it) {
-      PROTOTYPE* test_p = (PROTOTYPE *) first_node (list_it);
+      PROTOTYPE* test_p = reinterpret_cast<PROTOTYPE *>first_node (list_it);
       if (test_p != Prototype && !test_p->Merged) {
         float dist = ComputeDistance(Clusterer->SampleSize,
                                      Clusterer->ParamDesc,
@@ -591,7 +591,7 @@ void MergeInsignificantProtos(LIST ProtoList, const char* label,
     static_cast<int32_t>(clusterconfig->MinSamples * Clusterer->NumChar);
   pProtoList = ProtoList;
   iterate(pProtoList) {
-    Prototype = (PROTOTYPE *) first_node (pProtoList);
+    Prototype = reinterpret_cast<PROTOTYPE *>first_node (pProtoList);
     // Process insignificant protos that do not match a green one
     if (!Prototype->Significant && Prototype->NumSamples >= min_samples &&
         !Prototype->Merged) {
@@ -611,7 +611,7 @@ void CleanUpUnusedData(
 
   iterate(ProtoList)
   {
-    Prototype = (PROTOTYPE *) first_node (ProtoList);
+    Prototype = reinterpret_cast<PROTOTYPE *>first_node (ProtoList);
     free(Prototype->Variance.Elliptical);
     Prototype->Variance.Elliptical = nullptr;
     free(Prototype->Magnitude.Elliptical);
@@ -638,13 +638,13 @@ LIST RemoveInsignificantProtos(
   pProtoList = ProtoList;
   iterate(pProtoList)
   {
-    Proto = (PROTOTYPE *) first_node (pProtoList);
+    Proto = reinterpret_cast<PROTOTYPE *>first_node (pProtoList);
     if ((Proto->Significant && KeepSigProtos) ||
         (!Proto->Significant && KeepInsigProtos))
     {
-      NewProto = (PROTOTYPE *)Emalloc(sizeof(PROTOTYPE));
+      NewProto = static_cast<PROTOTYPE *>(Emalloc(sizeof(PROTOTYPE)));
 
-      NewProto->Mean = (float *)Emalloc(N * sizeof(float));
+      NewProto->Mean = static_cast<float *>(Emalloc(N * sizeof(float)));
       NewProto->Significant = Proto->Significant;
       NewProto->Style = Proto->Style;
       NewProto->NumSamples = Proto->NumSamples;
@@ -654,7 +654,7 @@ LIST RemoveInsignificantProtos(
       for (i=0; i < N; i++)
         NewProto->Mean[i] = Proto->Mean[i];
       if (Proto->Variance.Elliptical != nullptr) {
-        NewProto->Variance.Elliptical = (float *)Emalloc(N * sizeof(float));
+        NewProto->Variance.Elliptical = static_cast<float *>(Emalloc(N * sizeof(float)));
         for (i=0; i < N; i++)
           NewProto->Variance.Elliptical[i] = Proto->Variance.Elliptical[i];
       }
@@ -662,7 +662,7 @@ LIST RemoveInsignificantProtos(
         NewProto->Variance.Elliptical = nullptr;
       //---------------------------------------------
       if (Proto->Magnitude.Elliptical != nullptr) {
-        NewProto->Magnitude.Elliptical = (float *)Emalloc(N * sizeof(float));
+        NewProto->Magnitude.Elliptical = static_cast<float *>(Emalloc(N * sizeof(float)));
         for (i=0; i < N; i++)
           NewProto->Magnitude.Elliptical[i] = Proto->Magnitude.Elliptical[i];
       }
@@ -670,7 +670,7 @@ LIST RemoveInsignificantProtos(
         NewProto->Magnitude.Elliptical = nullptr;
       //------------------------------------------------
       if (Proto->Weight.Elliptical != nullptr) {
-        NewProto->Weight.Elliptical = (float *)Emalloc(N * sizeof(float));
+        NewProto->Weight.Elliptical = static_cast<float *>(Emalloc(N * sizeof(float)));
         for (i=0; i < N; i++)
           NewProto->Weight.Elliptical[i] = Proto->Weight.Elliptical[i];
       }
@@ -692,7 +692,7 @@ MERGE_CLASS FindClass(LIST List, const char* Label) {
 
   iterate (List)
   {
-    MergeClass = (MERGE_CLASS) first_node (List);
+    MergeClass = reinterpret_cast<MERGE_CLASS>first_node (List);
     if (strcmp (MergeClass->Label, Label) == 0)
       return (MergeClass);
   }
@@ -705,7 +705,7 @@ MERGE_CLASS NewLabeledClass(const char* Label) {
   MERGE_CLASS MergeClass;
 
   MergeClass = new MERGE_CLASS_NODE;
-  MergeClass->Label = (char*)Emalloc (strlen (Label)+1);
+  MergeClass->Label = static_cast<char*>(Emalloc (strlen (Label)+1));
   strcpy (MergeClass->Label, Label);
   MergeClass->Class = NewClass (MAX_NUM_PROTOS, MAX_NUM_CONFIGS);
   return (MergeClass);
@@ -726,7 +726,7 @@ void FreeLabeledClassList(LIST ClassList) {
   LIST nodes = ClassList;
   iterate(ClassList) /* iterate through all of the fonts */
   {
-    MergeClass = (MERGE_CLASS) first_node (ClassList);
+    MergeClass = reinterpret_cast<MERGE_CLASS>first_node (ClassList);
     free (MergeClass->Label);
     FreeClass(MergeClass->Class);
     delete MergeClass;
@@ -756,14 +756,14 @@ CLASS_STRUCT* SetUpForFloat2Int(const UNICHARSET& unicharset,
   iterate(LabeledClassList)
   {
     UnicityTableEqEq<int>   font_set;
-    MergeClass = (MERGE_CLASS) first_node (LabeledClassList);
+    MergeClass = reinterpret_cast<MERGE_CLASS>first_node (LabeledClassList);
     Class = &float_classes[unicharset.unichar_to_id(MergeClass->Label)];
     NumProtos = MergeClass->Class->NumProtos;
     NumConfigs = MergeClass->Class->NumConfigs;
     font_set.move(&MergeClass->Class->font_set);
     Class->NumProtos = NumProtos;
     Class->MaxNumProtos = NumProtos;
-    Class->Prototypes = (PROTO) Emalloc (sizeof(PROTO_STRUCT) * NumProtos);
+    Class->Prototypes = static_cast<PROTO>(Emalloc (sizeof(PROTO_STRUCT) * NumProtos));
     for(i=0; i < NumProtos; i++)
     {
       NewProto = ProtoIn(Class, i);
@@ -784,7 +784,7 @@ CLASS_STRUCT* SetUpForFloat2Int(const UNICHARSET& unicharset,
     Class->NumConfigs = NumConfigs;
     Class->MaxNumConfigs = NumConfigs;
     Class->font_set.move(&font_set);
-    Class->Configurations = (BIT_VECTOR*) Emalloc (sizeof(BIT_VECTOR) * NumConfigs);
+    Class->Configurations = static_cast<BIT_VECTOR*>(Emalloc (sizeof(BIT_VECTOR) * NumConfigs));
     NumWords = WordsInVectorOfSize(NumProtos);
     for(i=0; i < NumConfigs; i++)
     {
@@ -824,7 +824,7 @@ void FreeNormProtoList(LIST CharList)
   LIST nodes = CharList;
   iterate(CharList) /* iterate through all of the fonts */
   {
-    char_sample = (LABELEDLIST) first_node (CharList);
+    char_sample = reinterpret_cast<LABELEDLIST>first_node (CharList);
     FreeLabeledList (char_sample);
   }
   destroy(nodes);
@@ -843,7 +843,7 @@ void AddToNormProtosList(
   LabeledProtoList = NewLabeledList(CharName);
   iterate(ProtoList)
   {
-    Proto = (PROTOTYPE *) first_node (ProtoList);
+    Proto = reinterpret_cast<PROTOTYPE *>first_node (ProtoList);
     LabeledProtoList->List = push(LabeledProtoList->List, Proto);
   }
   *NormProtoList = push(*NormProtoList, LabeledProtoList);
@@ -855,7 +855,7 @@ int NumberOfProtos(LIST ProtoList, bool CountSigProtos,
   int N = 0;
   iterate(ProtoList)
   {
-    PROTOTYPE* Proto = (PROTOTYPE*)first_node(ProtoList);
+    PROTOTYPE* Proto = reinterpret_cast<PROTOTYPE*>first_node(ProtoList);
     if ((Proto->Significant && CountSigProtos) ||
         (!Proto->Significant && CountInsigProtos))
       N++;

--- a/src/training/mergenf.cpp
+++ b/src/training/mergenf.cpp
@@ -170,7 +170,7 @@ int FindClosestExistingProto(CLASS_TYPE Class, int NumMerged[],
   for (Pid = 0; Pid < Class->NumProtos; Pid++) {
     Proto  = ProtoIn(Class, Pid);
     ComputeMergedProto(Proto, &NewProto,
-      (float) NumMerged[Pid], 1.0, &MergedProto);
+      static_cast<float>(NumMerged[Pid]), 1.0, &MergedProto);
     OldMatch = CompareProtos(Proto, &MergedProto);
     NewMatch = CompareProtos(&NewProto, &MergedProto);
     Match = std::min(OldMatch, NewMatch);

--- a/src/wordrec/chop.cpp
+++ b/src/wordrec/chop.cpp
@@ -45,7 +45,7 @@ namespace tesseract {
  * split. The argument should be of type EDGEPT.
  */
 PRIORITY Wordrec::point_priority(EDGEPT *point) {
-  return (PRIORITY)angle_change(point->prev, point, point->next);
+  return static_cast<PRIORITY>(angle_change(point->prev, point, point->next));
 }
 
 
@@ -91,7 +91,7 @@ int Wordrec::angle_change(EDGEPT *point1, EDGEPT *point2, EDGEPT *point3) {
   vector2.y = point3->pos.y - point2->pos.y;
   /* Use cross product */
   float length = std::sqrt(static_cast<float>(LENGTH(vector1)) * LENGTH(vector2));
-  if ((int) length == 0)
+  if (static_cast<int>(length) == 0)
     return (0);
   angle = static_cast<int>(floor(asin(CROSS (vector1, vector2) /
                                       length) / M_PI * 180.0 + 0.5));

--- a/src/wordrec/outlines.cpp
+++ b/src/wordrec/outlines.cpp
@@ -52,7 +52,7 @@ bool Wordrec::near_point(EDGEPT *point,
 
   if (x0 == x1) {
                                  /* Handle vertical line */
-    p.x = (int16_t) x0;
+    p.x = static_cast<int16_t>(x0);
     p.y = point->pos.y;
   }
   else {
@@ -61,9 +61,9 @@ bool Wordrec::near_point(EDGEPT *point,
     intercept = y1 - x1 * slope;
 
     /* Find perpendicular */
-    p.x = (int16_t) ((point->pos.x + (point->pos.y - intercept) * slope) /
+    p.x = static_cast<int16_t>((point->pos.x + (point->pos.y - intercept) * slope) /
       (slope * slope + 1));
-    p.y = (int16_t) (slope * p.x + intercept);
+    p.y = static_cast<int16_t>(slope * p.x + intercept);
   }
 
   if (is_on_line (p, line_pt_0->pos, line_pt_1->pos) &&

--- a/src/wordrec/plotedges.cpp
+++ b/src/wordrec/plotedges.cpp
@@ -56,7 +56,7 @@ void display_edgepts(LIST outlines) {
   window = edge_window;
   /* Reclaim old memory */
   iterate(outlines) {
-    render_edgepts (window, (EDGEPT *) first_node (outlines), White);
+    render_edgepts (window, reinterpret_cast<EDGEPT *>first_node (outlines), White);
   }
 }
 


### PR DESCRIPTION
This was done using clang-tidy.

Signed-off-by: Stefan Weil <sw@weilnetz.de>