### PR TITLE
Fix bug in max_max_dist

### DIFF
--- a/src/classify/trainingsampleset.cpp
+++ b/src/classify/trainingsampleset.cpp
@@ -618,6 +618,7 @@ void TrainingSampleSet::ComputeCanonicalSamples(const IntFeatureMap& map,
           if (dist > max_dist) {
             max_dist = dist;
             if (dist > max_max_dist) {
+              max_max_dist = dist;
               max_s1 = s1;
               max_s2 = s2;
             }


### PR DESCRIPTION
Fix bug in `max_max_dist` in `trainingsampleset.cpp`. This follows from https://github.com/tesseract-ocr/tesseract/pull/2451#discussion_r286318784