### PR TITLE
Improved lstm_choice_mode

### DIFF
--- a/src/api/hocrrenderer.cpp
+++ b/src/api/hocrrenderer.cpp
@@ -345,7 +345,7 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
           tcnt++;
         }
       }
-    } else if (tesseract_->lstm_choice_mode == 4 ) {
+    } else if (tesseract_->lstm_choice_mode == 4) {
       for (auto timestep : *CTCMap) {
         if (timestep.size() > 0) {
           hocr_str << "\n       <span class='ocrx_cinfo'"

--- a/src/api/hocrrenderer.cpp
+++ b/src/api/hocrrenderer.cpp
@@ -353,16 +353,16 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
                    << "lstm_choices_" << page_id << "_" << wcnt << "_" << tcnt
                    << "'>";
           for (auto& j : timestep) {
-            float confidence = 100 - 5 * j.second;
-            if (confidence < 0.0f)
-              confidence = 0.0f;
-            if (confidence > 100.0f)
-              confidence = 100.0f;
+            float conf = 100 - tesseract_->lstm_rating_coefficient * j.second;
+            if (conf < 0.0f)
+              conf = 0.0f;
+            if (conf > 100.0f)
+              conf = 100.0f;
             hocr_str << "<span class='ocr_glyph'"
                      << " id='"
                      << "choice_" << page_id << "_" << wcnt << "_" << gcnt
                      << "'"
-                     << " title='x_confs " << confidence << "'>"
+                     << " title='x_confs " << conf << "'>"
                      << j.first << "</span>";
             gcnt++;
           }

--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -239,7 +239,8 @@ void Tesseract::LSTMRecognizeWord(const BLOCK& block, ROW *row, WERD_RES *word,
   if (im_data == nullptr) return;
   lstm_recognizer_->RecognizeLine(*im_data, true, classify_debug_level > 0,
                                   kWorstDictCertainty / kCertaintyScale,
-                                  word_box, words, lstm_choice_mode, lstm_choice_amount);
+                                  word_box, words, lstm_choice_mode,
+                                  lstm_choice_amount);
   delete im_data;
   SearchWords(words);
 }

--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -239,7 +239,7 @@ void Tesseract::LSTMRecognizeWord(const BLOCK& block, ROW *row, WERD_RES *word,
   if (im_data == nullptr) return;
   lstm_recognizer_->RecognizeLine(*im_data, true, classify_debug_level > 0,
                                   kWorstDictCertainty / kCertaintyScale,
-                                  word_box, words, lstm_choice_mode);
+                                  word_box, words, lstm_choice_mode, lstm_choice_amount);
   delete im_data;
   SearchWords(words);
 }

--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -359,6 +359,7 @@ ChoiceIterator::ChoiceIterator(const LTRResultIterator& result_it) {
   word_res_ = result_it.it_->word();
   oemLSTM_ = word_res_->tesseract->AnyLSTMLang();
   oemLegacy_ = word_res_->tesseract->AnyTessLang();
+  rating_coefficient_ = word_res_->tesseract->lstm_rating_coefficient;
   BLOB_CHOICE_LIST* choices = nullptr;
   tstep_index_ = &result_it.blob_index_;
   if (oemLSTM_ && !word_res_->CTC_symbol_choices.empty()) {
@@ -424,10 +425,10 @@ float ChoiceIterator::Confidence() const {
   float confidence = 0.0f;
   if (oemLSTM_ && LSTM_choices_ != nullptr && !LSTM_choices_->empty()) {
     std::pair<const char*, float> choice = *LSTM_choice_it_;
-    confidence = 100 - 5 * choice.second;
+    confidence = 100 - rating_coefficient_ * choice.second;
   } else {
     if (choice_it_ == nullptr) return 0.0f;
-    float confidence = 100 + 5 * choice_it_->data()->certainty();
+    confidence = 100 + 5 * choice_it_->data()->certainty();
   }
   if (confidence < 0.0f)
     confidence = 0.0f;

--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -422,7 +422,7 @@ const char* ChoiceIterator::GetUTF8Text() const {
 // interpreted as a percent probability. (0.0f-100.0f) In this case probabilities
 // won't add up to 100. Each one stands on its own.
 float ChoiceIterator::Confidence() const {
-  float confidence = 0.0f;
+  float confidence;
   if (oemLSTM_ && LSTM_choices_ != nullptr && !LSTM_choices_->empty()) {
     std::pair<const char*, float> choice = *LSTM_choice_it_;
     confidence = 100 - rating_coefficient_ * choice.second;
@@ -430,10 +430,12 @@ float ChoiceIterator::Confidence() const {
     if (choice_it_ == nullptr) return 0.0f;
     confidence = 100 + 5 * choice_it_->data()->certainty();
   }
-  if (confidence < 0.0f)
+  if (confidence < 0.0f) {
     confidence = 0.0f;
-  if (confidence > 100.0f)
+  }   
+  if (confidence > 100.0f) {
     confidence = 100.0f;
+  }  
   return confidence;
 }
 

--- a/src/ccmain/ltrresultiterator.h
+++ b/src/ccmain/ltrresultiterator.h
@@ -233,7 +233,6 @@ class ChoiceIterator {
   std::vector<std::pair<const char*, float>>::iterator LSTM_choice_it_;
 
   const int* tstep_index_;
-  bool LSTM_mode_ = false;
   //true when there is lstm engine related trained data
   bool oemLSTM_;
   // true when there is legacy engine related trained data

--- a/src/ccmain/ltrresultiterator.h
+++ b/src/ccmain/ltrresultiterator.h
@@ -233,10 +233,12 @@ class ChoiceIterator {
   std::vector<std::pair<const char*, float>>::iterator LSTM_choice_it_;
 
   const int* tstep_index_;
-  //true when there is lstm engine related trained data
+  // true when there is lstm engine related trained data
   bool oemLSTM_;
   // true when there is legacy engine related trained data
   bool oemLegacy_;
+  // regulates the rating granularity
+  double rating_coefficient_;
 };
 
 }  // namespace tesseract.

--- a/src/ccmain/resultiterator.h
+++ b/src/ccmain/resultiterator.h
@@ -104,6 +104,8 @@ class TESS_API ResultIterator : public LTRResultIterator {
   GetRawLSTMTimesteps() const;
   virtual std::vector<std::vector<std::pair<const char*, float>>>*
     GetBestLSTMSymbolChoices() const;
+  virtual std::vector<std::vector<std::pair<const char*, float>>>*
+  GetBestCTCSymbolChoices() const;
   virtual std::vector<std::vector<std::vector<std::pair<const char*, float>>>>*
     GetSegmentedLSTMTimesteps() const;
 

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -530,6 +530,18 @@ Tesseract::Tesseract()
           "With 3 the alternative symbol choices per timestep are included "
           "and separated by the suggested segmentation of Tesseract",
           this->params()),
+      INT_MEMBER(
+          lstm_choice_amount, 5,
+          "Sets the number of choices one get per character in "
+          "lstm_choice_mode. Note that lstm_choice_mode must be set to a "
+          "value greater than 0 to produce results.",
+                 this->params()),
+      double_MEMBER(
+          lstm_rating_coefficient, 5,
+          "Sets the rating coefficient for the lstm choices. The smaller the "
+          "coefficient, the better are the ratings for each choice and less "
+          "information is lost due to the cut off at 0. The standard value is "
+          "5", this->params()),
 
       backup_config_file_(nullptr),
       pix_binary_(nullptr),

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -528,7 +528,10 @@ Tesseract::Tesseract()
           "With 2 the alternative symbol choices are accumulated per "
           "character. "
           "With 3 the alternative symbol choices per timestep are included "
-          "and separated by the suggested segmentation of Tesseract",
+          "and separated by the suggested segmentation of Tesseract. "
+          "With 4 alternative symbol choices are extracted from the CTC "
+          "process instead of the lattice. The choices are mapped per "
+          "character.",
           this->params()),
       INT_MEMBER(
           lstm_choice_amount, 5,

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -1094,6 +1094,15 @@ class Tesseract : public Wordrec {
             "character. "
             "With 3 the alternative symbol choices per timestep are included "
             "and separated by the suggested segmentation of Tesseract");
+  INT_VAR_H(lstm_choice_amount, 5,
+            "Sets the number of choices one get per character in "
+            "lstm_choice_mode. Note that lstm_choice_mode must be set to "
+            "a value greater than 0 to produce results.");
+  double_VAR_H(lstm_rating_coefficient, 5, 
+               "Sets the rating coefficient for the lstm choices. The smaller "
+               "the coefficient, the better are the ratings for each choice "
+               "and less information is lost due to the cut off at 0. The "
+               "standard value is 5.");
 
   //// ambigsrecog.cpp /////////////////////////////////////////////////////////
   FILE* init_recog_training(const STRING& fname);

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -1093,7 +1093,10 @@ class Tesseract : public Wordrec {
             "With 2 the alternative symbol choices are accumulated per "
             "character. "
             "With 3 the alternative symbol choices per timestep are included "
-            "and separated by the suggested segmentation of Tesseract");
+            "and separated by the suggested segmentation of Tesseract. "
+            "With 4 alternative symbol choices are extracted from the CTC "
+            "process instead of the lattice. The choices are mapped per "
+            "character.");
   INT_VAR_H(lstm_choice_amount, 5,
             "Sets the number of choices one get per character in "
             "lstm_choice_mode. Note that lstm_choice_mode must be set to "

--- a/src/ccstruct/pageres.h
+++ b/src/ccstruct/pageres.h
@@ -223,8 +223,10 @@ class WERD_RES : public ELIST_LINK {
   std::vector<std::vector<std::pair<const char*, float>>> accumulated_timesteps;
   std::vector<std::vector<std::vector<std::pair<const char*, float>>>>
       symbol_steps;
-  //Stores if the timestep vector starts with a space
-  bool leadingSpace = false;
+  //Symbolchoices aquired during CTC
+  std::vector<std::vector<std::pair<const char*, float>>> CTC_symbol_choices;
+  // Stores if the timestep vector starts with a space
+  bool leading_space = false;
   // Ratings matrix contains classifier choices for each classified combination
   // of blobs. The dimension is the same as the number of blobs in chopped_word
   // and the leading diagonal corresponds to classifier results of the blobs

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -183,7 +183,7 @@ void LSTMRecognizer::RecognizeLine(const ImageData& image_data, bool invert,
                                    bool debug, double worst_dict_cert,
                                    const TBOX& line_box,
                                    PointerVector<WERD_RES>* words,
-                                   int lstm_choice_mode) {
+                                   int lstm_choice_mode, int lstm_choice_amount) {
   NetworkIO outputs;
   float scale_factor;
   NetworkIO inputs;
@@ -201,8 +201,7 @@ void LSTMRecognizer::RecognizeLine(const ImageData& image_data, bool invert,
                                   &GetUnicharset(), words, lstm_choice_mode);
   if (lstm_choice_mode){
     search_->extractSymbolChoices(&GetUnicharset());
-    int cascades = 5;
-    for (int i = 0; i < cascades; ++i) {
+    for (int i = 0; i < lstm_choice_amount; ++i) {
       search_->DecodeSecondaryBeams(outputs, kDictRatio, kCertOffset,
                                     worst_dict_cert, &GetUnicharset(),
                                     lstm_choice_mode);

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -39,6 +39,9 @@
 #include "statistc.h"
 #include "tprintf.h"
 
+#include <unordered_set>
+#include <vector>
+
 namespace tesseract {
 
 // Default ratio between dict and non-dict words.
@@ -191,10 +194,32 @@ void LSTMRecognizer::RecognizeLine(const ImageData& image_data, bool invert,
     search_ =
         new RecodeBeamSearch(recoder_, null_char_, SimpleTextOutput(), dict_);
   }
+  search_->excludedUnichars.clear();
   search_->Decode(outputs, kDictRatio, kCertOffset, worst_dict_cert,
                   &GetUnicharset(), lstm_choice_mode);
   search_->ExtractBestPathAsWords(line_box, scale_factor, debug,
                                   &GetUnicharset(), words, lstm_choice_mode);
+  if (lstm_choice_mode){
+    search_->extractSymbolChoices(&GetUnicharset());
+    int cascades = 5;
+    for (int i = 0; i < cascades; ++i) {
+      search_->DecodeSecondaryBeams(outputs, kDictRatio, kCertOffset,
+                                    worst_dict_cert, &GetUnicharset(),
+                                    lstm_choice_mode);
+      search_->extractSymbolChoices(&GetUnicharset());
+    }
+    int ctc_it = 0;
+    for (int i = 0; i < words->size(); ++i) {
+      for (int j = 0; j < words->get(i)->accumulated_timesteps.size(); ++j) {
+        if (ctc_it < search_->ctc_choices.size())
+          words->get(i)->CTC_symbol_choices.push_back(
+              search_->ctc_choices[ctc_it]);
+        ++ctc_it;
+      }
+    }
+    search_->ctc_choices.clear();
+    search_->excludedUnichars.clear();
+  }
 }
 
 // Helper computes min and mean best results in the output.

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -183,7 +183,8 @@ void LSTMRecognizer::RecognizeLine(const ImageData& image_data, bool invert,
                                    bool debug, double worst_dict_cert,
                                    const TBOX& line_box,
                                    PointerVector<WERD_RES>* words,
-                                   int lstm_choice_mode, int lstm_choice_amount) {
+                                   int lstm_choice_mode,
+                                   int lstm_choice_amount) {
   NetworkIO outputs;
   float scale_factor;
   NetworkIO inputs;

--- a/src/lstm/lstmrecognizer.h
+++ b/src/lstm/lstmrecognizer.h
@@ -175,7 +175,8 @@ class LSTMRecognizer {
   // will be used in a dictionary word.
   void RecognizeLine(const ImageData& image_data, bool invert, bool debug,
                      double worst_dict_cert, const TBOX& line_box,
-                     PointerVector<WERD_RES>* words, int lstm_choice_mode = 0);
+                     PointerVector<WERD_RES>* words, int lstm_choice_mode = 0,
+                     int lstm_choice_amount = 5);
 
   // Helper computes min and mean best results in the output.
   void OutputStats(const NetworkIO& outputs, float* min_output,

--- a/src/lstm/recodebeam.h
+++ b/src/lstm/recodebeam.h
@@ -31,6 +31,7 @@
 #include <set>
 #include <tuple>
 #include <vector>
+#include <unordered_set>
 
 namespace tesseract {
 
@@ -191,6 +192,11 @@ class RecodeBeamSearch {
               double cert_offset, double worst_dict_cert,
               const UNICHARSET* charset);
 
+  void DecodeSecondaryBeams(const NetworkIO& output, double dict_ratio,
+                            double cert_offset, double worst_dict_cert,
+                            const UNICHARSET* charset,
+                            int lstm_choice_mode = 0);
+
   // Returns the best path as labels/scores/xcoords similar to simple CTC.
   void ExtractBestPathAsLabels(GenericVector<int>* labels,
                                GenericVector<int>* xcoords) const;
@@ -211,10 +217,20 @@ class RecodeBeamSearch {
   // Generates debug output of the content of the beams after a Decode.
   void DebugBeams(const UNICHARSET& unicharset) const;
 
+  // Extract the best charakters from the current decode iteration and block
+  // those symbols for the next iteration
+  void extractSymbolChoices(const UNICHARSET* unicharset);
+  
+  // Generates debug output of the content of the beams after a Decode.
+  void PrintBeam2(bool uids, int num_outputs, const UNICHARSET* charset,
+                  bool secondary) const;
   // Stores the alternative characters of every timestep together with their
   // probability.
   std::vector< std::vector<std::pair<const char*, float>>> timesteps;
-
+  std::vector<std::vector<std::pair<const char*, float>>> ctc_choices;
+  std::vector<std::unordered_set<int>> excludedUnichars;
+  // Stores the character boundaries regarding timesteps.
+  std::vector<int> character_boundaries_;
   // Clipping value for certainty inside Tesseract. Reflects the minimum value
   // of certainty that will be returned by ExtractBestPathAsUnicharIds.
   // Supposedly on a uniform scale that can be compared across languages and
@@ -282,6 +298,7 @@ class RecodeBeamSearch {
       const GenericVector<const RecodeNode*>& best_nodes,
       GenericVector<int>* unichar_ids, GenericVector<float>* certs,
       GenericVector<float>* ratings, GenericVector<int>* xcoords,
+      std::vector<int>* character_boundaries = nullptr,
       std::deque<std::tuple<int, int>>* best_choices = nullptr,
       std::deque<std::tuple<int, int>>* best_choices_acc = nullptr);
 
@@ -297,6 +314,9 @@ class RecodeBeamSearch {
   // is one of the top_n.
   void ComputeTopN(const float* outputs, int num_outputs, int top_n);
 
+  void ComputeSecTopN(std::unordered_set<int>* exList,
+                      const float* outputs, int num_outputs, int top_n);
+
   // Adds the computation for the current time-step to the beam. Call at each
   // time-step in sequence from left to right. outputs is the activation vector
   // for the current timestep.
@@ -304,8 +324,17 @@ class RecodeBeamSearch {
                   double cert_offset, double worst_dict_cert,
                   const UNICHARSET* charset, bool debug = false);
 
+  void DecodeSecondaryStep(const float* outputs, int t, double dict_ratio,
+                  double cert_offset, double worst_dict_cert,
+                  const UNICHARSET* charset, bool debug = false);
+
   //Saves the most certain choices for the current time-step
   void SaveMostCertainChoices(const float* outputs, int num_outputs, const UNICHARSET* charset, int xCoord);
+
+  static void calculateCharBoundaries(std::vector<int>* starts,
+                                      std::vector<int>* ends,
+                                      std::vector<int>* character_boundaries_,
+                                      int maxWidth);
 
   // Adds to the appropriate beams the legal (according to recoder)
   // continuations of context prev, which is from the given index to beams_,
@@ -362,6 +391,9 @@ class RecodeBeamSearch {
   // path and reversing it.
   void ExtractPath(const RecodeNode* node,
                    GenericVector<const RecodeNode*>* path) const;
+  void ExtractPath(const RecodeNode* node,
+                   GenericVector<const RecodeNode*>* path,
+                   int limiter) const;
   // Helper prints debug information on the given lattice path.
   void DebugPath(const UNICHARSET* unicharset,
                  const GenericVector<const RecodeNode*>& path) const;
@@ -379,8 +411,11 @@ class RecodeBeamSearch {
   const UnicharCompress& recoder_;
   // The beam for each timestep in the output.
   PointerVector<RecodeBeam> beam_;
+  // Secondary Beam for Results with less Probability
+  PointerVector<RecodeBeam> secondary_beam_;
   // The number of timesteps valid in beam_;
   int beam_size_;
+  int secondary_beam_size_;
   // A flag to indicate which outputs are the top-n choices. Current timestep
   // only.
   GenericVector<TopNState> top_n_flags_;

--- a/src/lstm/recodebeam.h
+++ b/src/lstm/recodebeam.h
@@ -218,7 +218,10 @@ class RecodeBeamSearch {
   void DebugBeams(const UNICHARSET& unicharset) const;
 
   // Extract the best charakters from the current decode iteration and block
-  // those symbols for the next iteration
+  // those symbols for the next iteration. In contrast to tesseracts standard
+  // method to chose the best overall node chain, this methods looks at a short
+  // node chain segmented by the character boundaries and chooses the best 
+  // option independent of the remaining node chain.
   void extractSymbolChoices(const UNICHARSET* unicharset);
   
   // Generates debug output of the content of the beams after a Decode.
@@ -328,9 +331,12 @@ class RecodeBeamSearch {
                   double cert_offset, double worst_dict_cert,
                   const UNICHARSET* charset, bool debug = false);
 
-  //Saves the most certain choices for the current time-step
-  void SaveMostCertainChoices(const float* outputs, int num_outputs, const UNICHARSET* charset, int xCoord);
+  // Saves the most certain choices for the current time-step.
+  void SaveMostCertainChoices(const float* outputs, int num_outputs, 
+                              const UNICHARSET* charset, int xCoord);
 
+  // Calculates more accurate character boundaries which can be used to
+  // provide more acurate alternative symbol choices.
   static void calculateCharBoundaries(std::vector<int>* starts,
                                       std::vector<int>* ends,
                                       std::vector<int>* character_boundaries_,


### PR DESCRIPTION
Added an improved version of the lstm_choice_mode 

The new version extracts its ratings and alternative symbol choices from the
CTC process instead of the lattice. It also makes the beamsearch broader in
an uninvasive way by doing several cascading beamsearches. After every iteration
the best symbol choice is extracted and blocked for the next iteration.