### PR TITLE
fix #2616: allow building of training data

### DIFF
--- a/tessdata/configs/lstm.train
+++ b/tessdata/configs/lstm.train
@@ -10,3 +10,4 @@ edges_childarea 0.65
 edges_boxarea 0.9
 tessedit_train_line_recognizer T
 textord_no_rejects T
+tessedit_init_config_only T


### PR DESCRIPTION
This fixes Issue #2616 by preventing an attempt to build the recognition engine when running tesstrain.sh.