### PR TITLE
Do not link librt on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ case "${host_os}" in
         OPENCL_INC=""
         AM_CONDITIONAL([ADD_RT], false)
         ;;
-    *android*)
+    *android*|openbsd*)
         AM_CONDITIONAL([ADD_RT], false)
         ;;
     powerpc-*-darwin*)


### PR DESCRIPTION
This prevents a link error on OpenBSD:
```
warning: could not find a rt library
Link error: rt not found!
```