### PR TITLE
Remove member functions STRING::string and StringParam::string

### DIFF
--- a/src/api/altorenderer.cpp
+++ b/src/api/altorenderer.cpp
@@ -133,9 +133,9 @@ char* TessBaseAPI::GetAltoText(ETEXT_DESC* monitor, int page_number) {
 #ifdef _WIN32
   // convert input name from ANSI encoding to utf-8
   int str16_len =
-      MultiByteToWideChar(CP_ACP, 0, input_file_->string(), -1, nullptr, 0);
+      MultiByteToWideChar(CP_ACP, 0, input_file_->c_str(), -1, nullptr, 0);
   wchar_t* uni16_str = new WCHAR[str16_len];
-  str16_len = MultiByteToWideChar(CP_ACP, 0, input_file_->string(), -1,
+  str16_len = MultiByteToWideChar(CP_ACP, 0, input_file_->c_str(), -1,
                                   uni16_str, str16_len);
   int utf8_len = WideCharToMultiByte(CP_UTF8, 0, uni16_str, str16_len, nullptr,
                                      0, nullptr, nullptr);

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -121,11 +121,11 @@ const int kMaxIntSize = 22;
 static void addAvailableLanguages(const STRING &datadir, const STRING &base,
                                   GenericVector<STRING>* langs)
 {
-  const STRING base2 = (base.string()[0] == '\0') ? base : base + "/";
+  const STRING base2 = (base.c_str()[0] == '\0') ? base : base + "/";
   const size_t extlen = sizeof(kTrainedDataSuffix);
 #ifdef _WIN32
     WIN32_FIND_DATA data;
-    HANDLE handle = FindFirstFile((datadir + base2 + "*").string(), &data);
+    HANDLE handle = FindFirstFile((datadir + base2 + "*").c_str(), &data);
     if (handle != INVALID_HANDLE_VALUE) {
       BOOL result = TRUE;
       for (; result;) {
@@ -149,7 +149,7 @@ static void addAvailableLanguages(const STRING &datadir, const STRING &base,
       FindClose(handle);
     }
 #else  // _WIN32
-  DIR* dir = opendir((datadir + base).string());
+  DIR* dir = opendir((datadir + base).c_str());
   if (dir != nullptr) {
     dirent *de;
     while ((de = readdir(dir))) {
@@ -157,7 +157,7 @@ static void addAvailableLanguages(const STRING &datadir, const STRING &base,
       // Skip '.', '..', and hidden files
       if (name[0] != '.') {
         struct stat st;
-        if (stat((datadir + base2 + name).string(), &st) == 0 &&
+        if (stat((datadir + base2 + name).c_str(), &st) == 0 &&
             (st.st_mode & S_IFDIR) == S_IFDIR) {
           addAvailableLanguages(datadir, base2 + name, langs);
         } else {
@@ -301,7 +301,7 @@ bool TessBaseAPI::GetBoolVariable(const char *name, bool *value) const {
 const char *TessBaseAPI::GetStringVariable(const char *name) const {
   auto *p = ParamUtils::FindParam<StringParam>(
       name, GlobalParams()->string_params, tesseract_->params()->string_params);
-  return (p != nullptr) ? p->string() : nullptr;
+  return (p != nullptr) ? p->c_str() : nullptr;
 }
 
 bool TessBaseAPI::GetDoubleVariable(const char *name, double *value) const {
@@ -376,8 +376,8 @@ int TessBaseAPI::Init(const char* data, int data_size, const char* language,
       mgr.LoadMemBuffer(language, data, data_size);
     }
     if (tesseract_->init_tesseract(
-            datapath.string(),
-            output_file_ != nullptr ? output_file_->string() : nullptr,
+            datapath.c_str(),
+            output_file_ != nullptr ? output_file_->c_str() : nullptr,
             language, oem, configs, configs_size, vars_vec, vars_values,
             set_only_non_debug_params, &mgr) != 0) {
       return -1;
@@ -389,8 +389,8 @@ int TessBaseAPI::Init(const char* data, int data_size, const char* language,
     datapath_ = new STRING(datapath);
   else
     *datapath_ = datapath;
-  if ((strcmp(datapath_->string(), "") == 0) &&
-      (strcmp(tesseract_->datadir.string(), "") != 0))
+  if ((strcmp(datapath_->c_str(), "") == 0) &&
+      (strcmp(tesseract_->datadir.c_str(), "") != 0))
      *datapath_ = tesseract_->datadir;
 
   if (language_ == nullptr)
@@ -417,8 +417,8 @@ int TessBaseAPI::Init(const char* data, int data_size, const char* language,
  * The returned string should NOT be deleted.
  */
 const char* TessBaseAPI::GetInitLanguagesAsString() const {
-  return (language_ == nullptr || language_->string() == nullptr) ?
-      "" : language_->string();
+  return (language_ == nullptr || language_->c_str() == nullptr) ?
+      "" : language_->c_str();
 }
 
 /**
@@ -1073,7 +1073,7 @@ bool TessBaseAPI::ProcessPages(const char* filename, const char* retry_config,
   if (result) {
     if (tesseract_->tessedit_train_from_boxes &&
         !tesseract_->WriteTRFile(*output_file_)) {
-      tprintf("Write of TR file failed: %s\n", output_file_->string());
+      tprintf("Write of TR file failed: %s\n", output_file_->c_str());
       return false;
     }
   }
@@ -1317,7 +1317,7 @@ char* TessBaseAPI::GetUTF8Text() {
     text += para_text.get();
   } while (it->Next(RIL_PARA));
   char* result = new char[text.length() + 1];
-  strncpy(result, text.string(), text.length() + 1);
+  strncpy(result, text.c_str(), text.length() + 1);
   delete it;
   return result;
 }
@@ -1439,7 +1439,7 @@ char* TessBaseAPI::GetTSVText(int page_number) {
   }
 
   char* ret = new char[tsv_str.length() + 1];
-  strcpy(ret, tsv_str.string());
+  strcpy(ret, tsv_str.c_str());
   delete res_it;
   return ret;
 }
@@ -1571,7 +1571,7 @@ char* TessBaseAPI::GetUNLVText() {
       // NORMAL PROCESSING of non tilde crunched words.
       tilde_crunch_written = false;
       tesseract_->set_unlv_suspects(word);
-      const char* wordstr = word->best_choice->unichar_string().string();
+      const char* wordstr = word->best_choice->unichar_string().c_str();
       const STRING& lengths = word->best_choice->unichar_lengths();
       int length = lengths.length();
       int i = 0;
@@ -2048,7 +2048,7 @@ int TessBaseAPI::FindLines() {
 #ifndef DISABLED_LEGACY_ENGINE
   if (tesseract_->textord_equation_detect) {
     if (equ_detect_ == nullptr && datapath_ != nullptr) {
-      equ_detect_ = new EquationDetect(datapath_->string(), nullptr);
+      equ_detect_ = new EquationDetect(datapath_->c_str(), nullptr);
     }
     if (equ_detect_ == nullptr) {
       tprintf("Warning: Could not set equation detector\n");
@@ -2062,7 +2062,7 @@ int TessBaseAPI::FindLines() {
   OSResults osr;
   if (PSM_OSD_ENABLED(tesseract_->tessedit_pageseg_mode) &&
       osd_tess == nullptr) {
-    if (strcmp(language_->string(), "osd") == 0) {
+    if (strcmp(language_->c_str(), "osd") == 0) {
       osd_tess = tesseract_;
     } else {
       osd_tesseract_ = new Tesseract;
@@ -2072,7 +2072,7 @@ int TessBaseAPI::FindLines() {
                 " but data path is undefined\n");
         delete osd_tesseract_;
         osd_tesseract_ = nullptr;
-      } else if (osd_tesseract_->init_tesseract(datapath_->string(), nullptr,
+      } else if (osd_tesseract_->init_tesseract(datapath_->c_str(), nullptr,
                                                 "osd", OEM_TESSERACT_ONLY,
                                                 nullptr, 0, nullptr, nullptr,
                                                 false, &mgr) == 0) {
@@ -2485,8 +2485,8 @@ static void extract_result(TESS_CHAR_IT* out,
   int word_count = 0;
   while (page_res_it.word() != nullptr) {
     WERD_RES *word = page_res_it.word();
-    const char *str = word->best_choice->unichar_string().string();
-    const char *len = word->best_choice->unichar_lengths().string();
+    const char *str = word->best_choice->unichar_string().c_str();
+    const char *len = word->best_choice->unichar_lengths().c_str();
     TBOX real_rect = word->word->bounding_box();
 
     if (word_count)

--- a/src/api/hocrrenderer.cpp
+++ b/src/api/hocrrenderer.cpp
@@ -147,9 +147,9 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
 #ifdef _WIN32
   // convert input name from ANSI encoding to utf-8
   int str16_len =
-      MultiByteToWideChar(CP_ACP, 0, input_file_->string(), -1, nullptr, 0);
+      MultiByteToWideChar(CP_ACP, 0, input_file_->c_str(), -1, nullptr, 0);
   wchar_t* uni16_str = new WCHAR[str16_len];
-  str16_len = MultiByteToWideChar(CP_ACP, 0, input_file_->string(), -1,
+  str16_len = MultiByteToWideChar(CP_ACP, 0, input_file_->c_str(), -1,
                                   uni16_str, str16_len);
   int utf8_len = WideCharToMultiByte(CP_UTF8, 0, uni16_str, str16_len, nullptr,
                                      0, nullptr, nullptr);
@@ -171,7 +171,7 @@ char* TessBaseAPI::GetHOCRText(ETEXT_DESC* monitor, int page_number) {
            << "page_" << page_id << "'";
   hocr_str << " title='image \"";
   if (input_file_) {
-    hocr_str << HOcrEscape(input_file_->string()).c_str();
+    hocr_str << HOcrEscape(input_file_->c_str()).c_str();
   } else {
     hocr_str << "unknown";
   }

--- a/src/api/lstmboxrenderer.cpp
+++ b/src/api/lstmboxrenderer.cpp
@@ -84,7 +84,7 @@ char* TessBaseAPI::GetLSTMBoxText(int page_number=0) {
     lstm_box_str += "\n";  // end of PAGE
   }
   char* ret = new char[lstm_box_str.length() + 1];
-  strcpy(ret, lstm_box_str.string());
+  strcpy(ret, lstm_box_str.c_str());
   delete res_it;
   return ret;
 }

--- a/src/api/renderer.cpp
+++ b/src/api/renderer.cpp
@@ -39,7 +39,7 @@ TessResultRenderer::TessResultRenderer(const char *outputbase,
       happy_(true) {
   if (strcmp(outputbase, "-") && strcmp(outputbase, "stdout")) {
     STRING outfile = STRING(outputbase) + STRING(".") + STRING(file_extension_);
-    fout_ = fopen(outfile.string(), "wb");
+    fout_ = fopen(outfile.c_str(), "wb");
     if (fout_ == nullptr) {
       happy_ = false;
     }

--- a/src/api/tesseractmain.cpp
+++ b/src/api/tesseractmain.cpp
@@ -293,7 +293,7 @@ static void PrintLangsList(tesseract::TessBaseAPI* api) {
   printf("List of available languages (%d):\n", languages.size());
   for (int index = 0; index < languages.size(); ++index) {
     STRING& string = languages[index];
-    printf("%s\n", string.string());
+    printf("%s\n", string.c_str());
   }
   api->End();
 }

--- a/src/api/wordstrboxrenderer.cpp
+++ b/src/api/wordstrboxrenderer.cpp
@@ -81,7 +81,7 @@ char* TessBaseAPI::GetWordStrBoxText(int page_number=0) {
     wordstr_box_str += "\n";
   }
   char* ret = new char[wordstr_box_str.length() + 1];
-  strcpy(ret, wordstr_box_str.string());
+  strcpy(ret, wordstr_box_str.c_str());
   delete res_it;
   return ret;
 }

--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -174,48 +174,48 @@ void SIMDDetect::Update() {
   // Select code for calculation of dot product based on the
   // value of the config variable if that value is not empty.
   const char* dotproduct_method = "generic";
-  if (!strcmp(dotproduct.string(), "auto")) {
+  if (!strcmp(dotproduct.c_str(), "auto")) {
     // Automatic detection. Nothing to be done.
-  } else if (!strcmp(dotproduct.string(), "generic")) {
+  } else if (!strcmp(dotproduct.c_str(), "generic")) {
     // Generic code selected by config variable.
     SetDotProduct(DotProductGeneric);
     dotproduct_method = "generic";
-  } else if (!strcmp(dotproduct.string(), "native")) {
+  } else if (!strcmp(dotproduct.c_str(), "native")) {
     // Native optimized code selected by config variable.
     SetDotProduct(DotProductNative);
     dotproduct_method = "native";
 #if defined(AVX2)
-  } else if (!strcmp(dotproduct.string(), "avx2")) {
+  } else if (!strcmp(dotproduct.c_str(), "avx2")) {
     // AVX2 selected by config variable.
     SetDotProduct(DotProductAVX, &IntSimdMatrix::intSimdMatrixAVX2);
     dotproduct_method = "avx2";
 #endif
 #if defined(AVX)
-  } else if (!strcmp(dotproduct.string(), "avx")) {
+  } else if (!strcmp(dotproduct.c_str(), "avx")) {
     // AVX selected by config variable.
     SetDotProduct(DotProductAVX, &IntSimdMatrix::intSimdMatrixSSE);
     dotproduct_method = "avx";
 #endif
 #if defined(FMA)
-  } else if (!strcmp(dotproduct.string(), "fma")) {
+  } else if (!strcmp(dotproduct.c_str(), "fma")) {
     // FMA selected by config variable.
     SetDotProduct(DotProductFMA, IntSimdMatrix::intSimdMatrix);
     dotproduct_method = "fma";
 #endif
 #if defined(SSE4_1)
-  } else if (!strcmp(dotproduct.string(), "sse")) {
+  } else if (!strcmp(dotproduct.c_str(), "sse")) {
     // SSE selected by config variable.
     SetDotProduct(DotProductSSE, &IntSimdMatrix::intSimdMatrixSSE);
     dotproduct_method = "sse";
 #endif
-  } else if (!strcmp(dotproduct.string(), "std::inner_product")) {
+  } else if (!strcmp(dotproduct.c_str(), "std::inner_product")) {
     // std::inner_product selected by config variable.
     SetDotProduct(DotProductStdInnerProduct);
     dotproduct_method = "std::inner_product";
   } else {
     // Unsupported value of config variable.
     tprintf("Warning, ignoring unsupported config variable value: dotproduct=%s\n",
-            dotproduct.string());
+            dotproduct.c_str());
     tprintf("Support values for dotproduct: auto generic native"
 #if defined(AVX)
             " avx"

--- a/src/ccmain/adaptions.cpp
+++ b/src/ccmain/adaptions.cpp
@@ -36,7 +36,7 @@ bool Tesseract::word_adaptable(  //should we adapt?
         uint16_t mode) {
   if (tessedit_adaption_debug) {
     tprintf("Running word_adaptable() for %s rating %.4f certainty %.4f\n",
-          word->best_choice->unichar_string().string(),
+          word->best_choice->unichar_string().c_str(),
           word->best_choice->rating(), word->best_choice->certainty());
   }
 
@@ -94,7 +94,7 @@ bool Tesseract::word_adaptable(  //should we adapt?
   }
 
   if (flags.bit (CHECK_SPACES) &&
-    (strchr(word->best_choice->unichar_string().string(), ' ') != nullptr)) {
+    (strchr(word->best_choice->unichar_string().c_str(), ' ') != nullptr)) {
     if (tessedit_adaption_debug) tprintf("word contains spaces\n");
     return false;
   }

--- a/src/ccmain/applybox.cpp
+++ b/src/ccmain/applybox.cpp
@@ -132,15 +132,15 @@ PAGE_RES* Tesseract::ApplyBoxes(const STRING& fname,
                                  (i == 0) ? nullptr : &boxes[i - 1],
                                  boxes[i],
                                  (i == box_count - 1) ? nullptr : &boxes[i + 1],
-                                 full_texts[i].string());
+                                 full_texts[i].c_str());
     } else {
       foundit = ResegmentWordBox(block_list, boxes[i],
                                  (i == box_count - 1) ? nullptr : &boxes[i + 1],
-                                 texts[i].string());
+                                 texts[i].c_str());
     }
     if (!foundit) {
       box_failures++;
-      ReportFailedBox(i, boxes[i], texts[i].string(),
+      ReportFailedBox(i, boxes[i], texts[i].c_str(),
                       "FAILURE! Couldn't find a matching blob");
     }
   }
@@ -408,7 +408,7 @@ bool Tesseract::ResegmentCharBox(PAGE_RES* page_res, const TBOX* prev_box,
           tprintf("\n");
           tprintf("Correct text = [[ ");
           for (int j = 0; j < word_res->correct_text.size(); ++j) {
-            tprintf("%s ", word_res->correct_text[j].string());
+            tprintf("%s ", word_res->correct_text[j].c_str());
           }
           tprintf("]]\n");
         }
@@ -784,7 +784,7 @@ void Tesseract::CorrectClassifyWords(PAGE_RES* page_res) {
       // rest is the bounding box location and page number.
       GenericVector<STRING> tokens;
       word_res->correct_text[i].split(' ', &tokens);
-      UNICHAR_ID char_id = unicharset.unichar_to_id(tokens[0].string());
+      UNICHAR_ID char_id = unicharset.unichar_to_id(tokens[0].c_str());
       choice->append_unichar_id_space_allocated(char_id,
                                                 word_res->best_state[i],
                                                 0.0f, 0.0f);
@@ -805,7 +805,7 @@ void Tesseract::ApplyBoxTraining(const STRING& fontname, PAGE_RES* page_res) {
   int word_count = 0;
   for (WERD_RES *word_res = pr_it.word(); word_res != nullptr;
        word_res = pr_it.forward()) {
-    LearnWord(fontname.string(), word_res);
+    LearnWord(fontname.c_str(), word_res);
     ++word_count;
   }
   tprintf("Generated training data for %d words\n", word_count);

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -267,8 +267,8 @@ bool Tesseract::RecogAllWordsPassN(int pass_n, ETEXT_DESC* monitor,
     classify_word_and_language(pass_n, pr_it, word);
     if (tessedit_dump_choices || debug_noise_removal) {
       tprintf("Pass%d: %s [%s]\n", pass_n,
-              word->word->best_choice->unichar_string().string(),
-              word->word->best_choice->debug_string().string());
+              word->word->best_choice->unichar_string().c_str(),
+              word->word->best_choice->debug_string().c_str());
     }
     pr_it->forward();
     if (make_next_word_fuzzy && pr_it->word() != nullptr) {
@@ -508,13 +508,13 @@ void Tesseract::bigram_correction_pass(PAGE_RES *page_res) {
     if (w->tesseract->getDict().valid_bigram(prev_best, this_best)) {
       if (tessedit_bigram_debug) {
         tprintf("Top choice \"%s %s\" verified by bigram model.\n",
-                orig_w1_str.string(), orig_w2_str.string());
+                orig_w1_str.c_str(), orig_w2_str.c_str());
       }
       continue;
     }
     if (tessedit_bigram_debug > 2) {
       tprintf("Examining alt choices for \"%s %s\".\n",
-              orig_w1_str.string(), orig_w2_str.string());
+              orig_w1_str.c_str(), orig_w2_str.c_str());
     }
     if (tessedit_bigram_debug > 1) {
       if (!w_prev->best_choices.singleton()) {
@@ -563,7 +563,7 @@ void Tesseract::bigram_correction_pass(PAGE_RES *page_res) {
                                             *overrides_word2[best_idx])) {
         if (tessedit_bigram_debug > 1) {
           tprintf("Top choice \"%s %s\" verified (sans case) by bigram "
-                  "model.\n", orig_w1_str.string(), orig_w2_str.string());
+                  "model.\n", orig_w1_str.c_str(), orig_w2_str.c_str());
         }
         continue;
       }
@@ -601,9 +601,9 @@ void Tesseract::bigram_correction_pass(PAGE_RES *page_res) {
           }
         }
         tprintf("Replaced \"%s %s\" with \"%s %s\" with bigram model. %s\n",
-                orig_w1_str.string(), orig_w2_str.string(),
-                new_w1_str.string(), new_w2_str.string(),
-                choices_description.string());
+                orig_w1_str.c_str(), orig_w2_str.c_str(),
+                new_w1_str.c_str(), new_w2_str.c_str(),
+                choices_description.c_str());
       }
     }
   }
@@ -724,7 +724,7 @@ void Tesseract::blamer_pass(PAGE_RES* page_res) {
   if (page_res->misadaption_log.length() > 0) {
     tprintf("Misadaption log:\n");
     for (int i = 0; i < page_res->misadaption_log.length(); ++i) {
-      tprintf("%s\n", page_res->misadaption_log[i].string());
+      tprintf("%s\n", page_res->misadaption_log[i].c_str());
     }
   }
 }
@@ -906,7 +906,7 @@ int Tesseract::RetryWithLanguage(const WordData& word_data,
                                  PointerVector<WERD_RES>* best_words) {
   if (debug) {
     tprintf("Trying word using lang %s, oem %d\n",
-            lang.string(), static_cast<int>(tessedit_ocr_engine_mode));
+            lang.c_str(), static_cast<int>(tessedit_ocr_engine_mode));
   }
   // Run the recognizer on the word.
   PointerVector<WERD_RES> new_words;
@@ -1146,7 +1146,7 @@ bool Tesseract::SelectGoodDiacriticOutlines(
     float target_c2;
     target_cert = ClassifyBlobAsWord(pass, pr_it, blob, &best_str, &target_c2);
     if (debug_noise_removal) {
-      tprintf("No Noise blob classified as %s=%g(%g) at:", best_str.string(),
+      tprintf("No Noise blob classified as %s=%g(%g) at:", best_str.c_str(),
               target_cert, target_c2);
       blob->bounding_box().print();
     }
@@ -1164,7 +1164,7 @@ bool Tesseract::SelectGoodDiacriticOutlines(
       if (test_outlines[i]) ol_box += outlines[i]->bounding_box();
     }
     tprintf("All Noise blob classified as %s=%g, delta=%g at:",
-            all_str.string(), best_cert, best_cert - target_cert);
+            all_str.c_str(), best_cert, best_cert - target_cert);
     ol_box.print();
   }
   // Iteratively zero out the bit that improves the certainty the most, until
@@ -1186,7 +1186,7 @@ bool Tesseract::SelectGoodDiacriticOutlines(
             if (test_outlines[j]) ol_box += outlines[j]->bounding_box();
             tprintf("%d", test_outlines[j]);
           }
-          tprintf(" blob classified as %s=%g, delta=%g) at:", str.string(),
+          tprintf(" blob classified as %s=%g, delta=%g) at:", str.c_str(),
                   cert, cert - target_cert);
           ol_box.print();
         }
@@ -1333,7 +1333,7 @@ void Tesseract::classify_word_and_language(int pass_n, PAGE_RES_IT* pr_it,
   if (debug) {
     tprintf("%s word with lang %s at:",
             word->done ? "Already done" : "Processing",
-            most_recently_used_->lang.string());
+            most_recently_used_->lang.c_str());
     word->word->bounding_box().print();
   }
   if (word->done) {
@@ -1386,7 +1386,7 @@ void Tesseract::classify_word_and_language(int pass_n, PAGE_RES_IT* pr_it,
   clock_t ocr_t = clock();
   if (tessedit_timing_debug) {
     tprintf("%s (ocr took %.2f sec)\n",
-            word_data->word->best_choice->unichar_string().string(),
+            word_data->word->best_choice->unichar_string().c_str(),
             static_cast<double>(ocr_t-start_t)/CLOCKS_PER_SEC);
   }
 }
@@ -1461,12 +1461,12 @@ void Tesseract::classify_word_pass1(const WordData& word_data,
 void Tesseract::ReportXhtFixResult(bool accept_new_word, float new_x_ht,
                                    WERD_RES* word, WERD_RES* new_word) {
   tprintf("New XHT Match:%s = %s ",
-          word->best_choice->unichar_string().string(),
-          word->best_choice->debug_string().string());
+          word->best_choice->unichar_string().c_str(),
+          word->best_choice->debug_string().c_str());
   word->reject_map.print(debug_fp);
   tprintf(" -> %s = %s ",
-          new_word->best_choice->unichar_string().string(),
-          new_word->best_choice->debug_string().string());
+          new_word->best_choice->unichar_string().c_str(),
+          new_word->best_choice->debug_string().c_str());
   new_word->reject_map.print(debug_fp);
   tprintf(" %s->%s %s %s\n",
           word->guessed_x_ht ? "GUESS" : "CERT",
@@ -1640,7 +1640,7 @@ void Tesseract::match_word_pass_n(int pass_n, WERD_RES *word,
       if (word->best_choice->length() != word->box_word->length()) {
         tprintf("POST FIX_QUOTES FAIL String:\"%s\"; Strlen=%d;"
                 " #Blobs=%d\n",
-                word->best_choice->debug_string().string(),
+                word->best_choice->debug_string().c_str(),
                 word->best_choice->length(),
                 word->box_word->length());
 
@@ -1719,7 +1719,7 @@ void Tesseract::fix_rep_char(PAGE_RES_IT* page_res_it) {
   BLOB_CHOICE* best_choice = FindBestMatchingChoice(maxch_id, word_res);
   if (best_choice == nullptr) {
     tprintf("Failed to find a choice for %s, occurring %d times\n",
-            word_res->uch_set->debug_str(maxch_id).string(), max_count);
+            word_res->uch_set->debug_str(maxch_id).c_str(), max_count);
     return;
   }
   word_res->done = true;
@@ -1906,11 +1906,11 @@ bool Tesseract::check_debug_pt(WERD_RES* word, int location) {
         break;
     }
     if (word->best_choice != nullptr) {
-      tprintf(" \"%s\" ", word->best_choice->unichar_string().string());
+      tprintf(" \"%s\" ", word->best_choice->unichar_string().c_str());
       word->reject_map.print(debug_fp);
       tprintf("\n");
       if (show_map_detail) {
-        tprintf("\"%s\"\n", word->best_choice->unichar_string().string());
+        tprintf("\"%s\"\n", word->best_choice->unichar_string().c_str());
         for (i = 0; word->best_choice->unichar_string()[i] != '\0'; i++) {
           tprintf("**** \"%c\" ****\n", word->best_choice->unichar_string()[i]);
           word->reject_map[i].full_print(debug_fp);
@@ -1973,7 +1973,7 @@ void Tesseract::set_word_fonts(WERD_RES *word) {
   // Compute the font scores for the word
   if (tessedit_debug_fonts) {
     tprintf("Examining fonts in %s\n",
-            word->best_choice->debug_string().string());
+            word->best_choice->debug_string().c_str());
   }
   for (int b = 0; b < word->best_choice->length(); ++b) {
     const BLOB_CHOICE* choice = word->GetBlobChoice(b);
@@ -2108,8 +2108,8 @@ void Tesseract::dictionary_correction_pass(PAGE_RES *page_res) {
         // The alternate choice is in the dictionary.
         if (tessedit_bigram_debug) {
           tprintf("Dictionary correction replaces best choice '%s' with '%s'\n",
-                  best->unichar_string().string(),
-                  alternate->unichar_string().string());
+                  best->unichar_string().c_str(),
+                  alternate->unichar_string().c_str());
         }
         // Replace the 'best' choice with a better choice.
         word->ReplaceBestChoice(alternate);

--- a/src/ccmain/docqual.cpp
+++ b/src/ccmain/docqual.cpp
@@ -167,8 +167,8 @@ void Tesseract::unrej_good_quality_words(  //unreject potential
       if (word->reject_map.quality_recoverable_rejects() &&
           (tessedit_unrej_any_wd ||
            acceptable_word_string(*word->uch_set,
-                                  word->best_choice->unichar_string().string(),
-                                  word->best_choice->unichar_lengths().string())
+                                  word->best_choice->unichar_string().c_str(),
+                                  word->best_choice->unichar_lengths().c_str())
                != AC_UNACCEPTABLE)) {
         unrej_good_chs(word);
       }
@@ -266,8 +266,8 @@ void Tesseract::doc_and_block_rejection(  //reject big chunks
                 word->reject_map.length() >= tessedit_preserve_min_wd_len &&
                 acceptable_word_string(
                     *word->uch_set,
-                    word->best_choice->unichar_string().string(),
-                    word->best_choice->unichar_lengths().string()) !=
+                    word->best_choice->unichar_string().c_str(),
+                    word->best_choice->unichar_lengths().c_str()) !=
                 AC_UNACCEPTABLE) {
               word_char_quality(word, &char_quality, &accepted_char_quality);
               rej_word = char_quality != word->reject_map.length();
@@ -335,8 +335,8 @@ void Tesseract::doc_and_block_rejection(  //reject big chunks
                 if (rej_word && tessedit_dont_rowrej_good_wds &&
                     word->reject_map.length() >= tessedit_preserve_min_wd_len &&
                     acceptable_word_string(*word->uch_set,
-                        word->best_choice->unichar_string().string(),
-                        word->best_choice->unichar_lengths().string()) !=
+                        word->best_choice->unichar_string().c_str(),
+                        word->best_choice->unichar_lengths().c_str()) !=
                             AC_UNACCEPTABLE) {
                   word_char_quality(word, &char_quality,
                                     &accepted_char_quality);
@@ -431,14 +431,14 @@ void Tesseract::tilde_crunch(PAGE_RES_IT &page_res_it) {
       (terrible_word_crunch (word, garbage_level))) {
         if (crunch_debug > 0) {
           tprintf ("T CRUNCHING: \"%s\"\n",
-            word->best_choice->unichar_string().string());
+            word->best_choice->unichar_string().c_str());
         }
         word->unlv_crunch_mode = CR_KEEP_SPACE;
         if (prev_potential_marked) {
           while (copy_it.word () != word) {
             if (crunch_debug > 0) {
               tprintf ("P1 CRUNCHING: \"%s\"\n",
-                copy_it.word()->best_choice->unichar_string().string());
+                copy_it.word()->best_choice->unichar_string().c_str());
             }
             copy_it.word ()->unlv_crunch_mode = CR_KEEP_SPACE;
             copy_it.forward ();
@@ -453,7 +453,7 @@ void Tesseract::tilde_crunch(PAGE_RES_IT &page_res_it) {
         if (found_terrible_word) {
           if (crunch_debug > 0) {
             tprintf ("P2 CRUNCHING: \"%s\"\n",
-              word->best_choice->unichar_string().string());
+              word->best_choice->unichar_string().c_str());
           }
           word->unlv_crunch_mode = CR_KEEP_SPACE;
         }
@@ -462,7 +462,7 @@ void Tesseract::tilde_crunch(PAGE_RES_IT &page_res_it) {
           prev_potential_marked = true;
           if (crunch_debug > 1) {
             tprintf ("P3 CRUNCHING: \"%s\"\n",
-              word->best_choice->unichar_string().string());
+              word->best_choice->unichar_string().c_str());
           }
         }
       }
@@ -472,7 +472,7 @@ void Tesseract::tilde_crunch(PAGE_RES_IT &page_res_it) {
         prev_potential_marked = false;
         if (crunch_debug > 2) {
           tprintf ("NO CRUNCH: \"%s\"\n",
-            word->best_choice->unichar_string().string());
+            word->best_choice->unichar_string().c_str());
         }
       }
     }
@@ -488,7 +488,7 @@ bool Tesseract::terrible_word_crunch(WERD_RES* word,
   int crunch_mode = 0;
 
   if ((word->best_choice->unichar_string().length() == 0) ||
-      (strspn(word->best_choice->unichar_string().string(), " ") ==
+      (strspn(word->best_choice->unichar_string().c_str(), " ") ==
        word->best_choice->unichar_string().unsigned_size()))
     crunch_mode = 1;
   else {
@@ -511,7 +511,7 @@ bool Tesseract::terrible_word_crunch(WERD_RES* word,
   if (crunch_mode > 0) {
     if (crunch_debug > 2) {
       tprintf ("Terrible_word_crunch (%d) on \"%s\"\n",
-        crunch_mode, word->best_choice->unichar_string().string());
+        crunch_mode, word->best_choice->unichar_string().c_str());
     }
     return true;
   }
@@ -524,8 +524,8 @@ bool Tesseract::potential_word_crunch(WERD_RES* word,
                                       bool ok_dict_word) {
   float rating_per_ch;
   int adjusted_len;
-  const char *str = word->best_choice->unichar_string().string();
-  const char *lengths = word->best_choice->unichar_lengths().string();
+  const char *str = word->best_choice->unichar_string().c_str();
+  const char *lengths = word->best_choice->unichar_lengths().c_str();
   bool word_crunchable;
   int poor_indicator_count = 0;
 
@@ -543,7 +543,7 @@ bool Tesseract::potential_word_crunch(WERD_RES* word,
   if (rating_per_ch > crunch_pot_poor_rate) {
     if (crunch_debug > 2) {
       tprintf("Potential poor rating on \"%s\"\n",
-              word->best_choice->unichar_string().string());
+              word->best_choice->unichar_string().c_str());
     }
     poor_indicator_count++;
   }
@@ -552,7 +552,7 @@ bool Tesseract::potential_word_crunch(WERD_RES* word,
       word->best_choice->certainty() < crunch_pot_poor_cert) {
     if (crunch_debug > 2) {
       tprintf("Potential poor cert on \"%s\"\n",
-              word->best_choice->unichar_string().string());
+              word->best_choice->unichar_string().c_str());
     }
     poor_indicator_count++;
   }
@@ -560,7 +560,7 @@ bool Tesseract::potential_word_crunch(WERD_RES* word,
   if (garbage_level != G_OK) {
     if (crunch_debug > 2) {
       tprintf("Potential garbage on \"%s\"\n",
-              word->best_choice->unichar_string().string());
+              word->best_choice->unichar_string().c_str());
     }
     poor_indicator_count++;
   }
@@ -587,7 +587,7 @@ void Tesseract::tilde_delete(PAGE_RES_IT &page_res_it) {
         if (crunch_debug > 0) {
           tprintf ("BOL CRUNCH DELETING(%d): \"%s\"\n",
             debug_delete_mode,
-            word->best_choice->unichar_string().string());
+            word->best_choice->unichar_string().c_str());
         }
         word->unlv_crunch_mode = delete_mode;
         deleting_from_bol = true;
@@ -599,7 +599,7 @@ void Tesseract::tilde_delete(PAGE_RES_IT &page_res_it) {
             if (crunch_debug > 0) {
               tprintf ("EOL CRUNCH DELETING(%d): \"%s\"\n",
                 x_debug_delete_mode,
-                copy_it.word()->best_choice->unichar_string().string());
+                copy_it.word()->best_choice->unichar_string().c_str());
             }
             copy_it.word ()->unlv_crunch_mode = x_delete_mode;
             copy_it.forward ();
@@ -608,7 +608,7 @@ void Tesseract::tilde_delete(PAGE_RES_IT &page_res_it) {
         if (crunch_debug > 0) {
           tprintf ("EOL CRUNCH DELETING(%d): \"%s\"\n",
             debug_delete_mode,
-            word->best_choice->unichar_string().string());
+            word->best_choice->unichar_string().c_str());
         }
         word->unlv_crunch_mode = delete_mode;
         deleting_from_bol = false;
@@ -668,8 +668,8 @@ GARBAGE_LEVEL Tesseract::garbage_word(WERD_RES *word, bool ok_dict_word) {
     SUBSEQUENT_LOWER,
     SUBSEQUENT_NUM
   };
-  const char *str = word->best_choice->unichar_string().string();
-  const char *lengths = word->best_choice->unichar_lengths().string();
+  const char *str = word->best_choice->unichar_string().c_str();
+  const char *lengths = word->best_choice->unichar_lengths().c_str();
   STATES state = JUNK;
   int len = 0;
   int isolated_digits = 0;
@@ -827,7 +827,7 @@ GARBAGE_LEVEL Tesseract::garbage_word(WERD_RES *word, bool ok_dict_word) {
 
   if (crunch_debug > 3) {
     tprintf("garbage_word: \"%s\"\n",
-            word->best_choice->unichar_string().string());
+            word->best_choice->unichar_string().c_str());
     tprintf("LEN: %d  bad: %d  iso_N: %d  iso_A: %d  rej: %d\n",
             len,
             bad_char_count, isolated_digits, isolated_alphas, tess_rejs);
@@ -947,7 +947,7 @@ CRUNCH_MODE Tesseract::word_deletable(WERD_RES *word, int16_t &delete_mode) {
 }
 
 int16_t Tesseract::failure_count(WERD_RES *word) {
-  const char *str = word->best_choice->unichar_string().string();
+  const char *str = word->best_choice->unichar_string().c_str();
   int tess_rejs = 0;
 
   for (; *str != '\0'; str++) {

--- a/src/ccmain/equationdetect.cpp
+++ b/src/ccmain/equationdetect.cpp
@@ -237,7 +237,7 @@ BlobSpecialTextType EquationDetect::EstimateTypeForUnichar(
       int i = 0;
       while (kCharsToEx[i] != "") {
         ids_to_exclude.push_back(
-            unicharset.unichar_to_id(kCharsToEx[i++].string()));
+            unicharset.unichar_to_id(kCharsToEx[i++].c_str()));
       }
       ids_to_exclude.sort();
     }
@@ -374,7 +374,7 @@ int EquationDetect::FindEquationParts(
 
   if (equationdetect_save_bi_image) {
     GetOutputTiffName("_bi", &outfile);
-    pixWrite(outfile.string(), lang_tesseract_->pix_binary(), IFF_TIFF_G4);
+    pixWrite(outfile.c_str(), lang_tesseract_->pix_binary(), IFF_TIFF_G4);
   }
 
   // Pass 0: Compute special text type for blobs.
@@ -1474,7 +1474,7 @@ void EquationDetect::PaintSpecialTexts(const STRING& outfile) const {
     }
   }
 
-  pixWrite(outfile.string(), pix, IFF_TIFF_LZW);
+  pixWrite(outfile.c_str(), pix, IFF_TIFF_LZW);
   pixDestroy(&pix);
 }
 
@@ -1497,7 +1497,7 @@ void EquationDetect::PaintColParts(const STRING& outfile) const {
     boxDestroy(&box);
   }
 
-  pixWrite(outfile.string(), pix, IFF_TIFF_LZW);
+  pixWrite(outfile.c_str(), pix, IFF_TIFF_LZW);
   pixDestroy(&pix);
 }
 

--- a/src/ccmain/fixspace.cpp
+++ b/src/ccmain/fixspace.cpp
@@ -306,7 +306,7 @@ int16_t Tesseract::eval_word_spacing(WERD_RES_LIST &word_res_list) {
       if (!((prev_char_1 && digit_or_numeric_punct(word, 0)) ||
             (prev_char_digit && (
                 (word_done &&
-                 word->best_choice->unichar_lengths().string()[0] == 1 &&
+                 word->best_choice->unichar_lengths().c_str()[0] == 1 &&
                  word->best_choice->unichar_string()[0] == '1') ||
                 (!word_done && STRING(conflict_set_I_l_1).contains(
                       word->best_choice->unichar_string()[0])))))) {
@@ -375,11 +375,11 @@ bool Tesseract::digit_or_numeric_punct(WERD_RES *word, int char_position) {
        offset += word->best_choice->unichar_lengths()[i++]);
   return (
       word->uch_set->get_isdigit(
-          word->best_choice->unichar_string().string() + offset,
+          word->best_choice->unichar_string().c_str() + offset,
           word->best_choice->unichar_lengths()[i]) ||
       (word->best_choice->permuter() == NUMBER_PERM &&
        STRING(numeric_punctuation).contains(
-           word->best_choice->unichar_string().string()[offset])));
+           word->best_choice->unichar_string().c_str()[offset])));
 }
 
 }  // namespace tesseract
@@ -507,18 +507,18 @@ void Tesseract::dump_words(WERD_RES_LIST &perm, int16_t score,
            word_res_it.forward()) {
         if (!word_res_it.data()->part_of_combo) {
           tprintf("%s/%1d ",
-                  word_res_it.data()->best_choice->unichar_string().string(),
+                  word_res_it.data()->best_choice->unichar_string().c_str(),
                   static_cast<int>(word_res_it.data()->best_choice->permuter()));
         }
       }
       tprintf("\"\n");
     } else if (improved) {
-      tprintf("FIX SPACING \"%s\" => \"", stats_.dump_words_str.string());
+      tprintf("FIX SPACING \"%s\" => \"", stats_.dump_words_str.c_str());
       for (word_res_it.mark_cycle_pt(); !word_res_it.cycled_list();
            word_res_it.forward()) {
         if (!word_res_it.data()->part_of_combo) {
           tprintf("%s/%1d ",
-                  word_res_it.data()->best_choice->unichar_string().string(),
+                  word_res_it.data()->best_choice->unichar_string().c_str(),
                   static_cast<int>(word_res_it.data()->best_choice->permuter()));
         }
       }
@@ -540,7 +540,7 @@ bool Tesseract::fixspace_thinks_word_done(WERD_RES *word) {
       (word->tess_accepted ||
        (fixsp_done_mode == 2 && word->reject_map.reject_count() == 0) ||
        fixsp_done_mode == 3) &&
-      (strchr(word->best_choice->unichar_string().string(), ' ') == nullptr) &&
+      (strchr(word->best_choice->unichar_string().c_str(), ' ') == nullptr) &&
       ((word->best_choice->permuter() == SYSTEM_DAWG_PERM) ||
        (word->best_choice->permuter() == FREQ_DAWG_PERM) ||
        (word->best_choice->permuter() == USER_DAWG_PERM) ||
@@ -581,7 +581,7 @@ void Tesseract::fix_sp_fp_word(WERD_RES_IT &word_res_it, ROW *row,
 
   if (debug_fix_space_level > 1) {
     tprintf("FP fixspace working on \"%s\"\n",
-            word_res->best_choice->unichar_string().string());
+            word_res->best_choice->unichar_string().c_str());
   }
   word_res->word->rej_cblob_list()->sort(c_blob_comparator);
   sub_word_list_it.add_after_stay_put(word_res_it.extract());
@@ -729,7 +729,7 @@ int16_t Tesseract::worst_noise_blob(WERD_RES *word_res,
   #ifndef SECURE_NAMES
   if (debug_fix_space_level > 5)
     tprintf("FP fixspace Noise metrics for \"%s\": ",
-            word_res->best_choice->unichar_string().string());
+            word_res->best_choice->unichar_string().c_str());
   #endif
 
   for (i = 0; i < blob_count && i < word_res->rebuild_word->NumBlobs(); i++) {
@@ -825,7 +825,7 @@ void fixspace_dbg(WERD_RES *word) {
   int16_t i;
 
   box.print();
-  tprintf(" \"%s\" ", word->best_choice->unichar_string().string());
+  tprintf(" \"%s\" ", word->best_choice->unichar_string().c_str());
   tprintf("Blob count: %d (word); %d/%d (rebuild word)\n",
           word->word->cblob_list()->length(),
           word->rebuild_word->NumBlobs(),
@@ -833,7 +833,7 @@ void fixspace_dbg(WERD_RES *word) {
   word->reject_map.print(debug_fp);
   tprintf("\n");
   if (show_map_detail) {
-    tprintf("\"%s\"\n", word->best_choice->unichar_string().string());
+    tprintf("\"%s\"\n", word->best_choice->unichar_string().c_str());
     for (i = 0; word->best_choice->unichar_string()[i] != '\0'; i++) {
       tprintf("**** \"%c\" ****\n", word->best_choice->unichar_string()[i]);
       word->reject_map[i].full_print(debug_fp);

--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -2,7 +2,6 @@
 // File:        linerec.cpp
 // Description: Top-level line-based recognition module for Tesseract.
 // Author:      Ray Smith
-// Created:     Thu May 02 09:47:06 PST 2013
 //
 // (C) Copyright 2013, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,8 +46,8 @@ void Tesseract::TrainLineRecognizer(const STRING& input_imagename,
   DocumentData images(lstmf_name);
   if (applybox_page > 0) {
     // Load existing document for the previous pages.
-    if (!images.LoadDocument(lstmf_name.string(), 0, 0, nullptr)) {
-      tprintf("Failed to read training data from %s!\n", lstmf_name.string());
+    if (!images.LoadDocument(lstmf_name.c_str(), 0, 0, nullptr)) {
+      tprintf("Failed to read training data from %s!\n", lstmf_name.c_str());
       return;
     }
   }
@@ -58,13 +57,13 @@ void Tesseract::TrainLineRecognizer(const STRING& input_imagename,
   if (!ReadAllBoxes(applybox_page, false, input_imagename, &boxes, &texts, nullptr,
                     nullptr) ||
       boxes.empty()) {
-    tprintf("Failed to read boxes from %s\n", input_imagename.string());
+    tprintf("Failed to read boxes from %s\n", input_imagename.c_str());
     return;
   }
   TrainFromBoxes(boxes, texts, block_list, &images);
   images.Shuffle();
-  if (!images.SaveDocument(lstmf_name.string(), nullptr)) {
-    tprintf("Failed to write training data to %s!\n", lstmf_name.string());
+  if (!images.SaveDocument(lstmf_name.c_str(), nullptr)) {
+    tprintf("Failed to write training data to %s!\n", lstmf_name.c_str());
   }
 }
 
@@ -110,7 +109,7 @@ void Tesseract::TrainFromBoxes(const GenericVector<TBOX>& boxes,
     }
     ImageData* imagedata = nullptr;
     if (best_block == nullptr) {
-      tprintf("No block overlapping textline: %s\n", line_str.string());
+      tprintf("No block overlapping textline: %s\n", line_str.c_str());
     } else {
       imagedata = GetLineData(line_box, boxes, texts, start_box, end_box,
                               *best_block);

--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -77,7 +77,7 @@ char* LTRResultIterator::GetUTF8Text(PageIteratorLevel level) const {
   }
   int length = text.length() + 1;
   char* result = new char[length];
-  strncpy(result, text.string(), length);
+  strncpy(result, text.c_str(), length);
   return result;
 }
 
@@ -213,7 +213,7 @@ const char* LTRResultIterator::WordFontAttributes(
 const char* LTRResultIterator::WordRecognitionLanguage() const {
   if (it_->word() == nullptr || it_->word()->tesseract == nullptr)
     return nullptr;
-  return it_->word()->tesseract->lang.string();
+  return it_->word()->tesseract->lang.c_str();
 }
 
 // Return the overall directionality of this word.
@@ -274,13 +274,13 @@ const void* LTRResultIterator::GetParamsTrainingBundle() const {
 // Returns the pointer to the string with blamer information for this word.
 // Assumes that the word's blamer_bundle is not nullptr.
 const char* LTRResultIterator::GetBlamerDebug() const {
-  return it_->word()->blamer_bundle->debug().string();
+  return it_->word()->blamer_bundle->debug().c_str();
 }
 
 // Returns the pointer to the string with misadaption information for this word.
 // Assumes that the word's blamer_bundle is not nullptr.
 const char* LTRResultIterator::GetBlamerMisadaptionDebug() const {
-  return it_->word()->blamer_bundle->misadaption_debug().string();
+  return it_->word()->blamer_bundle->misadaption_debug().c_str();
 }
 
 // Returns true if a truth string was recorded for the current word.
@@ -312,7 +312,7 @@ char* LTRResultIterator::WordTruthUTF8Text() const {
   STRING truth_text = it_->word()->blamer_bundle->TruthString();
   int length = truth_text.length() + 1;
   char* result = new char[length];
-  strncpy(result, truth_text.string(), length);
+  strncpy(result, truth_text.c_str(), length);
   return result;
 }
 
@@ -330,7 +330,7 @@ char* LTRResultIterator::WordNormedUTF8Text() const {
   }
   int length = ocr_text.length() + 1;
   char* result = new char[length];
-  strncpy(result, ocr_text.string(), length);
+  strncpy(result, ocr_text.c_str(), length);
   return result;
 }
 

--- a/src/ccmain/osdetect.cpp
+++ b/src/ccmain/osdetect.cpp
@@ -194,9 +194,9 @@ int orientation_and_script_detection(STRING& filename,
   const char *lastdot;           //of name
   TBOX page_box;
 
-  lastdot = strrchr (name.string (), '.');
+  lastdot = strrchr(name.c_str(), '.');
   if (lastdot != nullptr)
-    name[lastdot-name.string()] = '\0';
+    name[lastdot-name.c_str()] = '\0';
 
   ASSERT_HOST(tess->pix_binary() != nullptr);
   int width = pixGetWidth(tess->pix_binary());

--- a/src/ccmain/output.cpp
+++ b/src/ccmain/output.cpp
@@ -180,7 +180,7 @@ void Tesseract::write_results(PAGE_RES_IT& page_res_it,
   check_debug_pt (word, 120);
   if (tessedit_rejection_debug) {
     tprintf ("Dict word: \"%s\": %d\n",
-             word->best_choice->debug_string().string(),
+             word->best_choice->debug_string().c_str(),
              dict_word(*(word->best_choice)));
   }
   if (!word->word->flag(W_REP_CHAR) || !tessedit_write_rep_codes) {
@@ -256,7 +256,7 @@ UNICHAR_ID Tesseract::get_rep_char(WERD_RES *word) {  // what char is repeated?
   if (i < word->reject_map.length()) {
     return word->best_choice->unichar_id(i);
   } else {
-    return word->uch_set->unichar_to_id(unrecognised_char.string());
+    return word->uch_set->unichar_to_id(unrecognised_char.c_str());
   }
 }
 
@@ -344,11 +344,11 @@ void Tesseract::set_unlv_suspects(WERD_RES *word_res) {
   }
 
   if (acceptable_word_string(*word_res->uch_set,
-                             word.unichar_string().string(),
-                             word.unichar_lengths().string()) !=
+                             word.unichar_string().c_str(),
+                             word.unichar_lengths().c_str()) !=
                                  AC_UNACCEPTABLE ||
-      acceptable_number_string(word.unichar_string().string(),
-                               word.unichar_lengths().string())) {
+      acceptable_number_string(word.unichar_string().c_str(),
+                               word.unichar_lengths().c_str())) {
     if (word_res->reject_map.length() > suspect_short_words) {
       for (i = 0; i < len; i++) {
         if (word_res->reject_map[i].rejected() &&

--- a/src/ccmain/pageiterator.cpp
+++ b/src/ccmain/pageiterator.cpp
@@ -3,7 +3,6 @@
 // Description: Iterator for tesseract page structure that avoids using
 //              tesseract internal data structures.
 // Author:      Ray Smith
-// Created:     Fri Feb 26 14:32:09 PST 2010
 //
 // (C) Copyright 2010, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -591,7 +590,7 @@ void PageIterator::BeginWord(int offset) {
     if (word_res->box_word != nullptr) {
       if (word_res->box_word->length() != word_length_) {
         tprintf("Corrupted word! best_choice[len=%d] = %s, box_word[len=%d]: ",
-                word_length_, word_res->best_choice->unichar_string().string(),
+                word_length_, word_res->best_choice->unichar_string().c_str(),
                 word_res->box_word->length());
         word_res->box_word->bounding_box().print();
       }

--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -108,9 +108,9 @@ int Tesseract::SegmentPage(const STRING* input_file, BLOCK_LIST* blocks,
   if (!PSM_COL_FIND_ENABLED(pageseg_mode) &&
       input_file != nullptr && input_file->length() > 0) {
     STRING name = *input_file;
-    const char* lastdot = strrchr(name.string(), '.');
+    const char* lastdot = strrchr(name.c_str(), '.');
     if (lastdot != nullptr)
-      name[lastdot - name.string()] = '\0';
+      name[lastdot - name.c_str()] = '\0';
     read_unlv_file(name, width, height, blocks);
   }
   if (blocks->empty()) {

--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -125,8 +125,8 @@ static void PrintTable(const GenericVector<GenericVector<STRING> > &rows,
   for (int r = 0; r < rows.size(); r++) {
     for (int c = 0; c < rows[r].size(); c++) {
       if (c > 0)
-        tprintf("%s", colsep.string());
-      tprintf(col_width_patterns[c].string(), rows[r][c].string());
+        tprintf("%s", colsep.c_str());
+      tprintf(col_width_patterns[c].c_str(), rows[r][c].c_str());
     }
     tprintf("\n");
   }
@@ -177,7 +177,7 @@ static void PrintDetectorState(const ParagraphTheory &theory,
 
   tprintf("Active Paragraph Models:\n");
   for (int m = 0; m < theory.models().size(); m++) {
-    tprintf(" %d: %s\n", m + 1, theory.models()[m]->ToString().string());
+    tprintf(" %d: %s\n", m + 1, theory.models()[m]->ToString().c_str());
   }
 }
 
@@ -188,7 +188,7 @@ static void DebugDump(
     const GenericVector<RowScratchRegisters> &rows) {
   if (!should_print)
     return;
-  tprintf("# %s\n", phase.string());
+  tprintf("# %s\n", phase.c_str());
   PrintDetectorState(theory, rows);
 }
 
@@ -197,7 +197,7 @@ static void PrintRowRange(const GenericVector<RowScratchRegisters> &rows,
                           int row_start, int row_end) {
   tprintf("======================================\n");
   for (int row = row_start; row < row_end; row++) {
-    tprintf("%s\n", rows[row].ri_->text.string());
+    tprintf("%s\n", rows[row].ri_->text.c_str());
   }
   tprintf("======================================\n");
 }
@@ -247,7 +247,7 @@ static bool LikelyListNumeral(const STRING &word) {
   const char *kClose = "]})";
 
   int num_segments = 0;
-  const char *pos = word.string();
+  const char *pos = word.c_str();
   while (*pos != '\0' && num_segments < 3) {
     // skip up to two open parens.
     const char *numeral_start = SkipOne(SkipOne(pos, kOpen), kOpen);
@@ -2489,8 +2489,8 @@ static void InitializeRowInfo(bool after_recognition,
   info->num_words = werds.size();
   if (!werds.empty()) {
     WERD_RES *lword = werds[0], *rword = werds[werds.size() - 1];
-    info->lword_text = lword->best_choice->unichar_string().string();
-    info->rword_text = rword->best_choice->unichar_string().string();
+    info->lword_text = lword->best_choice->unichar_string().c_str();
+    info->rword_text = rword->best_choice->unichar_string().c_str();
     info->lword_box = lword->word->bounding_box();
     info->rword_box = rword->word->bounding_box();
     LeftWordAttributes(lword->uch_set, lword->best_choice,

--- a/src/ccmain/paramsd.cpp
+++ b/src/ccmain/paramsd.cpp
@@ -141,8 +141,8 @@ STRING ParamContent::GetValue() const {
   } else if (param_type_ == VT_DOUBLE) {
     result.add_str_double("", *dIt);
   } else if (param_type_ == VT_STRING) {
-    if (STRING(*(sIt)).string() != nullptr) {
-      result = sIt->string();
+    if (STRING(*(sIt)).c_str() != nullptr) {
+      result = sIt->c_str();
     } else {
       result = "Null";
     }
@@ -230,9 +230,9 @@ SVMenuNode* ParamsEditor::BuildListOfAllLeaves(tesseract::Tesseract *tess) {
     STRING tag3;
 
     GetPrefixes(vc->GetName(), &tag, &tag2, &tag3);
-    amount[tag.string()]++;
-    amount[tag2.string()]++;
-    amount[tag3.string()]++;
+    amount[tag.c_str()]++;
+    amount[tag2.c_str()]++;
+    amount[tag3.c_str()]++;
   }
 
   vclist.sort(ParamContent::Compare);  // Sort the list alphabetically.
@@ -248,19 +248,19 @@ SVMenuNode* ParamsEditor::BuildListOfAllLeaves(tesseract::Tesseract *tess) {
     STRING tag3;
     GetPrefixes(vc->GetName(), &tag, &tag2, &tag3);
 
-    if (amount[tag.string()] == 1) {
-      other->AddChild(vc->GetName(), vc->GetId(), vc->GetValue().string(),
+    if (amount[tag.c_str()] == 1) {
+      other->AddChild(vc->GetName(), vc->GetId(), vc->GetValue().c_str(),
                       vc->GetDescription());
     } else {  // More than one would use this submenu -> create submenu.
-      SVMenuNode* sv = mr->AddChild(tag.string());
-      if ((amount[tag.string()] <= MAX_ITEMS_IN_SUBMENU) ||
-          (amount[tag2.string()] <= 1)) {
+      SVMenuNode* sv = mr->AddChild(tag.c_str());
+      if ((amount[tag.c_str()] <= MAX_ITEMS_IN_SUBMENU) ||
+          (amount[tag2.c_str()] <= 1)) {
         sv->AddChild(vc->GetName(), vc->GetId(),
-                     vc->GetValue().string(), vc->GetDescription());
+                     vc->GetValue().c_str(), vc->GetDescription());
       } else {  // Make subsubmenus.
-        SVMenuNode* sv2 = sv->AddChild(tag2.string());
+        SVMenuNode* sv2 = sv->AddChild(tag2.c_str());
         sv2->AddChild(vc->GetName(), vc->GetId(),
-                      vc->GetValue().string(), vc->GetDescription());
+                      vc->GetValue().c_str(), vc->GetDescription());
       }
     }
   }
@@ -280,7 +280,7 @@ void ParamsEditor::Notify(const SVEvent* sve) {
           sve->command_id);
       vc->SetValue(param);
       sv_window_->AddMessage("Setting %s to %s",
-                             vc->GetName(), vc->GetValue().string());
+                             vc->GetName(), vc->GetValue().c_str());
     }
   }
 }
@@ -311,11 +311,11 @@ ParamsEditor::ParamsEditor(tesseract::Tesseract* tess,
 
   writeCommands[0] = nrParams+1;
   std_menu->AddChild("All Parameters", writeCommands[0],
-                     paramfile.string(), "Config file name?");
+                     paramfile.c_str(), "Config file name?");
 
   writeCommands[1] = nrParams+2;
   std_menu->AddChild ("changed_ Parameters Only", writeCommands[1],
-                      paramfile.string(), "Config file name?");
+                      paramfile.c_str(), "Config file name?");
 
   svMenuRoot->BuildMenu(sv, false);
 }
@@ -350,7 +350,7 @@ void ParamsEditor::WriteParams(char *filename,
     ParamContent* cur = iter.second;
     if (!changes_only || cur->HasChanged()) {
       fprintf(fp, "%-25s   %-12s   # %s\n",
-              cur->GetName(), cur->GetValue().string(), cur->GetDescription());
+              cur->GetName(), cur->GetValue().c_str(), cur->GetDescription());
     }
   }
   fclose(fp);

--- a/src/ccmain/pgedit.cpp
+++ b/src/ccmain/pgedit.cpp
@@ -219,7 +219,7 @@ static ScrollView* bln_word_window_handle() {  // return handle
                                  // not opened yet
   if (bln_word_window == nullptr) {
     pgeditor_msg("Creating BLN word window...");
-    bln_word_window = new ScrollView(editor_word_name.string(),
+    bln_word_window = new ScrollView(editor_word_name.c_str(),
       editor_word_xpos, editor_word_ypos, editor_word_width,
       editor_word_height, 4000, 4000, true);
     auto* a = new BlnEventHandler();
@@ -238,7 +238,7 @@ static ScrollView* bln_word_window_handle() {  // return handle
 
 static void build_image_window(int width, int height) {
   delete image_win;
-  image_win = new ScrollView(editor_image_win_name.string(),
+  image_win = new ScrollView(editor_image_win_name.c_str(),
                              editor_image_xpos, editor_image_ypos,
                              width + 1,
                              height + editor_image_menuheight + 1,
@@ -668,7 +668,7 @@ void Tesseract::debug_word(PAGE_RES* page_res, const TBOX &selection_box) {
 #ifndef DISABLED_LEGACY_ENGINE
   ResetAdaptiveClassifier();
 #endif
-  recog_all_words(page_res, nullptr, &selection_box, word_config_.string(), 0);
+  recog_all_words(page_res, nullptr, &selection_box, word_config_.c_str(), 0);
 }
 }  // namespace tesseract
 
@@ -879,11 +879,11 @@ bool Tesseract::word_display(PAGE_RES_IT* pr_it) {
     image_win->TextAttributes("Arial", text_height, false, false, false);
     shift = (word_height < word_bb.width()) ? 0.25 * word_height : 0.0f;
     image_win->Text(word_bb.left() + shift,
-                    word_bb.bottom() + 0.25 * word_height, text.string());
+                    word_bb.bottom() + 0.25 * word_height, text.c_str());
     if (blame.length() > 0) {
       image_win->Text(word_bb.left() + shift,
                       word_bb.bottom() + 0.25 * word_height - text_height,
-                      blame.string());
+                      blame.c_str());
     }
 
     displayed_something = true;
@@ -916,7 +916,7 @@ bool Tesseract::word_dumper(PAGE_RES_IT* pr_it) {
   if (word_res->blamer_bundle != nullptr && wordrec_debug_blamer &&
       word_res->blamer_bundle->incorrect_result_reason() != IRR_CORRECT) {
     tprintf("Current blamer debug: %s\n",
-            word_res->blamer_bundle->debug().string());
+            word_res->blamer_bundle->debug().c_str());
   }
   return true;
 }

--- a/src/ccmain/recogtraining.cpp
+++ b/src/ccmain/recogtraining.cpp
@@ -42,13 +42,13 @@ FILE* Tesseract::init_recog_training(const STRING& fname) {
   }
 
   STRING output_fname = fname;
-  const char* lastdot = strrchr(output_fname.string(), '.');
+  const char* lastdot = strrchr(output_fname.c_str(), '.');
   if (lastdot != nullptr)
-    output_fname[lastdot - output_fname.string()] = '\0';
+    output_fname[lastdot - output_fname.c_str()] = '\0';
   output_fname += ".txt";
-  FILE* output_file = fopen(output_fname.string(), "a+");
+  FILE* output_file = fopen(output_fname.c_str(), "a+");
   if (output_file == nullptr) {
-    tprintf("Error: Could not open file %s\n", output_fname.string());
+    tprintf("Error: Could not open file %s\n", output_fname.c_str());
     ASSERT_HOST(output_file);
   }
   return output_file;
@@ -86,14 +86,14 @@ void Tesseract::recog_training_segmented(const STRING& fname,
                                          volatile ETEXT_DESC* monitor,
                                          FILE* output_file) {
   STRING box_fname = fname;
-  const char* lastdot = strrchr(box_fname.string(), '.');
+  const char* lastdot = strrchr(box_fname.c_str(), '.');
   if (lastdot != nullptr)
-    box_fname[lastdot - box_fname.string()] = '\0';
+    box_fname[lastdot - box_fname.c_str()] = '\0';
   box_fname += ".box";
   // ReadNextBox() will close box_file
-  FILE* box_file = fopen(box_fname.string(), "r");
+  FILE* box_file = fopen(box_fname.c_str(), "r");
   if (box_file == nullptr) {
-    tprintf("Error: Could not open file %s\n", box_fname.string());
+    tprintf("Error: Could not open file %s\n", box_fname.c_str());
     ASSERT_HOST(box_file);
   }
 
@@ -137,7 +137,7 @@ void Tesseract::recog_training_segmented(const STRING& fname,
     if (keep_going &&
         NearlyEqual<int>(tbox.right(), bbox.right(), kMaxBoxEdgeDiff) &&
         NearlyEqual<int>(tbox.top(), bbox.top(), kMaxBoxEdgeDiff)) {
-      ambigs_classify_and_output(label.string(), &page_res_it, output_file);
+      ambigs_classify_and_output(label.c_str(), &page_res_it, output_file);
       examined_words++;
     }
     page_res_it.forward();

--- a/src/ccmain/reject.cpp
+++ b/src/ccmain/reject.cpp
@@ -59,7 +59,7 @@ CLISTIZEH (STRING) CLISTIZE (STRING)
 namespace tesseract {
 void Tesseract::set_done(WERD_RES *word, int16_t pass) {
   word->done = word->tess_accepted &&
-      (strchr(word->best_choice->unichar_string().string(), ' ') == nullptr);
+      (strchr(word->best_choice->unichar_string().c_str(), ' ') == nullptr);
   bool word_is_ambig = word->best_choice->dangerous_ambig_found();
   bool word_from_dict = word->best_choice->permuter() == SYSTEM_DAWG_PERM ||
       word->best_choice->permuter() == FREQ_DAWG_PERM ||
@@ -123,7 +123,7 @@ void Tesseract::make_reject_map(WERD_RES *word, ROW *row, int16_t pass) {
         word->reject_map.rej_word_not_tess_accepted ();
 
       if (rej_use_tess_blanks &&
-        (strchr (word->best_choice->unichar_string().string (), ' ') != nullptr))
+        (strchr (word->best_choice->unichar_string().c_str(), ' ') != nullptr))
         word->reject_map.rej_word_contains_blanks ();
 
       WERD_CHOICE* best_choice = word->best_choice;
@@ -133,8 +133,8 @@ void Tesseract::make_reject_map(WERD_RES *word, ROW *row, int16_t pass) {
              best_choice->permuter() == USER_DAWG_PERM) &&
             (!rej_use_sensible_wd ||
              acceptable_word_string(*word->uch_set,
-                                    best_choice->unichar_string().string(),
-                                    best_choice->unichar_lengths().string()) !=
+                                    best_choice->unichar_string().c_str(),
+                                    best_choice->unichar_lengths().c_str()) !=
                                         AC_UNACCEPTABLE)) {
           // PASSED TEST
         } else if (best_choice->permuter() == NUMBER_PERM) {
@@ -144,7 +144,7 @@ void Tesseract::make_reject_map(WERD_RES *word, ROW *row, int16_t pass) {
                  offset += best_choice->unichar_lengths()[i++]) {
               if (word->reject_map[i].accepted() &&
                   word->uch_set->get_isalpha(
-                      best_choice->unichar_string().string() + offset,
+                      best_choice->unichar_string().c_str() + offset,
                       best_choice->unichar_lengths()[i]))
                 word->reject_map[i].setrej_bad_permuter();
               // rej alpha
@@ -306,14 +306,14 @@ bool Tesseract::one_ell_conflict(WERD_RES* word_res, bool update_map) {
   bool dict_word_ok;
   int dict_word_type;
 
-  word = word_res->best_choice->unichar_string().string ();
-  lengths = word_res->best_choice->unichar_lengths().string();
+  word = word_res->best_choice->unichar_string().c_str();
+  lengths = word_res->best_choice->unichar_lengths().c_str();
   word_len = strlen(lengths);
   /*
     If there are no occurrences of the conflict set characters then the word
     is OK.
   */
-  if (strpbrk(word, conflict_set_I_l_1.string ()) == nullptr)
+  if (strpbrk(word, conflict_set_I_l_1.c_str()) == nullptr)
     return false;
 
   /*
@@ -528,8 +528,8 @@ void Tesseract::dont_allow_1Il(WERD_RES *word) {
   int i = 0;
   int offset;
   int word_len = word->reject_map.length();
-  const char *s = word->best_choice->unichar_string().string();
-  const char *lengths = word->best_choice->unichar_lengths().string();
+  const char *s = word->best_choice->unichar_string().c_str();
+  const char *lengths = word->best_choice->unichar_lengths().c_str();
   bool accepted_1Il = false;
 
   for (i = 0, offset = 0; i < word_len;

--- a/src/ccmain/resultiterator.cpp
+++ b/src/ccmain/resultiterator.cpp
@@ -4,7 +4,6 @@
 //              iterating in proper reading order over Bi Directional
 //              (e.g. mixed Hebrew and English) text.
 // Author:      David Eger
-// Created:     Fri May 27 13:58:06 PST 2011
 //
 // (C) Copyright 2011, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -636,7 +635,7 @@ char* ResultIterator::GetUTF8Text(PageIteratorLevel level) const {
   }
   int length = text.length() + 1;
   char* result = new char[length];
-  strncpy(result, text.string(), length);
+  strncpy(result, text.c_str(), length);
   return result;
 }
 std::vector<std::vector<std::vector<std::pair<const char*, float>>>>*
@@ -706,7 +705,7 @@ void ResultIterator::IterateAndAppendUTF8TextlineText(STRING* text) {
     AppendUTF8WordText(text);
     words_appended++;
     if (BidiDebug(2)) {
-      tprintf("Num spaces=%d, text=%s\n", numSpaces, text->string());
+      tprintf("Num spaces=%d, text=%s\n", numSpaces, text->c_str());
     }
   } while (Next(RIL_WORD) && !IsAtBeginningOf(RIL_TEXTLINE));
   if (BidiDebug(1)) {

--- a/src/ccmain/superscript.cpp
+++ b/src/ccmain/superscript.cpp
@@ -2,7 +2,6 @@
  * File:        superscript.cpp
  * Description: Correction pass to fix superscripts and subscripts.
  * Author:      David Eger
- * Created:     Mon Mar 12 14:05:00 PDT 2012
  *
  * (C) Copyright 2012, Google, Inc.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,7 +167,7 @@ bool Tesseract::SubAndSuperscriptFix(WERD_RES *word) {
 
   if (superscript_debug >= 1) {
     tprintf("Candidate for superscript detection: %s (",
-            word->best_choice->unichar_string().string());
+            word->best_choice->unichar_string().c_str());
     if (num_leading || num_remainder_leading) {
       tprintf("%d.%d %s-leading ", num_leading, num_remainder_leading,
               leading_pos);
@@ -426,7 +425,7 @@ WERD_RES *Tesseract::TrySuperscriptSplits(
     if (superscript_debug >= 2) {
       tprintf(" The leading bits look like %s %s\n",
               ScriptPosToString(leading_pos),
-              prefix->best_choice->unichar_string().string());
+              prefix->best_choice->unichar_string().c_str());
     }
 
     // Restore the normal y-position penalties.
@@ -451,7 +450,7 @@ WERD_RES *Tesseract::TrySuperscriptSplits(
     if (superscript_debug >= 2) {
       tprintf(" The trailing bits look like %s %s\n",
               ScriptPosToString(trailing_pos),
-              suffix->best_choice->unichar_string().string());
+              suffix->best_choice->unichar_string().c_str());
     }
 
     // Restore the normal y-position penalties.
@@ -495,7 +494,7 @@ WERD_RES *Tesseract::TrySuperscriptSplits(
 
   if (superscript_debug >= 1) {
     tprintf("%s superscript fix: %s\n", *is_good ? "ACCEPT" : "REJECT",
-            core->best_choice->unichar_string().string());
+            core->best_choice->unichar_string().c_str());
   }
   return core;
 }

--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -51,19 +51,19 @@ void Tesseract::read_config_file(const char* filename,
   path += "configs/";
   path += filename;
   FILE* fp;
-  if ((fp = fopen(path.string(), "rb")) != nullptr) {
+  if ((fp = fopen(path.c_str(), "rb")) != nullptr) {
     fclose(fp);
   } else {
     path = datadir;
     path += "tessconfigs/";
     path += filename;
-    if ((fp = fopen(path.string(), "rb")) != nullptr) {
+    if ((fp = fopen(path.c_str(), "rb")) != nullptr) {
       fclose(fp);
     } else {
       path = filename;
     }
   }
-  ParamUtils::ReadParamsFile(path.string(), constraint, this->params());
+  ParamUtils::ReadParamsFile(path.c_str(), constraint, this->params());
 }
 
 // Returns false if a unicharset file for the specified language was not found
@@ -93,8 +93,8 @@ bool Tesseract::init_tesseract_lang_data(
 
   // Initialize TessdataManager.
   STRING tessdata_path = language_data_path_prefix + kTrainedDataSuffix;
-  if (!mgr->is_loaded() && !mgr->Init(tessdata_path.string())) {
-    tprintf("Error opening data file %s\n", tessdata_path.string());
+  if (!mgr->is_loaded() && !mgr->Init(tessdata_path.c_str())) {
+    tprintf("Error opening data file %s\n", tessdata_path.c_str());
     tprintf(
         "Please make sure the TESSDATA_PREFIX environment variable is set"
         " to your \"tessdata\" directory.\n");
@@ -135,23 +135,23 @@ bool Tesseract::init_tesseract_lang_data(
   // files, so that params in vars_vec can override those from files).
   if (vars_vec != nullptr && vars_values != nullptr) {
     for (int i = 0; i < vars_vec->size(); ++i) {
-      if (!ParamUtils::SetParam((*vars_vec)[i].string(),
-                                (*vars_values)[i].string(),
+      if (!ParamUtils::SetParam((*vars_vec)[i].c_str(),
+                                (*vars_values)[i].c_str(),
                                 set_params_constraint, this->params())) {
-        tprintf("Error setting param %s\n", (*vars_vec)[i].string());
+        tprintf("Error setting param %s\n", (*vars_vec)[i].c_str());
         exit(1);
       }
     }
   }
 
   if (!tessedit_write_params_to_file.empty()) {
-    FILE* params_file = fopen(tessedit_write_params_to_file.string(), "wb");
+    FILE* params_file = fopen(tessedit_write_params_to_file.c_str(), "wb");
     if (params_file != nullptr) {
       ParamUtils::PrintParams(params_file, this->params());
       fclose(params_file);
     } else {
       tprintf("Failed to open %s for writing params.\n",
-              tessedit_write_params_to_file.string());
+              tessedit_write_params_to_file.c_str());
     }
   }
 
@@ -226,7 +226,7 @@ bool Tesseract::init_tesseract_lang_data(
     language_model_->getParamsModel().SetPass(
         static_cast<ParamsModel::PassEnum>(p));
     if (mgr->GetComponent(TESSDATA_PARAMS_MODEL, &fp)) {
-      if (!language_model_->getParamsModel().LoadFromFp(lang.string(), &fp)) {
+      if (!language_model_->getParamsModel().LoadFromFp(lang.c_str(), &fp)) {
         return false;
       }
     }
@@ -256,7 +256,7 @@ void Tesseract::ParseLanguageString(const char* lang_str,
   STRING remains(lang_str);
   while (remains.length() > 0) {
     // Find the start of the lang code and which vector to add to.
-    const char* start = remains.string();
+    const char* start = remains.c_str();
     while (*start == '+') ++start;
     GenericVector<STRING>* target = to_load;
     if (*start == '~') {
@@ -301,7 +301,7 @@ int Tesseract::init_tesseract(const char* arg0, const char* textbase,
   // Load the rest into sub_langs_.
   for (int lang_index = 0; lang_index < langs_to_load.size(); ++lang_index) {
     if (!IsStrInList(langs_to_load[lang_index], langs_not_to_load)) {
-      const char* lang_str = langs_to_load[lang_index].string();
+      const char* lang_str = langs_to_load[lang_index].c_str();
       Tesseract* tess_to_init;
       if (!loaded_primary) {
         tess_to_init = this;
@@ -319,7 +319,7 @@ int Tesseract::init_tesseract(const char* arg0, const char* textbase,
         if (result < 0) {
           tprintf("Failed loading language '%s'\n", lang_str);
         } else {
-          ParseLanguageString(tess_to_init->tessedit_load_sublangs.string(),
+          ParseLanguageString(tess_to_init->tessedit_load_sublangs.c_str(),
                               &langs_to_load, &langs_not_to_load);
           loaded_primary = true;
         }
@@ -330,7 +330,7 @@ int Tesseract::init_tesseract(const char* arg0, const char* textbase,
         } else {
           sub_langs_.push_back(tess_to_init);
           // Add any languages that this language requires
-          ParseLanguageString(tess_to_init->tessedit_load_sublangs.string(),
+          ParseLanguageString(tess_to_init->tessedit_load_sublangs.c_str(),
                               &langs_to_load, &langs_not_to_load);
         }
       }

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -585,7 +585,7 @@ Dict& Tesseract::getDict() {
 
 void Tesseract::Clear() {
   STRING debug_name = imagebasename + "_debug.pdf";
-  pixa_debug_.WritePDF(debug_name.string());
+  pixa_debug_.WritePDF(debug_name.c_str());
   pixDestroy(&pix_binary_);
   pixDestroy(&pix_grey_);
   pixDestroy(&pix_thresholds_);
@@ -625,25 +625,25 @@ void Tesseract::ResetDocumentDictionary() {
 
 void Tesseract::SetBlackAndWhitelist() {
   // Set the white and blacklists (if any)
-  unicharset.set_black_and_whitelist(tessedit_char_blacklist.string(),
-                                     tessedit_char_whitelist.string(),
-                                     tessedit_char_unblacklist.string());
+  unicharset.set_black_and_whitelist(tessedit_char_blacklist.c_str(),
+                                     tessedit_char_whitelist.c_str(),
+                                     tessedit_char_unblacklist.c_str());
   if (lstm_recognizer_) {
     UNICHARSET& lstm_unicharset = lstm_recognizer_->GetUnicharset();
-    lstm_unicharset.set_black_and_whitelist(tessedit_char_blacklist.string(),
-                                            tessedit_char_whitelist.string(),
-                                            tessedit_char_unblacklist.string());
+    lstm_unicharset.set_black_and_whitelist(tessedit_char_blacklist.c_str(),
+                                            tessedit_char_whitelist.c_str(),
+                                            tessedit_char_unblacklist.c_str());
   }
   // Black and white lists should apply to all loaded classifiers.
   for (int i = 0; i < sub_langs_.size(); ++i) {
     sub_langs_[i]->unicharset.set_black_and_whitelist(
-        tessedit_char_blacklist.string(), tessedit_char_whitelist.string(),
-        tessedit_char_unblacklist.string());
+        tessedit_char_blacklist.c_str(), tessedit_char_whitelist.c_str(),
+        tessedit_char_unblacklist.c_str());
     if (sub_langs_[i]->lstm_recognizer_) {
       UNICHARSET& lstm_unicharset = sub_langs_[i]->lstm_recognizer_->GetUnicharset();
-      lstm_unicharset.set_black_and_whitelist(tessedit_char_blacklist.string(),
-                                              tessedit_char_whitelist.string(),
-                                              tessedit_char_unblacklist.string());
+      lstm_unicharset.set_black_and_whitelist(tessedit_char_blacklist.c_str(),
+                                              tessedit_char_whitelist.c_str(),
+                                              tessedit_char_unblacklist.c_str());
     }
   }
 }

--- a/src/ccmain/tfacepp.cpp
+++ b/src/ccmain/tfacepp.cpp
@@ -1,8 +1,7 @@
 /**********************************************************************
  * File:        tfacepp.cpp  (Formerly tface++.c)
  * Description: C++ side of the C/C++ Tess/Editor interface.
- * Author:                  Ray Smith
- * Created:                 Thu Apr 23 15:39:23 BST 1992
+ * Author:      Ray Smith
  *
  * (C) Copyright 1992, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +49,7 @@ void Tesseract::recog_word(WERD_RES *word) {
   if (word->best_choice->length() != word->box_word->length()) {
     tprintf("recog_word ASSERT FAIL String:\"%s\"; "
             "Strlen=%d; #Blobs=%d\n",
-            word->best_choice->debug_string().string(),
+            word->best_choice->debug_string().c_str(),
             word->best_choice->length(), word->box_word->length());
   }
   ASSERT_HOST(word->best_choice->length() == word->box_word->length());
@@ -70,8 +69,8 @@ void Tesseract::recog_word(WERD_RES *word) {
       if (((real_dict_perm_type == SYSTEM_DAWG_PERM) ||
            (real_dict_perm_type == FREQ_DAWG_PERM) ||
            (real_dict_perm_type == USER_DAWG_PERM)) &&
-          (alpha_count(word->best_choice->unichar_string().string(),
-                       word->best_choice->unichar_lengths().string()) > 0)) {
+          (alpha_count(word->best_choice->unichar_string().c_str(),
+                       word->best_choice->unichar_lengths().c_str()) > 0)) {
         word->best_choice->set_permuter(real_dict_perm_type);  // use dict perm
       }
     }
@@ -84,7 +83,7 @@ void Tesseract::recog_word(WERD_RES *word) {
   // Factored out from control.cpp
   ASSERT_HOST((word->best_choice == nullptr) == (word->raw_choice == nullptr));
   if (word->best_choice == nullptr || word->best_choice->length() == 0 ||
-      static_cast<int>(strspn(word->best_choice->unichar_string().string(),
+      static_cast<int>(strspn(word->best_choice->unichar_string().c_str(),
                               " ")) == word->best_choice->length()) {
     word->tess_failed = true;
     word->reject_map.initialise(word->box_word->length());
@@ -114,7 +113,7 @@ void Tesseract::recog_word_recursive(WERD_RES *word) {
     word->best_choice->make_bad();  // should never happen
     tprintf("recog_word: Discarded long string \"%s\""
             " (%d characters vs %d blobs)\n",
-            word->best_choice->unichar_string().string(),
+            word->best_choice->unichar_string().c_str(),
             word->best_choice->length(), word_length);
     tprintf("Word is at:");
     word->word->bounding_box().print();

--- a/src/ccstruct/blamer.cpp
+++ b/src/ccstruct/blamer.cpp
@@ -277,7 +277,7 @@ void BlamerBundle::BlameClassifier(const UNICHARSET& unicharset,
       bool found = false;
       bool incorrect_adapted = false;
       UNICHAR_ID incorrect_adapted_id = INVALID_UNICHAR_ID;
-      const char *truth_str = truth_text_[b].string();
+      const char *truth_str = truth_text_[b].c_str();
       // We promise not to modify the list or its contents, using a
       // const BLOB_CHOICE* below.
       BLOB_CHOICE_IT choices_it(const_cast<BLOB_CHOICE_LIST*>(&choices));
@@ -572,7 +572,7 @@ void BlamerBundle::LastChanceBlame(bool debug, WERD_RES* word) {
                                     debug);
     } else if (irr != IRR_CORRECT && correct) {
       if (debug) {
-        tprintf("Corrected %s\n", word->blamer_bundle->debug_.string());
+        tprintf("Corrected %s\n", word->blamer_bundle->debug_.c_str());
       }
       word->blamer_bundle->incorrect_result_reason_ = IRR_CORRECT;
       word->blamer_bundle->debug_ = "";
@@ -591,7 +591,7 @@ void BlamerBundle::SetMisAdaptionDebug(const WERD_CHOICE *best_choice,
     misadaption_debug_ += "): ";
     FillDebugString("", best_choice, &misadaption_debug_);
     if (debug) {
-      tprintf("%s\n", misadaption_debug_.string());
+      tprintf("%s\n", misadaption_debug_.c_str());
     }
   }
 }

--- a/src/ccstruct/blamer.h
+++ b/src/ccstruct/blamer.h
@@ -299,7 +299,7 @@ struct BlamerBundle {
     debug_ = IncorrectReason();
     debug_ += " to blame: ";
     FillDebugString(msg, choice, &debug_);
-    if (debug) tprintf("SetBlame(): %s", debug_.string());
+    if (debug) tprintf("SetBlame(): %s", debug_.c_str());
   }
 
  private:

--- a/src/ccstruct/blread.cpp
+++ b/src/ccstruct/blread.cpp
@@ -44,12 +44,12 @@ bool read_unlv_file(                    //print list of sides
   BLOCK_IT block_it = blocks;    //block iterator
 
   name += UNLV_EXT;              //add extension
-  if ((pdfp = fopen (name.string (), "rb")) == nullptr) {
+  if ((pdfp = fopen (name.c_str (), "rb")) == nullptr) {
     return false;                //didn't read one
   } else {
     while (tfscanf(pdfp, "%d %d %d %d %*s", &x, &y, &width, &height) >= 4) {
                                  //make rect block
-      block = new BLOCK (name.string (), true, 0, 0,
+      block = new BLOCK (name.c_str (), true, 0, 0,
                          static_cast<int16_t>(x), static_cast<int16_t>(ysize - y - height),
                          static_cast<int16_t>(x + width), static_cast<int16_t>(ysize - y));
                                  //on end of list
@@ -57,7 +57,7 @@ bool read_unlv_file(                    //print list of sides
     }
     fclose(pdfp);
   }
-  tprintf("UZN file %s loaded.\n", name.string());
+  tprintf("UZN file %s loaded.\n", name.c_str());
   return true;
 }
 

--- a/src/ccstruct/boxread.cpp
+++ b/src/ccstruct/boxread.cpp
@@ -36,9 +36,9 @@ static const char* kMultiBlobLabelCode = "WordStr";
 FILE* OpenBoxFile(const STRING& fname) {
   STRING filename = BoxFileName(fname);
   FILE* box_file = nullptr;
-  if (!(box_file = fopen(filename.string(), "rb"))) {
+  if (!(box_file = fopen(filename.c_str(), "rb"))) {
     CANTOPENFILE.error("read_next_box", TESSEXIT, "Can't open box file %s",
-                       filename.string());
+                       filename.c_str());
   }
   return box_file;
 }
@@ -81,7 +81,7 @@ bool ReadMemBoxes(int target_page, bool skip_blanks, const char* box_data,
     int page = 0;
     STRING utf8_str;
     TBOX box;
-    if (!ParseBoxFileStr(lines[i].string(), &page, &utf8_str, &box)) {
+    if (!ParseBoxFileStr(lines[i].c_str(), &page, &utf8_str, &box)) {
       if (continue_on_failure)
         continue;
       else
@@ -93,7 +93,7 @@ bool ReadMemBoxes(int target_page, bool skip_blanks, const char* box_data,
     if (texts != nullptr) texts->push_back(utf8_str);
     if (box_texts != nullptr) {
       STRING full_text;
-      MakeBoxFileStr(utf8_str.string(), box, target_page, &full_text);
+      MakeBoxFileStr(utf8_str.c_str(), box, target_page, &full_text);
       box_texts->push_back(full_text);
     }
     if (pages != nullptr) pages->push_back(page);
@@ -105,9 +105,9 @@ bool ReadMemBoxes(int target_page, bool skip_blanks, const char* box_data,
 // Returns the box file name corresponding to the given image_filename.
 STRING BoxFileName(const STRING& image_filename) {
   STRING box_filename = image_filename;
-  const char *lastdot = strrchr(box_filename.string(), '.');
+  const char *lastdot = strrchr(box_filename.c_str(), '.');
   if (lastdot != nullptr)
-    box_filename.truncate_at(lastdot - box_filename.string());
+    box_filename.truncate_at(lastdot - box_filename.c_str());
 
   box_filename += ".box";
   return box_filename;

--- a/src/ccstruct/imagedata.cpp
+++ b/src/ccstruct/imagedata.cpp
@@ -294,12 +294,12 @@ void ImageData::Display() const {
   if (!boxes_.empty()) {
     for (int b = 0; b < boxes_.size(); ++b) {
       boxes_[b].plot(win);
-      win->Text(boxes_[b].left(), height + kTextSize, box_texts_[b].string());
+      win->Text(boxes_[b].left(), height + kTextSize, box_texts_[b].c_str());
     }
   } else {
     // The full transcription.
     win->Pen(ScrollView::CYAN);
-    win->Text(0, height + kTextSize * 2, transcription_.string());
+    win->Text(0, height + kTextSize * 2, transcription_.c_str());
   }
   win->Update();
   window_wait(win);
@@ -363,7 +363,7 @@ bool ImageData::AddBoxes(const char* box_text) {
       return true;
     } else {
       tprintf("Error: No boxes for page %d from image %s!\n",
-              page_number_, imagefilename_.string());
+              page_number_, imagefilename_.c_str());
     }
   }
   return false;
@@ -487,7 +487,7 @@ int64_t DocumentData::UnCache() {
   set_total_pages(-1);
   set_memory_used(0);
   tprintf("Unloaded document %s, saving %" PRId64 " memory\n",
-          document_name_.string(), memory_saved);
+          document_name_.c_str(), memory_saved);
   return memory_saved;
 }
 
@@ -496,7 +496,7 @@ void DocumentData::Shuffle() {
   TRand random;
   // Different documents get shuffled differently, but the same for the same
   // name.
-  random.set_seed(document_name_.string());
+  random.set_seed(document_name_.c_str());
   int num_pages = pages_.size();
   // Execute one random swap for each page in the document.
   for (int i = 0; i < num_pages; ++i) {
@@ -519,7 +519,7 @@ bool DocumentData::ReCachePages() {
   if (!fp.Open(document_name_, reader_) ||
       !PointerVector<ImageData>::DeSerializeSize(&fp, &loaded_pages) ||
       loaded_pages <= 0) {
-    tprintf("Deserialize header failed: %s\n", document_name_.string());
+    tprintf("Deserialize header failed: %s\n", document_name_.c_str());
     return false;
   }
   pages_offset_ %= loaded_pages;
@@ -545,12 +545,12 @@ bool DocumentData::ReCachePages() {
   }
   if (page < loaded_pages) {
     tprintf("Deserialize failed: %s read %d/%d lines\n",
-            document_name_.string(), page, loaded_pages);
+            document_name_.c_str(), page, loaded_pages);
     pages_.truncate(0);
   } else {
     tprintf("Loaded %d/%d lines (%d-%d) of document %s\n", pages_.size(),
             loaded_pages, pages_offset_ + 1, pages_offset_ + pages_.size(),
-            document_name_.string());
+            document_name_.c_str());
   }
   set_total_pages(loaded_pages);
   return !pages_.empty();
@@ -576,7 +576,7 @@ bool DocumentCache::LoadDocuments(const GenericVector<STRING>& filenames,
   for (int arg = 0; arg < filenames.size(); ++arg) {
     STRING filename = filenames[arg];
     auto* document = new DocumentData(filename);
-    document->SetDocument(filename.string(), fair_share_memory, reader);
+    document->SetDocument(filename.c_str(), fair_share_memory, reader);
     AddToCache(document);
   }
   if (!documents_.empty()) {

--- a/src/ccstruct/ocrblock.cpp
+++ b/src/ccstruct/ocrblock.cpp
@@ -198,7 +198,7 @@ void BLOCK::print(            //print list of sides
   tprintf ("Kerning= %d\n", kerning);
   tprintf ("Spacing= %d\n", spacing);
   tprintf ("Fixed_pitch=%d\n", pitch);
-  tprintf ("Filename= %s\n", filename.string ());
+  tprintf ("Filename= %s\n", filename.c_str ());
 
   if (dump) {
     tprintf ("Left side coords are:\n");

--- a/src/ccstruct/ocrblock.h
+++ b/src/ccstruct/ocrblock.h
@@ -100,7 +100,7 @@ class BLOCK:public ELIST_LINK
   }
   /// return filename
   const char *name() const {
-    return filename.string ();
+    return filename.c_str ();
   }
   /// return xheight
   int32_t x_height() const {

--- a/src/ccstruct/ocrpara.cpp
+++ b/src/ccstruct/ocrpara.cpp
@@ -2,7 +2,6 @@
 // File:        ocrpara.cpp
 // Description: OCR Paragraph Output Type
 // Author:      David Eger
-// Created:     2010-11-15
 //
 // (C) Copyright 2010, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,6 +94,6 @@ STRING ParagraphModel::ToString() const {
   const STRING &alignment = ParagraphJustificationToString(justification_);
   snprintf(buffer, sizeof(buffer),
            "margin: %d, first_indent: %d, body_indent: %d, alignment: %s",
-           margin_, first_indent_, body_indent_, alignment.string());
+           margin_, first_indent_, body_indent_, alignment.c_str());
   return STRING(buffer);
 }

--- a/src/ccstruct/pageres.cpp
+++ b/src/ccstruct/pageres.cpp
@@ -489,7 +489,7 @@ void WERD_RES::DebugWordChoices(bool debug, const char* word_to_debug) {
       WERD_CHOICE* choice = it.data();
       STRING label;
       label.add_str_int("\nCooked Choice #", index);
-      choice->print(label.string());
+      choice->print(label.c_str());
     }
   }
 }
@@ -636,7 +636,7 @@ bool WERD_RES::LogNewCookedChoice(int max_num_choices, bool debug,
         word_choice->string_and_lengths(&bad_string, nullptr);
         tprintf("Discarding choice \"%s\" with an overly low certainty"
                 " %.3f vs best choice certainty %.3f (Threshold: %.3f)\n",
-                bad_string.string(), word_choice->certainty(),
+                bad_string.c_str(), word_choice->certainty(),
                 best_choice->certainty(),
                 max_certainty_delta + best_choice->certainty());
       }
@@ -670,7 +670,7 @@ bool WERD_RES::LogNewCookedChoice(int max_num_choices, bool debug,
           // Old is better.
           if (debug) {
             tprintf("Discarding duplicate choice \"%s\", rating %g vs %g\n",
-                    new_str.string(), word_choice->rating(), choice->rating());
+                    new_str.c_str(), word_choice->rating(), choice->rating());
           }
           delete word_choice;
           return false;
@@ -721,7 +721,7 @@ void WERD_RES::PrintBestChoices() const {
     alternates_str += it.data()->unichar_string();
   }
   tprintf("Alternates for \"%s\": {\"%s\"}\n",
-          best_choice->unichar_string().string(), alternates_str.string());
+          best_choice->unichar_string().c_str(), alternates_str.c_str());
 }
 
 // Returns the sum of the widths of the blob between start_blob and last_blob

--- a/src/ccstruct/ratngs.cpp
+++ b/src/ccstruct/ratngs.cpp
@@ -2,7 +2,6 @@
  * File: ratngs.cpp  (Formerly ratings.c)
  * Description: Code to manipulate the BLOB_CHOICE and WERD_CHOICE classes.
  * Author: Ray Smith
- * Created: Thu Apr 23 13:23:29 BST 1992
  *
  * (C) Copyright 1992, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -229,7 +228,7 @@ WERD_CHOICE::WERD_CHOICE(const char *src_string,
                                nullptr)) {
     lengths.push_back('\0');
     STRING src_lengths = &lengths[0];
-    this->init(cleaned.c_str(), src_lengths.string(), 0.0, 0.0, NO_PERM);
+    this->init(cleaned.c_str(), src_lengths.c_str(), 0.0, 0.0, NO_PERM);
   } else {  // There must have been an invalid unichar in the string.
     this->init(8);
     this->make_bad();
@@ -587,7 +586,7 @@ void WERD_CHOICE::SetScriptPositions(bool small_caps, TWERD* word, int debug) {
     if (debug >= 2) {
       tprintf("Most characters of %s are subscript or superscript.\n"
               "That seems wrong, so I'll assume we got the baseline wrong\n",
-              unichar_string().string());
+              unichar_string().c_str());
     }
     for (int i = 0; i < length_; i++) {
       ScriptPos sp = script_pos_[i];
@@ -601,7 +600,7 @@ void WERD_CHOICE::SetScriptPositions(bool small_caps, TWERD* word, int debug) {
 
   if ((debug >= 1 && position_counts[tesseract::SP_NORMAL] < length_) ||
       debug >= 2) {
-    tprintf("SetScriptPosition on %s\n", unichar_string().string());
+    tprintf("SetScriptPosition on %s\n", unichar_string().c_str());
     int chunk_index = 0;
     for (int blob_index = 0; blob_index < length_; ++blob_index) {
       if (debug >= 2 || script_pos_[blob_index] != tesseract::SP_NORMAL) {

--- a/src/ccstruct/ratngs.h
+++ b/src/ccstruct/ratngs.h
@@ -2,7 +2,6 @@
  * File:        ratngs.h  (Formerly ratings.h)
  * Description: Definition of the WERD_CHOICE and BLOB_CHOICE classes.
  * Author:      Ray Smith
- * Created:     Thu Apr 23 11:40:38 BST 1992
  *
  * (C) Copyright 1992, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -172,7 +171,7 @@ class BLOB_CHOICE: public ELIST_LINK
               rating_, certainty_,
               min_xheight_, max_xheight_, unichar_id_,
               (unicharset == nullptr) ? "" :
-              unicharset->debug_str(unichar_id_).string());
+              unicharset->debug_str(unichar_id_).c_str());
     }
     void print_full() const {
       print(nullptr);

--- a/src/ccstruct/werd.cpp
+++ b/src/ccstruct/werd.cpp
@@ -268,7 +268,7 @@ void WERD::print() {
   tprintf("   W_REP_CHAR = %s\n", flags.bit(W_REP_CHAR) ? "TRUE" : "FALSE");
   tprintf("   W_FUZZY_SP = %s\n", flags.bit(W_FUZZY_SP) ? "TRUE" : "FALSE");
   tprintf("   W_FUZZY_NON = %s\n", flags.bit(W_FUZZY_NON) ? "TRUE" : "FALSE");
-  tprintf("Correct= %s\n", correct.string());
+  tprintf("Correct= %s\n", correct.c_str());
   tprintf("Rejected cblob count = %d\n", rej_cblobs.length());
   tprintf("Script = %d\n", script_id_);
 }

--- a/src/ccstruct/werd.h
+++ b/src/ccstruct/werd.h
@@ -111,7 +111,7 @@ class WERD : public ELIST2_LINK {
   // Returns the bounding box of only the good blobs.
   TBOX true_bounding_box() const;
 
-  const char* text() const { return correct.string(); }
+  const char* text() const { return correct.c_str(); }
   void set_text(const char* new_text) { correct = new_text; }
 
   bool flag(WERD_FLAGS mask) const { return flags.bit(mask); }

--- a/src/ccutil/ambigs.cpp
+++ b/src/ccutil/ambigs.cpp
@@ -187,7 +187,7 @@ void UnicharAmbigs::LoadUnicharAmbigs(const UNICHARSET& encoder_set,
         if (!lst->empty()) {
           tprintf("%s Ambiguities for %s:\n",
                   (tbl == 0) ? "Replaceable" : "Dangerous",
-                  unicharset->debug_str(i).string());
+                  unicharset->debug_str(i).c_str());
         }
         AmbigSpec_IT lst_it(lst);
         for (lst_it.mark_cycle_pt(); !lst_it.cycled_list(); lst_it.forward()) {
@@ -208,10 +208,10 @@ void UnicharAmbigs::LoadUnicharAmbigs(const UNICHARSET& encoder_set,
           if (adaption_ambigs_entry != nullptr) {
             tprintf("%sAmbigs for adaption for %s:\n",
                     (vec_id == 0) ? "" : "Reverse ",
-                    unicharset->debug_str(i).string());
+                    unicharset->debug_str(i).c_str());
             for (j = 0; j < adaption_ambigs_entry->size(); ++j) {
               tprintf("%s ", unicharset->debug_str(
-                  (*adaption_ambigs_entry)[j]).string());
+                  (*adaption_ambigs_entry)[j]).c_str());
             }
             tprintf("\n");
           }
@@ -236,7 +236,7 @@ bool UnicharAmbigs::ParseAmbiguityLine(
     }
     // Encode wrong-string.
     GenericVector<UNICHAR_ID> unichars;
-    if (!unicharset.encode_string(fields[0].string(), true, &unichars, nullptr,
+    if (!unicharset.encode_string(fields[0].c_str(), true, &unichars, nullptr,
                                   nullptr)) {
       return false;
     }
@@ -251,7 +251,7 @@ bool UnicharAmbigs::ParseAmbiguityLine(
       test_unichar_ids[i] = unichars[i];
     test_unichar_ids[unichars.size()] = INVALID_UNICHAR_ID;
     // Encode replacement-string to check validity.
-    if (!unicharset.encode_string(fields[1].string(), true, &unichars, nullptr,
+    if (!unicharset.encode_string(fields[1].c_str(), true, &unichars, nullptr,
                                   nullptr)) {
       return false;
     }
@@ -261,11 +261,11 @@ bool UnicharAmbigs::ParseAmbiguityLine(
         tprintf("Too many unichars in ambiguity on line %d\n", line_num);
       return false;
     }
-    if (sscanf(fields[2].string(), "%d", type) != 1) {
+    if (sscanf(fields[2].c_str(), "%d", type) != 1) {
       if (debug_level) tprintf(kIllegalMsg, line_num);
       return false;
     }
-    snprintf(replacement_string, kMaxAmbigStringSize, "%s", fields[1].string());
+    snprintf(replacement_string, kMaxAmbigStringSize, "%s", fields[1].c_str());
     return true;
   }
   int i;
@@ -377,8 +377,8 @@ bool UnicharAmbigs::InsertIntoTable(
     } else {
       STRING frag_str = CHAR_FRAGMENT::to_string(
           replacement_string, i, test_ambig_part_size, false);
-      unicharset->unichar_insert(frag_str.string(), OldUncleanUnichars::kTrue);
-      unichar_id = unicharset->unichar_to_id(frag_str.string());
+      unicharset->unichar_insert(frag_str.c_str(), OldUncleanUnichars::kTrue);
+      unichar_id = unicharset->unichar_to_id(frag_str.c_str());
     }
     ambig_spec->correct_fragments[i] = unichar_id;
   }

--- a/src/ccutil/mainblk.cpp
+++ b/src/ccutil/mainblk.cpp
@@ -53,7 +53,7 @@ void CCUtil::main_setup(const char *argv0, const char *basename) {
     /* Use tessdata prefix from the environment. */
     datadir = tessdata_prefix;
 #if defined(_WIN32)
-  } else if (datadir == nullptr || _access(datadir.string(), 0) != 0) {
+  } else if (datadir == nullptr || _access(datadir.c_str(), 0) != 0) {
     /* Look for tessdata in directory of executable. */
     char path[_MAX_PATH];
     DWORD length = GetModuleFileName(nullptr, path, sizeof(path));
@@ -83,7 +83,7 @@ void CCUtil::main_setup(const char *argv0, const char *basename) {
   }
 
   // check for missing directory separator
-  const char *lastchar = datadir.string();
+  const char *lastchar = datadir.c_str();
   lastchar += datadir.length() - 1;
   if ((strcmp(lastchar, "/") != 0) && (strcmp(lastchar, "\\") != 0))
     datadir += "/";

--- a/src/ccutil/object_cache.h
+++ b/src/ccutil/object_cache.h
@@ -42,7 +42,7 @@ class ObjectCache {
         tprintf("ObjectCache(%p)::~ObjectCache(): WARNING! LEAK! object %p "
                 "still has count %d (id %s)\n",
                 this, cache_[i].object, cache_[i].count,
-                cache_[i].id.string());
+                cache_[i].id.c_str());
       } else {
         delete cache_[i].object;
         cache_[i].object = nullptr;

--- a/src/ccutil/params.cpp
+++ b/src/ccutil/params.cpp
@@ -146,7 +146,7 @@ bool ParamUtils::GetParamAsString(const char *name,
   auto *sp = FindParam<StringParam>(name, GlobalParams()->string_params,
                                            member_params->string_params);
   if (sp) {
-    *value = sp->string();
+    *value = sp->c_str();
     return true;
   }
   // Look for the parameter among int parameters.
@@ -192,7 +192,7 @@ void ParamUtils::PrintParams(FILE *fp, const ParamsVectors *member_params) {
     }
     for (int i = 0; i < vec->string_params.size(); ++i) {
       fprintf(fp, "%s\t%s\t%s\n", vec->string_params[i]->name_str(),
-              vec->string_params[i]->string(), vec->string_params[i]->info_str());
+              vec->string_params[i]->c_str(), vec->string_params[i]->info_str());
     }
     for (int i = 0; i < vec->double_params.size(); ++i) {
       fprintf(fp, "%s\t%g\t%s\n", vec->double_params[i]->name_str(),

--- a/src/ccutil/params.h
+++ b/src/ccutil/params.h
@@ -213,8 +213,7 @@ class StringParam : public Param {
   }
   ~StringParam() { ParamUtils::RemoveParam<StringParam>(this, params_vec_); }
   operator STRING&() { return value_; }
-  const char* string() const { return value_.string(); }
-  const char* c_str() const { return value_.string(); }
+  const char* c_str() const { return value_.c_str(); }
   bool empty() { return value_.length() <= 0; }
   bool operator==(const STRING& other) { return value_ == other; }
   void operator=(const STRING& value) { value_ = value; }

--- a/src/ccutil/strngs.cpp
+++ b/src/ccutil/strngs.cpp
@@ -191,7 +191,7 @@ int32_t STRING::length() const {
   return GetHeader()->used_ - 1;
 }
 
-const char* STRING::string() const {
+const char* STRING::c_str() const {
   const STRING_HEADER* header = GetHeader();
   if (!header || header->used_ == 0)
     return nullptr;
@@ -200,10 +200,6 @@ const char* STRING::string() const {
   // cast away the const and mutate the string directly.
   header->used_ = -1;
   return GetCStr();
-}
-
-const char* STRING::c_str() const {
-  return string();
 }
 
 /******

--- a/src/ccutil/strngs.h
+++ b/src/ccutil/strngs.h
@@ -34,7 +34,7 @@ class TFile;
 // This allows the string to ensure internal integrity and maintain
 // its own string length. Unfortunately this is not possible because
 // STRINGS are used as direct-manipulation data buffers for things
-// like length arrays and many places cast away the const on string()
+// like length arrays and many places cast away the const on c_str()
 // to mutate the string. Turning this off means that internally we
 // cannot assume we know the strlen.
 #define STRING_IS_PROTECTED 0
@@ -74,7 +74,6 @@ class TESS_API STRING {
     assert(0 <= len);
     return static_cast<uint32_t>(len);
   }
-  const char* string() const;
   const char* c_str() const;
 
   inline char* strdup() const {
@@ -167,8 +166,8 @@ class TESS_API STRING {
   inline bool InvariantOk() const {
 #if STRING_IS_PROTECTED
     return (GetHeader()->used_ == 0)
-               ? (string() == nullptr)
-               : (GetHeader()->used_ == (strlen(string()) + 1));
+               ? (c_str() == nullptr)
+               : (GetHeader()->used_ == (strlen(c_str()) + 1));
 #else
     return true;
 #endif

--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -214,7 +214,7 @@ void TessdataManager::Directory() const {
 // Opens the given TFile pointer to the given component type.
 // Returns false in case of failure.
 bool TessdataManager::GetComponent(TessdataType type, TFile *fp) {
-  if (!is_loaded_ && !Init(data_file_name_.string())) return false;
+  if (!is_loaded_ && !Init(data_file_name_.c_str())) return false;
   const TessdataManager *const_this = this;
   return const_this->GetComponent(type, fp);
 }
@@ -250,11 +250,11 @@ bool TessdataManager::CombineDataFiles(
     ASSERT_HOST(TessdataTypeFromFileSuffix(filesuffix, &type));
     STRING filename = language_data_path_prefix;
     filename += filesuffix;
-    FILE *fp = fopen(filename.string(), "rb");
+    FILE *fp = fopen(filename.c_str(), "rb");
     if (fp != nullptr) {
       fclose(fp);
       if (!LoadDataFromFile(filename.c_str(), &entries_[type])) {
-        tprintf("Load of file %s failed!\n", filename.string());
+        tprintf("Load of file %s failed!\n", filename.c_str());
         return false;
       }
     }

--- a/src/ccutil/tprintf.cpp
+++ b/src/ccutil/tprintf.cpp
@@ -34,7 +34,7 @@ static STRING_VAR(debug_file, "", "File to send tprintf output to");
 // Trace printf
 DLLSYM void tprintf(const char *format, ...)
 {
-  const char* debug_file_name = debug_file.string();
+  const char* debug_file_name = debug_file.c_str();
   static FILE *debugfp = nullptr;   // debug file
 
   if (debug_file_name == nullptr) {

--- a/src/ccutil/unicharcompress.cpp
+++ b/src/ccutil/unicharcompress.cpp
@@ -76,7 +76,7 @@ static bool DecodeRadicalTable(STRING* radical_data, RSMap* radical_map) {
   for (int i = 0; i < lines.size(); ++i) {
     if (!DecodeRadicalLine(&lines[i], radical_map)) {
       tprintf("Invalid format in radical table at line %d: %s\n", i,
-              lines[i].string());
+              lines[i].c_str());
       return false;
     }
   }

--- a/src/ccutil/unicharset.cpp
+++ b/src/ccutil/unicharset.cpp
@@ -373,7 +373,7 @@ void UNICHARSET::set_normed_ids(UNICHAR_ID unichar_id) {
   unichars[unichar_id].properties.normed_ids.truncate(0);
   if (unichar_id == UNICHAR_SPACE && id_to_unichar(unichar_id)[0] == ' ') {
     unichars[unichar_id].properties.normed_ids.push_back(UNICHAR_SPACE);
-  } else if (!encode_string(unichars[unichar_id].properties.normed.string(),
+  } else if (!encode_string(unichars[unichar_id].properties.normed.c_str(),
                             true, &unichars[unichar_id].properties.normed_ids,
                             nullptr, nullptr)) {
     unichars[unichar_id].properties.normed_ids.truncate(0);
@@ -722,7 +722,7 @@ bool UNICHARSET::save_to_string(STRING *str) const {
               this->get_direction(id) << ' ' <<
               this->get_mirror(id) << ' ' <<
               this->get_normed_unichar(id) << "\t# " <<
-              this->debug_str(id).string() << '\n';
+              this->debug_str(id).c_str() << '\n';
       *str += stream.str().c_str();
     }
   }

--- a/src/ccutil/unicharset.h
+++ b/src/ccutil/unicharset.h
@@ -817,7 +817,7 @@ class UNICHARSET {
   // Returns normalized version of unichar with the given unichar_id.
   const char *get_normed_unichar(UNICHAR_ID unichar_id) const {
     if (unichar_id == UNICHAR_SPACE) return " ";
-    return unichars[unichar_id].properties.normed.string();
+    return unichars[unichar_id].properties.normed.c_str();
   }
   // Returns a vector of UNICHAR_IDs that represent the ids of the normalized
   // version of the given id. There may be more than one UNICHAR_ID in the

--- a/src/classify/adaptmatch.cpp
+++ b/src/classify/adaptmatch.cpp
@@ -259,7 +259,7 @@ void Classify::LearnWord(const char* fontname, WERD_RES* word) {
 
     if (classify_learning_debug_level >= 1)
       tprintf("\n\nAdapting to word = %s\n",
-              word->best_choice->debug_string().string());
+              word->best_choice->debug_string().c_str());
     thresholds = new float[word_len];
     word->ComputeAdaptionThresholds(certainty_scale,
                                     matcher_perfect_threshold,
@@ -284,13 +284,13 @@ void Classify::LearnWord(const char* fontname, WERD_RES* word) {
 
   for (int ch = 0; ch < word_len; ++ch) {
     if (classify_debug_character_fragments) {
-      tprintf("\nLearning %s\n",  word->correct_text[ch].string());
+      tprintf("\nLearning %s\n",  word->correct_text[ch].c_str());
     }
     if (word->correct_text[ch].length() > 0) {
       float threshold = thresholds != nullptr ? thresholds[ch] : 0.0f;
 
       LearnPieces(fontname, start_blob, word->best_state[ch], threshold,
-                  CST_WHOLE, word->correct_text[ch].string(), word);
+                  CST_WHOLE, word->correct_text[ch].c_str(), word);
 
       if (word->best_state[ch] > 1 && !disable_character_fragments) {
         // Check that the character breaks into meaningful fragments
@@ -314,7 +314,7 @@ void Classify::LearnWord(const char* fontname, WERD_RES* word) {
               word->correct_text[ch].split(' ', &tokens);
 
               tokens[0] = CHAR_FRAGMENT::to_string(
-                  tokens[0].string(), frag, word->best_state[ch],
+                  tokens[0].c_str(), frag, word->best_state[ch],
                   pieces_all_natural);
 
               STRING full_string;
@@ -324,7 +324,7 @@ void Classify::LearnWord(const char* fontname, WERD_RES* word) {
                   full_string += ' ';
               }
               LearnPieces(fontname, start_blob + frag, 1, threshold,
-                          CST_FRAGMENT, full_string.string(), word);
+                          CST_FRAGMENT, full_string.c_str(), word);
             }
           }
         }
@@ -353,7 +353,7 @@ void Classify::LearnWord(const char* fontname, WERD_RES* word) {
         joined_text += word->correct_text[ch + 1];
         LearnPieces(fontname, start_blob,
                     word->best_state[ch] + word->best_state[ch + 1],
-                    threshold, CST_NGRAM, joined_text.string(), word);
+                    threshold, CST_NGRAM, joined_text.c_str(), word);
       }
       */
     }
@@ -392,7 +392,7 @@ void Classify::LearnPieces(const char* fontname, int start, int length,
 
   #ifndef GRAPHICS_DISABLED
   // Draw debug windows showing the blob that is being learned if needed.
-  if (strcmp(classify_learn_debug_str.string(), correct_text) == 0) {
+  if (strcmp(classify_learn_debug_str.c_str(), correct_text) == 0) {
     RefreshDebugWindow(&learn_debug_win_, "LearnPieces", 600,
                        word->chopped_word->bounding_box());
     rotated_blob->plot(learn_debug_win_, ScrollView::GREEN, ScrollView::BROWN);
@@ -463,11 +463,11 @@ void Classify::EndAdaptiveClassifier() {
   if (AdaptedTemplates != nullptr &&
       classify_enable_adaptive_matcher && classify_save_adapted_templates) {
     Filename = imagefile + ADAPT_TEMPLATE_SUFFIX;
-    File = fopen (Filename.string(), "wb");
+    File = fopen (Filename.c_str(), "wb");
     if (File == nullptr)
-      cprintf ("Unable to save adapted templates to %s!\n", Filename.string());
+      cprintf ("Unable to save adapted templates to %s!\n", Filename.c_str());
     else {
-      cprintf ("\nSaving adapted templates to %s ...", Filename.string());
+      cprintf ("\nSaving adapted templates to %s ...", Filename.c_str());
       fflush(stdout);
       WriteAdaptedTemplates(File, AdaptedTemplates);
       cprintf ("\n");
@@ -574,11 +574,11 @@ void Classify::InitAdaptiveClassifier(TessdataManager* mgr) {
 
     Filename = imagefile;
     Filename += ADAPT_TEMPLATE_SUFFIX;
-    if (!fp.Open(Filename.string(), nullptr)) {
+    if (!fp.Open(Filename.c_str(), nullptr)) {
       AdaptedTemplates = NewAdaptedTemplates(true);
     } else {
       cprintf("\nReading pre-adapted templates from %s ...\n",
-              Filename.string());
+              Filename.c_str());
       fflush(stdout);
       AdaptedTemplates = ReadAdaptedTemplates(&fp);
       cprintf("\n");
@@ -1954,7 +1954,7 @@ void Classify::MakePermanent(ADAPT_TEMPLATES Templates,
   if (classify_learning_debug_level >= 1) {
     tprintf("Making config %d for %s (ClassId %d) permanent:"
             " fontinfo id %d, ambiguities '",
-            ConfigId, getDict().getUnicharset().debug_str(ClassId).string(),
+            ConfigId, getDict().getUnicharset().debug_str(ClassId).c_str(),
             ClassId, PermConfigFor(Class, ConfigId)->FontinfoId);
     for (UNICHAR_ID *AmbigsPointer = Ambigs;
         *AmbigsPointer >= 0; ++AmbigsPointer)
@@ -2012,7 +2012,7 @@ namespace tesseract {
  */
 void Classify::PrintAdaptiveMatchResults(const ADAPT_RESULTS& results) {
   for (int i = 0; i < results.match.size(); ++i) {
-    tprintf("%s  ", unicharset.debug_str(results.match[i].unichar_id).string());
+    tprintf("%s  ", unicharset.debug_str(results.match[i].unichar_id).c_str());
     results.match[i].Print();
   }
 }                              /* PrintAdaptiveMatchResults */
@@ -2237,7 +2237,7 @@ bool Classify::TempConfigReliable(CLASS_ID class_id,
                                   const TEMP_CONFIG &config) {
   if (classify_learning_debug_level >= 1) {
     tprintf("NumTimesSeen for config of %s is %d\n",
-            getDict().getUnicharset().debug_str(class_id).string(),
+            getDict().getUnicharset().debug_str(class_id).c_str(),
             config->NumTimesSeen);
   }
   if (config->NumTimesSeen >= matcher_sufficient_examples_for_prototyping) {
@@ -2260,8 +2260,8 @@ bool Classify::TempConfigReliable(CLASS_ID class_id,
           tprintf("Ambig %s has not been seen enough times,"
                   " not making config for %s permanent\n",
                   getDict().getUnicharset().debug_str(
-                      (*ambigs)[ambig]).string(),
-                  getDict().getUnicharset().debug_str(class_id).string());
+                      (*ambigs)[ambig]).c_str(),
+                  getDict().getUnicharset().debug_str(class_id).c_str());
         }
         return false;
       }
@@ -2276,7 +2276,7 @@ void Classify::UpdateAmbigsGroup(CLASS_ID class_id, TBLOB *Blob) {
   int ambigs_size = (ambigs == nullptr) ? 0 : ambigs->size();
   if (classify_learning_debug_level >= 1) {
     tprintf("Running UpdateAmbigsGroup for %s class_id=%d\n",
-            getDict().getUnicharset().debug_str(class_id).string(), class_id);
+            getDict().getUnicharset().debug_str(class_id).c_str(), class_id);
   }
   for (int ambig = 0; ambig < ambigs_size; ++ambig) {
     CLASS_ID ambig_class_id = (*ambigs)[ambig];
@@ -2289,7 +2289,7 @@ void Classify::UpdateAmbigsGroup(CLASS_ID class_id, TBLOB *Blob) {
         if (classify_learning_debug_level >= 1) {
           tprintf("Making config %d of %s permanent\n", cfg,
                   getDict().getUnicharset().debug_str(
-                      ambig_class_id).string());
+                      ambig_class_id).c_str());
         }
         MakePermanent(AdaptedTemplates, ambig_class_id, cfg, Blob);
       }

--- a/src/classify/blobclass.cpp
+++ b/src/classify/blobclass.cpp
@@ -47,9 +47,9 @@ void ExtractFontName(const STRING& filename, STRING* fontname) {
   if (*fontname == kUnknownFontName) {
     // filename is expected to be of the form [lang].[fontname].exp[num]
     // The [lang], [fontname] and [num] fields should not have '.' characters.
-    const char *basename = strrchr(filename.string(), '/');
-    const char *firstdot = strchr(basename ? basename : filename.string(), '.');
-    const char *lastdot  = strrchr(filename.string(), '.');
+    const char *basename = strrchr(filename.c_str(), '/');
+    const char *firstdot = strchr(basename ? basename : filename.c_str(), '.');
+    const char *lastdot  = strrchr(filename.c_str(), '.');
     if (firstdot != lastdot && firstdot != nullptr && lastdot != nullptr) {
       ++firstdot;
       *fontname = firstdot;
@@ -98,7 +98,7 @@ void Classify::LearnBlob(const STRING& fontname, TBLOB* blob,
 bool Classify::WriteTRFile(const STRING& filename) {
   bool result = false;
   STRING tr_filename = filename + ".tr";
-  FILE* fp = fopen(tr_filename.string(), "wb");
+  FILE* fp = fopen(tr_filename.c_str(), "wb");
   if (fp) {
     result =
       tesseract::Serialize(fp, &tr_file_data_[0], tr_file_data_.length());

--- a/src/classify/intmatcher.cpp
+++ b/src/classify/intmatcher.cpp
@@ -362,7 +362,7 @@ class ClassPruner {
             if (norm_count_[class_id] >= pruning_threshold_) {
               tprintf(" %s=%d,",
                       classify.ClassIDToDebugStr(int_templates,
-                                                 class_id, 0).string(),
+                                                 class_id, 0).c_str(),
                       pruner_word & CLASS_PRUNER_CLASS_MASK);
             }
             pruner_word >>= NUM_BITS_PER_CLASS;
@@ -385,7 +385,7 @@ class ClassPruner {
       STRING class_string = classify.ClassIDToDebugStr(int_templates,
                                                        class_id, 0);
       tprintf("%s:Initial=%d, E=%d, Xht-adj=%d, N=%d, Rat=%.2f\n",
-              class_string.string(),
+              class_string.c_str(),
               class_count_[class_id],
               expected_num_features[class_id],
               (norm_multiplier * normalization_factors[class_id]) >> 8,

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -1302,7 +1302,7 @@ CLASS_ID Classify::GetClassToDebug(const char *Prompt, bool* adaptive_on,
           }
           for (int s = 0; s < shape_table_->NumShapes(); ++s) {
             if (shape_table_->GetShape(s).ContainsUnichar(unichar_id)) {
-              tprintf("%s\n", shape_table_->DebugStr(s).string());
+              tprintf("%s\n", shape_table_->DebugStr(s).c_str());
             }
           }
         } else {

--- a/src/classify/shapeclassifier.cpp
+++ b/src/classify/shapeclassifier.cpp
@@ -5,7 +5,6 @@
 // Description: Base interface class for classifiers that return a
 //              shape index.
 // Author:      Ray Smith
-// Created:     Thu Dec 15 15:24:27 PST 2011
 //
 // (C) Copyright 2011, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -194,7 +193,7 @@ void ShapeClassifier::PrintResults(
       tprintf("[J]");
     if (results[i].broken)
       tprintf("[B]");
-    tprintf(" %s\n", GetShapeTable()->DebugStr(results[i].shape_id).string());
+    tprintf(" %s\n", GetShapeTable()->DebugStr(results[i].shape_id).c_str());
   }
 }
 

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -110,7 +110,7 @@ static void CallWithUTF8(std::function<void(const char*)> cb,
                          const WERD_CHOICE* wc) {
   STRING s;
   wc->string_and_lengths(&s, nullptr);
-  cb(s.string());
+  cb(s.c_str());
 }
 
 void Dawg::iterate_words(const UNICHARSET& unicharset,
@@ -329,7 +329,7 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
   if (!file->DeSerialize(&edges_[0], num_edges_)) return false;
   if (debug_level_ > 2) {
     tprintf("type: %d lang: %s perm: %d unicharset_size: %d num_edges: %d\n",
-            type_, lang_.string(), perm_, unicharset_size_, num_edges_);
+            type_, lang_.c_str(), perm_, unicharset_size_, num_edges_);
     for (EDGE_REF edge = 0; edge < num_edges_; ++edge) print_edge(edge);
   }
   return true;

--- a/src/dict/dict.cpp
+++ b/src/dict/dict.cpp
@@ -258,9 +258,9 @@ void Dict::Load(const STRING& lang, TessdataManager* data_file) {
       name = getCCUtil()->language_data_path_prefix;
       name += user_words_suffix;
     }
-    if (!trie_ptr->read_and_add_word_list(name.string(), getUnicharset(),
+    if (!trie_ptr->read_and_add_word_list(name.c_str(), getUnicharset(),
                                           Trie::RRP_REVERSE_IF_HAS_RTL)) {
-      tprintf("Error: failed to load %s\n", name.string());
+      tprintf("Error: failed to load %s\n", name.c_str());
       delete trie_ptr;
     } else {
       dawgs_ += trie_ptr;
@@ -277,8 +277,8 @@ void Dict::Load(const STRING& lang, TessdataManager* data_file) {
       name = getCCUtil()->language_data_path_prefix;
       name += user_patterns_suffix;
     }
-    if (!trie_ptr->read_pattern_list(name.string(), getUnicharset())) {
-      tprintf("Error: failed to load %s\n", name.string());
+    if (!trie_ptr->read_pattern_list(name.c_str(), getUnicharset())) {
+      tprintf("Error: failed to load %s\n", name.c_str());
       delete trie_ptr;
     } else {
       dawgs_ += trie_ptr;
@@ -325,9 +325,9 @@ void Dict::LoadLSTM(const STRING& lang, TessdataManager* data_file) {
       name = getCCUtil()->language_data_path_prefix;
       name += user_words_suffix;
     }
-    if (!trie_ptr->read_and_add_word_list(name.string(), getUnicharset(),
+    if (!trie_ptr->read_and_add_word_list(name.c_str(), getUnicharset(),
                                           Trie::RRP_REVERSE_IF_HAS_RTL)) {
-      tprintf("Error: failed to load %s\n", name.string());
+      tprintf("Error: failed to load %s\n", name.c_str());
       delete trie_ptr;
     } else {
       dawgs_ += trie_ptr;
@@ -344,8 +344,8 @@ void Dict::LoadLSTM(const STRING& lang, TessdataManager* data_file) {
       name = getCCUtil()->language_data_path_prefix;
       name += user_patterns_suffix;
     }
-    if (!trie_ptr->read_pattern_list(name.string(), getUnicharset())) {
-      tprintf("Error: failed to load %s\n", name.string());
+    if (!trie_ptr->read_pattern_list(name.c_str(), getUnicharset())) {
+      tprintf("Error: failed to load %s\n", name.c_str());
       delete trie_ptr;
     } else {
       dawgs_ += trie_ptr;
@@ -409,7 +409,7 @@ int Dict::def_letter_is_okay(void* void_dawg_args, const UNICHARSET& unicharset,
     tprintf(
         "def_letter_is_okay: current unichar=%s word_end=%d"
         " num active dawgs=%d\n",
-        getUnicharset().debug_str(unichar_id).string(), word_end,
+        getUnicharset().debug_str(unichar_id).c_str(), word_end,
         dawg_args->active_dawgs->length());
   }
 
@@ -694,12 +694,12 @@ void Dict::add_document_word(const WERD_CHOICE& best_choice) {
   if (save_doc_words) {
     STRING filename(getCCUtil()->imagefile);
     filename += ".doc";
-    FILE* doc_word_file = fopen(filename.string(), "a");
+    FILE* doc_word_file = fopen(filename.c_str(), "a");
     if (doc_word_file == nullptr) {
-      tprintf("Error: Could not open file %s\n", filename.string());
+      tprintf("Error: Could not open file %s\n", filename.c_str());
       ASSERT_HOST(doc_word_file);
     }
-    fprintf(doc_word_file, "%s\n", best_choice.debug_string().string());
+    fprintf(doc_word_file, "%s\n", best_choice.debug_string().c_str());
     fclose(doc_word_file);
   }
   document_words_->add_word_to_dawg(best_choice);
@@ -742,7 +742,7 @@ void Dict::adjust_word(WERD_CHOICE* word, bool nonword,
   }
   if (debug) {
     tprintf("%sWord: %s %4.2f%s", nonword ? "Non-" : "",
-            word->unichar_string().string(), word->rating(), xheight_triggered);
+            word->unichar_string().c_str(), word->rating(), xheight_triggered);
   }
 
   if (nonword) {  // non-dictionary word

--- a/src/dict/dict.h
+++ b/src/dict/dict.h
@@ -392,7 +392,7 @@ class Dict {
                               const char* character,
                               int character_bytes) {
     return (this->*probability_in_context_)(
-        getCCUtil()->lang.string(),
+        getCCUtil()->lang.c_str(),
         context, context_bytes,
         character, character_bytes);
   }
@@ -421,7 +421,7 @@ class Dict {
   float CallParamsModelClassify(void *path) {
     ASSERT_HOST(params_model_classify_ != nullptr);  // ASSERT_HOST -> assert
     return (this->*params_model_classify_)(
-        getCCUtil()->lang.string(), path);
+        getCCUtil()->lang.c_str(), path);
   }
 
   inline void SetWildcardID(UNICHAR_ID id) { wildcard_unichar_id_ = id; }

--- a/src/dict/permdawg.cpp
+++ b/src/dict/permdawg.cpp
@@ -59,7 +59,7 @@ void Dict::go_deeper_dawg_fxn(
   if (getUnicharset().get_isngram(orig_uch_id)) {
     if (dawg_debug_level) {
       tprintf("checking unigrams in an ngram %s\n",
-              getUnicharset().debug_str(orig_uch_id).string());
+              getUnicharset().debug_str(orig_uch_id).c_str());
     }
     int num_unigrams = 0;
     word->remove_last_unichar_id();
@@ -88,7 +88,7 @@ void Dict::go_deeper_dawg_fxn(
       (*unigram_dawg_args.active_dawgs) = *(unigram_dawg_args.updated_dawgs);
       if (dawg_debug_level) {
         tprintf("unigram %s is %s\n",
-                getUnicharset().debug_str(uch_id).string(),
+                getUnicharset().debug_str(uch_id).c_str(),
                 unigrams_ok ? "OK" : "not OK");
       }
     }
@@ -110,26 +110,26 @@ void Dict::go_deeper_dawg_fxn(
     // Add a new word choice
     if (word_ending) {
       if (dawg_debug_level) {
-        tprintf("found word = %s\n", word->debug_string().string());
+        tprintf("found word = %s\n", word->debug_string().c_str());
       }
-      if (strcmp(output_ambig_words_file.string(), "") != 0) {
+      if (strcmp(output_ambig_words_file.c_str(), "") != 0) {
         if (output_ambig_words_file_ == nullptr) {
           output_ambig_words_file_ =
-              fopen(output_ambig_words_file.string(), "wb+");
+              fopen(output_ambig_words_file.c_str(), "wb+");
           if (output_ambig_words_file_ == nullptr) {
             tprintf("Failed to open output_ambig_words_file %s\n",
-                    output_ambig_words_file.string());
+                    output_ambig_words_file.c_str());
             exit(1);
           }
           STRING word_str;
           word->string_and_lengths(&word_str, nullptr);
           word_str += " ";
-          fprintf(output_ambig_words_file_, "%s", word_str.string());
+          fprintf(output_ambig_words_file_, "%s", word_str.c_str());
         }
         STRING word_str;
         word->string_and_lengths(&word_str, nullptr);
         word_str += " ";
-        fprintf(output_ambig_words_file_, "%s", word_str.string());
+        fprintf(output_ambig_words_file_, "%s", word_str.c_str());
       }
       WERD_CHOICE *adjusted_word = word;
       adjusted_word->set_permuter(more_args->permuter);
@@ -150,7 +150,7 @@ void Dict::go_deeper_dawg_fxn(
   } else {
       if (dawg_debug_level) {
         tprintf("last unichar not OK at index %d in %s\n",
-                word_index, word->debug_string().string());
+                word_index, word->debug_string().c_str());
     }
   }
 }
@@ -209,7 +209,7 @@ void Dict::permute_choices(
     tprintf("%s permute_choices: char_choice_index=%d"
             " limit=%g rating=%g, certainty=%g word=%s\n",
             debug, char_choice_index, *limit, word->rating(),
-            word->certainty(), word->debug_string().string());
+            word->certainty(), word->debug_string().c_str());
   }
   if (char_choice_index < char_choices.length()) {
     BLOB_CHOICE_IT blob_choice_it;
@@ -324,13 +324,13 @@ bool Dict::fragment_state_okay(UNICHAR_ID curr_unichar_id,
   // Print debug info for fragments.
   if (debug && (prev_fragment || this_fragment)) {
     tprintf("%s check fragments: choice=%s word_ending=%d\n", debug,
-            getUnicharset().debug_str(curr_unichar_id).string(),
+            getUnicharset().debug_str(curr_unichar_id).c_str(),
             word_ending);
     if (prev_fragment) {
-      tprintf("prev_fragment %s\n", prev_fragment->to_string().string());
+      tprintf("prev_fragment %s\n", prev_fragment->to_string().c_str());
     }
     if (this_fragment) {
-      tprintf("this_fragment %s\n", this_fragment->to_string().string());
+      tprintf("this_fragment %s\n", this_fragment->to_string().c_str());
     }
   }
 
@@ -358,7 +358,7 @@ bool Dict::fragment_state_okay(UNICHAR_ID curr_unichar_id,
         if (debug) {
           tprintf("Built character %s from fragments\n",
                   getUnicharset().debug_str(
-                      char_frag_info->unichar_id).string());
+                      char_frag_info->unichar_id).c_str());
         }
       } else {
         if (debug) tprintf("Record fragment continuation\n");

--- a/src/dict/stopper.cpp
+++ b/src/dict/stopper.cpp
@@ -61,7 +61,7 @@ bool Dict::AcceptableChoice(const WERD_CHOICE& best_choice,
       default: xht = "UNKNOWN";
     }
     tprintf("\nStopper:  %s (word=%c, case=%c, xht_ok=%s=[%g,%g])\n",
-            best_choice.unichar_string().string(),
+            best_choice.unichar_string().c_str(),
             (is_valid_word ? 'y' : 'n'),
             (is_case_ok ? 'y' : 'n'),
             xht,
@@ -106,7 +106,7 @@ bool Dict::AcceptableResult(WERD_RES *word) const {
 
   if (stopper_debug_level >= 1) {
     tprintf("\nRejecter: %s (word=%c, case=%c, unambig=%c, multiple=%c)\n",
-            word->best_choice->debug_string().string(),
+            word->best_choice->debug_string().c_str(),
             (valid_word(*word->best_choice) ? 'y' : 'n'),
             (case_ok(*word->best_choice) ? 'y' : 'n'),
             word->best_choice->dangerous_ambig_found() ? 'n' : 'y',
@@ -147,7 +147,7 @@ bool Dict::NoDangerousAmbig(WERD_CHOICE *best_choice,
                             MATRIX *ratings) {
   if (stopper_debug_level > 2) {
     tprintf("\nRunning NoDangerousAmbig() for %s\n",
-            best_choice->debug_string().string());
+            best_choice->debug_string().c_str());
   }
 
   // Construct BLOB_CHOICE_LIST_VECTOR with ambiguities
@@ -198,7 +198,7 @@ bool Dict::NoDangerousAmbig(WERD_CHOICE *best_choice,
       if (stopper_debug_level > 2) {
         tprintf("Looking for %s ngrams starting with %s:\n",
                 replace ? "replaceable" : "ambiguous",
-                getUnicharset().debug_str(curr_unichar_id).string());
+                getUnicharset().debug_str(curr_unichar_id).c_str());
       }
       int num_wrong_blobs = best_choice->state(i);
       wrong_ngram_index = 0;
@@ -306,7 +306,7 @@ bool Dict::NoDangerousAmbig(WERD_CHOICE *best_choice,
     if (ambigs_found) {
       if (stopper_debug_level >= 1) {
         tprintf ("Stopper: Possible ambiguous word = %s\n",
-                 alt_word->debug_string().string());
+                 alt_word->debug_string().c_str());
       }
       if (fixpt != nullptr) {
         // Note: Currently character choices combined from fragments can only

--- a/src/dict/trie.cpp
+++ b/src/dict/trie.cpp
@@ -314,7 +314,7 @@ bool Trie::add_word_list(const GenericVector<STRING> &words,
                          const UNICHARSET &unicharset,
                          Trie::RTLReversePolicy reverse_policy) {
   for (int i = 0; i < words.size(); ++i) {
-    WERD_CHOICE word(words[i].string(), unicharset);
+    WERD_CHOICE word(words[i].c_str(), unicharset);
     if (word.length() == 0 || word.contains_unichar_id(INVALID_UNICHAR_ID))
       continue;
     if ((reverse_policy == RRP_REVERSE_IF_HAS_RTL &&
@@ -326,7 +326,7 @@ bool Trie::add_word_list(const GenericVector<STRING> &words,
       add_word_to_dawg(word);
       if (!word_in_dawg(word)) {
         tprintf("Error: word '%s' not in DAWG after adding it\n",
-                words[i].string());
+                words[i].c_str());
         return false;
       }
     }
@@ -456,7 +456,7 @@ bool Trie::read_pattern_list(const char *filename,
     // Insert the pattern into the trie.
     if (debug_level_ > 2) {
       tprintf("Inserting expanded user pattern %s\n",
-              word.debug_string().string());
+              word.debug_string().c_str());
     }
     if (!this->word_in_dawg(word)) {
       this->add_word_to_dawg(word, &repetitions_vec);

--- a/src/lstm/fullyconnected.cpp
+++ b/src/lstm/fullyconnected.cpp
@@ -2,7 +2,6 @@
 // File:        fullyconnected.cpp
 // Description: Simple feed-forward layer with various non-linearities.
 // Author:      Ray Smith
-// Created:     Wed Feb 26 14:49:15 PST 2014
 //
 // (C) Copyright 2014, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,7 +98,7 @@ void FullyConnected::ConvertToInt() {
 
 // Provides debug output on the weights.
 void FullyConnected::DebugWeights() {
-  weights_.Debug2D(name_.string());
+  weights_.Debug2D(name_.c_str());
 }
 
 // Writes to the given file. Returns false in case of error.
@@ -163,7 +162,7 @@ void FullyConnected::Forward(bool debug, const NetworkIO& input,
   }
   output->ZeroInvalidElements();
 #if DEBUG_DETAIL > 0
-  tprintf("F Output:%s\n", name_.string());
+  tprintf("F Output:%s\n", name_.c_str());
   output->Print(10);
 #endif
   if (debug) DisplayForward(*output);
@@ -254,7 +253,7 @@ bool FullyConnected::Backward(bool debug, const NetworkIO& fwd_deltas,
   if (needs_to_backprop_) {
     back_deltas->ZeroInvalidElements();
 #if DEBUG_DETAIL > 0
-    tprintf("F Backprop:%s\n", name_.string());
+    tprintf("F Backprop:%s\n", name_.c_str());
     back_deltas->Print(10);
 #endif
     return true;

--- a/src/lstm/lstm.cpp
+++ b/src/lstm/lstm.cpp
@@ -2,7 +2,6 @@
 // File:        lstm.cpp
 // Description: Long-term-short-term-memory Recurrent neural network.
 // Author:      Ray Smith
-// Created:     Wed May 01 17:43:06 PST 2013
 //
 // (C) Copyright 2013, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -196,7 +195,7 @@ void LSTM::DebugWeights() {
     if (w == GFS && !Is2D()) continue;
     STRING msg = name_;
     msg.add_str_int(" Gate weights ", w);
-    gate_weights_[w].Debug2D(msg.string());
+    gate_weights_[w].Debug2D(msg.c_str());
   }
   if (softmax_ != nullptr) {
     softmax_->DebugWeights();
@@ -426,11 +425,11 @@ void LSTM::Forward(bool debug, const NetworkIO& input,
     }
   } while (src_index.Increment());
 #if DEBUG_DETAIL > 0
-  tprintf("Source:%s\n", name_.string());
+  tprintf("Source:%s\n", name_.c_str());
   source_.Print(10);
-  tprintf("State:%s\n", name_.string());
+  tprintf("State:%s\n", name_.c_str());
   state_.Print(10);
-  tprintf("Output:%s\n", name_.string());
+  tprintf("Output:%s\n", name_.c_str());
   output->Print(10);
 #endif
   if (debug) DisplayForward(*output);
@@ -489,7 +488,7 @@ bool LSTM::Backward(bool debug, const NetworkIO& fwd_deltas,
   }
   double state_clip = Is2D() ? 9.0 : 4.0;
 #if DEBUG_DETAIL > 1
-  tprintf("fwd_deltas:%s\n", name_.string());
+  tprintf("fwd_deltas:%s\n", name_.c_str());
   fwd_deltas.Print(10);
 #endif
   StrideMap::Index dest_index(input_map_);
@@ -639,7 +638,7 @@ bool LSTM::Backward(bool debug, const NetworkIO& fwd_deltas,
   } while (dest_index.Decrement());
 #if DEBUG_DETAIL > 2
   for (int w = 0; w < WT_COUNT; ++w) {
-    tprintf("%s gate errors[%d]\n", name_.string(), w);
+    tprintf("%s gate errors[%d]\n", name_.c_str(), w);
     gate_errors_t[w].get()->PrintUnTransposed(10);
   }
 #endif
@@ -699,7 +698,7 @@ void LSTM::CountAlternators(const Network& other, double* same,
 
 // Prints the weights for debug purposes.
 void LSTM::PrintW() {
-  tprintf("Weight state:%s\n", name_.string());
+  tprintf("Weight state:%s\n", name_.c_str());
   for (int w = 0; w < WT_COUNT; ++w) {
     if (w == GFS && !Is2D()) continue;
     tprintf("Gate %d, inputs\n", w);
@@ -725,7 +724,7 @@ void LSTM::PrintW() {
 
 // Prints the weight deltas for debug purposes.
 void LSTM::PrintDW() {
-  tprintf("Delta state:%s\n", name_.string());
+  tprintf("Delta state:%s\n", name_.c_str());
   for (int w = 0; w < WT_COUNT; ++w) {
     if (w == GFS && !Is2D()) continue;
     tprintf("Gate %d, inputs\n", w);

--- a/src/lstm/network.cpp
+++ b/src/lstm/network.cpp
@@ -174,7 +174,7 @@ static NetworkType getNetworkType(TFile* fp) {
     for (data = 0; data < NT_COUNT && type_name != kTypeNames[data]; ++data) {
     }
     if (data == NT_COUNT) {
-      tprintf("Invalid network layer type:%s\n", type_name.string());
+      tprintf("Invalid network layer type:%s\n", type_name.c_str());
       return NT_NONE;
     }
   }
@@ -288,7 +288,7 @@ double Network::Random(double range) {
 void Network::DisplayForward(const NetworkIO& matrix) {
 #ifndef GRAPHICS_DISABLED  // do nothing if there's no graphics
   Pix* image = matrix.ToPix();
-  ClearWindow(false, name_.string(), pixGetWidth(image),
+  ClearWindow(false, name_.c_str(), pixGetWidth(image),
               pixGetHeight(image), &forward_win_);
   DisplayImage(image, forward_win_);
   forward_win_->Update();
@@ -300,7 +300,7 @@ void Network::DisplayBackward(const NetworkIO& matrix) {
 #ifndef GRAPHICS_DISABLED  // do nothing if there's no graphics
   Pix* image = matrix.ToPix();
   STRING window_name = name_ + "-back";
-  ClearWindow(false, window_name.string(), pixGetWidth(image),
+  ClearWindow(false, window_name.c_str(), pixGetWidth(image),
               pixGetHeight(image), &backward_win_);
   DisplayImage(image, backward_win_);
   backward_win_->Update();

--- a/src/lstm/recodebeam.cpp
+++ b/src/lstm/recodebeam.cpp
@@ -46,7 +46,7 @@ void RecodeNode::Print(int null_char, const UNICHARSET& unicharset,
     tprintf("null_char");
   } else {
     tprintf("label=%d, uid=%d=%s", code, unichar_id,
-            unicharset.debug_str(unichar_id).string());
+            unicharset.debug_str(unichar_id).c_str());
   }
   tprintf(" score=%g, c=%g,%s%s%s perm=%d, hash=%" PRIx64, score, certainty,
           start_of_dawg ? " DawgStart" : "", start_of_word ? " Start" : "",
@@ -1301,7 +1301,7 @@ void RecodeBeamSearch::DebugUnicharPath(
   for (int c = 0; c < num_ids; ++c) {
     int coord = xcoords[c];
     tprintf("%d %d=%s r=%g, c=%g, s=%d, e=%d, perm=%d\n", coord, unichar_ids[c],
-            unicharset->debug_str(unichar_ids[c]).string(), ratings[c],
+            unicharset->debug_str(unichar_ids[c]).c_str(), ratings[c],
             certs[c], path[coord]->start_of_word, path[coord]->end_of_word,
             path[coord]->permuter);
     total_rating += ratings[c];

--- a/src/lstm/series.cpp
+++ b/src/lstm/series.cpp
@@ -2,7 +2,6 @@
 // File:        series.cpp
 // Description: Runs networks in series on the same input.
 // Author:      Ray Smith
-// Created:     Thu May 02 08:26:06 PST 2013
 //
 // (C) Copyright 2013, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +49,7 @@ int Series::InitWeights(float range, TRand* randomizer) {
   for (int i = 0; i < stack_.size(); ++i) {
     int weights = stack_[i]->InitWeights(range, randomizer);
     tprintf("  %s:%d, %d\n",
-            stack_[i]->spec().string(), stack_[i]->NumOutputs(), weights);
+            stack_[i]->spec().c_str(), stack_[i]->NumOutputs(), weights);
     num_weights_ += weights;
   }
   tprintf("Total weights = %d\n", num_weights_);
@@ -64,7 +63,7 @@ int Series::RemapOutputs(int old_no, const std::vector<int>& code_map) {
   tprintf("Num (Extended) outputs,weights in Series:\n");
   for (int i = 0; i < stack_.size(); ++i) {
     int weights = stack_[i]->RemapOutputs(old_no, code_map);
-    tprintf("  %s:%d, %d\n", stack_[i]->spec().string(),
+    tprintf("  %s:%d, %d\n", stack_[i]->spec().c_str(),
             stack_[i]->NumOutputs(), weights);
     num_weights_ += weights;
   }

--- a/src/training/ambiguous_words.cpp
+++ b/src/training/ambiguous_words.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
   GenericVector<STRING> vars_values;
   vars_vec.push_back("output_ambig_words_file");
   vars_values.push_back(output_file_str);
-  api.Init(tessdata_dir, lang.string(), tesseract::OEM_TESSERACT_ONLY, nullptr,
+  api.Init(tessdata_dir, lang.c_str(), tesseract::OEM_TESSERACT_ONLY, nullptr,
            0, &vars_vec, &vars_values, false);
   tesseract::Dict &dict = api.tesseract()->getDict();
   FILE *input_file = fopen(input_file_str, "rb");

--- a/src/training/cntraining.cpp
+++ b/src/training/cntraining.cpp
@@ -206,8 +206,8 @@ static void WriteNormProtos(const char *Directory, LIST LabeledProtoList,
     Filename += "/";
   }
   Filename += "normproto";
-  printf ("\nWriting %s ...", Filename.string());
-  File = fopen(Filename.string(), "wb");
+  printf ("\nWriting %s ...", Filename.c_str());
+  File = fopen(Filename.c_str(), "wb");
   ASSERT_HOST(File);
   fprintf(File, "%0d\n", feature_desc->NumParams);
   WriteParamDesc(File, feature_desc->NumParams, feature_desc->ParamDesc);

--- a/src/training/combine_tessdata.cpp
+++ b/src/training/combine_tessdata.cpp
@@ -3,7 +3,6 @@
 // Description: Creates a unified traineddata file from several
 //              data files produced by the training process.
 // Author:      Daria Antonova
-// Created:     Wed Jun 03 11:26:43 PST 2009
 //
 // (C) Copyright 2009, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -82,11 +81,11 @@ int main(int argc, char **argv) {
       lang += '.';
     STRING output_file = lang;
     output_file += kTrainedDataSuffix;
-    if (!tm.CombineDataFiles(lang.string(), output_file.string())) {
+    if (!tm.CombineDataFiles(lang.c_str(), output_file.c_str())) {
       printf("Error combining tessdata files into %s\n",
-             output_file.string());
+             output_file.c_str());
     } else {
-      printf("Output %s created successfully.\n", output_file.string());
+      printf("Output %s created successfully.\n", output_file.c_str());
     }
   } else if (argc >= 4 && (strcmp(argv[1], "-e") == 0 ||
                            strcmp(argv[1], "-u") == 0)) {
@@ -119,11 +118,11 @@ int main(int argc, char **argv) {
           filename += '.';
         filename += tesseract::kTessdataFileSuffixes[i];
         errno = 0;
-        if (tm.ExtractToFile(filename.string())) {
-          printf("Wrote %s\n", filename.string());
+        if (tm.ExtractToFile(filename.c_str())) {
+          printf("Wrote %s\n", filename.c_str());
         } else if (errno != 0) {
           printf("Error, could not extract %s: %s\n",
-                 filename.string(), strerror(errno));
+                 filename.c_str(), strerror(errno));
           return EXIT_FAILURE;
         }
       }
@@ -133,14 +132,14 @@ int main(int argc, char **argv) {
     const char *new_traineddata_filename = argv[2];
     STRING traineddata_filename = new_traineddata_filename;
     traineddata_filename += ".__tmp__";
-    if (rename(new_traineddata_filename, traineddata_filename.string()) != 0) {
+    if (rename(new_traineddata_filename, traineddata_filename.c_str()) != 0) {
       tprintf("Failed to create a temporary file %s\n",
-              traineddata_filename.string());
+              traineddata_filename.c_str());
       return EXIT_FAILURE;
     }
 
     // Initialize TessdataManager with the data in the given traineddata file.
-    tm.Init(traineddata_filename.string());
+    tm.Init(traineddata_filename.c_str());
 
     // Write the updated traineddata file.
     tm.OverwriteComponents(new_traineddata_filename, argv+3, argc-3);

--- a/src/training/commandlineflags.cpp
+++ b/src/training/commandlineflags.cpp
@@ -24,7 +24,7 @@ static bool IntFlagExists(const char* flag_name, int32_t* value) {
   full_flag_name += flag_name;
   GenericVector<IntParam*> empty;
   IntParam *p = ParamUtils::FindParam<IntParam>(
-      full_flag_name.string(), GlobalParams()->int_params, empty);
+      full_flag_name.c_str(), GlobalParams()->int_params, empty);
   if (p == nullptr) return false;
   *value = (int32_t)(*p);
   return true;
@@ -35,7 +35,7 @@ static bool DoubleFlagExists(const char* flag_name, double* value) {
   full_flag_name += flag_name;
   GenericVector<DoubleParam*> empty;
   DoubleParam *p = ParamUtils::FindParam<DoubleParam>(
-      full_flag_name.string(), GlobalParams()->double_params, empty);
+      full_flag_name.c_str(), GlobalParams()->double_params, empty);
   if (p == nullptr) return false;
   *value = static_cast<double>(*p);
   return true;
@@ -46,7 +46,7 @@ static bool BoolFlagExists(const char* flag_name, bool* value) {
   full_flag_name += flag_name;
   GenericVector<BoolParam*> empty;
   BoolParam *p = ParamUtils::FindParam<BoolParam>(
-      full_flag_name.string(), GlobalParams()->bool_params, empty);
+      full_flag_name.c_str(), GlobalParams()->bool_params, empty);
   if (p == nullptr) return false;
   *value = bool(*p);
   return true;
@@ -57,8 +57,8 @@ static bool StringFlagExists(const char* flag_name, const char** value) {
   full_flag_name += flag_name;
   GenericVector<StringParam*> empty;
   StringParam *p = ParamUtils::FindParam<StringParam>(
-      full_flag_name.string(), GlobalParams()->string_params, empty);
-  *value = (p != nullptr) ? p->string() : nullptr;
+      full_flag_name.c_str(), GlobalParams()->string_params, empty);
+  *value = (p != nullptr) ? p->c_str() : nullptr;
   return p != nullptr;
 }
 
@@ -67,7 +67,7 @@ static void SetIntFlagValue(const char* flag_name, const int32_t new_val) {
   full_flag_name += flag_name;
   GenericVector<IntParam*> empty;
   IntParam *p = ParamUtils::FindParam<IntParam>(
-      full_flag_name.string(), GlobalParams()->int_params, empty);
+      full_flag_name.c_str(), GlobalParams()->int_params, empty);
   ASSERT_HOST(p != nullptr);
   p->set_value(new_val);
 }
@@ -77,7 +77,7 @@ static void SetDoubleFlagValue(const char* flag_name, const double new_val) {
   full_flag_name += flag_name;
   GenericVector<DoubleParam*> empty;
   DoubleParam *p = ParamUtils::FindParam<DoubleParam>(
-      full_flag_name.string(), GlobalParams()->double_params, empty);
+      full_flag_name.c_str(), GlobalParams()->double_params, empty);
   ASSERT_HOST(p != nullptr);
   p->set_value(new_val);
 }
@@ -87,7 +87,7 @@ static void SetBoolFlagValue(const char* flag_name, const bool new_val) {
   full_flag_name += flag_name;
   GenericVector<BoolParam*> empty;
   BoolParam *p = ParamUtils::FindParam<BoolParam>(
-      full_flag_name.string(), GlobalParams()->bool_params, empty);
+      full_flag_name.c_str(), GlobalParams()->bool_params, empty);
   ASSERT_HOST(p != nullptr);
   p->set_value(new_val);
 }
@@ -97,7 +97,7 @@ static void SetStringFlagValue(const char* flag_name, const char* new_val) {
   full_flag_name += flag_name;
   GenericVector<StringParam*> empty;
   StringParam *p = ParamUtils::FindParam<StringParam>(
-      full_flag_name.string(), GlobalParams()->string_params, empty);
+      full_flag_name.c_str(), GlobalParams()->string_params, empty);
   ASSERT_HOST(p != nullptr);
   p->set_value(STRING(new_val));
 }
@@ -158,7 +158,7 @@ static void PrintCommandLineFlags() {
       printf("  --%s  %s  (type:string default:%s)\n",
              GlobalParams()->string_params[i]->name_str() + kFlagNamePrefixLen,
              GlobalParams()->string_params[i]->info_str(),
-             GlobalParams()->string_params[i]->string());
+             GlobalParams()->string_params[i]->c_str());
     }
   }
 }
@@ -218,7 +218,7 @@ void ParseCommandLineFlags(const char* usage,
     // Find the flag name in the list of global flags.
     // int32_t flag
     int32_t int_val;
-    if (IntFlagExists(lhs.string(), &int_val)) {
+    if (IntFlagExists(lhs.c_str(), &int_val)) {
       if (rhs != nullptr) {
         if (!strlen(rhs)) {
           // Bad input of the format --int_flag=
@@ -234,7 +234,7 @@ void ParseCommandLineFlags(const char* usage,
         // We need to parse the next argument
         if (i + 1 >= *argc) {
           tprintf("ERROR: Could not find value argument for flag %s\n",
-                  lhs.string());
+                  lhs.c_str());
           exit(1);
         } else {
           ++i;
@@ -244,13 +244,13 @@ void ParseCommandLineFlags(const char* usage,
           }
         }
       }
-      SetIntFlagValue(lhs.string(), int_val);
+      SetIntFlagValue(lhs.c_str(), int_val);
       continue;
     }
 
     // double flag
     double double_val;
-    if (DoubleFlagExists(lhs.string(), &double_val)) {
+    if (DoubleFlagExists(lhs.c_str(), &double_val)) {
       if (rhs != nullptr) {
         if (!strlen(rhs)) {
           // Bad input of the format --double_flag=
@@ -266,7 +266,7 @@ void ParseCommandLineFlags(const char* usage,
         // We need to parse the next argument
         if (i + 1 >= *argc) {
           tprintf("ERROR: Could not find value argument for flag %s\n",
-                  lhs.string());
+                  lhs.c_str());
           exit(1);
         } else {
           ++i;
@@ -276,14 +276,14 @@ void ParseCommandLineFlags(const char* usage,
           }
         }
       }
-      SetDoubleFlagValue(lhs.string(), double_val);
+      SetDoubleFlagValue(lhs.c_str(), double_val);
       continue;
     }
 
     // Bool flag. Allow input forms --flag (equivalent to --flag=true),
     // --flag=false, --flag=true, --flag=0 and --flag=1
     bool bool_val;
-    if (BoolFlagExists(lhs.string(), &bool_val)) {
+    if (BoolFlagExists(lhs.c_str(), &bool_val)) {
       if (rhs == nullptr) {
         // --flag form
         bool_val = true;
@@ -302,26 +302,26 @@ void ParseCommandLineFlags(const char* usage,
           exit(1);
         }
       }
-      SetBoolFlagValue(lhs.string(), bool_val);
+      SetBoolFlagValue(lhs.c_str(), bool_val);
       continue;
     }
 
     // string flag
     const char* string_val;
-    if (StringFlagExists(lhs.string(), &string_val)) {
+    if (StringFlagExists(lhs.c_str(), &string_val)) {
       if (rhs != nullptr) {
         string_val = rhs;
       } else {
         // Pick the next argument
         if (i + 1 >= *argc) {
           tprintf("ERROR: Could not find string value for flag %s\n",
-                  lhs.string());
+                  lhs.c_str());
           exit(1);
         } else {
           string_val = (*argv)[++i];
         }
       }
-      SetStringFlagValue(lhs.string(), string_val);
+      SetStringFlagValue(lhs.c_str(), string_val);
       continue;
     }
 

--- a/src/training/commontraining.cpp
+++ b/src/training/commontraining.cpp
@@ -156,21 +156,21 @@ ShapeTable* LoadShapeTable(const STRING& file_prefix) {
   STRING shape_table_file = file_prefix;
   shape_table_file += kShapeTableFileSuffix;
   TFile shape_fp;
-  if (shape_fp.Open(shape_table_file.string(), nullptr)) {
+  if (shape_fp.Open(shape_table_file.c_str(), nullptr)) {
     shape_table = new ShapeTable;
     if (!shape_table->DeSerialize(&shape_fp)) {
       delete shape_table;
       shape_table = nullptr;
       tprintf("Error: Failed to read shape table %s\n",
-              shape_table_file.string());
+              shape_table_file.c_str());
     } else {
       int num_shapes = shape_table->NumShapes();
       tprintf("Read shape table %s of %d shapes\n",
-              shape_table_file.string(), num_shapes);
+              shape_table_file.c_str(), num_shapes);
     }
   } else {
     tprintf("Warning: No shape table file present: %s\n",
-            shape_table_file.string());
+            shape_table_file.c_str());
   }
   return shape_table;
 }
@@ -179,16 +179,16 @@ ShapeTable* LoadShapeTable(const STRING& file_prefix) {
 void WriteShapeTable(const STRING& file_prefix, const ShapeTable& shape_table) {
   STRING shape_table_file = file_prefix;
   shape_table_file += kShapeTableFileSuffix;
-  FILE* fp = fopen(shape_table_file.string(), "wb");
+  FILE* fp = fopen(shape_table_file.c_str(), "wb");
   if (fp != nullptr) {
     if (!shape_table.Serialize(fp)) {
       fprintf(stderr, "Error writing shape table: %s\n",
-              shape_table_file.string());
+              shape_table_file.c_str());
     }
     fclose(fp);
   } else {
     fprintf(stderr, "Error creating shape table: %s\n",
-            shape_table_file.string());
+            shape_table_file.c_str());
   }
 }
 
@@ -272,7 +272,7 @@ MasterTrainer* LoadTrainingData(int argc, const char* const * argv,
       // Chop off the tr and replace with tif. Extension must be tif!
       image_name.truncate_at(image_name.length() - 2);
       image_name += "tif";
-      trainer->LoadPageImages(image_name.string());
+      trainer->LoadPageImages(image_name.c_str());
     }
   }
   trainer->PostLoadCleanup();
@@ -300,7 +300,7 @@ MasterTrainer* LoadTrainingData(int argc, const char* const * argv,
       *shape_table = new ShapeTable;
       trainer->SetupFlatShapeTable(*shape_table);
       tprintf("Flat shape table summary: %s\n",
-              (*shape_table)->SummaryStr().string());
+              (*shape_table)->SummaryStr().c_str());
     }
     (*shape_table)->set_unicharset(trainer->unicharset());
   }

--- a/src/training/errorcounter.cpp
+++ b/src/training/errorcounter.cpp
@@ -77,7 +77,7 @@ double ErrorCounter::ComputeErrorRate(ShapeClassifier* classifier,
       // Running debug, keep the correct answer, and debug the classifier.
       tprintf("Error on sample %d: %s Classifier debug output:\n",
               it->GlobalSampleIndex(),
-              it->sample_set()->SampleToString(*mutable_sample).string());
+              it->sample_set()->SampleToString(*mutable_sample).c_str());
       classifier->DebugDisplay(*mutable_sample, page_pix, correct_id);
       --error_samples;
     }
@@ -358,7 +358,7 @@ double ErrorCounter::ReportErrors(int report_level, CountTypes boosting_mode,
       }
       if (report_level > 2) {
         // Report individual font error rates.
-        tprintf("%s: %s\n", fontinfo_table.get(f).name, font_report.string());
+        tprintf("%s: %s\n", fontinfo_table.get(f).name, font_report.c_str());
       }
     }
   }
@@ -376,7 +376,7 @@ double ErrorCounter::ReportErrors(int report_level, CountTypes boosting_mode,
     STRING total_report;
     if (any_results) {
       tprintf("TOTAL Scaled Err=%.4g%%, %s\n",
-              scaled_error_ * 100.0, total_report.string());
+              scaled_error_ * 100.0, total_report.c_str());
     }
     // Report the worst substitution error only for now.
     if (totals.n[CT_UNICHAR_TOP1_ERR] > 0) {

--- a/src/training/lang_model_helpers.cpp
+++ b/src/training/lang_model_helpers.cpp
@@ -118,7 +118,7 @@ bool WriteRecoder(const UNICHARSET& unicharset, bool pass_through,
   STRING suffix;
   suffix.add_str_int(".charset_size=", recoder.code_range());
   suffix += ".txt";
-  return WriteFile(output_dir, lang, suffix.string(), recoder_data, writer);
+  return WriteFile(output_dir, lang, suffix.c_str(), recoder_data, writer);
 }
 
 // Helper builds a dawg from the given words, using the unicharset as coding,

--- a/src/training/lstmeval.cpp
+++ b/src/training/lstmeval.cpp
@@ -76,6 +76,6 @@ int main(int argc, char **argv) {
   STRING result =
       tester.RunEvalSync(0, &errs, mgr,
                          /*training_stage (irrelevant)*/ 0, FLAGS_verbosity);
-  tprintf("%s\n", result.string());
+  tprintf("%s\n", result.c_str());
   return 0;
 } /* main */

--- a/src/training/lstmtester.cpp
+++ b/src/training/lstmtester.cpp
@@ -32,7 +32,7 @@ bool LSTMTester::LoadAllEvalData(const STRING& filenames_file) {
   GenericVector<STRING> filenames;
   if (!LoadFileLinesToStrings(filenames_file.c_str(), &filenames)) {
     tprintf("Failed to load list of eval filenames from %s\n",
-            filenames_file.string());
+            filenames_file.c_str());
     return false;
   }
   return LoadAllEvalData(filenames);
@@ -106,12 +106,12 @@ STRING LSTMTester::RunEvalSync(int iteration, const double* training_errors,
       word_error += trainer.NewSingleError(tesseract::ET_WORD_RECERR);
       ++error_count;
       if (verbosity > 1 || (verbosity > 0 && result != PERFECT)) {
-        tprintf("Truth:%s\n", trainingdata->transcription().string());
+        tprintf("Truth:%s\n", trainingdata->transcription().c_str());
         GenericVector<int> ocr_labels;
         GenericVector<int> xcoords;
         trainer.LabelsFromOutputs(fwd_outputs, &ocr_labels, &xcoords);
         STRING ocr_text = trainer.DecodeLabels(ocr_labels);
-        tprintf("OCR  :%s\n", ocr_text.string());
+        tprintf("OCR  :%s\n", ocr_text.c_str());
       }
     }
   }

--- a/src/training/lstmtraining.cpp
+++ b/src/training/lstmtraining.cpp
@@ -143,10 +143,10 @@ int main(int argc, char **argv) {
   }
 
   // Checkpoints always take priority if they are available.
-  if (trainer.TryLoadingCheckpoint(checkpoint_file.string(), nullptr) ||
-      trainer.TryLoadingCheckpoint(checkpoint_bak.string(), nullptr)) {
+  if (trainer.TryLoadingCheckpoint(checkpoint_file.c_str(), nullptr) ||
+      trainer.TryLoadingCheckpoint(checkpoint_bak.c_str(), nullptr)) {
     tprintf("Successfully restored trainer from %s\n",
-            checkpoint_file.string());
+            checkpoint_file.c_str());
   } else {
     if (!FLAGS_continue_from.empty()) {
       // Load a past model file to improve upon.
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
     }
     STRING log_str;
     trainer.MaintainCheckpoints(tester_callback, &log_str);
-    tprintf("%s\n", log_str.string());
+    tprintf("%s\n", log_str.c_str());
   } while (trainer.best_error_rate() > FLAGS_target_error_rate &&
            (trainer.training_iteration() < FLAGS_max_iterations ||
             FLAGS_max_iterations == 0));

--- a/src/training/mastertrainer.cpp
+++ b/src/training/mastertrainer.cpp
@@ -2,7 +2,6 @@
 // File:        mastertrainer.cpp
 // Description: Trainer to build the MasterClassifier.
 // Author:      Ray Smith
-// Created:     Wed Nov 03 18:10:01 PDT 2010
 //
 // (C) Copyright 2010, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -151,7 +150,7 @@ void MasterTrainer::ReadTrainingSamples(const char* page_name,
     sample->set_bounding_box(bounding_box);
     sample->ExtractCharDesc(int_feature_type, micro_feature_type,
                             cn_feature_type, geo_feature_type, char_desc);
-    AddSample(verification, unichar.string(), sample);
+    AddSample(verification, unichar.c_str(), sample);
     FreeCharDescription(char_desc);
   }
   charsetsize_ = unicharset_.size();
@@ -278,7 +277,7 @@ void MasterTrainer::SetupMasterShapes() {
   ClusterShapes(kMinClusteredShapes, kMaxUnicharsPerCluster,
                 kFontMergeDistance, &char_shapes);
   master_shapes_.AppendMasterShapes(char_shapes, nullptr);
-  tprintf("Master shape_table:%s\n", master_shapes_.SummaryStr().string());
+  tprintf("Master shape_table:%s\n", master_shapes_.SummaryStr().c_str());
 }
 
 // Adds the junk_samples_ to the main samples_ set. Junk samples are initially
@@ -866,7 +865,7 @@ void MasterTrainer::ReplaceFragmentedSamples() {
     // Mark the chars for all parts of the fragment as good in good_junk.
     for (int part = 0; part < frag->get_total(); ++part) {
       frag->set_pos(part);
-      int good_ch = frag_set.unichar_to_id(frag->to_string().string());
+      int good_ch = frag_set.unichar_to_id(frag->to_string().c_str());
       if (good_ch != INVALID_UNICHAR_ID)
         good_junk[good_ch] = true;  // We want this one.
     }
@@ -974,7 +973,7 @@ void MasterTrainer::ClusterShapes(int min_shapes,  int max_shape_unichars,
   if (debug_level_ > 1) {
     for (int s1 = 0; s1 < num_shapes; ++s1) {
       if (shapes->MasterDestinationIndex(s1) == s1) {
-        tprintf("Master shape:%s\n", shapes->DebugStr(s1).string());
+        tprintf("Master shape:%s\n", shapes->DebugStr(s1).c_str());
       }
     }
   }

--- a/src/training/mftraining.cpp
+++ b/src/training/mftraining.cpp
@@ -272,8 +272,8 @@ int main (int argc, char **argv) {
   // Now write the inttemp and pffmtable.
   trainer->WriteInttempAndPFFMTable(trainer->unicharset(), *unicharset,
                                     *shape_table, float_classes,
-                                    inttemp_file.string(),
-                                    pffmtable_file.string());
+                                    inttemp_file.c_str(),
+                                    pffmtable_file.c_str());
   for (int c = 0; c < unicharset->size(); ++c) {
     FreeClassFields(&float_classes[c]);
   }

--- a/src/training/trainingsampleset.cpp
+++ b/src/training/trainingsampleset.cpp
@@ -644,10 +644,10 @@ void TrainingSampleSet::ComputeCanonicalSamples(const IntFeatureMap& map,
       if (debug) {
         tprintf("Found %d samples of class %d=%s, font %d, "
                 "dist range [%g, %g], worst pair= %s, %s\n",
-                samples_found, c, unicharset_.debug_str(c).string(),
+                samples_found, c, unicharset_.debug_str(c).c_str(),
                 font_index, min_max_dist, max_max_dist,
-                SampleToString(*samples_[max_s1]).string(),
-                SampleToString(*samples_[max_s2]).string());
+                SampleToString(*samples_[max_s1]).c_str(),
+                SampleToString(*samples_[max_s2]).c_str());
       }
     }
   }

--- a/src/training/unicharset_extractor.cpp
+++ b/src/training/unicharset_extractor.cpp
@@ -47,7 +47,7 @@ static void AddStringsToUnicharset(const GenericVector<STRING>& strings,
     if (NormalizeCleanAndSegmentUTF8(UnicodeNormMode::kNFC, OCRNorm::kNone,
                                      static_cast<GraphemeNormMode>(norm_mode),
                                      /*report_errors*/ true,
-                                     strings[i].string(), &normalized)) {
+                                     strings[i].c_str(), &normalized)) {
       for (const std::string& normed : normalized) {
 
        // normed is a UTF-8 encoded string

--- a/src/viewer/svmnode.cpp
+++ b/src/viewer/svmnode.cpp
@@ -120,16 +120,16 @@ void SVMenuNode::AddChild(SVMenuNode* svmn) {
 void SVMenuNode::BuildMenu(ScrollView* sv, bool menu_bar) {
   if ((parent_ != nullptr) && (menu_bar)) {
     if (is_check_box_entry_) {
-      sv->MenuItem(parent_->text_.string(), text_.string(), cmd_event_,
+      sv->MenuItem(parent_->text_.c_str(), text_.c_str(), cmd_event_,
                    toggle_value_);
     } else {
-      sv->MenuItem(parent_->text_.string(), text_.string(), cmd_event_); }
+      sv->MenuItem(parent_->text_.c_str(), text_.c_str(), cmd_event_); }
   } else if ((parent_ != nullptr) && (!menu_bar)) {
     if (description_.length() > 0) {
-      sv->PopupItem(parent_->text_.string(), text_.string(), cmd_event_,
-                    value_.string(), description_.string());
+      sv->PopupItem(parent_->text_.c_str(), text_.c_str(), cmd_event_,
+                    value_.c_str(), description_.c_str());
       } else {
-      sv->PopupItem(parent_->text_.string(), text_.string());
+      sv->PopupItem(parent_->text_.c_str(), text_.c_str());
     }
   }
   if (child_ != nullptr) {

--- a/src/wordrec/language_model.cpp
+++ b/src/wordrec/language_model.cpp
@@ -157,7 +157,7 @@ void LanguageModel::InitForWord(const WERD_CHOICE *prev_word,
     } else {
       prev_word_str_ = " ";
     }
-    const char *str_ptr = prev_word_str_.string();
+    const char *str_ptr = prev_word_str_.c_str();
     const char *str_end = str_ptr + prev_word_str_.length();
     int step;
     prev_word_unichar_step_len_ = 0;
@@ -882,10 +882,10 @@ LanguageModelNgramInfo *LanguageModel::GenerateNgramInfo(
   const char *pcontext_ptr = "";
   int pcontext_unichar_step_len = 0;
   if (parent_vse == nullptr) {
-    pcontext_ptr = prev_word_str_.string();
+    pcontext_ptr = prev_word_str_.c_str();
     pcontext_unichar_step_len = prev_word_unichar_step_len_;
   } else {
-    pcontext_ptr = parent_vse->ngram_info->context.string();
+    pcontext_ptr = parent_vse->ngram_info->context.c_str();
     pcontext_unichar_step_len =
       parent_vse->ngram_info->context_unichar_step_len;
   }
@@ -1251,7 +1251,7 @@ void LanguageModel::UpdateBestChoice(
   if (dict_->stopper_debug_level >= 1) {
     STRING word_str;
     word->string_and_lengths(&word_str, nullptr);
-    vse->Print(word_str.string());
+    vse->Print(word_str.c_str());
   }
   if (language_model_debug_level > 0) {
     word->print("UpdateBestChoice() constructed word");
@@ -1266,7 +1266,7 @@ void LanguageModel::UpdateBestChoice(
     curr_hyp.cost = vse->cost;  // record cost for error rate computations
     if (language_model_debug_level > 0) {
       tprintf("Raw features extracted from %s (cost=%g) [ ",
-              curr_hyp.str.string(), curr_hyp.cost);
+              curr_hyp.str.c_str(), curr_hyp.cost);
       for (float feature : curr_hyp.features) {
         tprintf("%g ", feature);
       }

--- a/src/wordrec/lm_state.cpp
+++ b/src/wordrec/lm_state.cpp
@@ -3,7 +3,6 @@
 // Description: Structures and functionality for capturing the state of
 //              segmentation search guided by the language model.
 // Author:      Rika Antonova
-// Created:     Mon Jun 20 11:26:43 PST 2012
 //
 // (C) Copyright 2012, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +27,7 @@ void ViterbiStateEntry::Print(const char *msg) const {
   tprintf("%s ViterbiStateEntry", msg);
   if (updated) tprintf("(NEW)");
   if (this->debug_str != nullptr) {
-    tprintf(" str=%s", this->debug_str->string());
+    tprintf(" str=%s", this->debug_str->c_str());
   }
   tprintf(" with ratings_sum=%.4f length=%d cost=%.6f",
           this->ratings_sum, this->length, this->cost);
@@ -47,7 +46,7 @@ void ViterbiStateEntry::Print(const char *msg) const {
   if (this->ngram_info) {
     tprintf(" ngram_cl_cost=%g context=%s ngram pruned=%d",
             this->ngram_info->ngram_and_classifier_cost,
-            this->ngram_info->context.string(),
+            this->ngram_info->context.c_str(),
             this->ngram_info->pruned);
   }
   if (this->associate_stats.shape_cost > 0.0f) {

--- a/src/wordrec/params_model.cpp
+++ b/src/wordrec/params_model.cpp
@@ -36,7 +36,7 @@ static const float kMaxFinalCost = 100.0f;
 
 void ParamsModel::Print() {
   for (int p = 0; p < PTRAIN_NUM_PASSES; ++p) {
-    tprintf("ParamsModel for pass %d lang %s\n", p, lang_.string());
+    tprintf("ParamsModel for pass %d lang %s\n", p, lang_.c_str());
     for (int i = 0; i < weights_vec_[p].size(); ++i) {
       tprintf("%s = %g\n", kParamsTrainingFeatureTypeName[i],
               weights_vec_[p][i]);

--- a/src/wordrec/tface.cpp
+++ b/src/wordrec/tface.cpp
@@ -126,7 +126,7 @@ void Wordrec::cc_recog(WERD_RES *word) {
   getDict().reset_hyphen_vars(word->word->flag(W_EOL));
   chop_word_main(word);
   word->DebugWordChoices(getDict().stopper_debug_level >= 1,
-                         getDict().word_to_debug.string());
+                         getDict().word_to_debug.c_str());
   ASSERT_HOST(word->StatesAllValid());
 }
 


### PR DESCRIPTION
They were redundant because there exist member functions 'c_str' which do the same.

Signed-off-by: Stefan Weil <sw@weilnetz.de>