### PR TITLE
Add new parameter "document_title" to set the title in OCR output files

### DIFF
--- a/src/api/altorenderer.cpp
+++ b/src/api/altorenderer.cpp
@@ -20,6 +20,7 @@
 # include "host.h"    // windows.h for MultiByteToWideChar, ...
 #endif
 #include "renderer.h"
+#include "strngs.h" // for STRING
 
 namespace tesseract {
 
@@ -68,7 +69,7 @@ bool TessAltoRenderer::BeginDocumentHandler() {
   AppendString(title());
 
   AppendString(
-      "\t\t\t</fileName>\n"
+      "</fileName>\n"
       "\t\t</sourceImageInformation>\n"
       "\t\t<OCRProcessing ID=\"OCR_0\">\n"
       "\t\t\t<ocrProcessingStep>\n"

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -96,6 +96,7 @@
 #include "werd.h"              // for WERD, WERD_IT, W_FUZZY_NON, W_FUZZY_SP
 
 static BOOL_VAR(stream_filelist, false, "Stream a filelist from stdin");
+static STRING_VAR(document_title, "", "Title of output document (used for hOCR and PDF output)");
 
 namespace tesseract {
 
@@ -993,7 +994,7 @@ bool TessBaseAPI::ProcessPagesFileList(FILE *flist,
   }
 
   // Begin producing output
-  if (renderer && !renderer->BeginDocument(unknown_title_)) {
+  if (renderer && !renderer->BeginDocument(document_title.c_str())) {
     return false;
   }
 
@@ -1208,7 +1209,7 @@ bool TessBaseAPI::ProcessPagesInternal(const char* filename,
   }
 
   // Begin the output
-  if (renderer && !renderer->BeginDocument(unknown_title_)) {
+  if (renderer && !renderer->BeginDocument(document_title.c_str())) {
     pixDestroy(&pix);
     return false;
   }

--- a/src/api/baseapi.h
+++ b/src/api/baseapi.h
@@ -923,12 +923,6 @@ class TESS_API TessBaseAPI {
                                  int timeout_millisec,
                                  TessResultRenderer* renderer,
                                  int tessedit_page_number);
-  // There's currently no way to pass a document title from the
-  // Tesseract command line, and we have multiple places that choose
-  // to set the title to an empty string. Using a single named
-  // variable will hopefully reduce confusion if the situation changes
-  // in the future.
-  const char *unknown_title_ = "";
 };  // class TessBaseAPI.
 
 /** Escape a char string - remove &<>"' with HTML codes. */


### PR DESCRIPTION
The title can be set for hOCR and PDF output.

Currently it is also used for ALTO, so setting the title can be used
as a workaround for issue #2700.

The constant unknown_title_ is no longer needed and therefore removed.

Signed-off-by: Stefan Weil <sw@weilnetz.de>