### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/ccmain/pgedit.cpp
+++ b/src/ccmain/pgedit.cpp
@@ -44,7 +44,7 @@
 #define DESC_HEIGHT     0
 #define MAXSPACING      128      /*max expected spacing in pix */
 
-const ERRCODE EMPTYBLOCKLIST = "No blocks to edit";
+constexpr ERRCODE EMPTYBLOCKLIST("No blocks to edit");
 
 enum CMD_EVENTS
 {

--- a/src/ccstruct/linlsq.cpp
+++ b/src/ccstruct/linlsq.cpp
@@ -21,7 +21,7 @@
 #include "errcode.h"
 #include "linlsq.h"
 
-const ERRCODE EMPTY_LLSQ = "Can't delete from an empty LLSQ";
+constexpr ERRCODE EMPTY_LLSQ("Can't delete from an empty LLSQ");
 
 /**********************************************************************
  * LLSQ::clear

--- a/src/ccstruct/pdblock.cpp
+++ b/src/ccstruct/pdblock.cpp
@@ -29,8 +29,8 @@
 
 #define BLOCK_LABEL_HEIGHT  150  //char height of block id
 
-const ERRCODE BADBLOCKLINE = "Y coordinate in block out of bounds";
-const ERRCODE LOSTBLOCKLINE = "Can't find rectangle for line";
+constexpr ERRCODE BADBLOCKLINE("Y coordinate in block out of bounds");
+constexpr ERRCODE LOSTBLOCKLINE("Can't find rectangle for line");
 
 CLISTIZE (PDBLK)
 /**********************************************************************

--- a/src/ccstruct/werd.cpp
+++ b/src/ccstruct/werd.cpp
@@ -29,8 +29,8 @@
 #define LAST_COLOUR ScrollView::AQUAMARINE  ///< last rainbow colour
 #define CHILD_COLOUR ScrollView::BROWN      ///< colour of children
 
-const ERRCODE CANT_SCALE_EDGESTEPS =
-    "Attempted to scale an edgestep format word";
+constexpr ERRCODE CANT_SCALE_EDGESTEPS(
+  "Attempted to scale an edgestep format word");
 
 ELIST2IZE(WERD)
 

--- a/src/ccutil/clst.cpp
+++ b/src/ccutil/clst.cpp
@@ -96,8 +96,8 @@ void CLIST::shallow_clear() {  //destroy all links
 void CLIST::assign_to_sublist(                           //to this list
                               CLIST_ITERATOR *start_it,  //from list start
                               CLIST_ITERATOR *end_it) {  //from list end
-  const ERRCODE LIST_NOT_EMPTY =
-    "Destination list must be empty before extracting a sublist";
+  constexpr ERRCODE LIST_NOT_EMPTY(
+    "Destination list must be empty before extracting a sublist");
 
   if (!empty ())
     LIST_NOT_EMPTY.error ("CLIST.assign_to_sublist", ABORT, nullptr);
@@ -343,8 +343,8 @@ void *CLIST_ITERATOR::move_to_last() {
 
 void CLIST_ITERATOR::exchange(                             //positions of 2 links
                               CLIST_ITERATOR *other_it) {  //other iterator
-  const ERRCODE DONT_EXCHANGE_DELETED =
-    "Can't exchange deleted elements of lists";
+  constexpr ERRCODE DONT_EXCHANGE_DELETED(
+    "Can't exchange deleted elements of lists");
 
   CLIST_LINK *old_current;
 
@@ -443,12 +443,12 @@ CLIST_LINK *CLIST_ITERATOR::extract_sublist(                             //from 
   CLIST_ITERATOR temp_it = *this;
   CLIST_LINK *end_of_new_list;
 
-  const ERRCODE BAD_SUBLIST = "Can't find sublist end point in original list";
+  constexpr ERRCODE BAD_SUBLIST("Can't find sublist end point in original list");
   #ifndef NDEBUG
-  const ERRCODE BAD_EXTRACTION_PTS =
-    "Can't extract sublist from points on different lists";
-  const ERRCODE DONT_EXTRACT_DELETED =
-    "Can't extract a sublist marked by deleted points";
+  constexpr ERRCODE BAD_EXTRACTION_PTS(
+    "Can't extract sublist from points on different lists");
+  constexpr ERRCODE DONT_EXTRACT_DELETED(
+    "Can't extract a sublist marked by deleted points");
 
   if (!other_it)
     BAD_PARAMETER.error ("CLIST_ITERATOR::extract_sublist", ABORT,

--- a/src/ccutil/elst.cpp
+++ b/src/ccutil/elst.cpp
@@ -71,8 +71,8 @@ void (*zapper) (ELIST_LINK *)) {
 void ELIST::assign_to_sublist(                           //to this list
                               ELIST_ITERATOR *start_it,  //from list start
                               ELIST_ITERATOR *end_it) {  //from list end
-  const ERRCODE LIST_NOT_EMPTY =
-    "Destination list must be empty before extracting a sublist";
+  constexpr ERRCODE LIST_NOT_EMPTY(
+    "Destination list must be empty before extracting a sublist");
 
   if (!empty ())
     LIST_NOT_EMPTY.error ("ELIST.assign_to_sublist", ABORT, nullptr);
@@ -290,8 +290,8 @@ ELIST_LINK *ELIST_ITERATOR::move_to_last() {
 
 void ELIST_ITERATOR::exchange(                             //positions of 2 links
                               ELIST_ITERATOR *other_it) {  //other iterator
-  const ERRCODE DONT_EXCHANGE_DELETED =
-    "Can't exchange deleted elements of lists";
+  constexpr ERRCODE DONT_EXCHANGE_DELETED(
+    "Can't exchange deleted elements of lists");
 
   ELIST_LINK *old_current;
 
@@ -388,12 +388,12 @@ void ELIST_ITERATOR::exchange(                             //positions of 2 link
 ELIST_LINK *ELIST_ITERATOR::extract_sublist(                             //from this current
                                             ELIST_ITERATOR *other_it) {  //to other current
   #ifndef NDEBUG
-  const ERRCODE BAD_EXTRACTION_PTS =
-    "Can't extract sublist from points on different lists";
-  const ERRCODE DONT_EXTRACT_DELETED =
-    "Can't extract a sublist marked by deleted points";
+  constexpr ERRCODE BAD_EXTRACTION_PTS(
+    "Can't extract sublist from points on different lists");
+  constexpr ERRCODE DONT_EXTRACT_DELETED(
+    "Can't extract a sublist marked by deleted points");
   #endif
-  const ERRCODE BAD_SUBLIST = "Can't find sublist end point in original list";
+  constexpr ERRCODE BAD_SUBLIST("Can't find sublist end point in original list");
 
   ELIST_ITERATOR temp_it = *this;
   ELIST_LINK *end_of_new_list;

--- a/src/ccutil/elst2.cpp
+++ b/src/ccutil/elst2.cpp
@@ -71,8 +71,8 @@ void (*zapper) (ELIST2_LINK *)) {
 void ELIST2::assign_to_sublist(                            //to this list
                                ELIST2_ITERATOR *start_it,  //from list start
                                ELIST2_ITERATOR *end_it) {  //from list end
-  const ERRCODE LIST_NOT_EMPTY =
-    "Destination list must be empty before extracting a sublist";
+  constexpr ERRCODE LIST_NOT_EMPTY(
+    "Destination list must be empty before extracting a sublist");
 
   if (!empty ())
     LIST_NOT_EMPTY.error ("ELIST2.assign_to_sublist", ABORT, nullptr);
@@ -301,8 +301,8 @@ ELIST2_LINK *ELIST2_ITERATOR::data_relative(                //get data + or - ..
 
 void ELIST2_ITERATOR::exchange(                              //positions of 2 links
                                ELIST2_ITERATOR *other_it) {  //other iterator
-  const ERRCODE DONT_EXCHANGE_DELETED =
-    "Can't exchange deleted elements of lists";
+  constexpr ERRCODE DONT_EXCHANGE_DELETED(
+    "Can't exchange deleted elements of lists");
 
   ELIST2_LINK *old_current;
 
@@ -411,12 +411,12 @@ void ELIST2_ITERATOR::exchange(                              //positions of 2 li
 ELIST2_LINK *ELIST2_ITERATOR::extract_sublist(                              //from this current
                                               ELIST2_ITERATOR *other_it) {  //to other current
   #ifndef NDEBUG
-  const ERRCODE BAD_EXTRACTION_PTS =
-    "Can't extract sublist from points on different lists";
-  const ERRCODE DONT_EXTRACT_DELETED =
-    "Can't extract a sublist marked by deleted points";
+  constexpr ERRCODE BAD_EXTRACTION_PTS(
+    "Can't extract sublist from points on different lists");
+  constexpr ERRCODE DONT_EXTRACT_DELETED(
+    "Can't extract a sublist marked by deleted points");
   #endif
-  const ERRCODE BAD_SUBLIST = "Can't find sublist end point in original list";
+  constexpr ERRCODE BAD_SUBLIST("Can't find sublist end point in original list");
 
   ELIST2_ITERATOR temp_it = *this;
   ELIST2_LINK *end_of_new_list;

--- a/src/ccutil/errcode.cpp
+++ b/src/ccutil/errcode.cpp
@@ -22,7 +22,7 @@
 #include <cstring>
 #include "errcode.h"
 
-const ERRCODE BADERRACTION = "Illegal error action";
+constexpr ERRCODE BADERRACTION("Illegal error action");
 #define MAX_MSG       1024
 
 /**********************************************************************

--- a/src/ccutil/errcode.h
+++ b/src/ccutil/errcode.h
@@ -73,12 +73,11 @@ class TESS_API ERRCODE {           // error handler class
     TessErrorLogCode action,   // action to take
     const char *format, ...    // fprintf format
   ) const;
-  ERRCODE(const char *string) {
-    message = string;
+  constexpr ERRCODE(const char *string) : message(string) {
   }                            // initialize with string
 };
 
-const ERRCODE ASSERT_FAILED = "Assert failed";
+constexpr ERRCODE ASSERT_FAILED("Assert failed");
 
 #if defined __cplusplus
 # define DO_NOTHING static_cast<void>(0)

--- a/src/ccutil/fileerr.h
+++ b/src/ccutil/fileerr.h
@@ -2,7 +2,6 @@
  * File:        fileerr.h  (Formerly filerr.h)
  * Description: Errors for file utilities.
  * Author:      Ray Smith
- * Created:     Tue Aug 14 15:45:16 BST 1990
  *
  * (C) Copyright 1990, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,13 +21,13 @@
 
 #include          "errcode.h"
 
-const ERRCODE CANTOPENFILE = "Can't open file";
-const ERRCODE CANTCREATEFILE = "Can't create file";
-const ERRCODE CANTMAKEPIPE = "Can't create pipe";
-const ERRCODE CANTCONNECTPIPE = "Can't reconnect pipes to stdin/stdout";
-const ERRCODE READFAILED = "Read of file failed";
-const ERRCODE WRITEFAILED = "Write of file failed";
-const ERRCODE SELECTFAILED = "Select failed";
+constexpr ERRCODE CANTOPENFILE("Can't open file");
+constexpr ERRCODE CANTCREATEFILE("Can't create file");
+constexpr ERRCODE CANTMAKEPIPE("Can't create pipe");
+constexpr ERRCODE CANTCONNECTPIPE("Can't reconnect pipes to stdin/stdout");
+constexpr ERRCODE READFAILED("Read of file failed");
+constexpr ERRCODE WRITEFAILED("Write of file failed");
+constexpr ERRCODE SELECTFAILED("Select failed");
 
-const ERRCODE EXECFAILED = "Could not exec new process";
+constexpr ERRCODE EXECFAILED("Could not exec new process");
 #endif

--- a/src/ccutil/lsterr.h
+++ b/src/ccutil/lsterr.h
@@ -2,7 +2,6 @@
  * File:        lsterr.h  (Formerly listerr.h)
  * Description: Errors shared by list modules
  * Author:      Phil Cheatle
- * Created:     Wed Jan 23 09:10:35 GMT 1991
  *
  * (C) Copyright 1990, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,25 +19,25 @@
 #ifndef TESSERACT_CCUTIL_LSTERR_H_
 #define TESSERACT_CCUTIL_LSTERR_H_
 
-#include          "errcode.h"    //must be last include
+#include "errcode.h"    //must be last include
 
-const ERRCODE DONT_CONSTRUCT_LIST_BY_COPY =
-"Can't create a list by assignment";
-const ERRCODE DONT_ASSIGN_LISTS = "Can't assign to lists";
-const ERRCODE SERIALISE_LINKS = "Attempted to (de)serialise a link element";
+constexpr ERRCODE DONT_CONSTRUCT_LIST_BY_COPY(
+"Can't create a list by assignment");
+constexpr ERRCODE DONT_ASSIGN_LISTS("Can't assign to lists");
+constexpr ERRCODE SERIALISE_LINKS("Attempted to (de)serialise a link element");
 
 #ifndef NDEBUG
 
-const ERRCODE NO_LIST = "Iterator not set to a list";
-const ERRCODE NULL_OBJECT = "List found this = nullptr!";
-const ERRCODE NULL_DATA = "List would have returned a nullptr data pointer";
-const ERRCODE NULL_CURRENT = "List current position is nullptr";
-const ERRCODE NULL_NEXT = "Next element on the list is nullptr";
-const ERRCODE NULL_PREV = "Previous element on the list is nullptr";
-const ERRCODE EMPTY_LIST = "List is empty";
-const ERRCODE BAD_PARAMETER = "List parameter error";
-const ERRCODE STILL_LINKED =
-    "Attempting to add an element with non nullptr links, to a list";
+constexpr ERRCODE NO_LIST("Iterator not set to a list");
+constexpr ERRCODE NULL_OBJECT("List found this = nullptr!");
+constexpr ERRCODE NULL_DATA("List would have returned a nullptr data pointer");
+constexpr ERRCODE NULL_CURRENT("List current position is nullptr");
+constexpr ERRCODE NULL_NEXT("Next element on the list is nullptr");
+constexpr ERRCODE NULL_PREV("Previous element on the list is nullptr");
+constexpr ERRCODE EMPTY_LIST("List is empty");
+constexpr ERRCODE BAD_PARAMETER("List parameter error");
+constexpr ERRCODE STILL_LINKED(
+    "Attempting to add an element with non nullptr links, to a list");
 
 #endif  // !NDEBUG
 #endif  // TESSERACT_CCUTIL_LSTERR_H_

--- a/src/textord/edgloop.cpp
+++ b/src/textord/edgloop.cpp
@@ -72,7 +72,7 @@ ScrollView::Color check_path_legal(                  //certify outline
   int32_t length;                  //length of loop
   int32_t chainsum;                //sum of chain diffs
   CRACKEDGE *edgept;             //current point
-  const ERRCODE ED_ILLEGAL_SUM = "Illegal sum of chain codes";
+  constexpr ERRCODE ED_ILLEGAL_SUM("Illegal sum of chain codes");
 
   length = 0;
   chainsum = 0;                  //sum of chain codes


### PR DESCRIPTION
This fixes lots of warnings related to ERRCODE like the following one:

    src/ccutil/errcode.h:81:15: warning:
      declaration requires a global constructor [-Wglobal-constructors]

Signed-off-by: Stefan Weil <sw@weilnetz.de>