### PR TITLE
Extend function BoxFileName to handle more common image names

### DIFF
--- a/src/ccstruct/boxread.h
+++ b/src/ccstruct/boxread.h
@@ -2,7 +2,6 @@
  * File:        boxread.h
  * Description: Read data from a box file.
  * Author:      Ray Smith
- * Created:     Fri Aug 24 17:47:23 PDT 2007
  *
  * (C) Copyright 2007, Google Inc.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,9 +57,6 @@ bool ReadMemBoxes(int target_page, bool skip_blanks, const char* box_data,
                   GenericVector<STRING>* texts,
                   GenericVector<STRING>* box_texts,
                   GenericVector<int>* pages);
-
-// Returns the box file name corresponding to the given image_filename.
-STRING BoxFileName(const STRING& image_filename);
 
 // ReadNextBox factors out the code to interpret a line of a box
 // file so that applybox and unicharset_extractor interpret the same way.


### PR DESCRIPTION
The function derives the file name for the .box file from an image name.

For training from existing line images, it is useful to directly support
the image names which are commonly used.

While generated images for Tesseract training typically use the name
pattern NAME.tif, other ground truth sets use NAME.bin.png for binarized
or NAME.nrm.png for grayscale images.

BoxFileName is also now a local function as it is only used locally.

Signed-off-by: Stefan Weil <sw@weilnetz.de>