### PR TITLE
configure: Fix for latest developer tools on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,31 +111,24 @@ case "${host_os}" in
         ;;
 esac
 
+# The test code used by AX_CHECK_COMPILE_FLAG uses macros which are unused.
+# That must not break the check, so disable a related warning if necessary.
+WERROR=-Werror
+AX_CHECK_COMPILE_FLAG([-Wno-unused-macros], [WERROR="$WERROR -Wno-unused-macros"])
+
 ## Checks for supported compiler options.
-AM_CONDITIONAL([AVX_OPT], false)
-AM_CONDITIONAL([AVX2_OPT], false)
-AM_CONDITIONAL([SSE41_OPT], false)
-AM_CONDITIONAL([MARCH_NATIVE_OPT], false)
 
-AX_CHECK_COMPILE_FLAG([-mavx], [avx=true], [avx=false], [-Werror])
-if $avx; then
-    AM_CONDITIONAL([AVX_OPT], true)
-fi
+AX_CHECK_COMPILE_FLAG([-mavx], [avx=true], [avx=false], [$WERROR])
+AM_CONDITIONAL([AVX_OPT], ${avx})
 
-AX_CHECK_COMPILE_FLAG([-mavx2], [avx2=true], [avx2=false], [-Werror])
-if $avx2; then
-    AM_CONDITIONAL([AVX2_OPT], true)
-fi
+AX_CHECK_COMPILE_FLAG([-mavx2], [avx2=true], [avx2=false], [$WERROR])
+AM_CONDITIONAL([AVX2_OPT], $avx2)
 
-AX_CHECK_COMPILE_FLAG([-msse4.1], [sse41=true], [sse41=false], [-Werror])
-if $sse41; then
-    AM_CONDITIONAL([SSE41_OPT], true)
-fi
+AX_CHECK_COMPILE_FLAG([-msse4.1], [sse41=true], [sse41=false], [$WERROR])
+AM_CONDITIONAL([SSE41_OPT], $sse41)
 
-AX_CHECK_COMPILE_FLAG([-march=native], [arch_native=true], [arch_native=false], [-Werror])
-if $arch_native; then
-    AM_CONDITIONAL([MARCH_NATIVE_OPT], true)
-fi
+AX_CHECK_COMPILE_FLAG([-march=native], [arch_native=true], [arch_native=false], [$WERROR])
+AM_CONDITIONAL([MARCH_NATIVE_OPT], $arch_native)
 
 AC_ARG_WITH([extra-includes],
             [AS_HELP_STRING([--with-extra-includes=DIR],
@@ -337,12 +330,12 @@ dnl **********************
 
 CPLUSPLUS=
 
-AX_CHECK_COMPILE_FLAG([-std=c++11], [cplusplus11=true], [cplusplus11=false], [-Werror])
+AX_CHECK_COMPILE_FLAG([-std=c++11], [cplusplus11=true], [cplusplus11=false], [$WERROR])
 if $cplusplus11; then
   CPLUSPLUS=11
 fi
 
-AX_CHECK_COMPILE_FLAG([-std=c++14], [cplusplus14=true], [cplusplus14=false], [-Werror])
+AX_CHECK_COMPILE_FLAG([-std=c++14], [cplusplus14=true], [cplusplus14=false], [$WERROR])
 if $cplusplus14; then
   CPLUSPLUS=14
 fi


### PR DESCRIPTION
AX_CHECK_COMPILE_FLAG fails if it is used with -Werror and the compiler
raises error -Wunused-macros. Add -Wno-unused-macros to disable those
errors if possible.

Simplify also the setting of several conditionals (AVX, AVX2, ...).

Signed-off-by: Stefan Weil <sw@weilnetz.de>