### PR TITLE
Remove unused italic, bold in class BLOCK_RES and class WORD_RES

### DIFF
--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -1981,8 +1981,6 @@ void Tesseract::set_word_fonts(WERD_RES *word) {
   GenericVector<int> font_total_score;
   font_total_score.init_to_size(fontinfo_size, 0);
 
-  word->italic = 0;
-  word->bold = 0;
   // Compute the font scores for the word
   if (tessedit_debug_fonts) {
     tprintf("Examining fonts in %s\n",
@@ -2036,8 +2034,6 @@ void Tesseract::set_word_fonts(WERD_RES *word) {
                 fi.name, word->fontinfo_id_count);
       }
     }
-    word->italic = (fi.is_italic() ? 1 : -1) * word->fontinfo_id_count;
-    word->bold = (fi.is_bold() ? 1 : -1) * word->fontinfo_id_count;
   }
 #endif  // ndef DISABLED_LEGACY_ENGINE
 }
@@ -2096,8 +2092,6 @@ void Tesseract::font_recognition_pass(PAGE_RES* page_res) {
       word->fontinfo = modal_font;
       // Counts only get 1 as it came from the doc.
       word->fontinfo_id_count = 1;
-      word->italic = modal_font->is_italic() ? 1 : -1;
-      word->bold = modal_font->is_bold() ? 1 : -1;
     }
   }
 }

--- a/src/ccstruct/pageres.cpp
+++ b/src/ccstruct/pageres.cpp
@@ -101,8 +101,6 @@ BLOCK_RES::BLOCK_RES(bool merge_similar_words, BLOCK *the_block) {
   font_class = -1;               //not assigned
   x_height = -1.0;
   font_assigned = false;
-  bold = false;
-  italic = false;
   row_count = 0;
 
   block = the_block;
@@ -257,8 +255,6 @@ void WERD_RES::CopySimpleFields(const WERD_RES& source) {
   unlv_crunch_mode = source.unlv_crunch_mode;
   small_caps = source.small_caps;
   odd_size = source.odd_size;
-  italic = source.italic;
-  bold = source.bold;
   fontinfo = source.fontinfo;
   fontinfo2 = source.fontinfo2;
   fontinfo_id_count = source.fontinfo_id_count;

--- a/src/ccstruct/pageres.h
+++ b/src/ccstruct/pageres.h
@@ -120,8 +120,6 @@ class BLOCK_RES:public ELIST_LINK {
   float x_height;
   bool font_assigned;         // block already
   //      processed
-  bool bold;                  // all bold
-  bool italic;                // all italic
 
   ROW_RES_LIST row_res_list;
 
@@ -306,8 +304,6 @@ class WERD_RES : public ELIST_LINK {
   bool done = false;            // ready for output?
   bool small_caps = false;      // word appears to be small caps
   bool odd_size = false;        // word is bigger than line or leader dots.
-  bool italic = false;
-  bool bold = false;
   // The fontinfos are pointers to data owned by the classifier.
   const FontInfo* fontinfo = nullptr;
   const FontInfo* fontinfo2 = nullptr;


### PR DESCRIPTION
This also fixes CID 1405626 and CID 1405627 which were introduced by commit
8ff321e41a5786f399139669ff7a94145749c45a.

Signed-off-by: Stefan Weil <sw@weilnetz.de>