### PR TITLE
Add glib and gobject libs for text2image (workaround for Pango 1.43)

### DIFF
--- a/src/training/CMakeLists.txt
+++ b/src/training/CMakeLists.txt
@@ -271,6 +271,7 @@ pkg_check_modules(Cairo REQUIRED cairo)
 pkg_check_modules(PangoFt2 REQUIRED pangoft2)
 pkg_check_modules(PangoCairo REQUIRED pangocairo)
 pkg_check_modules(FontConfig REQUIRED fontconfig)
+pkg_check_modules(Glib REQUIRED glib-2.0 gobject-2.0)
 endif()
 
 set(text2image_src
@@ -306,6 +307,7 @@ target_link_libraries       (text2image
     ${PangoCairo_LIBRARIES}
     ${PangoFt2_LIBRARIES}
     ${FontConfig_LIBRARIES}
+    ${Glib_LIBRARIES}
 )
 endif()
 if (CPPAN_BUILD)


### PR DESCRIPTION
training/text2image requires glib and gobject:
/usr/bin/ld: CMakeFiles/text2image.dir/pango_font_info.cpp.o: undefined reference to symbol 'g_free'
/usr/bin/ld: /usr/lib/libglib-2.0.so.0: error adding symbols: DSO missing from command line

/usr/bin/ld: CMakeFiles/text2image.dir/pango_font_info.cpp.o: undefined reference to symbol 'g_object_unref'
/usr/bin/ld: /usr/lib/libgobject-2.0.so.0: error adding symbols: DSO missing from command line
