### PR TITLE
Optional speed optimisation

### DIFF
--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -236,7 +236,9 @@ void Tesseract::LSTMRecognizeWord(const BLOCK& block, ROW *row, WERD_RES *word,
   }
   ImageData* im_data = GetRectImage(word_box, block, kImagePadding, &word_box);
   if (im_data == nullptr) return;
-  lstm_recognizer_->RecognizeLine(*im_data, true, classify_debug_level > 0,
+
+  bool do_invert = tessedit_do_invert;
+  lstm_recognizer_->RecognizeLine(*im_data, do_invert, classify_debug_level > 0,
                                   kWorstDictCertainty / kCertaintyScale,
                                   word_box, words, lstm_choice_mode,
                                   lstm_choice_iterations);

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -66,6 +66,8 @@ Tesseract::Tesseract()
       BOOL_MEMBER(tessedit_dump_pageseg_images, false,
                   "Dump intermediate images made during page segmentation",
                   this->params()),
+      BOOL_MEMBER(tessedit_do_invert, true,
+                 "Try inverting the image in `LSTMRecognizeWord`", this->params()),
       // The default for pageseg_mode is the old behaviour, so as not to
       // upset anything that relies on that.
       INT_MEMBER(

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -790,6 +790,8 @@ class Tesseract : public Wordrec {
              "Break input into lines and remap boxes if present");
   BOOL_VAR_H(tessedit_dump_pageseg_images, false,
              "Dump intermediate images made during page segmentation");
+  BOOL_VAR_H(tessedit_do_invert, true,
+             "Try inverting the image in `LSTMRecognizeWord`");
   INT_VAR_H(tessedit_pageseg_mode, PSM_SINGLE_BLOCK,
             "Page seg mode: 0=osd only, 1=auto+osd, 2=auto, 3=col, 4=block,"
             " 5=line, 6=word, 7=char"


### PR DESCRIPTION
Allows for disabling automatic inverting of lines when tesseract feels the inverting could be of help.