### PR TITLE
[4.1] Fix text2image compilation on C++17 compilers

### DIFF
--- a/src/training/text2image.cpp
+++ b/src/training/text2image.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <iostream>
 #include <map>
+#include <random>
 #include <string>
 #include <utility>
 #include <vector>
@@ -571,8 +572,11 @@ static int Main() {
       offset += step;
       offset += SpanUTF8Whitespace(str8 + offset);
     }
-    if (FLAGS_render_ngrams)
-      std::random_shuffle(offsets.begin(), offsets.end());
+    if (FLAGS_render_ngrams) {
+      std::seed_seq seed{kRandomSeed};
+      std::mt19937 random_gen(seed);
+      std::shuffle(offsets.begin(), offsets.end(), random_gen);
+    }
 
     for (size_t i = 0, line = 1; i < offsets.size(); ++i) {
       const char *curr_pos = str8 + offsets[i].first;


### PR DESCRIPTION
C++17 drops support for `std::random_shuffle`, breaking C++17 compilers
that run to compile text2image.cpp. std::shuffle is valid on C++11
through C++17, so use std::shuffle instead.

Due to the use `std::random_shuffle`, `text2image --render_ngrams`
would not give consistent results for different compilers or platforms.
With the current change, the same random number generator is used for
all platforms and initialized to the same seed, so training output
should be consistent.