### PR TITLE
Remove local definition of M_PI

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -16,6 +16,8 @@
  *
  **********************************************************************/
 
+#define _USE_MATH_DEFINES // for M_PI
+
 // Include automatically generated configuration file if running autoconf.
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"

--- a/src/ccstruct/points.cpp
+++ b/src/ccstruct/points.cpp
@@ -2,7 +2,6 @@
  * File:        points.cpp  (Formerly coords.c)
  * Description: Member functions for coordinate classes.
  * Author:      Ray Smith
- * Created:     Fri Mar 15 08:58:17 GMT 1991
  *
  * (C) Copyright 1991, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,11 +16,10 @@
  *
  **********************************************************************/
 
-#ifdef _MSC_VER
-#define _USE_MATH_DEFINES
-#endif  // _MSC_VER
+#define _USE_MATH_DEFINES       // for M_PI
 
 #include <algorithm>
+#include <cmath>                // for M_PI
 #include <cstdlib>
 #include "helpers.h"
 #include "serialis.h"

--- a/src/ccutil/platform.h
+++ b/src/ccutil/platform.h
@@ -33,12 +33,6 @@
 #endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-#  ifndef M_PI
-#    define M_PI 3.14159265358979323846
-#  endif
-#endif
-
-#if defined(_WIN32) || defined(__CYGWIN__)
 #  if defined(TESS_EXPORTS)
 #    define TESS_API __declspec(dllexport)
 #  elif defined(TESS_IMPORTS)

--- a/src/classify/cluster.cpp
+++ b/src/classify/cluster.cpp
@@ -15,8 +15,9 @@
  ** limitations under the License.
  *****************************************************************************/
 
+#define _USE_MATH_DEFINES // for M_PI
 #include <cfloat>       // for FLT_MAX
-#include <cmath>
+#include <cmath>        // for M_PI
 #include <vector>       // for std::vector
 
 #include "cluster.h"

--- a/src/classify/clusttool.cpp
+++ b/src/classify/clusttool.cpp
@@ -16,8 +16,9 @@
  *****************************************************************************/
 
 //--------------------------Include Files----------------------------------
+#define _USE_MATH_DEFINES   // for M_PI
 #include "clusttool.h"
-#include <cmath>            // for std::isnan
+#include <cmath>            // for M_PI, std::isnan
 #include <locale>           // for std::locale::classic
 #include <sstream>          // for std::stringstream
 #include "emalloc.h"

--- a/src/classify/fpoint.cpp
+++ b/src/classify/fpoint.cpp
@@ -17,10 +17,10 @@
 /*----------------------------------------------------------------------------
           Include Files and Type Defines
 ----------------------------------------------------------------------------*/
+#define _USE_MATH_DEFINES       // for M_PI
 #include "fpoint.h"
 #include <cstdio>
-#include <cmath>
-#include "platform.h"   // M_PI
+#include <cmath>                // for M_PI
 
 /*----------------------------------------------------------------------------
               Public Code

--- a/src/classify/intfeaturespace.cpp
+++ b/src/classify/intfeaturespace.cpp
@@ -3,7 +3,6 @@
 ///////////////////////////////////////////////////////////////////////
 // File:        intfeaturespace.cpp
 // Description: Indexed feature space based on INT_FEATURE_STRUCT.
-// Created:     Wed Mar 24 11:21:27 PDT 2010
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +16,9 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
+#define _USE_MATH_DEFINES       // for M_PI
 #include "intfeaturespace.h"
+#include <cmath>                // for M_PI
 #include "intfx.h"
 
 namespace tesseract {

--- a/src/classify/intfx.cpp
+++ b/src/classify/intfx.cpp
@@ -1,13 +1,9 @@
 /******************************************************************************
- **      Filename:    intfx.c
- **      Purpose:     Integer character normalization & feature extraction
- **      Author:      Robert Moss, rays@google.com (Ray Smith)
- **      History:     Tue May 21 15:51:57 MDT 1991, RWM, Created.
- **                   Tue Feb 28 10:42:00 PST 2012, vastly rewritten to allow
-                                                    greyscale fx and non-linear
-                                                    normalization.
+ ** Filename:    intfx.c
+ ** Purpose:     Integer character normalization & feature extraction
+ ** Author:      Robert Moss, rays@google.com (Ray Smith)
  **
- **      (c) Copyright Hewlett-Packard Company, 1988.
+ ** (c) Copyright Hewlett-Packard Company, 1988.
  ** Licensed under the Apache License, Version 2.0 (the "License");
  ** you may not use this file except in compliance with the License.
  ** You may obtain a copy of the License at
@@ -21,7 +17,10 @@
 /**----------------------------------------------------------------------------
           Include Files and Type Defines
 ----------------------------------------------------------------------------**/
