### PR TITLE
Remove UNICHARSET::load_from_inmemory_file and related code

### DIFF
--- a/src/ccutil/unicharset.cpp
+++ b/src/ccutil/unicharset.cpp
@@ -729,44 +729,6 @@ bool UNICHARSET::save_to_string(STRING *str) const {
   return true;
 }
 
-// TODO(rays) Replace with TFile everywhere.
-class InMemoryFilePointer {
- public:
-  InMemoryFilePointer(const char *memory, int mem_size)
-      : memory_(memory), fgets_ptr_(memory), mem_size_(mem_size) { }
-
-  char *fgets(char *orig_dst, int size) {
-    const char *src_end = memory_ + mem_size_;
-    char *dst_end = orig_dst + size - 1;
-    if (size < 1) {
-      return fgets_ptr_ < src_end ? orig_dst : nullptr;
-    }
-
-    char *dst = orig_dst;
-    char ch = '^';
-    while (fgets_ptr_ < src_end && dst < dst_end && ch != '\n') {
-      ch = *dst++ = *fgets_ptr_++;
-    }
-    *dst = 0;
-    return (dst == orig_dst) ? nullptr : orig_dst;
-  }
-
- private:
-  const char *memory_;
-  const char *fgets_ptr_;
-  const int mem_size_;
-};
-
-bool UNICHARSET::load_from_inmemory_file(
-    const char *memory, int mem_size, bool skip_fragments) {
-  InMemoryFilePointer mem_fp(memory, mem_size);
-  using namespace std::placeholders;  // for _1, _2
-  std::function<char*(char*, int)> fgets_cb =
-      std::bind(&InMemoryFilePointer::fgets, &mem_fp, _1, _2);
-  bool success = load_via_fgets(fgets_cb, skip_fragments);
-  return success;
-}
-
 class LocalFilePointer {
  public:
   LocalFilePointer(FILE *stream) : fp_(stream) {}

--- a/src/ccutil/unicharset.h
+++ b/src/ccutil/unicharset.h
@@ -372,16 +372,6 @@ class UNICHARSET {
   // Returns true if the operation is successful.
   bool save_to_string(STRING *str) const;
 
-  // Load a unicharset from a unicharset file that has been loaded into
-  // the given memory buffer.
-  // Returns true if the operation is successful.
-  bool load_from_inmemory_file(const char* const memory, int mem_size,
-                               bool skip_fragments);
-  // Returns true if the operation is successful.
-  bool load_from_inmemory_file(const char* const memory, int mem_size) {
-    return load_from_inmemory_file(memory, mem_size, false);
-  }
-
   // Opens the file indicated by filename and loads the UNICHARSET
   // from the given file. The previous data is lost.
   // Returns true if the operation is successful.
@@ -1002,7 +992,7 @@ class UNICHARSET {
 
   // Load ourselves from a "file" where our only interface to the file is
   // an implementation of fgets().  This is the parsing primitive accessed by
-  // the public routines load_from_file() and load_from_inmemory_file().
+  // the public routines load_from_file().
   bool load_via_fgets(std::function<char*(char*, int)> fgets_cb,
                       bool skip_fragments);
 

--- a/unittest/recodebeam_test.cc
+++ b/unittest/recodebeam_test.cc
@@ -82,13 +82,10 @@ class RecodeBeamTest : public ::testing::Test {
                                                 "radical-stroke.txt");
     std::string unicharset_file =
         file::JoinPath(TESTDATA_DIR, unicharset_name);
-    std::string uni_data;
-    CHECK_OK(file::GetContents(unicharset_file, &uni_data, file::Defaults()));
     std::string radical_data;
     CHECK_OK(file::GetContents(radical_stroke_file, &radical_data,
                                file::Defaults()));
-    CHECK(ccutil_.unicharset.load_from_inmemory_file(uni_data.data(),
-                                                     uni_data.size()));
+    CHECK(ccutil_.unicharset.load_from_file(unicharset_file.c_str()));
     unichar_null_char_ = ccutil_.unicharset.has_special_codes()
                              ? UNICHAR_BROKEN
                              : ccutil_.unicharset.size();

--- a/unittest/unicharcompress_test.cc
+++ b/unittest/unicharcompress_test.cc
@@ -37,13 +37,10 @@ class UnicharcompressTest : public ::testing::Test {
         file::JoinPath(LANGDATA_DIR, "radical-stroke.txt");
     std::string unicharset_file =
         file::JoinPath(TESTDATA_DIR, unicharset_name);
-    std::string uni_data;
-    CHECK_OK(file::GetContents(unicharset_file, &uni_data, file::Defaults()));
     std::string radical_data;
     CHECK_OK(file::GetContents(radical_stroke_file, &radical_data,
                                file::Defaults()));
-    CHECK(
-        unicharset_.load_from_inmemory_file(uni_data.data(), uni_data.size()));
+    CHECK(unicharset_.load_from_file(unicharset_file.c_str()));
     STRING radical_str(radical_data.c_str());
     null_char_ =
         unicharset_.has_special_codes() ? UNICHAR_BROKEN : unicharset_.size();


### PR DESCRIPTION
The method was only used in unittest where it can be replaced by
UNICHARSET::load_from_file which also simplifies the code.

This allows removing the class InMemoryFilePointer and fixes a TODO.

Signed-off-by: Stefan Weil <sw@weilnetz.de>