### PR TITLE
Fix reading of parameter from traineddata normproto component and make function independent of locale

### DIFF
--- a/src/classify/clusttool.cpp
+++ b/src/classify/clusttool.cpp
@@ -154,7 +154,7 @@ PARAM_DESC *ReadParamDesc(TFile *fp, uint16_t N) {
                 linear_token, essential_token, &ParamDesc[i].Min,
                 &ParamDesc[i].Max) == 4);
     ParamDesc[i].Circular = (linear_token[0] == 'c');
-    ParamDesc[i].NonEssential = (linear_token[0] != 'e');
+    ParamDesc[i].NonEssential = (essential_token[0] != 'e');
     ParamDesc[i].Range = ParamDesc[i].Max - ParamDesc[i].Min;
     ParamDesc[i].HalfRange = ParamDesc[i].Range / 2;
     ParamDesc[i].MidRange = (ParamDesc[i].Max + ParamDesc[i].Min) / 2;


### PR DESCRIPTION
The NonEssential parameter was wrongly derived from linear_token instead
of essential_token and therefore always set to true.

Signed-off-by: Stefan Weil <sw@weilnetz.de>