### PR TITLE
Simplify indirect call of LMPainPoints::GeneratePainPoint

### DIFF
--- a/src/ccstruct/Makefile.am
+++ b/src/ccstruct/Makefile.am
@@ -1,6 +1,8 @@
 AM_CPPFLAGS += \
     -I$(top_srcdir)/src/ccutil \
     -I$(top_srcdir)/src/cutil \
+    -I$(top_srcdir)/src/dict \
+    -I$(top_srcdir)/src/wordrec \
     -I$(top_srcdir)/src/viewer \
     -I$(top_srcdir)/src/opencl
 AM_CPPFLAGS += $(OPENCL_CPPFLAGS)

--- a/src/ccstruct/blamer.cpp
+++ b/src/ccstruct/blamer.cpp
@@ -3,7 +3,6 @@
 // Description: Module allowing precise error causes to be allocated.
 // Author:      Rike Antonova
 // Refactored:  Ray Smith
-// Created:     Mon Feb 04 14:37:01 PST 2013
 //
 // (C) Copyright 2013, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,10 +22,10 @@
 #include <cstdlib>         // for abs
 #include "blobs.h"         // for TPOINT, TWERD, TBLOB
 #include "errcode.h"       // for ASSERT_HOST
+#include "lm_pain_points.h" // for LMPainPoints
 #include "matrix.h"        // for MATRIX
 #include "normalis.h"      // for DENORM
 #include "pageres.h"       // for WERD_RES
-#include "tesscallback.h"  // for TessResultCallback2
 #include "unicharset.h"    // for UNICHARSET
 
 // Names for each value of IncorrectResultReason enum. Keep in sync.
@@ -471,14 +470,12 @@ bool BlamerBundle::GuidedSegsearchNeeded(const WERD_CHOICE *best_choice) const {
 }
 
 // Setup ready to guide the segmentation search to the correct segmentation.
