### PR TITLE
Simplify class LSTMTrainer

### DIFF
--- a/src/ccutil/tesscallback.h
+++ b/src/ccutil/tesscallback.h
@@ -608,72 +608,6 @@ NewPermanentTessCallback(R (*function)(P1, A1),
 }
 
 template <bool del, class R, class T, class A1, class A2>
-class _ConstTessMemberResultCallback_0_2
-    : public TessResultCallback2<R, A1, A2> {
- public:
-  typedef TessResultCallback2<R, A1, A2> base;
-  using MemberSignature = R (T::*)(A1, A2) const;
-
- private:
-  const T* object_;
-  MemberSignature member_;
-
- public:
-  inline _ConstTessMemberResultCallback_0_2(const T* object,
-                                            MemberSignature member)
-      : object_(object), member_(member) {}
-
-  R Run(A1 a1, A2 a2) override {
-    if (!del) {
-      R result = (object_->*member_)(a1, a2);
-      return result;
-    }
-    R result = (object_->*member_)(a1, a2);
-    //  zero out the pointer to ensure segfault if used again
-    member_ = nullptr;
-    delete this;
-    return result;
-  }
-};
-
-template <bool del, class T, class A1, class A2>
-class _ConstTessMemberResultCallback_0_2<del, void, T, A1, A2>
-    : public TessCallback2<A1, A2> {
- public:
-  typedef TessCallback2<A1, A2> base;
-  using MemberSignature = void (T::*)(A1, A2) const;
-
- private:
-  const T* object_;
-  MemberSignature member_;
-
- public:
-  inline _ConstTessMemberResultCallback_0_2(const T* object,
-                                            MemberSignature member)
-      : object_(object), member_(member) {}
-
-  virtual void Run(A1 a1, A2 a2) {
-    if (!del) {
-      (object_->*member_)(a1, a2);
-    } else {
-      (object_->*member_)(a1, a2);
-      //  zero out the pointer to ensure segfault if used again
-      member_ = nullptr;
-      delete this;
-    }
-  }
-};
-
-#ifndef SWIG
-template <class T1, class T2, class R, class A1, class A2>
-inline typename _ConstTessMemberResultCallback_0_2<false, R, T1, A1, A2>::base*
-NewPermanentTessCallback(const T1* obj, R (T2::*member)(A1, A2) const) {
-  return new _ConstTessMemberResultCallback_0_2<false, R, T1, A1, A2>(obj,
-                                                                      member);
-}
-#endif
-
-template <bool del, class R, class T, class A1, class A2>
 class _TessMemberResultCallback_0_2 : public TessResultCallback2<R, A1, A2> {
  public:
   typedef TessResultCallback2<R, A1, A2> base;
@@ -792,45 +726,6 @@ inline typename _TessFunctionResultCallback_0_2<false, R, A1, A2>::base*
 NewPermanentTessCallback(R (*function)(A1, A2)) {
   return new _TessFunctionResultCallback_0_2<false, R, A1, A2>(function);
 }
-
-template <bool del, class R, class T, class A1, class A2, class A3>
-class _ConstTessMemberResultCallback_0_3
-    : public TessResultCallback3<R, A1, A2, A3> {
- public:
-  typedef TessResultCallback3<R, A1, A2, A3> base;
-  using MemberSignature = R (T::*)(A1, A2, A3) const;
-
- private:
-  const T* object_;
-  MemberSignature member_;
-
- public:
-  inline _ConstTessMemberResultCallback_0_3(const T* object,
-                                            MemberSignature member)
-      : object_(object), member_(member) {}
-
-  R Run(A1 a1, A2 a2, A3 a3) override {
-    if (!del) {
-      R result = (object_->*member_)(a1, a2, a3);
-      return result;
-    }
-    R result = (object_->*member_)(a1, a2, a3);
-    //  zero out the pointer to ensure segfault if used again
-    member_ = nullptr;
-    delete this;
-    return result;
-  }
-};
-
-#ifndef SWIG
-template <class T1, class T2, class R, class A1, class A2, class A3>
-inline
-    typename _ConstTessMemberResultCallback_0_3<false, R, T1, A1, A2, A3>::base*
-    NewPermanentTessCallback(const T1* obj, R (T2::*member)(A1, A2, A3) const) {
-  return new _ConstTessMemberResultCallback_0_3<false, R, T1, A1, A2, A3>(
-      obj, member);
-}
-#endif
 
 template <bool del, class R, class T, class A1, class A2, class A3, class A4>
 class _TessMemberResultCallback_0_4

--- a/src/lstm/lstmtrainer.h
+++ b/src/lstm/lstmtrainer.h
@@ -2,7 +2,6 @@
 // File:        lstmtrainer.h
 // Description: Top-level line trainer class for LSTM-based networks.
 // Author:      Ray Smith
-// Created:     Fri May 03 09:07:06 PST 2013
 //
 // (C) Copyright 2013, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,15 +66,6 @@ enum SubTrainerResult {
 };
 
 class LSTMTrainer;
