### PR TITLE
classify: Use fixed size bit vector

### DIFF
--- a/src/classify/protos.cpp
+++ b/src/classify/protos.cpp
@@ -51,6 +51,7 @@ int AddConfigToClass(CLASS_TYPE Class) {
   BIT_VECTOR Config;
 
   MaxNumProtos = Class->MaxNumProtos;
+  ASSERT_HOST(MaxNumProtos <= MAX_NUM_PROTOS);
 
   if (Class->NumConfigs >= Class->MaxNumConfigs) {
     /* add configs in CONFIG_INCREMENT chunks at a time */
@@ -64,9 +65,9 @@ int AddConfigToClass(CLASS_TYPE Class) {
     Class->MaxNumConfigs = NewNumConfigs;
   }
   NewConfig = Class->NumConfigs++;
-  Config = NewBitVector (MaxNumProtos);
+  Config = NewBitVector(MAX_NUM_PROTOS);
   Class->Configurations[NewConfig] = Config;
-  zero_all_bits (Config, WordsInVectorOfSize (MaxNumProtos));
+  zero_all_bits (Config, WordsInVectorOfSize(MAX_NUM_PROTOS));
 
   return (NewConfig);
 }
@@ -97,20 +98,10 @@ int AddProtoToClass(CLASS_TYPE Class) {
       NewNumProtos));
 
     Class->MaxNumProtos = NewNumProtos;
-
-    for (i = 0; i < Class->NumConfigs; i++) {
-      Config = Class->Configurations[i];
-      Class->Configurations[i] = ExpandBitVector (Config, NewNumProtos);
-
-      for (Bit = Class->NumProtos; Bit < NewNumProtos; Bit++)
-        reset_bit(Config, Bit);
-    }
+    ASSERT_HOST(NewNumProtos <= MAX_NUM_PROTOS);
   }
   NewProto = Class->NumProtos++;
-  if (Class->NumProtos > MAX_NUM_PROTOS) {
-    tprintf("Ouch! number of protos = %d, vs max of %d!",
-            Class->NumProtos, MAX_NUM_PROTOS);
-  }
+  ASSERT_HOST(Class->NumProtos <= MAX_NUM_PROTOS);
   return (NewProto);
 }
 

--- a/src/cutil/bitvec.cpp
+++ b/src/cutil/bitvec.cpp
@@ -27,24 +27,6 @@
 /*-----------------------------------------------------------------------------
               Public Code
 -----------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/**
- * This routine uses realloc to increase the size of
- * the specified bit vector.
- *
- * Globals:
- * - none
- *
- * @param Vector bit vector to be expanded
- * @param NewNumBits new size of bit vector
- *
- * @return New expanded bit vector.
- */
-BIT_VECTOR ExpandBitVector(BIT_VECTOR Vector, int NewNumBits) {
-  return (static_cast<BIT_VECTOR>(Erealloc(Vector,
-    sizeof(Vector[0]) * WordsInVectorOfSize(NewNumBits))));
-}                                /* ExpandBitVector */
-
 
 /*---------------------------------------------------------------------------*/
 void FreeBitVector(BIT_VECTOR BitVector) {

--- a/src/cutil/bitvec.h
+++ b/src/cutil/bitvec.h
@@ -63,11 +63,6 @@ using BIT_VECTOR = uint32_t *;
 #define WordsInVectorOfSize(NumBits) \
 (((NumBits) + BITSINLONG - 1) / BITSINLONG)
 
-/*--------------------------------------------------------------------------
-        Public Function Prototypes
---------------------------------------------------------------------------*/
-BIT_VECTOR ExpandBitVector(BIT_VECTOR Vector, int NewNumBits);
-
 void FreeBitVector(BIT_VECTOR BitVector);
 
 BIT_VECTOR NewBitVector(int NumBits);


### PR DESCRIPTION
The vector was already limited to MAX_NUM_PROTOS (512) entries or 64 bytes
in the old code. Now it uses that size right from the start which avoids
reallocating it later when entries are added.

The old code which reallocated the vector to expand it was buggy because
the realloc function can return a different pointer, but the code still
used the original pointer to reset the new bits.

Function ExpandBitVector is now unused and therefore removed.

Signed-off-by: Stefan Weil <sw@weilnetz.de>