-// The callback pp_cb is used to avoid a cyclic dependency.
-// It calls into LMPainPoints::GenerateForBlamer by pre-binding the
-// WERD_RES, and the LMPainPoints itself.
-// pp_cb must be a permanent callback, and should be deleted by the caller.
-void BlamerBundle::InitForSegSearch(const WERD_CHOICE *best_choice,
+void BlamerBundle::InitForSegSearch(const WERD_CHOICE* best_choice,
                                     MATRIX* ratings, UNICHAR_ID wildcard_id,
-                                    bool debug, STRING *debug_str,
-                                    TessResultCallback2<bool, int, int>* cb) {
+                                    bool debug, STRING* debug_str,
+                                    tesseract::LMPainPoints* pain_points,
+                                    double max_char_wh_ratio,
+                                    WERD_RES* word_res) {
   segsearch_is_looking_for_blame_ = true;
   if (debug) {
     tprintf("segsearch starting to look for blame\n");
@@ -493,8 +490,10 @@ void BlamerBundle::InitForSegSearch(const WERD_CHOICE *best_choice,
     if (!ratings->Classified(correct_segmentation_cols_[idx],
                              correct_segmentation_rows_[idx],
                              wildcard_id) &&
-        !cb->Run(correct_segmentation_cols_[idx],
-                 correct_segmentation_rows_[idx])) {
+        !pain_points->GeneratePainPoint(correct_segmentation_cols_[idx],
+                                        correct_segmentation_rows_[idx],
+                                        tesseract::LM_PPTYPE_BLAMER, 0.0,
+                                        false, max_char_wh_ratio, word_res)) {
       segsearch_is_looking_for_blame_ = false;
       *debug_str += "\nFailed to insert pain point\n";
       SetBlame(IRR_SEGSEARCH_HEUR, *debug_str, best_choice, debug);

--- a/src/ccstruct/blamer.h
+++ b/src/ccstruct/blamer.h
@@ -3,7 +3,6 @@
 // Description: Module allowing precise error causes to be allocated.
 // Author:      Rike Antonova
 // Refactored:  Ray Smith
-// Created:     Mon Feb 04 14:37:01 PST 2013
 //
 // (C) Copyright 2013, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +39,9 @@ class WERD_RES;
 struct MATRIX_COORD;
 struct TWERD;
 
-template <class R, class A1, class A2> class TessResultCallback2;
+namespace tesseract {
+  class LMPainPoints;
+}
 
 static const int16_t kBlamerBoxTolerance = 5;
 
@@ -266,14 +267,11 @@ struct BlamerBundle {
   // Returns true if a guided segmentation search is needed.
   bool GuidedSegsearchNeeded(const WERD_CHOICE *best_choice) const;
   // Setup ready to guide the segmentation search to the correct segmentation.
-  // The callback pp_cb is used to avoid a cyclic dependency.
-  // It calls into LMPainPoints::GenerateForBlamer by pre-binding the
-  // WERD_RES, and the LMPainPoints itself.
-  // pp_cb must be a permanent callback, and should be deleted by the caller.
-  void InitForSegSearch(const WERD_CHOICE *best_choice,
+  void InitForSegSearch(const WERD_CHOICE* best_choice,
                         MATRIX* ratings, UNICHAR_ID wildcard_id,
-                        bool debug, STRING *debug_str,
-                        TessResultCallback2<bool, int, int>* pp_cb);
+                        bool debug, STRING* debug_str,
+                        tesseract::LMPainPoints* pain_points,
+                        double max_char_wh_ratio, WERD_RES* word_res);
   // Returns true if the guided segsearch is in progress.
   bool GuidedSegsearchStillGoing() const;
   // The segmentation search has ended. Sets the blame appropriately.

--- a/src/ccutil/tesscallback.h
+++ b/src/ccutil/tesscallback.h
@@ -793,48 +793,6 @@ NewPermanentTessCallback(R (*function)(A1, A2)) {
   return new _TessFunctionResultCallback_0_2<false, R, A1, A2>(function);
 }
 
-template <bool del, class R, class T, class P1, class P2, class A1, class A2>
-class _TessMemberResultCallback_2_2 : public TessResultCallback2<R, A1, A2> {
- public:
-  typedef TessResultCallback2<R, A1, A2> base;
-  using MemberSignature = R (T::*)(P1, P2, A1, A2);
-
- private:
-  T* object_;
-  MemberSignature member_;
-  typename remove_reference<P1>::type p1_;
-  typename remove_reference<P2>::type p2_;
-
- public:
-  inline _TessMemberResultCallback_2_2(T* object, MemberSignature member, P1 p1,
-                                       P2 p2)
-      : object_(object), member_(member), p1_(p1), p2_(p2) {}
-
-  R Run(A1 a1, A2 a2) override {
-    if (!del) {
-      R result = (object_->*member_)(p1_, p2_, a1, a2);
-      return result;
-    }
-    R result = (object_->*member_)(p1_, p2_, a1, a2);
-    //  zero out the pointer to ensure segfault if used again
-    member_ = nullptr;
-    delete this;
-    return result;
-  }
-};
-
-#ifndef SWIG
-template <class T1, class T2, class R, class P1, class P2, class A1, class A2>
-inline
-    typename _TessMemberResultCallback_2_2<false, R, T1, P1, P2, A1, A2>::base*
-    NewPermanentTessCallback(T1* obj, R (T2::*member)(P1, P2, A1, A2),
-                             typename Identity<P1>::type p1,
-                             typename Identity<P2>::type p2) {
-  return new _TessMemberResultCallback_2_2<false, R, T1, P1, P2, A1, A2>(
-      obj, member, p1, p2);
-}
-#endif
-
 template <bool del, class R, class T, class A1, class A2, class A3>
 class _ConstTessMemberResultCallback_0_3
     : public TessResultCallback3<R, A1, A2, A3> {

--- a/src/wordrec/lm_pain_points.h
+++ b/src/wordrec/lm_pain_points.h
@@ -5,7 +5,6 @@
 //              to generate "pain points" - the locations in the ratings
 //              matrix which should be classified next.
 // Author:      Rika Antonova
-// Created:     Mon Jun 20 11:26:43 PST 2012
 //
 // (C) Copyright 2012, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -98,13 +97,6 @@ class LMPainPoints {
   // Generate pain points from dangerous ambiguities in best choice.
   void GenerateFromAmbigs(const DANGERR &fixpt, ViterbiStateEntry *vse,
                           WERD_RES *word_res);
-
-  // Generate a pain point for the blamer.
-  bool GenerateForBlamer(double max_char_wh_ratio, WERD_RES *word_res,
-                         int col, int row) {
-    return GeneratePainPoint(col, row, LM_PPTYPE_BLAMER, 0.0, false,
-                             max_char_wh_ratio, word_res);
-  }
 
   // Adds a pain point to classify chunks_record->ratings(col, row).
   // Returns true if a new pain point was added to an appropriate heap.

--- a/src/wordrec/segsearch.cpp
+++ b/src/wordrec/segsearch.cpp
@@ -27,7 +27,6 @@
 #include "params.h"          // for BoolParam, IntParam, DoubleParam
 #include "ratngs.h"          // for BLOB_CHOICE_LIST, BLOB_CHOICE_IT
 #include "strngs.h"          // for STRING
-#include "tesscallback.h"    // for TessResultCallback2
 #include "tprintf.h"         // for tprintf
 #include "wordrec.h"         // for Wordrec, SegSearchPending (ptr only)
 
@@ -330,13 +329,10 @@ void Wordrec::InitBlamerForSegSearch(WERD_RES *word_res,
                                      BlamerBundle *blamer_bundle,
                                      STRING *blamer_debug) {
   pain_points->Clear();  // Clear pain points heap.
-  TessResultCallback2<bool, int, int>* pp_cb = NewPermanentTessCallback(
-      pain_points, &LMPainPoints::GenerateForBlamer,
-      static_cast<double>(segsearch_max_char_wh_ratio), word_res);
   blamer_bundle->InitForSegSearch(word_res->best_choice, word_res->ratings,
                                   getDict().WildcardID(), wordrec_debug_blamer,
-                                  blamer_debug, pp_cb);
-  delete pp_cb;
+                                  blamer_debug, pain_points,
+                                  segsearch_max_char_wh_ratio, word_res);
 }
 
 }  // namespace tesseract


### PR DESCRIPTION
It does neither need a temporary TessResultCallback2 nor the function
LMPainPoints::GenerateForBlamer.

This also allows removing more code from tesscallback.h.

Signed-off-by: Stefan Weil <sw@weilnetz.de>