### PR TITLE
Optimize tprintf implementation

### DIFF
--- a/src/ccutil/ccutil.cpp
+++ b/src/ccutil/ccutil.cpp
@@ -52,5 +52,4 @@ void CCUtilMutex::Unlock() {
 #endif
 }
 
-CCUtilMutex tprintfMutex;  // should remain global
 } // namespace tesseract

--- a/src/ccutil/ccutil.h
+++ b/src/ccutil/ccutil.h
@@ -87,7 +87,6 @@ class CCUtil {
              "Use ambigs for deciding whether to adapt to a character");
 };
 
-extern CCUtilMutex tprintfMutex;  // should remain global
 }  // namespace tesseract
 
 #endif  // TESSERACT_CCUTIL_CCUTIL_H_


### PR DESCRIPTION
It no longer uses a local buffer, so it needs less memory
and no mutex.

Signed-off-by: Stefan Weil <sw@weilnetz.de>