+
+#define _USE_MATH_DEFINES       // for M_PI
 #include "intfx.h"
+#include <cmath>                // for M_PI
 #include "allheaders.h"
 #include "ccutil.h"
 #include "classify.h"
@@ -49,7 +48,7 @@ tesseract::CCUtilMutex atan_table_mutex;
 /**----------------------------------------------------------------------------
             Public Code
 ----------------------------------------------------------------------------**/
-/*---------------------------------------------------------------------------*/
+
 void InitIntegerFX() {
   static bool atan_table_init = false;
   atan_table_mutex.Lock();

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -18,8 +18,9 @@
           Include Files and Type Defines
 -----------------------------------------------------------------------------*/
 
+#define _USE_MATH_DEFINES  // for M_PI
 #include <algorithm>
-#include <cmath>           // for std::floor
+#include <cmath>           // for M_PI, std::floor
 #include <cstdio>
 #include <cassert>
 

--- a/src/classify/mfx.cpp
+++ b/src/classify/mfx.cpp
@@ -1,9 +1,9 @@
 /******************************************************************************
- **      Filename:       mfx.c
- **      Purpose:        Micro feature extraction routines
- **      Author:         Dan Johnson
+ ** Filename:       mfx.c
+ ** Purpose:        Micro feature extraction routines
+ ** Author:         Dan Johnson
  **
- **      (c) Copyright Hewlett-Packard Company, 1988.
+ ** (c) Copyright Hewlett-Packard Company, 1988.
  ** Licensed under the Apache License, Version 2.0 (the "License");
  ** you may not use this file except in compliance with the License.
  ** You may obtain a copy of the License at
@@ -17,15 +17,16 @@
 /*----------------------------------------------------------------------------
           Include Files and Type Defines
 ----------------------------------------------------------------------------*/
+
+#define _USE_MATH_DEFINES       // for M_PI
 #include "mfx.h"
+#include <cmath>                // for M_PI
 #include "mfdefs.h"
 #include "mfoutline.h"
-#include "clusttool.h"           //NEEDED
+#include "clusttool.h"          //NEEDED
 #include "intfx.h"
 #include "normalis.h"
 #include "params.h"
-
-#include <cmath>
 
 /*----------------------------------------------------------------------------
           Variables

--- a/src/classify/protos.cpp
+++ b/src/classify/protos.cpp
@@ -19,16 +19,16 @@
 /*----------------------------------------------------------------------
               I n c l u d e s
 ----------------------------------------------------------------------*/
+#define _USE_MATH_DEFINES       // for M_PI
 #include "protos.h"
+#include <cmath>                // for M_PI
+#include <cstdio>
 #include "emalloc.h"
 #include "callcpp.h"
 #include "tprintf.h"
 #include "classify.h"
 #include "params.h"
 #include "intproto.h"
-
-#include <cstdio>
-#include <cmath>
 
 #define PROTO_INCREMENT   32
 #define CONFIG_INCREMENT  16

--- a/src/classify/trainingsample.cpp
+++ b/src/classify/trainingsample.cpp
@@ -13,6 +13,7 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
+#define _USE_MATH_DEFINES       // for M_PI
 // Include automatically generated configuration file if running autoconf.
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
@@ -20,7 +21,7 @@
 
 #include "trainingsample.h"
 
-#include <cmath>
+#include <cmath>                // for M_PI
 #include "allheaders.h"
 #include "helpers.h"
 #include "intfeaturemap.h"

--- a/src/textord/baselinedetect.cpp
+++ b/src/textord/baselinedetect.cpp
@@ -3,7 +3,6 @@
 // Description: Initial Baseline Determination.
 // Copyright 2012 Google Inc. All Rights Reserved.
 // Author:      rays@google.com (Ray Smith)
-// Created:     Mon Apr 30 10:15:31 PDT 2012
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +16,7 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-#define _USE_MATH_DEFINES
-#endif  // _MSC_VER
+#define _USE_MATH_DEFINES       // for M_PI
 
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
@@ -28,8 +25,8 @@
 #include "baselinedetect.h"
 
 #include <algorithm>
-#include <cfloat>      // for FLT_MAX
-#include <cmath>
+#include <cfloat>               // for FLT_MAX
+#include <cmath>                // for M_PI
 #include "allheaders.h"
 #include "blobbox.h"
 #include "detlinefit.h"

--- a/src/textord/tordmain.cpp
+++ b/src/textord/tordmain.cpp
@@ -2,7 +2,6 @@
  * File:        tordmain.cpp  (Formerly textordp.c)
  * Description: C++ top level textord code.
  * Author:      Ray Smith
- * Created:     Tue Jul 28 17:12:33 BST 1992
  *
  * (C) Copyright 1992, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +16,7 @@
  *
  **********************************************************************/
 
+#define _USE_MATH_DEFINES       // for M_PI
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
 #endif

--- a/src/training/commontraining.cpp
+++ b/src/training/commontraining.cpp
@@ -11,17 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define _USE_MATH_DEFINES       // for M_PI
 #include "commontraining.h"
+#include <algorithm>
+#include <cmath>                // for M_PI
 
 #ifdef DISABLED_LEGACY_ENGINE
-
-#include <algorithm>
-#include <cmath>
 
 #include "params.h"
 #include "tessopt.h"
 #include "tprintf.h"
-
 
 INT_PARAM_FLAG(debug_level, 0, "Level of Trainer debugging");
 INT_PARAM_FLAG(load_images, 0, "Load images with tr files");
@@ -33,7 +32,6 @@ STRING_PARAM_FLAG(U, "unicharset", "File to load unicharset from");
 STRING_PARAM_FLAG(O, "", "File to write unicharset to");
 STRING_PARAM_FLAG(output_trainer, "", "File to write trainer to");
 STRING_PARAM_FLAG(test_ch, "", "UTF8 test character string");
-
 
 /**
  * This routine parses the command line arguments that were
@@ -58,9 +56,6 @@ void ParseArguments(int* argc, char ***argv) {
 }
 
 #else
-
-#include <algorithm>
-#include <cmath>
 
 #include "allheaders.h"
 #include "ccutil.h"

--- a/src/training/mergenf.cpp
+++ b/src/training/mergenf.cpp
@@ -14,6 +14,14 @@
  ** See the License for the specific language governing permissions and
  ** limitations under the License.
 ******************************************************************************/
+
+#define _USE_MATH_DEFINES // for M_PI
+#include <algorithm>
+#include <cfloat>       // for FLT_MAX
+#include <cmath>        // for M_PI
+#include <cstdio>
+#include <cstring>
+
 #include "mergenf.h"
 #include "clusttool.h"
 #include "cluster.h"
@@ -23,11 +31,6 @@
 #include "featdefs.h"
 #include "intproto.h"
 #include "params.h"
-
-#include <algorithm>
-#include <cstdio>
-#include <cstring>
-#include <cmath>
 
 /*-------------------once in subfeat---------------------------------*/
 double_VAR(training_angle_match_scale, 1.0, "Angle Match Scale ...");

--- a/src/training/mftraining.cpp
+++ b/src/training/mftraining.cpp
@@ -20,14 +20,15 @@
 /*----------------------------------------------------------------------------
           Include Files and Type Defines
 ----------------------------------------------------------------------------*/
+
+#define _USE_MATH_DEFINES       // for M_PI
 #ifdef HAVE_CONFIG_H
 #include "config_auto.h"
 #endif
 
+#include <cmath>                // for M_PI
 #include <cstring>
 #include <cstdio>
-#define _USE_MATH_DEFINES
-#include <cmath>
 
 #include "classify.h"
 #include "cluster.h"

--- a/src/wordrec/chop.cpp
+++ b/src/wordrec/chop.cpp
@@ -21,13 +21,13 @@
               I n c l u d e s
 ----------------------------------------------------------------------*/
 
+#define _USE_MATH_DEFINES       // for M_PI
+#include <cmath>                // for M_PI
 #include "chop.h"
 #include "outlines.h"
 #include "callcpp.h"
 #include "plotedges.h"
 #include "wordrec.h"
-
-#include <cmath>
 
 // Include automatically generated configuration file if running autoconf.
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
It is defined for all platforms when math.h or cmath is included
after defining the macro _USE_MATH_DEFINES.

Define _USE_MATH_DEFINES before any include statement to make sure
that M_PI gets defined. It is not necessary to define it conditionally
only for Windows.

Signed-off-by: Stefan Weil <sw@weilnetz.de>