### PR TITLE
Don't include windows.h from platform.h

### DIFF
--- a/src/ccutil/params.cpp
+++ b/src/ccutil/params.cpp
@@ -25,9 +25,9 @@
 #include <sstream>          // for std::stringstream
 
 #include "genericvector.h"
+#include "host.h"           // platform.h, windows.h for MAX_PATH
 #include "tprintf.h"
 #include "params.h"
-#include "platform.h"  // MAX_PATH
 
 #define PLUS          '+'        //flag states
 #define MINUS         '-'

--- a/src/ccutil/platform.h
+++ b/src/ccutil/platform.h
@@ -20,7 +20,6 @@
 
 #define DLLSYM
 #ifdef _WIN32
-#  include <windows.h>   // MAX_PATH
 #  ifndef NOMINMAX
 #    define NOMINMAX
 #  endif /* NOMINMAX */


### PR DESCRIPTION
This partially reverts commit c150b9832d7d07761ec7869a625e6c46ba62206a.
Now params.cpp includes host.h which also gets the definition for MAX_PATH.

Signed-off-by: Stefan Weil <sw@weilnetz.de>