### PR TITLE
Lstm choice ril

### DIFF
--- a/src/api/hocrrenderer.cpp
+++ b/src/api/hocrrenderer.cpp
@@ -133,7 +133,7 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
   if (tesseract_ == nullptr || (page_res_ == nullptr && Recognize(monitor) < 0))
     return nullptr;
 
-  int lcnt = 1, bcnt = 1, pcnt = 1, wcnt = 1, scnt = 1, tcnt = 1, gcnt = 1;
+  int lcnt = 1, bcnt = 1, pcnt = 1, wcnt = 1, scnt = 1, tcnt = 1, ccnt = 1;
   int page_id = page_number + 1;  // hOCR uses 1-based page numbers.
   bool para_is_ltr = true;        // Default direction is LTR
   const char* paragraph_lang = nullptr;
@@ -296,6 +296,56 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
         hocr_str << HOcrEscape(grapheme.get()).c_str();
         if (hocr_boxes) {
           hocr_str << "</span>";
+          tesseract::ChoiceIterator ci(*res_it);
+          if (lstm_choice_mode == 1 && ci.Timesteps() != nullptr) {
+            std::vector<std::vector<std::pair<const char*, float>>>* symbol =
+                ci.Timesteps();
+              hocr_str << "\n        <span class='ocr_symbol'"
+                       << " id='"
+                       << "symbol_" << page_id << "_" << wcnt << "_" << scnt
+                       << "'>";
+              for (auto timestep : *symbol) {
+                hocr_str << "\n         <span class='ocrx_cinfo'"
+                         << " id='"
+                         << "timestep" << page_id << "_" << wcnt << "_" << tcnt
+                         << "'>";
+                for (auto conf : timestep) {
+                  hocr_str << "\n          <span class='ocrx_cinfo'"
+                           << " id='"
+                           << "choice_" << page_id << "_" << wcnt << "_" << ccnt
+                           << "'"
+                           << " title='x_confs " << int(conf.second * 100)
+                           << "'>" << HOcrEscape(conf.first).c_str()
+                           << "</span>";
+                  ++ccnt;
+                }
+                hocr_str << "</span>";
+                ++tcnt;
+              }
+              hocr_str << "\n        </span>";
+              ++scnt;
+          } else if (lstm_choice_mode == 2) {
+            tesseract::ChoiceIterator ci(*res_it);
+            hocr_str << "\n        <span class='ocrx_cinfo'"
+                     << " id='"
+                     << "lstm_choices_" << page_id << "_" << wcnt << "_" << tcnt
+                     << "'>";
+            do {
+              const char* choice = ci.GetUTF8Text();
+              float choiceconf = ci.Confidence();
+              if (choice != nullptr) {
+                hocr_str << "\n         <span class='ocrx_cinfo'"
+                         << " id='"
+                         << "choice_" << page_id << "_" << wcnt << "_" << ccnt
+                         << "'"
+                         << " title='x_confs " << choiceconf << "'>"
+                         << HOcrEscape(choice).c_str() << "</span>";
+                ccnt++;
+              }
+            } while (ci.Next());
+            hocr_str << "\n        </span>";
+            tcnt++;
+          }
         }
       }
       res_it->Next(RIL_SYMBOL);
@@ -303,27 +353,32 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
     if (italic) hocr_str << "</em>";
     if (bold) hocr_str << "</strong>";
     // If the lstm choice mode is required it is added here
