### PR TITLE
scanutils.cpp: include sys/types.h

### DIFF
--- a/src/ccutil/scanutils.cpp
+++ b/src/ccutil/scanutils.cpp
@@ -26,6 +26,10 @@
 #include <cstring>
 #include <limits>       // for std::numeric_limits
 
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>  // for off_t
+#endif
+
 #include "scanutils.h"
 
 enum Flags {


### PR DESCRIPTION
Include sys/types.h (if available) to avoid the following build failure:

scanutils.cpp: In function 'int tvfscanf(FILE*, const char*, va_list)':
scanutils.cpp:217:3: error: 'off_t' was not declared in this scope
   off_t start_off = ftell(stream)

Fixes:
 - http://autobuild.buildroot.org/results/bdfbafa105ddf0b9b9399d94b557d318ad587d79

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>