### PR TITLE
Fix error when OUTPUT_DIR did not exist

### DIFF
--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -160,6 +160,7 @@ parse_flags() {
                 DISTORT_IMAGE=true ;;
             --output_dir)
                 parse_value "OUTPUT_DIR" ${ARGV[$j]:-}
+                mkdir -p $OUTPUT_DIR
                 i=$j ;;
             --overwrite)
                 OVERWRITE=true ;;


### PR DESCRIPTION
If `OUTPUT_DIR` did not exist then bash script was creating a file named `OUTPUT_DIR` while copying box/tiff files and getting error later. 

```
Output /tmp/eng-2019-06-16.Fzq/eng.traineddata created successfully.
Creating new directory ./MICR-legacy
mkdir: cannot create directory ‘./MICR-legacy’: File exists
```

This PR fixes the error.