### PR TITLE
Add different classes to hocr output depending on BlockType

### DIFF
--- a/src/api/hocrrenderer.cpp
+++ b/src/api/hocrrenderer.cpp
@@ -209,8 +209,21 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
       AddBoxTohOCR(res_it.get(), RIL_PARA, hocr_str);
     }
     if (res_it->IsAtBeginningOf(RIL_TEXTLINE)) {
-      hocr_str << "\n     <span class='ocr_line'"
-               << " id='"
+      hocr_str << "\n     <span class='";
+      switch (res_it->BlockType()) {
+        case PT_HEADING_TEXT:
+          hocr_str << "ocr_header";
+          break;
+        case PT_PULLOUT_TEXT:
+          hocr_str << "ocr_textfloat";
+          break;
+        case PT_CAPTION_TEXT:
+          hocr_str << "ocr_caption";
+          break;
+        default:
+          hocr_str << "ocr_line";
+      }
+      hocr_str << "' id='"
                << "line_" << page_id << "_" << lcnt << "'";
       AddBoxTohOCR(res_it.get(), RIL_TEXTLINE, hocr_str);
     }


### PR DESCRIPTION
These classes are taken from the hOCR specification, and seem
to map well onto the BlockType types. There are probably more that
could be added.

Note that I haven't read the hOCR specification closely, so there's a
chance I misunderstood something. @kba, can you take a look and
check that the hOCR produced is valid and sensible?