### PR TITLE
Fix text2image compilation on C++17 compilers

### DIFF
--- a/src/training/text2image.cpp
+++ b/src/training/text2image.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <iostream>
 #include <map>
+#include <random>
 #include <string>
 #include <utility>
 #include <vector>
@@ -573,8 +574,11 @@ static int Main() {
       offset += step;
       offset += SpanUTF8Whitespace(str8 + offset);
     }
-    if (FLAGS_render_ngrams)
-      std::random_shuffle(offsets.begin(), offsets.end());
+    if (FLAGS_render_ngrams) {
+      std::seed_seq seed{kRandomSeed};
+      std::mt19937 random_gen(seed);
+      std::shuffle(offsets.begin(), offsets.end(), random_gen);
+    }
 
     for (size_t i = 0, line = 1; i < offsets.size(); ++i) {
       const char *curr_pos = str8 + offsets[i].first;


### PR DESCRIPTION
C++17 drops support for `std::random_shuffle`, breaking C++17 compilers that run to compile text2image.cpp. std::shuffle is valid on C++11 through C++17, so use std::shuffle instead.