-    if (lstm_choice_mode == 1 && rawTimestepMap != nullptr) {
-      for (auto timesteps : *rawTimestepMap) {
+    if (lstm_choice_mode == 1 && !hocr_boxes && rawTimestepMap != nullptr) {
+      for (auto symbol : *rawTimestepMap) {
         hocr_str << "\n       <span class='ocr_symbol'"
                  << " id='"
                  << "symbol_" << page_id << "_" << wcnt << "_" << scnt << "'>";
-        for (auto timestep : timesteps) {
-
+        for (auto timestep : symbol) {
+          hocr_str << "\n        <span class='ocrx_cinfo'"
+                   << " id='"
+                   << "timestep" << page_id << "_" << wcnt << "_" << tcnt
+                   << "'>";
           for (auto conf : timestep) {
-            hocr_str << "\n        <span class='ocrx_cinfo'"
+            hocr_str << "\n         <span class='ocrx_cinfo'"
                      << " id='"
-                     << "choice_" << page_id << "_" << wcnt << "_" << gcnt
+                     << "choice_" << page_id << "_" << wcnt << "_" << ccnt
                      << "'"
                      << " title='x_confs " << int(conf.second * 100) << "'>"
                      << HOcrEscape(conf.first).c_str() << "</span>";
-            gcnt++;
+            ++ccnt;
           }
           hocr_str << "</span>";
-          tcnt++;
+          ++tcnt;
         }
+        hocr_str << "</span>";
+        ++scnt;
       }
-    } else if (lstm_choice_mode == 2 && CTCMap != nullptr) {
+    } else if (lstm_choice_mode == 2 && !hocr_boxes && CTCMap != nullptr) {
       for (auto timestep : *CTCMap) {
         if (timestep.size() > 0) {
           hocr_str << "\n       <span class='ocrx_cinfo'"
@@ -336,13 +391,13 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
               conf = 0.0f;
             if (conf > 100.0f)
               conf = 100.0f;
-            hocr_str << "<span class='ocr_glyph'"
+            hocr_str << "\n        <span class='ocrx_cinfo'"
                      << " id='"
-                     << "choice_" << page_id << "_" << wcnt << "_" << gcnt
+                     << "choice_" << page_id << "_" << wcnt << "_" << ccnt
                      << "'"
                      << " title='x_confs " << conf << "'>"
                      << HOcrEscape(j.first).c_str() << "</span>";
-            gcnt++;
+            ccnt++;
           }
           hocr_str << "</span>";
           tcnt++;
@@ -355,7 +410,7 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
     }
     hocr_str << "</span>";
     tcnt = 1;
-    gcnt = 1;
+    ccnt = 1;
     wcnt++;
     // Close any ending block/paragraph/textline.
     if (last_word_in_line) {

--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -240,7 +240,7 @@ void Tesseract::LSTMRecognizeWord(const BLOCK& block, ROW *row, WERD_RES *word,
   lstm_recognizer_->RecognizeLine(*im_data, true, classify_debug_level > 0,
                                   kWorstDictCertainty / kCertaintyScale,
                                   word_box, words, lstm_choice_mode,
-                                  lstm_choice_amount);
+                                  lstm_choice_iterations);
   delete im_data;
   SearchWords(words);
 }

--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -43,7 +43,8 @@ LTRResultIterator::~LTRResultIterator() = default;
 // Returns the null terminated UTF-8 encoded text string for the current
 // object at the given level. Use delete [] to free after use.
 char* LTRResultIterator::GetUTF8Text(PageIteratorLevel level) const {
-  if (it_->word() == nullptr) return nullptr;  // Already at the end!
+  if (it_->word() == nullptr)
+    return nullptr;  // Already at the end!
   STRING text;
   PAGE_RES_IT res_it(*it_);
   WERD_CHOICE* best_choice = res_it.word()->best_choice;
@@ -70,7 +71,8 @@ char* LTRResultIterator::GetUTF8Text(PageIteratorLevel level) const {
         eop = res_it.block() != res_it.prev_block() ||
               res_it.row()->row->para() != res_it.prev_row()->row->para();
       } while (level != RIL_TEXTLINE && !eop);
-      if (eop) text += paragraph_separator_;
+      if (eop)
+        text += paragraph_separator_;
     } while (level == RIL_BLOCK && res_it.block() == res_it.prev_block());
   }
   int length = text.length() + 1;
@@ -92,7 +94,8 @@ void LTRResultIterator::SetParagraphSeparator(const char* new_para) {
 // Returns the mean confidence of the current object at the given level.
 // The number should be interpreted as a percent probability. (0.0f-100.0f)
 float LTRResultIterator::Confidence(PageIteratorLevel level) const {
-  if (it_->word() == nullptr) return 0.0f;  // Already at the end!
+  if (it_->word() == nullptr)
+    return 0.0f;  // Already at the end!
   float mean_certainty = 0.0f;
   int certainty_count = 0;
   PAGE_RES_IT res_it(*it_);
@@ -211,18 +214,23 @@ const char* LTRResultIterator::WordRecognitionLanguage() const {
 
 // Return the overall directionality of this word.
 StrongScriptDirection LTRResultIterator::WordDirection() const {
-  if (it_->word() == nullptr) return DIR_NEUTRAL;
+  if (it_->word() == nullptr)
+    return DIR_NEUTRAL;
   bool has_rtl = it_->word()->AnyRtlCharsInWord();
   bool has_ltr = it_->word()->AnyLtrCharsInWord();
-  if (has_rtl && !has_ltr) return DIR_RIGHT_TO_LEFT;
-  if (has_ltr && !has_rtl) return DIR_LEFT_TO_RIGHT;
-  if (!has_ltr && !has_rtl) return DIR_NEUTRAL;
+  if (has_rtl && !has_ltr)
+    return DIR_RIGHT_TO_LEFT;
+  if (has_ltr && !has_rtl)
+    return DIR_LEFT_TO_RIGHT;
+  if (!has_ltr && !has_rtl)
+    return DIR_NEUTRAL;
   return DIR_MIX;
 }
 
 // Returns true if the current word was found in a dictionary.
 bool LTRResultIterator::WordIsFromDictionary() const {
-  if (it_->word() == nullptr) return false;  // Already at the end!
+  if (it_->word() == nullptr)
+    return false;  // Already at the end!
   int permuter = it_->word()->best_choice->permuter();
   return permuter == SYSTEM_DAWG_PERM || permuter == FREQ_DAWG_PERM ||
          permuter == USER_DAWG_PERM;
@@ -230,13 +238,15 @@ bool LTRResultIterator::WordIsFromDictionary() const {
 
 // Returns the number of blanks before the current word.
 int LTRResultIterator::BlanksBeforeWord() const {
-  if (it_->word() == nullptr) return 1;
+  if (it_->word() == nullptr)
+    return 1;
   return it_->word()->word->space();
 }
 
 // Returns true if the current word is numeric.
 bool LTRResultIterator::WordIsNumeric() const {
-  if (it_->word() == nullptr) return false;  // Already at the end!
+  if (it_->word() == nullptr)
+    return false;  // Already at the end!
   int permuter = it_->word()->best_choice->permuter();
   return permuter == NUMBER_PERM;
 }
@@ -269,7 +279,8 @@ const char* LTRResultIterator::GetBlamerMisadaptionDebug() const {
 
 // Returns true if a truth string was recorded for the current word.
 bool LTRResultIterator::HasTruthString() const {
-  if (it_->word() == nullptr) return false;  // Already at the end!
+  if (it_->word() == nullptr)
+    return false;  // Already at the end!
   if (it_->word()->blamer_bundle == nullptr ||
       it_->word()->blamer_bundle->NoTruth()) {
     return false;  // no truth information for this word
@@ -280,7 +291,8 @@ bool LTRResultIterator::HasTruthString() const {
 // Returns true if the given string is equivalent to the truth string for
 // the current word.
 bool LTRResultIterator::EquivalentToTruth(const char* str) const {
-  if (!HasTruthString()) return false;
+  if (!HasTruthString())
+    return false;
   ASSERT_HOST(it_->word()->uch_set != nullptr);
   WERD_CHOICE str_wd(str, *(it_->word()->uch_set));
   return it_->word()->blamer_bundle->ChoiceIsCorrect(&str_wd);
@@ -289,7 +301,8 @@ bool LTRResultIterator::EquivalentToTruth(const char* str) const {
 // Returns the null terminated UTF-8 encoded truth string for the current word.
 // Use delete [] to free after use.
 char* LTRResultIterator::WordTruthUTF8Text() const {
-  if (!HasTruthString()) return nullptr;
+  if (!HasTruthString())
+    return nullptr;
   STRING truth_text = it_->word()->blamer_bundle->TruthString();
   int length = truth_text.length() + 1;
   char* result = new char[length];
@@ -300,7 +313,8 @@ char* LTRResultIterator::WordTruthUTF8Text() const {
 // Returns the null terminated UTF-8 encoded normalized OCR string for the
 // current word. Use delete [] to free after use.
 char* LTRResultIterator::WordNormedUTF8Text() const {
-  if (it_->word() == nullptr) return nullptr;  // Already at the end!
+  if (it_->word() == nullptr)
+    return nullptr;  // Already at the end!
   STRING ocr_text;
   WERD_CHOICE* best_choice = it_->word()->best_choice;
   const UNICHARSET* unicharset = it_->word()->uch_set;
@@ -317,8 +331,10 @@ char* LTRResultIterator::WordNormedUTF8Text() const {
 // Returns a pointer to serialized choice lattice.
 // Fills lattice_size with the number of bytes in lattice data.
 const char* LTRResultIterator::WordLattice(int* lattice_size) const {
-  if (it_->word() == nullptr) return nullptr;  // Already at the end!
-  if (it_->word()->blamer_bundle == nullptr) return nullptr;
+  if (it_->word() == nullptr)
+    return nullptr;  // Already at the end!
+  if (it_->word()->blamer_bundle == nullptr)
+    return nullptr;
   *lattice_size = it_->word()->blamer_bundle->lattice_size();
   return it_->word()->blamer_bundle->lattice_data();
 }
@@ -357,11 +373,15 @@ ChoiceIterator::ChoiceIterator(const LTRResultIterator& result_it) {
   oemLSTM_ = word_res_->tesseract->AnyLSTMLang();
   oemLegacy_ = word_res_->tesseract->AnyTessLang();
   rating_coefficient_ = word_res_->tesseract->lstm_rating_coefficient;
-  BLOB_CHOICE_LIST* choices = nullptr;
+  blanks_before_word_ = result_it.BlanksBeforeWord();
+  BLOB_CHOICE_LIST* choices = nullptr; 
   tstep_index_ = &result_it.blob_index_;
   if (oemLSTM_ && !word_res_->CTC_symbol_choices.empty()) {
+    if (strcmp(word_res_->CTC_symbol_choices[0][0].first, " ")) {
+      blanks_before_word_ = 0;
+    }
     auto index = *tstep_index_;
-    if (word_res_->leading_space) ++index;
+    index += blanks_before_word_;
     if (index < word_res_->CTC_symbol_choices.size()) {
       LSTM_choices_ = &word_res_->CTC_symbol_choices[index];
       filterSpaces();
@@ -379,7 +399,9 @@ ChoiceIterator::ChoiceIterator(const LTRResultIterator& result_it) {
     LSTM_choice_it_ = LSTM_choices_->begin();
   }
 }
-ChoiceIterator::~ChoiceIterator() { delete choice_it_; }
+ChoiceIterator::~ChoiceIterator() {
+  delete choice_it_;
+}
 
 // Moves to the next choice for the symbol and returns false if there
 // are none left.
@@ -393,7 +415,8 @@ bool ChoiceIterator::Next() {
       return true;
     }
   } else {
-    if (choice_it_ == nullptr) return false;
+    if (choice_it_ == nullptr)
+      return false;
     choice_it_->forward();
     return !choice_it_->cycled_list();
   }
@@ -406,7 +429,8 @@ const char* ChoiceIterator::GetUTF8Text() const {
     std::pair<const char*, float> choice = *LSTM_choice_it_;
     return choice.first;
   } else {
-    if (choice_it_ == nullptr) return nullptr;
+    if (choice_it_ == nullptr)
+      return nullptr;
     UNICHAR_ID id = choice_it_->data()->unichar_id();
     return word_res_->uch_set->id_to_unichar_ext(id);
   }
@@ -416,15 +440,16 @@ const char* ChoiceIterator::GetUTF8Text() const {
 // data. If only LSTM traineddata is used the value range is 0.0f - 1.0f. All
 // choices for one symbol should roughly add up to 1.0f.
 // If only traineddata of the legacy engine is used, the number should be
-// interpreted as a percent probability. (0.0f-100.0f) In this case probabilities
-// won't add up to 100. Each one stands on its own.
+// interpreted as a percent probability. (0.0f-100.0f) In this case
+// probabilities won't add up to 100. Each one stands on its own.
 float ChoiceIterator::Confidence() const {
   float confidence;
   if (oemLSTM_ && LSTM_choices_ != nullptr && !LSTM_choices_->empty()) {
     std::pair<const char*, float> choice = *LSTM_choice_it_;
     confidence = 100 - rating_coefficient_ * choice.second;
   } else {
-    if (choice_it_ == nullptr) return 0.0f;
+    if (choice_it_ == nullptr)
+      return 0.0f;
     confidence = 100 + 5 * choice_it_->data()->certainty();
   }
   return ClipToRange(confidence, 0.0f, 100.0f);
@@ -433,17 +458,16 @@ float ChoiceIterator::Confidence() const {
 // Returns the set of timesteps which belong to the current symbol
 std::vector<std::vector<std::pair<const char*, float>>>*
 ChoiceIterator::Timesteps() const {
-  if (word_res_->segmented_timesteps.empty() || !oemLSTM_)
+  int offset = *tstep_index_ + blanks_before_word_;
+  if (offset >= word_res_->segmented_timesteps.size() || !oemLSTM_) {
     return nullptr;
-  if (word_res_->leading_space) {
-    return &word_res_->segmented_timesteps[*(tstep_index_) + 1];
-  } else {
-    return &word_res_->segmented_timesteps[*tstep_index_];
   }
+  return &word_res_->segmented_timesteps[*tstep_index_ + blanks_before_word_];
 }
 
 void ChoiceIterator::filterSpaces() {
-  if (LSTM_choices_->empty()) return;
+  if (LSTM_choices_->empty())
+    return;
   std::vector<std::pair<const char*, float>>::iterator it;
   for (it = LSTM_choices_->begin(); it != LSTM_choices_->end();) {
     if (!strcmp(it->first, " ")) {

--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -433,11 +433,12 @@ float ChoiceIterator::Confidence() const {
 // Returns the set of timesteps which belong to the current symbol
 std::vector<std::vector<std::pair<const char*, float>>>*
 ChoiceIterator::Timesteps() const {
-  if (word_res_->symbol_steps.empty() || !oemLSTM_) return nullptr;
+  if (word_res_->segmented_timesteps.empty() || !oemLSTM_)
+    return nullptr;
   if (word_res_->leading_space) {
-    return &word_res_->symbol_steps[*(tstep_index_) + 1];
+    return &word_res_->segmented_timesteps[*(tstep_index_) + 1];
   } else {
-    return &word_res_->symbol_steps[*tstep_index_];
+    return &word_res_->segmented_timesteps[*tstep_index_];
   }
 }
 

--- a/src/ccmain/ltrresultiterator.h
+++ b/src/ccmain/ltrresultiterator.h
@@ -239,6 +239,8 @@ class ChoiceIterator {
   bool oemLegacy_;
   // regulates the rating granularity
   double rating_coefficient_;
+  // leading blanks
+  int blanks_before_word_;
 };
 
 }  // namespace tesseract.

--- a/src/ccmain/resultiterator.cpp
+++ b/src/ccmain/resultiterator.cpp
@@ -639,10 +639,10 @@ char* ResultIterator::GetUTF8Text(PageIteratorLevel level) const {
   strncpy(result, text.string(), length);
   return result;
 }
-std::vector<std::vector<std::pair<const char*, float>>>*
+std::vector<std::vector<std::vector<std::pair<const char*, float>>>>*
 ResultIterator::GetRawLSTMTimesteps() const {
   if (it_->word() != nullptr) {
-    return &it_->word()->raw_timesteps;
+    return &it_->word()->segmented_timesteps;
   } else {
     return nullptr;
   }
@@ -651,25 +651,7 @@ ResultIterator::GetRawLSTMTimesteps() const {
 std::vector<std::vector<std::pair<const char*, float>>>*
 ResultIterator::GetBestLSTMSymbolChoices() const {
   if (it_->word() != nullptr) {
-    return &it_->word()->accumulated_timesteps;
-  } else {
-    return nullptr;
-  }
-}
-
-std::vector<std::vector<std::pair<const char*, float>>>*
-ResultIterator::GetBestCTCSymbolChoices() const {
-  if (it_->word() != nullptr) {
     return &it_->word()->CTC_symbol_choices;
-  } else {
-    return nullptr;
-  }
-}
-
-std::vector<std::vector<std::vector<std::pair<const char*, float>>>>*
-ResultIterator::GetSegmentedLSTMTimesteps() const {
-  if (it_->word() != nullptr) {
-    return &it_->word()->symbol_steps;
   } else {
     return nullptr;
   }

--- a/src/ccmain/resultiterator.h
+++ b/src/ccmain/resultiterator.h
@@ -100,14 +100,10 @@ class TESS_API ResultIterator : public LTRResultIterator {
   /**
    * Returns the LSTM choices for every LSTM timestep for the current word.
   */
-  virtual std::vector<std::vector<std::pair<const char*, float>>>*
+  virtual std::vector<std::vector<std::vector<std::pair<const char*, float>>>>*
   GetRawLSTMTimesteps() const;
   virtual std::vector<std::vector<std::pair<const char*, float>>>*
     GetBestLSTMSymbolChoices() const;
-  virtual std::vector<std::vector<std::pair<const char*, float>>>*
-  GetBestCTCSymbolChoices() const;
-  virtual std::vector<std::vector<std::vector<std::pair<const char*, float>>>>*
-    GetSegmentedLSTMTimesteps() const;
 
   /**
    * Return whether the current paragraph's dominant reading direction

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -529,8 +529,8 @@ Tesseract::Tesseract()
           "character.",
           this->params()),
       INT_MEMBER(
-          lstm_choice_amount, 5,
-          "Sets the number of choices one get per character in "
+          lstm_choice_iterations, 5,
+          "Sets the number of cascading iterations for the Beamsearch in "
           "lstm_choice_mode. Note that lstm_choice_mode must be set to a "
           "value greater than 0 to produce results.",
                  this->params()),

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -522,13 +522,9 @@ Tesseract::Tesseract()
                     this->params()),
       INT_MEMBER(lstm_choice_mode, 0,
           "Allows to include alternative symbols choices in the hOCR output. "
-          "Valid input values are 0, 1, 2 and 3. 0 is the default value. "
+          "Valid input values are 0, 1 and 2. 0 is the default value. "
           "With 1 the alternative symbol choices per timestep are included. "
-          "With 2 the alternative symbol choices are accumulated per "
-          "character. "
-          "With 3 the alternative symbol choices per timestep are included "
-          "and separated by the suggested segmentation of Tesseract. "
-          "With 4 alternative symbol choices are extracted from the CTC "
+          "With 2 alternative symbol choices are extracted from the CTC "
           "process instead of the lattice. The choices are mapped per "
           "character.",
           this->params()),

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -1091,8 +1091,8 @@ class Tesseract : public Wordrec {
             "With 2 the alternative symbol choices are extracted from the CTC "
             "process instead of the lattice. The choices are mapped per "
             "character.");
-  INT_VAR_H(lstm_choice_amount, 5,
-            "Sets the number of choices one get per character in "
+  INT_VAR_H(lstm_choice_iterations, 5,
+            "Sets the number of cascading iterations for the Beamsearch in "
             "lstm_choice_mode. Note that lstm_choice_mode must be set to "
             "a value greater than 0 to produce results.");
   double_VAR_H(lstm_rating_coefficient, 5, 

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -1086,13 +1086,9 @@ class Tesseract : public Wordrec {
   INT_VAR_H(lstm_choice_mode, 0,
             "Allows to include alternative symbols choices in the hOCR "
             "output. "
-            "Valid input values are 0, 1, 2 and 3. 0 is the default value. "
+            "Valid input values are 0, 1 and 2. 0 is the default value. "
             "With 1 the alternative symbol choices per timestep are included. "
-            "With 2 the alternative symbol choices are accumulated per "
-            "character. "
-            "With 3 the alternative symbol choices per timestep are included "
-            "and separated by the suggested segmentation of Tesseract. "
-            "With 4 alternative symbol choices are extracted from the CTC "
+            "With 2 the alternative symbol choices are extracted from the CTC "
             "process instead of the lattice. The choices are mapped per "
             "character.");
   INT_VAR_H(lstm_choice_amount, 5,

--- a/src/ccstruct/pageres.h
+++ b/src/ccstruct/pageres.h
@@ -219,14 +219,15 @@ class WERD_RES : public ELIST_LINK {
   // blob i and blob i+1.
   GenericVector<int> blob_gaps;
   // Stores the lstm choices of every timestep
-  std::vector<std::vector<std::pair<const char*, float>>> raw_timesteps;
-  std::vector<std::vector<std::pair<const char*, float>>> accumulated_timesteps;
-  std::vector<std::vector<std::vector<std::pair<const char*, float>>>>
-      symbol_steps;
+  std::vector<std::vector<std::pair<const char*, float>>> timesteps;
+  // Stores the lstm choices of every timestep segmented by character
+  std::vector<std::vector<std::vector<std::pair<const char*, float>>>> segmented_timesteps;
   //Symbolchoices aquired during CTC
   std::vector<std::vector<std::pair<const char*, float>>> CTC_symbol_choices;
   // Stores if the timestep vector starts with a space
   bool leading_space = false;
+  // Stores value when the word ends
+  int end;
   // Ratings matrix contains classifier choices for each classified combination
   // of blobs. The dimension is the same as the number of blobs in chopped_word
   // and the leading diagonal corresponds to classifier results of the blobs

--- a/src/ccstruct/pageres.h
+++ b/src/ccstruct/pageres.h
@@ -221,7 +221,8 @@ class WERD_RES : public ELIST_LINK {
   // Stores the lstm choices of every timestep
   std::vector<std::vector<std::pair<const char*, float>>> timesteps;
   // Stores the lstm choices of every timestep segmented by character
-  std::vector<std::vector<std::vector<std::pair<const char*, float>>>> segmented_timesteps;
+  std::vector<std::vector<std::vector<
+    std::pair<const char*, float>>>> segmented_timesteps;
   //Symbolchoices aquired during CTC
   std::vector<std::vector<std::pair<const char*, float>>> CTC_symbol_choices;
   // Stores if the timestep vector starts with a space

--- a/src/lstm/recodebeam.cpp
+++ b/src/lstm/recodebeam.cpp
@@ -119,8 +119,8 @@ void RecodeBeamSearch::DecodeSecondaryBeams(const NetworkIO& output,
     {
       ++bucketNumber;
     }
-    ComputeSecTopN(&(excludedUnichars)[bucketNumber], output.f(t), output.NumFeatures(),
-                   kBeamWidths[0]);
+    ComputeSecTopN(&(excludedUnichars)[bucketNumber], output.f(t),
+                     output.NumFeatures(), kBeamWidths[0]);
     DecodeSecondaryStep(output.f(t), t, dict_ratio, cert_offset, worst_dict_cert,
                charset);
   }
@@ -161,7 +161,7 @@ void RecodeBeamSearch::segmentTimestepsByCharacters() {
       segment.push_back(timesteps[j]);
     }
     segmentedTimesteps.push_back(segment);
-  } 
+  }
 }
 std::vector<std::vector<std::pair<const char*, float>>>
   RecodeBeamSearch::combineSegmentedTimesteps(
@@ -628,7 +628,7 @@ WERD_RES* RecodeBeamSearch::InitializeWord(bool leading_space,
   WERD* word = new WERD(&blobs, leading_space, nullptr);
   // Make a WERD_RES from the word.
   auto* word_res = new WERD_RES(word);
-  word_res->end = word_end;
+  word_res->end = word_end - word_start + leading_space;
   word_res->uch_set = unicharset;
   word_res->combination = true;  // Give it ownership of the word.
   word_res->space_certainty = space_certainty;
@@ -675,7 +675,8 @@ void RecodeBeamSearch::ComputeSecTopN(std::unordered_set<int>* exList,
   second_code_ = -1;
   top_heap_.clear();
   for (int i = 0; i < num_outputs; ++i) {
-    if ((top_heap_.size() < top_n || outputs[i] > top_heap_.PeekTop().key) && !exList->count(i)) {
+    if ((top_heap_.size() < top_n || outputs[i] > top_heap_.PeekTop().key)
+        && !exList->count(i)) {
       TopPair entry(outputs[i], i);
       top_heap_.Push(&entry);
       if (top_heap_.size() > top_n) top_heap_.Pop(&entry);

--- a/src/lstm/recodebeam.h
+++ b/src/lstm/recodebeam.h
@@ -227,9 +227,17 @@ class RecodeBeamSearch {
   // Generates debug output of the content of the beams after a Decode.
   void PrintBeam2(bool uids, int num_outputs, const UNICHARSET* charset,
                   bool secondary) const;
+
+  void segmentTimestepsByCharacters();
+  std::vector<std::vector<std::pair<const char*, float>>>
+  combineSegmentedTimesteps(
+      std::vector<std::vector<std::vector<std::pair<const char*, float>>>>*
+          segmentedTimesteps);
   // Stores the alternative characters of every timestep together with their
   // probability.
   std::vector< std::vector<std::pair<const char*, float>>> timesteps;
+  std::vector<std::vector<std::vector<std::pair<const char*, float>>>>
+      segmentedTimesteps;
   std::vector<std::vector<std::pair<const char*, float>>> ctc_choices;
   std::vector<std::unordered_set<int>> excludedUnichars;
   // Stores the character boundaries regarding timesteps.
@@ -301,9 +309,7 @@ class RecodeBeamSearch {
       const GenericVector<const RecodeNode*>& best_nodes,
       GenericVector<int>* unichar_ids, GenericVector<float>* certs,
       GenericVector<float>* ratings, GenericVector<int>* xcoords,
-      std::vector<int>* character_boundaries = nullptr,
-      std::deque<std::tuple<int, int>>* best_choices = nullptr,
-      std::deque<std::tuple<int, int>>* best_choices_acc = nullptr);
+      std::vector<int>* character_boundaries = nullptr);
 
   // Sets up a word with the ratings matrix and fake blobs with boxes in the
   // right places.

--- a/src/lstm/recodebeam.h
+++ b/src/lstm/recodebeam.h
@@ -227,9 +227,10 @@ class RecodeBeamSearch {
   // Generates debug output of the content of the beams after a Decode.
   void PrintBeam2(bool uids, int num_outputs, const UNICHARSET* charset,
                   bool secondary) const;
-
+  // Segments the timestep bundle by the character_boundaries.
   void segmentTimestepsByCharacters();
   std::vector<std::vector<std::pair<const char*, float>>>
+  // Unions the segmented timestep character bundles to one big bundle.
   combineSegmentedTimesteps(
       std::vector<std::vector<std::vector<std::pair<const char*, float>>>>*
           segmentedTimesteps);
@@ -238,7 +239,9 @@ class RecodeBeamSearch {
   std::vector< std::vector<std::pair<const char*, float>>> timesteps;
   std::vector<std::vector<std::vector<std::pair<const char*, float>>>>
       segmentedTimesteps;
+  // Stores the character choices found in the ctc algorithm
   std::vector<std::vector<std::pair<const char*, float>>> ctc_choices;
+  // Stores all unicharids which are excluded for future iterations
   std::vector<std::unordered_set<int>> excludedUnichars;
   // Stores the character boundaries regarding timesteps.
   std::vector<int> character_boundaries_;


### PR DESCRIPTION
Overhaul of the lstm_choice_mode

- Made the `lstm_choice_mode` compatible with `hocr_char_boxes`.

- Improved the choice mode algorithm to increase the performance.

- Cut down the different modes to the two essentiell ones.
  - `lstm_choice_mode`=1 returns the timesteps segemented by character. This replaces mode 1 and 3 with no loss of information.
  - `lstm_choice_mode`=2 returns alternative choices per character based on the new ctc retrieval algorithm. This replaces mode 2 and 4. The former mode 2 is completely dropped as it worked only for languages with a smaller amount of characters than output channels of the LSTM.
- Renamed `lstm_choice_amount` to `lstm_choice_iterations` because of the misleading title.

    