### PR TITLE
Remove SavePixForCrash and related code

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -65,7 +65,6 @@
 #include "environ.h"           // for l_uint8
 #include "equationdetect.h"    // for EquationDetect
 #include "errcode.h"           // for ASSERT_HOST
-#include "globaloc.h"          // for SavePixForCrash, signal_exit
 #include "helpers.h"           // for IntCastRounded, chomp_string
 #include "imageio.h"           // for IFF_TIFF_G4, IFF_TIFF, IFF_TIFF_G3
 #ifndef DISABLED_LEGACY_ENGINE
@@ -252,25 +251,6 @@ size_t TessBaseAPI::getOpenCLDevice(void **data) {
 
   *data = nullptr;
   return 0;
-}
-
-/**
- * Writes the thresholded image to stderr as a PBM file on receipt of a
- * SIGSEGV, SIGFPE, or SIGBUS signal. (Linux/Unix only).
- */
-void TessBaseAPI::CatchSignals() {
-#ifdef __linux__
-  struct sigaction action;
-  memset(&action, 0, sizeof(action));
-  action.sa_handler = &signal_exit;
-  action.sa_flags = SA_RESETHAND;
-  sigaction(SIGSEGV, &action, nullptr);
-  sigaction(SIGFPE, &action, nullptr);
-  sigaction(SIGBUS, &action, nullptr);
-#else
-  // Warn API users that an implementation is needed.
-  tprintf("CatchSignals has no non-linux implementation!\n");
-#endif
 }
 
 /**
@@ -2027,7 +2007,6 @@ bool TessBaseAPI::Threshold(Pix** pix) {
             thresholder_->GetScaledEstimatedResolution(), estimated_res);
   }
   tesseract_->set_source_resolution(estimated_res);
-  SavePixForCrash(estimated_res, *pix);
   return true;
 }
 
@@ -2124,7 +2103,6 @@ void TessBaseAPI::ClearResults() {
     delete paragraph_models_;
     paragraph_models_ = nullptr;
   }
-  SavePixForCrash(0, nullptr);
 }
 
 /**

--- a/src/api/baseapi.h
+++ b/src/api/baseapi.h
@@ -108,12 +108,6 @@ class TESS_API TessBaseAPI {
   static size_t getOpenCLDevice(void **device);
 
   /**
-   * Writes the thresholded image to stderr as a PBM file on receipt of a
-   * SIGSEGV, SIGFPE, or SIGBUS signal. (Linux/Unix only).
-   */
-  static void CatchSignals();
-
-  /**
    * Set the name of the input file. Needed for training and
    * reading a UNLV zone file, and for searchable PDF output.
    */

--- a/src/ccmain/reject.cpp
+++ b/src/ccmain/reject.cpp
@@ -1,8 +1,7 @@
 /**********************************************************************
  * File:        reject.cpp  (Formerly reject.c)
  * Description: Rejection functions used in tessedit
- * Author:    Phil Cheatle
- * Created:   Wed Sep 23 16:50:21 BST 1992
+ * Author:      Phil Cheatle
  *
  * (C) Copyright 1992, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,11 +44,9 @@ int16_t Tesseract::safe_dict_word(const WERD_RES *werd_res) {
 #include "reject.h"
 #include "control.h"
 #include "docqual.h"
-#include "globaloc.h"  // For err_exit.
 #include "helpers.h"
 
 #include "tesseractclass.h"
-
 
 CLISTIZEH (STRING) CLISTIZE (STRING)
 
@@ -161,7 +158,7 @@ void Tesseract::make_reject_map(WERD_RES *word, ROW *row, int16_t pass) {
     }
   } else {
     tprintf("BAD tessedit_reject_mode\n");
-    err_exit();
+    ASSERT_HOST("Fatal error encountered!" == nullptr);
   }
 
   if (tessedit_image_border > -1)

--- a/src/ccutil/errcode.cpp
+++ b/src/ccutil/errcode.cpp
@@ -74,7 +74,6 @@ const char *format, ...          // special message
     case TESSLOG:
       return;                    //report only
     case TESSEXIT:
-      //err_exit();
     case ABORT:
 #if !defined(NDEBUG)
       // Create a deliberate abnormal exit as the stack trace is more useful

--- a/src/ccutil/globaloc.h
+++ b/src/ccutil/globaloc.h
@@ -19,14 +19,6 @@
 #ifndef GLOBALOC_H
 #define GLOBALOC_H
 
-// Saves a clone of the given pix, and notes its resolution in thread-specific
-// data, so that the image can be written prior to a crash.
-struct Pix;
-void SavePixForCrash(int resolution, Pix* pix);
-
-void signal_exit(int signal_code);
-
-void err_exit();
 
 void set_global_loc_code(int loc_code);
 


### PR DESCRIPTION
That debugging code uses very much memory and is no longer useful.

    text	   data	    bss	    dec	    hex	filename
     815	      0	 262144	 262959	  4032f	src/ccutil/globaloc.o

Remove also the function err_exit which was only used in ccmain/reject.cpp.

Signed-off-by: Stefan Weil <sw@weilnetz.de>