### PR TITLE
unittest: Fix and enable params_model_test

### DIFF
--- a/src/wordrec/params_model.cpp
+++ b/src/wordrec/params_model.cpp
@@ -2,7 +2,6 @@
 // File:        params_model.cpp
 // Description: Trained language model parameters.
 // Author:      David Eger
-// Created:     Mon Jun 11 11:26:42 PDT 2012
 //
 // (C) Copyright 2012, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -98,17 +97,6 @@ bool ParamsModel::Equivalent(const ParamsModel &that) const {
     }
   }
   return true;
-}
-
-bool ParamsModel::LoadFromFile(
-    const char *lang,
-    const char *full_path) {
-  TFile fp;
-  if (!fp.Open(full_path, nullptr)) {
-    tprintf("Error opening file %s\n", full_path);
-    return false;
-  }
-  return LoadFromFp(lang, &fp);
 }
 
 bool ParamsModel::LoadFromFp(const char *lang, TFile *fp) {

--- a/src/wordrec/params_model.h
+++ b/src/wordrec/params_model.h
@@ -2,7 +2,6 @@
 // File:        params_model.h
 // Description: Trained feature serialization for language parameter training.
 // Author:      David Eger
-// Created:     Mon Jun 11 11:26:42 PDT 2012
 //
 // (C) Copyright 2011, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,7 +61,6 @@ class ParamsModel {
   bool SaveToFile(const char *full_path) const;
 
   // Returns true on success.
-  bool LoadFromFile(const char *lang, const char *full_path);
   bool LoadFromFp(const char *lang, TFile *fp);
 
   const GenericVector<float>& weights() const {

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -123,7 +123,9 @@ check_PROGRAMS = \
   matrix_test \
   nthitem_test \
   osd_test \
-  paragraphs_test \
+  paragraphs_test
+check_PROGRAMS += params_model_test
+check_PROGRAMS += \
   progress_test \
   qrsequence_test \
   recodebeam_test \
@@ -258,6 +260,9 @@ nthitem_test_LDADD = $(GTEST_LIBS) $(TESS_LIBS)
 
 paragraphs_test_SOURCES = paragraphs_test.cc
 paragraphs_test_LDADD = $(ABSEIL_LIBS) $(GTEST_LIBS) $(TESS_LIBS)
+
+params_model_test_SOURCES = params_model_test.cc
+params_model_test_LDADD = $(GTEST_LIBS) $(TESS_LIBS)
 
 osd_test_SOURCES = osd_test.cc
 osd_test_LDADD = $(GTEST_LIBS) $(TESS_LIBS) $(LEPTONICA_LIBS)

--- a/unittest/params_model_test.cc
+++ b/unittest/params_model_test.cc
@@ -1,32 +1,55 @@
+// (C) Copyright 2017, Google Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+#include <string>         // std::string
 #include <vector>
 
-#include "tesseract/wordrec/params_model.h"
+#include "include_gunit.h"
+#include "params_model.h"
+#include "serialis.h"     // TFile
+#include "tprintf.h"      // tprintf
 
 namespace {
 
 // Test some basic I/O of params model files (automated learning of language
 // model weights).
+static bool LoadFromFile(tesseract::ParamsModel& model, const char* lang, const char* full_path) {
+  tesseract::TFile fp;
+  if (!fp.Open(full_path, nullptr)) {
+    tprintf("Error opening file %s\n", full_path);
+    return false;
+  }
+  return model.LoadFromFp(lang, &fp);
+}
+
 class ParamsModelTest : public testing::Test {
  protected:
-  string TestDataNameToPath(const string& name) const {
-    return file::JoinPath(FLAGS_test_srcdir, "testdata/" + name);
+  std::string TestDataNameToPath(const std::string& name) const {
+    return file::JoinPath(TESTDATA_DIR, name);
   }
-  string OutputNameToPath(const string& name) const {
+  std::string OutputNameToPath(const std::string& name) const {
     return file::JoinPath(FLAGS_test_tmpdir, name);
   }
   // Test that we are able to load a params model, save it, reload it,
   // and verify that the re-serialized version is the same as the original.
-  void TestParamsModelRoundTrip(const string& params_model_filename) const {
+  void TestParamsModelRoundTrip(const std::string& params_model_filename) const {
     tesseract::ParamsModel orig_model;
     tesseract::ParamsModel duplicate_model;
-    string orig_file = TestDataNameToPath(params_model_filename);
-    string out_file = OutputNameToPath(params_model_filename);
+    std::string orig_file = TestDataNameToPath(params_model_filename);
+    std::string out_file = OutputNameToPath(params_model_filename);
 
-    EXPECT_TRUE(orig_model.LoadFromFile("eng", orig_file.c_str()));
+    EXPECT_TRUE(LoadFromFile(orig_model, "eng", orig_file.c_str()));
     EXPECT_TRUE(orig_model.SaveToFile(out_file.c_str()));
 
-    EXPECT_TRUE(duplicate_model.LoadFromFile("eng", out_file.c_str()));
+    EXPECT_TRUE(LoadFromFile(duplicate_model, "eng", out_file.c_str()));
     EXPECT_TRUE(orig_model.Equivalent(duplicate_model));
   }
 };


### PR DESCRIPTION
This needs the latest test submodule.

The test uses LoadFromFile which is not used otherwise, so remove that
function from class ParamsModel.

Signed-off-by: Stefan Weil <sw@weilnetz.de>