-// Function to restore the trainer state from a given checkpoint.
-// Returns false on failure.
-typedef TessResultCallback2<bool, const GenericVector<char>&, LSTMTrainer*>*
-    CheckPointReader;
-// Function to save a checkpoint of the current trainer state.
-// Returns false on failure. SerializeAmount determines the amount of the
-// trainer to serialize, typically used for saving the best state.
-typedef TessResultCallback3<bool, SerializeAmount, const LSTMTrainer*,
-                            GenericVector<char>*>* CheckPointWriter;
 // Function to compute and record error rates on some external test set(s).
 // Args are: iteration, mean errors, model, training stage.
 // Returns a STRING containing logging information about the tests.
@@ -89,11 +79,7 @@ typedef TessResultCallback4<STRING, int, const double*, const TessdataManager&,
 class LSTMTrainer : public LSTMRecognizer {
  public:
   LSTMTrainer();
-  // Callbacks may be null, in which case defaults are used.
-  LSTMTrainer(FileReader file_reader, FileWriter file_writer,
-              CheckPointReader checkpoint_reader,
-              CheckPointWriter checkpoint_writer,
-              const char* model_base, const char* checkpoint_name,
+  LSTMTrainer(const char* model_base, const char* checkpoint_name,
               int debug_interval, int64_t max_memory);
   virtual ~LSTMTrainer();
 
@@ -416,13 +402,6 @@ class LSTMTrainer : public LSTMRecognizer {
   STRING best_model_name_;
   // Number of available training stages.
   int num_training_stages_;
-  // Checkpointing callbacks.
-  FileReader file_reader_;
-  FileWriter file_writer_;
-  // TODO(rays) These are pointers, and must be deleted. Switch to unique_ptr
-  // when we can commit to c++11.
-  CheckPointReader checkpoint_reader_;
-  CheckPointWriter checkpoint_writer_;
 
   // ===Serialized data to ensure that a restart produces the same results.===
   // These members are only serialized when serialize_amount != LIGHT.

--- a/src/training/lstmtraining.cpp
+++ b/src/training/lstmtraining.cpp
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
   checkpoint_file += "_checkpoint";
   STRING checkpoint_bak = checkpoint_file + ".bak";
   tesseract::LSTMTrainer trainer(
-      nullptr, nullptr, nullptr, nullptr, FLAGS_model_output.c_str(),
+      FLAGS_model_output.c_str(),
       checkpoint_file.c_str(), FLAGS_debug_interval,
       static_cast<int64_t>(FLAGS_max_image_MB) * 1048576);
   trainer.InitCharSet(FLAGS_traineddata.c_str());

--- a/unittest/lstm_test.h
+++ b/unittest/lstm_test.h
@@ -84,8 +84,7 @@ class LSTMTrainerTest : public testing::Test {
                                   nullptr, nullptr));
     std::string model_path = file::JoinPath(FLAGS_test_tmpdir, model_name);
     std::string checkpoint_path = model_path + "_checkpoint";
-    trainer_.reset(new LSTMTrainer(nullptr, nullptr, nullptr, nullptr,
-                                   model_path.c_str(), checkpoint_path.c_str(),
+    trainer_.reset(new LSTMTrainer(model_path.c_str(), checkpoint_path.c_str(),
                                    0, 0));
     trainer_->InitCharSet(file::JoinPath(FLAGS_test_tmpdir, kLang,
     absl::StrCat(kLang, ".traineddata")));


### PR DESCRIPTION
The function pointers and callbacks file_reader_, file_writer_,
checkpointer_reader_ and checkpoint_writer_ are always set to
the same values. Replacing them by direct function calls
simplifies the code and allows removing more code from tesscallback.h.

Signed-off-by: Stefan Weil <sw@weilnetz.de>