### PR TITLE
fix the coordinates for EOL tab

### DIFF
--- a/src/api/wordstrboxrenderer.cpp
+++ b/src/api/wordstrboxrenderer.cpp
@@ -44,8 +44,6 @@ char* TessBaseAPI::GetWordStrBoxText(int page_number=0) {
       continue;
     }
 
-    // Use bounding box for whole line for WordStr
-    res_it->BoundingBox(RIL_TEXTLINE, &left, &top, &right, &bottom);
     if (res_it->IsAtBeginningOf(RIL_TEXTLINE)) {
       if (!first_line) {
         wordstr_box_str.add_str_int("\n\t ", right + 1);
@@ -57,6 +55,8 @@ char* TessBaseAPI::GetWordStrBoxText(int page_number=0) {
       } else {
         first_line = false;
       }
+     // Use bounding box for whole line for WordStr
+     res_it->BoundingBox(RIL_TEXTLINE, &left, &top, &right, &bottom);
       wordstr_box_str.add_str_int("WordStr ", left);
       wordstr_box_str.add_str_int(" ", image_height_ - bottom);
       wordstr_box_str.add_str_int(" ", right);


### PR DESCRIPTION
This reverts one of the changes made in commit https://github.com/tesseract-ocr/tesseract/commit/f47c7c92dd5c30af98861dad07e13b7690291454

Incorrect boxfile

```
WordStr 44 521 1493 622 0 #॥ इति श्रीरामरहस्योक्ता श्रीहनुमदष्टोत्तशतनामावळिः ॥
	 941 433 945 491 0
WordStr 646 433 940 491 0 #॥ समाप्ता ॥
	 1310 273 1314 357 0
WordStr 344 273 1309 357 0 #॥ श्रीरामभक्तिकल्पलता समाप्ता ॥
	 889 222 893 249 0
WordStr 627 222 888 249 0 #० - ----- - ०
	 1090 119 1094 211 0
WordStr 338 119 1089 211 0 #असुकरलाभैर्ग्रन्थैरमुद्रितै रद्ययावदतिरस्यैः ।
	 1171 79 1175 177 0
WordStr 118 79 1170 177 0 #महिततनुवर्हतु मुदं मनसि सतां रामभक्तिकल्पलता ॥
	 1422 0 1426 99 0
WordStr 119 0 1421 99 0 #
	 1422 0 1426 99 0
```
Note the duplication of the coordinates for EOL on the last line and line before that. `	 1422 0 1426 99 0`


Boxfile after reverting the change:

```
WordStr 44 521 1493 622 0 #॥ इति श्रीरामरहस्योक्ता श्रीहनुमदष्टोत्तशतनामावळिः ॥
	 1494 521 1498 622 0
WordStr 646 433 940 491 0 #॥ समाप्ता ॥
	 941 433 945 491 0
WordStr 344 273 1309 357 0 #॥ श्रीरामभक्तिकल्पलता समाप्ता ॥
	 1310 273 1314 357 0
WordStr 627 222 888 249 0 #० - ----- - ०
	 889 222 893 249 0
WordStr 338 119 1089 211 0 #असुकरलाभैर्ग्रन्थैरमुद्रितै रद्ययावदतिरस्यैः ।
	 1090 119 1094 211 0
WordStr 118 79 1170 177 0 #महिततनुवर्हतु मुदं मनसि सतां रामभक्तिकल्पलता ॥
	 1171 79 1175 177 0
WordStr 119 0 1421 99 0 #
	 1422 0 1426 99 0
```

The EOL tab coordinates need to after the coordinates for the text line.