### PR TITLE
 Replace sscanf by std::stringstream

### DIFF
--- a/src/ccstruct/boxread.cpp
+++ b/src/ccstruct/boxread.cpp
@@ -2,7 +2,6 @@
  * File:        boxread.cpp
  * Description: Read data from a box file.
  * Author:      Ray Smith
- * Created:     Fri Aug 24 17:47:23 PDT 2007
  *
  * (C) Copyright 2007, Google Inc.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +18,8 @@
 
 #include "boxread.h"
 #include <cstring>          // for strchr, strcmp, strrchr
+#include <locale>           // for std::locale::classic
+#include <sstream>          // for std::stringstream
 #include "errcode.h"        // for ERRCODE, TESSEXIT
 #include "fileerr.h"        // for CANTOPENFILE
 #include "genericvector.h"  // for GenericVector
@@ -194,11 +195,19 @@ bool ParseBoxFileStr(const char* boxfile_str, int* page_number,
            uch_len < kBoxReadBufSize - 1);
   uch[uch_len] = '\0';
   if (*buffptr != '\0') ++buffptr;
-  int x_min, y_min, x_max, y_max;
+  int x_min = INT_MAX;
+  int y_min = INT_MAX;
+  int x_max = INT_MIN;
+  int y_max = INT_MIN;
   *page_number = 0;
-  int count = sscanf(buffptr, "%d %d %d %d %d",
-                 &x_min, &y_min, &x_max, &y_max, page_number);
-  if (count != 5 && count != 4) {
+  std::stringstream stream(buffptr);
+  stream.imbue(std::locale::classic());
+  stream >> x_min;
+  stream >> y_min;
+  stream >> x_max;
+  stream >> y_max;
+  stream >> *page_number;
+  if (x_max < x_min || y_max < y_min) {
     tprintf("Bad box coordinates in boxfile string! %s\n", ubuf);
     return false;
   }

--- a/src/ccutil/params.cpp
+++ b/src/ccutil/params.cpp
@@ -16,9 +16,13 @@
  *
  **********************************************************************/
 
+#include <climits>          // for INT_MIN, INT_MAX
+#include <cmath>            // for NAN, std::isnan
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <locale>           // for std::locale::classic
+#include <sstream>          // for std::stringstream
 
 #include "genericvector.h"
 #include "tprintf.h"
@@ -96,11 +100,17 @@ bool ParamUtils::SetParam(const char *name, const char* value,
   if (*value == '\0') return (sp != nullptr);
 
   // Look for the parameter among int parameters.
-  int intval;
   auto *ip = FindParam<IntParam>(name, GlobalParams()->int_params,
                                      member_params->int_params);
-  if (ip && ip->constraint_ok(constraint) && sscanf(value, "%d", &intval) == 1)
-    ip->set_value(intval);
+  if (ip && ip->constraint_ok(constraint)) {
+    int intval = INT_MIN;
+    std::stringstream stream(value);
+    stream.imbue(std::locale::classic());
+    stream >> intval;
+    if (intval != INT_MIN) {
+      ip->set_value(intval);
+    }
+  }
 
   // Look for the parameter among bool parameters.
   auto *bp = FindParam<BoolParam>(name, GlobalParams()->bool_params,
@@ -116,16 +126,16 @@ bool ParamUtils::SetParam(const char *name, const char* value,
   }
 
   // Look for the parameter among double parameters.
-  double doubleval;
   auto *dp = FindParam<DoubleParam>(name, GlobalParams()->double_params,
                                            member_params->double_params);
   if (dp != nullptr && dp->constraint_ok(constraint)) {
-#ifdef EMBEDDED
-      doubleval = strtofloat(value);
-#else
-      if (sscanf(value, "%lf", &doubleval) == 1)
-#endif
+    double doubleval = NAN;
+    std::stringstream stream(value);
+    stream.imbue(std::locale::classic());
+    stream >> doubleval;
+    if (!std::isnan(doubleval)) {
       dp->set_value(doubleval);
+    }
   }
   return (sp || ip || bp || dp);
 }

--- a/src/ccutil/scanutils.h
+++ b/src/ccutil/scanutils.h
@@ -57,11 +57,6 @@ int vfscanf(FILE* stream, const char *format, va_list ap);
 // information, as this function attempts to mimic its behavior.
 int creat(const char *pathname, mode_t mode);
 
-// Convert the specified C-String to a float. Returns the first parsed float,
-// or 0.0 if no floating point value could be found. Note that scientific
-// floating-point notation is not supported.
-double strtofloat(const char* s);
-
 #endif  // EMBEDDED
 
 #endif  // TESSERACT_CCUTIL_SCANUTILS_H_


### PR DESCRIPTION
Using std::stringstream allows working with the C locale, independent
of the current locale settings.

Signed-off-by: Stefan Weil <sw@weilnetz.de>