### PR TITLE
Fix several runtime errors detected by UndefinedBehaviorSanitizer

### DIFF
--- a/src/ccmain/osdetect.cpp
+++ b/src/ccmain/osdetect.cpp
@@ -105,7 +105,7 @@ void OSResults::update_best_script(int orientation) {
       second = scripts_na[orientation][i];
     }
   }
-  best_result.sconfidence =
+  best_result.sconfidence = (second == 0.0f) ? 2.0f :
       (first / second - 1.0) / (kScriptAcceptRatio - 1.0);
 }
 

--- a/src/ccutil/bitvector.cpp
+++ b/src/ccutil/bitvector.cpp
@@ -115,13 +115,19 @@ BitVector::BitVector(int length) : bit_size_(length) {
 }
 
 BitVector::BitVector(const BitVector& src) : bit_size_(src.bit_size_) {
-  array_ = new uint32_t[WordLength()];
-  memcpy(array_, src.array_, ByteLength());
+  if (src.bit_size_ > 0) {
+    array_ = new uint32_t[WordLength()];
+    memcpy(array_, src.array_, ByteLength());
+  } else {
+    array_ = nullptr;
+  }
 }
 
 BitVector& BitVector::operator=(const BitVector& src) {
   Alloc(src.bit_size_);
-  memcpy(array_, src.array_, ByteLength());
+  if (src.bit_size_ > 0) {
+    memcpy(array_, src.array_, ByteLength());
+  }
   return *this;
 }
 

--- a/src/ccutil/unicharcompress.h
+++ b/src/ccutil/unicharcompress.h
@@ -78,10 +78,10 @@ class RecodedCharID {
   }
   // Hash functor for RecodedCharID.
   struct RecodedCharIDHash {
-    size_t operator()(const RecodedCharID& code) const {
-      size_t result = 0;
+    uint64_t operator()(const RecodedCharID& code) const {
+      uint64_t result = 0;
       for (int i = 0; i < code.length_; ++i) {
-        result ^= code(i) << (7 * i);
+        result ^= static_cast<uint64_t>(code(i)) << (7 * i);
       }
       return result;
     }


### PR DESCRIPTION
Those errors can be reproduced by running the unit tests from a build with sanitizers:

    ./configure '--enable-debug' '--disable-openmp' '--disable-shared' 'CXX=clang++-7' \
      'CXXFLAGS=-g -O0 -D_GLIBCXX_DEBUG -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=fuzzer-no-link,address,undefined -fsanitize-address-use-after-scope'
    make training check
    grep UndefinedBehaviorSanitizer unittest/*log
