### PR TITLE
Remove 1870 warnings out of 1897 (27 left)

### DIFF
--- a/src/api/altorenderer.cpp
+++ b/src/api/altorenderer.cpp
@@ -42,7 +42,7 @@ static void AddBoxToAlto(const ResultIterator* it, PageIteratorLevel level,
   alto_str << " HEIGHT=\"" << height << "\"";
 
   if (level == RIL_WORD) {
-    int wc = it->Confidence(RIL_WORD);
+    int wc = static_cast<int>(it->Confidence(RIL_WORD));
     alto_str << " WC=\"0." << wc << "\"";
   } else {
     alto_str << ">";

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -1422,7 +1422,7 @@ char* TessBaseAPI::GetTSVText(int page_number) {
     tsv_str.add_str_int("\t", top);
     tsv_str.add_str_int("\t", right - left);
     tsv_str.add_str_int("\t", bottom - top);
-    tsv_str.add_str_int("\t", res_it->Confidence(RIL_WORD));
+    tsv_str.add_str_int("\t", static_cast<int>(res_it->Confidence(RIL_WORD)));
     tsv_str += "\t";
 
     // Increment counts if at end of block/paragraph/textline.
@@ -1501,7 +1501,7 @@ char* TessBaseAPI::GetBoxText(int page_number) {
       snprintf(result + output_length, total_length - output_length,
                "%s %d %d %d %d %d\n", text.get(), left, image_height_ - bottom,
                right, image_height_ - top, page_number);
-      output_length += strlen(result + output_length);
+      output_length += static_cast<int>(strlen(result + output_length));
       // Just in case...
       if (output_length + kMaxBytesPerLine > total_length)
         break;
@@ -1713,7 +1713,7 @@ int TessBaseAPI::MeanTextConf() {
   int sum = 0;
   int *pt = conf;
   while (*pt >= 0) sum += *pt++;
-  if (pt != conf) sum /= pt - conf;
+  if (pt != conf) sum = static_cast<int>(sum / (pt - conf));
   delete [] conf;
   return sum;
 }
@@ -1728,7 +1728,7 @@ int* TessBaseAPI::AllWordConfidences() {
   for (res_it.restart_page(); res_it.word() != nullptr; res_it.forward())
     n_word++;
 
-  int* conf = new int[n_word+1];
+  int* conf = new int[static_cast<size_t>(n_word)+1];
   n_word = 0;
   for (res_it.restart_page(); res_it.word() != nullptr; res_it.forward()) {
     WERD_RES *word = res_it.word();
@@ -2410,7 +2410,7 @@ void TessBaseAPI::AdaptToCharacter(const char *unichar_repr,
     }
   }
 
-  threshold = tesseract_->matcher_good_threshold;
+  threshold = static_cast<float>(tesseract_->matcher_good_threshold);
 
   if (blob->outlines)
     tesseract_->AdaptToChar(blob, id, kUnknownFontinfoId, threshold,
@@ -2442,7 +2442,7 @@ struct TESS_CHAR : ELIST_LINK {
   TBOX box;
 
   TESS_CHAR(float _cost, const char *repr, int len = -1) : cost(_cost) {
-    length = (len == -1 ? strlen(repr) : len);
+    length = (len == -1 ? static_cast<int>(strlen(repr)) : len);
     unicode_repr = new char[length + 1];
     strncpy(unicode_repr, repr, length);
   }
@@ -2492,7 +2492,7 @@ static void extract_result(TESS_CHAR_IT* out,
 
     if (word_count)
       add_space(out);
-    int n = strlen(len);
+    int n = static_cast<int>(strlen(len));
     for (int i = 0; i < n; i++) {
       auto *tc = new TESS_CHAR(rating_to_cost(word->best_choice->rating()),
                                     str, *len);

--- a/src/api/renderer.cpp
+++ b/src/api/renderer.cpp
@@ -100,7 +100,7 @@ bool TessResultRenderer::EndDocument() {
 }
 
 void TessResultRenderer::AppendString(const char* s) {
-  AppendData(s, strlen(s));
+  AppendData(s, static_cast<int>(strlen(s)));
 }
 
 void TessResultRenderer::AppendData(const char* s, int len) {

--- a/src/ccmain/applybox.cpp
+++ b/src/ccmain/applybox.cpp
@@ -283,7 +283,7 @@ void Tesseract::MaximallyChopWord(const GenericVector<TBOX>& boxes,
                                  &blob_number)) != nullptr) {
       word_res->InsertSeam(blob_number, seam);
       BLOB_CHOICE* left_choice = blob_choices[blob_number];
-      rating = left_choice->rating() / e;
+      rating = left_choice->rating() / static_cast<float>(e);
       left_choice->set_rating(rating);
       left_choice->set_certainty(-rating);
       // combine confidence w/ serial #
@@ -541,7 +541,7 @@ bool Tesseract::ConvertStringToUnichars(const char* utf8,
     const char* next_space = strchr(utf8, ' ');
     if (next_space == nullptr)
       next_space = utf8 + strlen(utf8);
-    step = next_space - utf8;
+    step = static_cast<int>(next_space - utf8);
     UNICHAR_ID class_id = unicharset.unichar_to_id(utf8, step);
     if (class_id == INVALID_UNICHAR_ID) {
       return false;

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -741,7 +741,7 @@ void Tesseract::script_pos_pass(PAGE_RES* page_res) {
       page_res_it.forward();
       continue;
     }
-    const float x_height = page_res_it.block()->block->x_height();
+    const float x_height = static_cast<float>(page_res_it.block()->block->x_height());
     float word_x_height = word->x_height;
     if (word_x_height < word->best_choice->min_x_height() ||
         word_x_height > word->best_choice->max_x_height()) {
@@ -1048,7 +1048,7 @@ void Tesseract::AssignDiacriticsToOverlappingBlobs(
     // combination of outlines that doesn't hurt the end-result classification
     // by too much. Mark them as wanted.
     if (0 < num_blob_outlines && num_blob_outlines < noise_maxperblob) {
-      if (SelectGoodDiacriticOutlines(pass, noise_cert_basechar, pr_it, blob,
+      if (SelectGoodDiacriticOutlines(pass, static_cast<float>(noise_cert_basechar), pr_it, blob,
                                       outlines, num_blob_outlines,
                                       &blob_wanted)) {
         for (int i = 0; i < blob_wanted.size(); ++i) {
@@ -1103,7 +1103,7 @@ void Tesseract::AssignDiacriticsToNewBlobs(
     C_BLOB* right_blob = blob_it.at_last() ? nullptr : blob_it.data_relative(1);
     if ((left_box.x_overlap(total_ol_box) || right_blob == nullptr ||
          !right_blob->bounding_box().x_overlap(total_ol_box)) &&
-        SelectGoodDiacriticOutlines(pass, noise_cert_disjoint, pr_it, left_blob,
+        SelectGoodDiacriticOutlines(pass, static_cast<float>(noise_cert_disjoint), pr_it, left_blob,
                                     outlines, num_blob_outlines,
                                     &blob_wanted)) {
       if (debug_noise_removal) tprintf("Added to left blob\n");
@@ -1116,7 +1116,7 @@ void Tesseract::AssignDiacriticsToNewBlobs(
     } else if (right_blob != nullptr &&
                (!left_box.x_overlap(total_ol_box) ||
                 right_blob->bounding_box().x_overlap(total_ol_box)) &&
-               SelectGoodDiacriticOutlines(pass, noise_cert_disjoint, pr_it,
+               SelectGoodDiacriticOutlines(pass, static_cast<float>(noise_cert_disjoint), pr_it,
                                            right_blob, outlines,
                                            num_blob_outlines, &blob_wanted)) {
       if (debug_noise_removal) tprintf("Added to right blob\n");
@@ -1126,7 +1126,7 @@ void Tesseract::AssignDiacriticsToNewBlobs(
           (*target_blobs)[j] = right_blob;
         }
       }
-    } else if (SelectGoodDiacriticOutlines(pass, noise_cert_punc, pr_it, nullptr,
+    } else if (SelectGoodDiacriticOutlines(pass, static_cast<float>(noise_cert_punc), pr_it, nullptr,
                                            outlines, num_blob_outlines,
                                            &blob_wanted)) {
       if (debug_noise_removal) tprintf("Fitted between blobs\n");
@@ -1159,7 +1159,7 @@ bool Tesseract::SelectGoodDiacriticOutlines(
               target_cert, target_c2);
       blob->bounding_box().print();
     }
-    target_cert -= (target_cert - certainty_threshold) * noise_cert_factor;
+    target_cert -= (target_cert - certainty_threshold) * static_cast<float>(noise_cert_factor);
   }
   GenericVector<bool> test_outlines = *ok_outlines;
   // Start with all the outlines in.
@@ -1870,7 +1870,7 @@ bool Tesseract::check_debug_pt(WERD_RES* word, int location) {
   tessedit_rejection_debug.set_value (false);
   debug_x_ht_level.set_value(0);
 
-  if (word->word->bounding_box().contains(FCOORD (test_pt_x, test_pt_y))) {
+  if (word->word->bounding_box().contains(FCOORD (static_cast<float>(test_pt_x), static_cast<float>(test_pt_y)))) {
     if (location < 0)
       return true;               // For breakpoint use
     tessedit_rejection_debug.set_value(true);

--- a/src/ccmain/docqual.cpp
+++ b/src/ccmain/docqual.cpp
@@ -982,7 +982,7 @@ bool Tesseract::noise_outlines(TWERD* word) {
   int16_t outline_count = 0;
   int16_t small_outline_count = 0;
   int16_t max_dimension;
-  float small_limit = kBlnXHeight * crunch_small_outlines_size;
+  float small_limit = static_cast<float>(kBlnXHeight * crunch_small_outlines_size);
 
   for (int b = 0; b < word->NumBlobs(); ++b) {
     TBLOB* blob = word->blobs[b];

--- a/src/ccmain/equationdetect.cpp
+++ b/src/ccmain/equationdetect.cpp
@@ -77,10 +77,10 @@ static int SortCPByHeight(const void* p1, const void* p2) {
 }
 
 // TODO(joeliu): we may want to parameterize these constants.
-const float kMathDigitDensityTh1 = 0.25;
-const float kMathDigitDensityTh2 = 0.1;
-const float kMathItalicDensityTh = 0.5;
-const float kUnclearDensityTh = 0.25;
+const float kMathDigitDensityTh1 = 0.25f;
+const float kMathDigitDensityTh2 = 0.1f;
+const float kMathItalicDensityTh = 0.5f;
+const float kUnclearDensityTh = 0.25f;
 const int kSeedBlobsCountTh = 10;
 const int kLeftIndentAlignmentCountTh = 1;
 
@@ -192,7 +192,7 @@ void EquationDetect::IdentifySpecialText(
   const float lang_score = lang_choice ? lang_choice->certainty() : -FLT_MAX;
   const float equ_score = equ_choice ? equ_choice->certainty() : -FLT_MAX;
 
-  const float kConfScoreTh = -5.0f, kConfDiffTh = 1.8;
+  const float kConfScoreTh = -5.0f, kConfDiffTh = 1.8f;
   // The scores here are negative, so the max/min == fabs(min/max).
   // float ratio = fmax(lang_score, equ_score) / fmin(lang_score, equ_score);
   const float diff = fabs(lang_score - equ_score);
@@ -332,7 +332,7 @@ void EquationDetect::IdentifyBlobsToSkip(ColPartition* part) {
       if (nextblob_box.left() >= blob_box.right()) {
         break;
       }
-      const float kWidthR = 0.4, kHeightR = 0.3;
+      const float kWidthR = 0.4f, kHeightR = 0.3f;
       const bool xoverlap = blob_box.major_x_overlap(nextblob_box),
           yoverlap = blob_box.y_overlap(nextblob_box);
       const float widthR = static_cast<float>(
@@ -478,8 +478,8 @@ void EquationDetect::SearchByOverlap(
   // Search iteratively.
   ColPartition *part;
   GenericVector<ColPartition*> parts;
-  const float kLargeOverlapTh = 0.95;
-  const float kEquXOverlap = 0.4, kEquYOverlap = 0.5;
+  const float kLargeOverlapTh = 0.95f;
+  const float kEquXOverlap = 0.4f, kEquYOverlap = 0.5f;
   while ((part = search.NextRadSearch()) != nullptr) {
     if (part == seed || !IsTextOrEquationType(part->type())) {
       continue;
@@ -487,8 +487,8 @@ void EquationDetect::SearchByOverlap(
     const TBOX& part_box(part->bounding_box());
     bool merge = false;
 
-    const float x_overlap_fraction = part_box.x_overlap_fraction(seed_box),
-        y_overlap_fraction = part_box.y_overlap_fraction(seed_box);
+    const float x_overlap_fraction = static_cast<float>(part_box.x_overlap_fraction(seed_box)),
+        y_overlap_fraction = static_cast<float>(part_box.y_overlap_fraction(seed_box));
 
     // If part is large overlapped with seed, then set merge to true.
     if (x_overlap_fraction >= kLargeOverlapTh &&
@@ -579,11 +579,11 @@ void EquationDetect::IdentifySeedParts() {
   // Sort the features collected from text regions.
   indented_texts_left.sort();
   texts_foreground_density.sort();
-  float foreground_density_th = 0.15;  // Default value.
+  float foreground_density_th = 0.15f;  // Default value.
   if (!texts_foreground_density.empty()) {
     // Use the median of the texts_foreground_density.
-    foreground_density_th = 0.8 * texts_foreground_density[
-        texts_foreground_density.size() / 2];
+    foreground_density_th = static_cast<float>(0.8 * texts_foreground_density[
+        texts_foreground_density.size() / 2]);
   }
 
   for (int i = 0; i < seeds1.size(); ++i) {
@@ -638,7 +638,7 @@ bool EquationDetect::CheckSeedFgDensity(const float density_th,
   }
 
   // If most sub parts passed, then we return true.
-  const float kSeedPartRatioTh = 0.3;
+  const float kSeedPartRatioTh = 0.3f;
   bool retval = (parts_passed / sub_boxes.size() >= kSeedPartRatioTh);
 
   return retval;
@@ -761,7 +761,7 @@ int EquationDetect::CountAlignment(
   if (sorted_vec.empty()) {
     return 0;
   }
-  const int kDistTh = static_cast<int>(roundf(0.03 * resolution_));
+  const int kDistTh = static_cast<int>(roundf(0.03f * resolution_));
   const int pos = sorted_vec.binary_search(val);
   int count = 0;
 
@@ -805,7 +805,7 @@ void EquationDetect::IdentifyInlinePartsHorizontal() {
   const int kMarginDiffTh = IntCastRounded(
       0.5 * lang_tesseract_->source_resolution());
   const int kGapTh = static_cast<int>(roundf(
-      1.0 * lang_tesseract_->source_resolution()));
+      1.0f * lang_tesseract_->source_resolution()));
   ColPartitionGridSearch search(part_grid_);
   search.SetUniqueMode(true);
   // The center x coordinate of the cp_super_bbox_.
@@ -966,8 +966,8 @@ bool EquationDetect::IsInline(const bool search_bottom,
     // Check if neighbor and part is inline similar.
     const float kHeightRatioTh = 0.5;
     const int kYGapTh = textparts_linespacing > 0 ?
-        textparts_linespacing + static_cast<int>(roundf(0.02 * resolution_)):
-        static_cast<int>(roundf(0.05 * resolution_));  // Default value.
+        textparts_linespacing + static_cast<int>(roundf(0.02f * resolution_)):
+        static_cast<int>(roundf(0.05f * resolution_));  // Default value.
     if (part_box.x_overlap(neighbor_box) &&  // Location feature.
         part_box.y_gap(neighbor_box) <= kYGapTh &&  // Line spacing.
         // Geo feature.
@@ -1023,9 +1023,9 @@ EquationDetect::IndentType EquationDetect::IsIndented(ColPartition* part) {
   ColPartitionGridSearch search(part_grid_);
   ColPartition *neighbor = nullptr;
   const TBOX& part_box(part->bounding_box());
-  const int kXGapTh = static_cast<int>(roundf(0.5 * resolution_));
-  const int kRadiusTh = static_cast<int>(roundf(3.0 * resolution_));
-  const int kYGapTh = static_cast<int>(roundf(0.5 * resolution_));
+  const int kXGapTh = static_cast<int>(roundf(0.5f * resolution_));
+  const int kRadiusTh = static_cast<int>(roundf(3.0f * resolution_));
+  const int kYGapTh = static_cast<int>(roundf(0.5f * resolution_));
 
   // Here we use a simple approximation algorithm: from the center of part, We
   // perform the radius search, and check if we can find a neighboring partition
@@ -1129,8 +1129,8 @@ void EquationDetect::ExpandSeedHorizontal(
     ColPartition* seed,
     GenericVector<ColPartition*>* parts_to_merge) {
   ASSERT_HOST(seed != nullptr && parts_to_merge != nullptr);
-  const float kYOverlapTh = 0.6;
-  const int kXGapTh = static_cast<int>(roundf(0.2 * resolution_));
+  const float kYOverlapTh = 0.6f;
+  const int kXGapTh = static_cast<int>(roundf(0.2f * resolution_));
 
   ColPartitionGridSearch search(part_grid_);
   const TBOX& seed_box(seed->bounding_box());
@@ -1186,8 +1186,8 @@ void EquationDetect::ExpandSeedVertical(
     GenericVector<ColPartition*>* parts_to_merge) {
   ASSERT_HOST(seed != nullptr && parts_to_merge != nullptr &&
               cps_super_bbox_ != nullptr);
-  const float kXOverlapTh = 0.4;
-  const int kYGapTh = static_cast<int>(roundf(0.2 * resolution_));
+  const float kXOverlapTh = 0.4f;
+  const int kYGapTh = static_cast<int>(roundf(0.2f * resolution_));
 
   ColPartitionGridSearch search(part_grid_);
   const TBOX& seed_box(seed->bounding_box());
@@ -1269,8 +1269,8 @@ void EquationDetect::ExpandSeedVertical(
 
 bool EquationDetect::IsNearSmallNeighbor(const TBOX& seed_box,
                                          const TBOX& part_box) const {
-  const int kXGapTh = static_cast<int>(roundf(0.25 * resolution_));
-  const int kYGapTh = static_cast<int>(roundf(0.05 * resolution_));
+  const int kXGapTh = static_cast<int>(roundf(0.25f * resolution_));
+  const int kYGapTh = static_cast<int>(roundf(0.05f * resolution_));
 
   // Check geometric feature.
   if (part_box.height() > seed_box.height() ||
@@ -1330,7 +1330,7 @@ void EquationDetect::ProcessMathBlockSatelliteParts() {
     const TBOX& text_box =
         text_parts[text_parts.size() / 2 - 1]->bounding_box();
     med_height = static_cast<int>(roundf(
-        0.5 * (text_box.height() + med_height)));
+        0.5f * (static_cast<int>(text_box.height()) + med_height)));
   }
 
   // Iterate every text_parts and check if it is a math block satellite.
@@ -1413,7 +1413,7 @@ ColPartition* EquationDetect::SearchNNVertical(
     const bool search_bottom, const ColPartition* part) {
   ASSERT_HOST(part);
   ColPartition *nearest_neighbor = nullptr, *neighbor = nullptr;
-  const int kYGapTh = static_cast<int>(roundf(resolution_ * 0.5));
+  const int kYGapTh = static_cast<int>(roundf(resolution_ * 0.5f));
 
   ColPartitionGridSearch search(part_grid_);
   search.SetUniqueMode(true);
@@ -1449,7 +1449,7 @@ bool EquationDetect::IsNearMathNeighbor(
   if (!neighbor) {
     return false;
   }
-  const int kYGapTh = static_cast<int>(roundf(resolution_ * 0.1));
+  const int kYGapTh = static_cast<int>(roundf(resolution_ * 0.1f));
   return neighbor->type() == PT_EQUATION && y_gap <= kYGapTh;
 }
 

--- a/src/ccmain/fixspace.cpp
+++ b/src/ccmain/fixspace.cpp
@@ -712,8 +712,8 @@ int16_t Tesseract::worst_noise_blob(WERD_RES *word_res,
   int max_noise_blob;            // last contender
   int non_noise_count;
   int worst_noise_blob;          // Worst blob
-  float small_limit = kBlnXHeight * fixsp_small_outlines_size;
-  float non_noise_limit = kBlnXHeight * 0.8;
+  float small_limit = kBlnXHeight * static_cast<float>(fixsp_small_outlines_size);
+  float non_noise_limit = kBlnXHeight * 0.8f;
 
   if (word_res->rebuild_word == nullptr)
     return -1;  // Can't handle cube words.
@@ -859,7 +859,7 @@ int16_t Tesseract::fp_eval_word_spacing(WERD_RES_LIST &word_res_list) {
   WERD_RES *word;
   int16_t score = 0;
   int16_t i;
-  float small_limit = kBlnXHeight * fixsp_small_outlines_size;
+  float small_limit = kBlnXHeight * static_cast<float>(fixsp_small_outlines_size);
 
   for (word_it.mark_cycle_pt(); !word_it.cycled_list(); word_it.forward()) {
     word = word_it.data();

--- a/src/ccmain/fixxht.cpp
+++ b/src/ccmain/fixxht.cpp
@@ -199,7 +199,7 @@ float Tesseract::ComputeCompatibleXheight(WERD_RES *word_res,
     return bottom_shift != 0 ? word_res->x_height : 0.0f;
   // The new xheight is just the median vote, which is then scaled out
   // of BLN space back to pixel space to get the x-height in pixel space.
-  float new_xht = top_stats.median();
+  float new_xht = static_cast<float>(top_stats.median());
   if (debug_x_ht_level >= 2) {
     tprintf("Median xht=%f\n", new_xht);
     tprintf("Mode20:A: New x-height = %f (norm), %f (orig)\n",

--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -229,11 +229,11 @@ void Tesseract::LSTMRecognizeWord(const BLOCK& block, ROW *row, WERD_RES *word,
     // interpretation.
     word_box = TBOX(0, 0, ImageWidth(), ImageHeight());
   } else {
-    float baseline = row->base_line((word_box.left() + word_box.right()) / 2);
+    float baseline = row->base_line(static_cast<float>((word_box.left() + word_box.right()) / 2));
     if (baseline + row->descenders() < word_box.bottom())
-      word_box.set_bottom(baseline + row->descenders());
+      word_box.set_bottom(static_cast<int>(baseline + row->descenders()));
     if (baseline + row->x_height() + row->ascenders() > word_box.top())
-      word_box.set_top(baseline + row->x_height() + row->ascenders());
+      word_box.set_top(static_cast<int>(baseline + row->x_height() + row->ascenders()));
   }
   ImageData* im_data = GetRectImage(word_box, block, kImagePadding, &word_box);
   if (im_data == nullptr) return;

--- a/src/ccmain/osdetect.cpp
+++ b/src/ccmain/osdetect.cpp
@@ -37,15 +37,15 @@
 #include "tesseractclass.h"
 #include "textord.h"
 
-const float kSizeRatioToReject = 2.0;
+const float kSizeRatioToReject = 2.0f;
 const int kMinAcceptableBlobHeight = 10;
 
-const float kScriptAcceptRatio = 1.3;
+const float kScriptAcceptRatio = 1.3f;
 
-const float kHanRatioInKorean = 0.7;
-const float kHanRatioInJapanese = 0.3;
+const float kHanRatioInKorean = 0.7f;
+const float kHanRatioInJapanese = 0.3f;
 
-const float kNonAmbiguousMargin = 1.0;
+const float kNonAmbiguousMargin = 1.0f;
 
 // General scripts
 static const char* han_script = "Han";
@@ -106,7 +106,7 @@ void OSResults::update_best_script(int orientation) {
     }
   }
   best_result.sconfidence =
-      (first / second - 1.0) / (kScriptAcceptRatio - 1.0);
+      (first / second - 1.0f) / (kScriptAcceptRatio - 1.0f);
 }
 
 int OSResults::get_best_script(int orientation_id) const {
@@ -196,7 +196,7 @@ int orientation_and_script_detection(STRING& filename,
 
   lastdot = strrchr (name.string (), '.');
   if (lastdot != nullptr)
-    name[lastdot-name.string()] = '\0';
+    name[static_cast<long int>(lastdot-name.string())] = '\0';
 
   ASSERT_HOST(tess->pix_binary() != nullptr);
   int width = pixGetWidth(tess->pix_binary());
@@ -406,7 +406,7 @@ bool OrientationDetector::detect_blob(BLOB_CHOICE_LIST* scores) {
       if (choice != nullptr) {
         // The certainty score ranges between [-20,0]. This is converted here to
         // [0,1], with 1 indicating best match.
-        blob_o_score[i] = 1 + 0.05 * choice->certainty();
+        blob_o_score[i] = 1 + 0.05f * choice->certainty();
         total_blob_o_score += blob_o_score[i];
       }
     }

--- a/src/ccmain/output.cpp
+++ b/src/ccmain/output.cpp
@@ -49,8 +49,8 @@ void Tesseract::output_pass(  //Tess output pass //send to api
     if (target_word_box) {
       TBOX current_word_box = page_res_it.word()->word->bounding_box();
       FCOORD center_pt(
-          (current_word_box.right() + current_word_box.left()) / 2,
-          (current_word_box.bottom() + current_word_box.top()) / 2);
+          static_cast<float>((current_word_box.right() + current_word_box.left()) / 2),
+          static_cast<float>((current_word_box.bottom() + current_word_box.top()) / 2));
       if (!target_word_box->contains(center_pt)) {
         page_res_it.forward();
         continue;

--- a/src/ccmain/pageiterator.cpp
+++ b/src/ccmain/pageiterator.cpp
@@ -495,9 +495,9 @@ bool PageIterator::Baseline(PageIteratorLevel level,
            ? word->bounding_box()
            : row->bounding_box();
   int left = box.left();
-  ICOORD startpt(left, static_cast<int16_t>(row->base_line(left) + 0.5));
+  ICOORD startpt(left, static_cast<int16_t>(row->base_line(static_cast<float>(left)) + 0.5f));
   int right = box.right();
-  ICOORD endpt(right, static_cast<int16_t>(row->base_line(right) + 0.5));
+  ICOORD endpt(right, static_cast<int16_t>(row->base_line(static_cast<float>(right)) + 0.5));
   // Rotate to image coordinates and convert to global image coords.
   startpt.rotate(it_->block()->block->re_rotation());
   endpt.rotate(it_->block()->block->re_rotation());

--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -110,7 +110,7 @@ int Tesseract::SegmentPage(const STRING* input_file, BLOCK_LIST* blocks,
     STRING name = *input_file;
     const char* lastdot = strrchr(name.string(), '.');
     if (lastdot != nullptr)
-      name[lastdot - name.string()] = '\0';
+      name[static_cast<long int>(lastdot - name.string())] = '\0';
     read_unlv_file(name, width, height, blocks);
   }
   if (blocks->empty()) {

--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -52,9 +52,9 @@ namespace tesseract {
 
 // Special "weak" ParagraphModels.
 const ParagraphModel *kCrownLeft
-    = reinterpret_cast<ParagraphModel *>(0xDEAD111F);
+    = reinterpret_cast<ParagraphModel *>(static_cast<__int64>(0xDEAD111F));
 const ParagraphModel *kCrownRight
-    = reinterpret_cast<ParagraphModel *>(0xDEAD888F);
+    = reinterpret_cast<ParagraphModel *>(static_cast<__int64>(0xDEAD888F));
 
 // Do the text and geometry of two rows support a paragraph break between them?
 static bool LikelyParagraphStart(const RowScratchRegisters &before,
@@ -1593,8 +1593,8 @@ void RecomputeMarginsAndClearHypotheses(
     lefts.add(sr.lmargin_ + sr.lindent_, 1);
     rights.add(sr.rmargin_ + sr.rindent_, 1);
   }
-  int ignorable_left = lefts.ile(ClipToRange(percentile, 0, 100) / 100.0);
-  int ignorable_right = rights.ile(ClipToRange(percentile, 0, 100) / 100.0);
+  int ignorable_left = static_cast<int>(lefts.ile(ClipToRange(percentile, 0, 100) / 100.0));
+  int ignorable_right = static_cast<int>(rights.ile(ClipToRange(percentile, 0, 100) / 100.0));
   for (int i = start; i < end; i++) {
     RowScratchRegisters &sr = (*rows)[i];
     int ldelta = ignorable_left - sr.lmargin_;
@@ -1623,7 +1623,7 @@ int InterwordSpace(const GenericVector<RowScratchRegisters> &rows,
   int minimum_reasonable_space = word_height / 3;
   if (minimum_reasonable_space < 2)
     minimum_reasonable_space = 2;
-  int median = spacing_widths.median();
+  int median = static_cast<int>(spacing_widths.median());
   return (median > minimum_reasonable_space)
       ? median : minimum_reasonable_space;
 }
@@ -2452,11 +2452,11 @@ static void InitializeRowInfo(bool after_recognition,
   }
   info->text = "";
   const std::unique_ptr<const char[]> text(it.GetUTF8Text(RIL_TEXTLINE));
-  int trailing_ws_idx = strlen(text.get());  // strip trailing space
+  int trailing_ws_idx = static_cast<int>(strlen(text.get()));  // strip trailing space
   while (trailing_ws_idx > 0 &&
          // isspace() only takes ASCII
-         isascii(text[trailing_ws_idx - 1]) &&
-         isspace(text[trailing_ws_idx - 1]))
+         isascii(text[static_cast<long int>(trailing_ws_idx - 1)]) &&
+         isspace(text[static_cast<long int>(trailing_ws_idx - 1)]))
     trailing_ws_idx--;
   if (trailing_ws_idx > 0) {
     int lspaces = info->pix_ldistance / info->average_interword_space;

--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -52,9 +52,9 @@ namespace tesseract {
 
 // Special "weak" ParagraphModels.
 const ParagraphModel *kCrownLeft =
-    reinterpret_cast<ParagraphModel*>(static_cast<int64_t>(0xDEAD111F));
+    reinterpret_cast<ParagraphModel*>(static_cast<uintptr_t>(0xDEAD111F));
 const ParagraphModel *kCrownRight =
-    reinterpret_cast<ParagraphModel*>(static_cast<int64_t>(0xDEAD888F));
+    reinterpret_cast<ParagraphModel*>(static_cast<uintptr_t>(0xDEAD888F));
 
 // Do the text and geometry of two rows support a paragraph break between them?
 static bool LikelyParagraphStart(const RowScratchRegisters &before,

--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -51,10 +51,10 @@
 namespace tesseract {
 
 // Special "weak" ParagraphModels.
-const ParagraphModel *kCrownLeft
-    = reinterpret_cast<ParagraphModel *>(static_cast<__int64>(0xDEAD111F));
-const ParagraphModel *kCrownRight
-    = reinterpret_cast<ParagraphModel *>(static_cast<__int64>(0xDEAD888F));
+const ParagraphModel *kCrownLeft =
+    reinterpret_cast<ParagraphModel*>(static_cast<int64_t>(0xDEAD111F));
+const ParagraphModel *kCrownRight =
+    reinterpret_cast<ParagraphModel*>(static_cast<int64_t>(0xDEAD888F));
 
 // Do the text and geometry of two rows support a paragraph break between them?
 static bool LikelyParagraphStart(const RowScratchRegisters &before,

--- a/src/ccmain/paramsd.cpp
+++ b/src/ccmain/paramsd.cpp
@@ -99,12 +99,12 @@ void ParamsEditor::GetFirstWords(
                      int n,          // number of words
                      char *t         // target string
                     ) {
-  int full_length = strlen(s);
+  int full_length = static_cast<int>(strlen(s));
   int reqd_len = 0;              // No. of chars requird
   const char *next_word = s;
 
   while ((n > 0) && reqd_len < full_length) {
-    reqd_len += strcspn(next_word, "_") + 1;
+    reqd_len += static_cast<int>(strcspn(next_word, "_") + 1);
     next_word += reqd_len;
     n--;
   }

--- a/src/ccmain/pgedit.cpp
+++ b/src/ccmain/pgedit.cpp
@@ -206,7 +206,7 @@ class BlnEventHandler : public SVEventHandler {
     if (sv_event->type == SVET_DESTROY)
       bln_word_window = nullptr;
     else if (sv_event->type == SVET_CLICK)
-      show_point(current_page_res, sv_event->x, sv_event->y);
+      show_point(current_page_res, static_cast<float>(sv_event->x), static_cast<float>(sv_event->y));
   }
 };
 
@@ -257,14 +257,14 @@ static void display_bln_lines(ScrollView* window, ScrollView::Color colour,
                               float scale_factor, float y_offset,
                               float minx, float maxx) {
   window->Pen(colour);
-  window->Line(minx, y_offset + scale_factor * DESC_HEIGHT,
-               maxx, y_offset + scale_factor * DESC_HEIGHT);
-  window->Line(minx, y_offset + scale_factor * BL_HEIGHT,
-               maxx, y_offset + scale_factor * BL_HEIGHT);
-  window->Line(minx, y_offset + scale_factor * X_HEIGHT,
-               maxx, y_offset + scale_factor * X_HEIGHT);
-  window->Line(minx, y_offset + scale_factor * ASC_HEIGHT,
-               maxx, y_offset + scale_factor * ASC_HEIGHT);
+  window->Line(static_cast<int>(minx), static_cast<int>(y_offset + scale_factor * DESC_HEIGHT),
+               static_cast<int>(maxx), static_cast<int>(y_offset + scale_factor * DESC_HEIGHT));
+  window->Line(static_cast<int>(minx), static_cast<int>(y_offset + scale_factor * BL_HEIGHT),
+               static_cast<int>(maxx), static_cast<int>(y_offset + scale_factor * BL_HEIGHT));
+  window->Line(static_cast<int>(minx), static_cast<int>(y_offset + scale_factor * X_HEIGHT),
+               static_cast<int>(maxx), static_cast<int>(y_offset + scale_factor * X_HEIGHT));
+  window->Line(static_cast<int>(minx), static_cast<int>(y_offset + scale_factor * ASC_HEIGHT),
+               static_cast<int>(maxx), static_cast<int>(y_offset + scale_factor * ASC_HEIGHT));
 }
 
 /**
@@ -602,7 +602,7 @@ void Tesseract::process_image_event( // action in image win
         down.set_x(event.x + event.x_size);
         down.set_y(event.y + event.y_size);
         if (mode == SHOW_POINT_CMD_EVENT)
-          show_point(current_page_res, event.x, event.y);
+          show_point(current_page_res, static_cast<float>(event.x), static_cast<float>(event.y));
       }
 
       up.set_x(event.x);
@@ -870,15 +870,15 @@ bool Tesseract::word_display(PAGE_RES_IT* pr_it) {
     word_bb = word->bounding_box();
     image_win->Pen(ScrollView::RED);
     word_height = word_bb.height();
-    int text_height = 0.50 * word_height;
+    int text_height = static_cast<int>(0.50 * word_height);
     if (text_height > 20) text_height = 20;
     image_win->TextAttributes("Arial", text_height, false, false, false);
-    shift = (word_height < word_bb.width()) ? 0.25 * word_height : 0.0f;
-    image_win->Text(word_bb.left() + shift,
-                    word_bb.bottom() + 0.25 * word_height, text.string());
+    shift = (word_height < word_bb.width()) ? 0.25f * word_height : 0.0f;
+    image_win->Text(static_cast<int>(word_bb.left() + shift),
+                    static_cast<int>(word_bb.bottom() + 0.25 * word_height), text.string());
     if (blame.length() > 0) {
-      image_win->Text(word_bb.left() + shift,
-                      word_bb.bottom() + 0.25 * word_height - text_height,
+      image_win->Text(static_cast<int>(word_bb.left() + shift),
+                      static_cast<int>(word_bb.bottom() + 0.25 * word_height - text_height),
                       blame.string());
     }
 

--- a/src/ccmain/recogtraining.cpp
+++ b/src/ccmain/recogtraining.cpp
@@ -44,7 +44,7 @@ FILE* Tesseract::init_recog_training(const STRING& fname) {
   STRING output_fname = fname;
   const char* lastdot = strrchr(output_fname.string(), '.');
   if (lastdot != nullptr)
-    output_fname[lastdot - output_fname.string()] = '\0';
+    output_fname[static_cast<long>(lastdot - output_fname.string())] = '\0';
   output_fname += ".txt";
   FILE* output_file = fopen(output_fname.string(), "a+");
   if (output_file == nullptr) {
@@ -88,7 +88,7 @@ void Tesseract::recog_training_segmented(const STRING& fname,
   STRING box_fname = fname;
   const char* lastdot = strrchr(box_fname.string(), '.');
   if (lastdot != nullptr)
-    box_fname[lastdot - box_fname.string()] = '\0';
+    box_fname[static_cast<long int>(lastdot - box_fname.string())] = '\0';
   box_fname += ".box";
   // ReadNextBox() will close box_file
   FILE* box_file = fopen(box_fname.string(), "r");

--- a/src/ccmain/reject.cpp
+++ b/src/ccmain/reject.cpp
@@ -308,7 +308,7 @@ bool Tesseract::one_ell_conflict(WERD_RES* word_res, bool update_map) {
 
   word = word_res->best_choice->unichar_string().string ();
   lengths = word_res->best_choice->unichar_lengths().string();
-  word_len = strlen(lengths);
+  word_len = static_cast<int16_t>(strlen(lengths));
   /*
     If there are no occurrences of the conflict set characters then the word
     is OK.

--- a/src/ccmain/superscript.cpp
+++ b/src/ccmain/superscript.cpp
@@ -127,9 +127,9 @@ bool Tesseract::SubAndSuperscriptFix(WERD_RES *word) {
   int num_remainder_leading = 0, num_remainder_trailing = 0;
   if (num_leading + num_trailing < num_blobs && unlikely_threshold < 0.0) {
     int super_y_bottom =
-        kBlnBaselineOffset + kBlnXHeight * superscript_min_y_bottom;
+        static_cast<int>(kBlnBaselineOffset + kBlnXHeight * superscript_min_y_bottom);
     int sub_y_top =
-        kBlnBaselineOffset + kBlnXHeight * subscript_max_y_top;
+        static_cast<int>(kBlnBaselineOffset + kBlnXHeight * subscript_max_y_top);
     int last_word_char = num_blobs - 1 - num_trailing;
     float last_char_certainty = word->best_choice->certainty(last_word_char);
     if (word->best_choice->unichar_id(last_word_char) != 0 &&
@@ -145,7 +145,7 @@ bool Tesseract::SubAndSuperscriptFix(WERD_RES *word) {
     }
     bool another_blob_available = (num_remainder_trailing == 0) ||
         num_leading + num_trailing + 1 < num_blobs;
-    int first_char_certainty = word->best_choice->certainty(num_leading);
+    int first_char_certainty = static_cast<int>(word->best_choice->certainty(num_leading));
     if (another_blob_available &&
         word->best_choice->unichar_id(num_leading) != 0 &&
         first_char_certainty <= unlikely_threshold) {
@@ -155,7 +155,7 @@ bool Tesseract::SubAndSuperscriptFix(WERD_RES *word) {
       if (num_leading > 0 && lpos != sp_leading) num_remainder_leading = 0;
       if (num_remainder_leading > 0 &&
           first_char_certainty < leading_certainty) {
-        leading_certainty = first_char_certainty;
+        leading_certainty = static_cast<float>(first_char_certainty);
       }
     }
   }
@@ -265,9 +265,9 @@ void Tesseract::GetSubAndSuperscriptCandidates(const WERD_RES *word,
   *leading_certainty = *trailing_certainty = 0.0f;
 
   int super_y_bottom =
-      kBlnBaselineOffset + kBlnXHeight * superscript_min_y_bottom;
+      static_cast<int>(kBlnBaselineOffset + kBlnXHeight * superscript_min_y_bottom);
   int sub_y_top =
-      kBlnBaselineOffset + kBlnXHeight * subscript_max_y_top;
+      static_cast<int>(kBlnBaselineOffset + kBlnXHeight * subscript_max_y_top);
 
   // Step one: Get an average certainty for "normally placed" characters.
 
@@ -318,7 +318,7 @@ void Tesseract::GetSubAndSuperscriptCandidates(const WERD_RES *word,
   }
   if (num_normal > 0) {
     *avg_certainty = normal_certainty_total / num_normal;
-    *unlikely_threshold = superscript_worse_certainty * (*avg_certainty);
+    *unlikely_threshold = static_cast<float>(superscript_worse_certainty * (*avg_certainty));
   }
   if (num_normal == 0 ||
       (leading_outliers == 0 && trailing_outliers == 0)) {
@@ -463,11 +463,11 @@ WERD_RES *Tesseract::TrySuperscriptSplits(
   // than what we already had.
   bool good_prefix = !prefix || BelievableSuperscript(
       superscript_debug >= 1, *prefix,
-      superscript_bettered_certainty * leading_certainty,
+      static_cast<float>(superscript_bettered_certainty * leading_certainty),
       retry_rebuild_leading, nullptr);
   bool good_suffix = !suffix || BelievableSuperscript(
       superscript_debug >= 1, *suffix,
-      superscript_bettered_certainty * trailing_certainty,
+      static_cast<float>(superscript_bettered_certainty * trailing_certainty),
       nullptr, retry_rebuild_trailing);
 
   *is_good = good_prefix && good_suffix;
@@ -556,8 +556,8 @@ bool Tesseract::BelievableSuperscript(bool debug,
       wc.unicharset()->get_top_bottom(unichar_id,
                                       &min_bot, &max_bot,
                                       &min_top, &max_top);
-      float hi_height = max_top - max_bot;
-      float lo_height = min_top - min_bot;
+      float hi_height = static_cast<float>(max_top - max_bot);
+      float lo_height = static_cast<float>(min_top - min_bot);
       normal_height = (hi_height + lo_height) / 2;
       if (normal_height >= kBlnXHeight) {
         // Only ding characters that we have decent information for because

--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -263,9 +263,9 @@ void Tesseract::ParseLanguageString(const char* lang_str,
       ++start;
     }
     // Find the index of the end of the lang code in string start.
-    int end = strlen(start);
+    int end = static_cast<int>(strlen(start));
     const char* plus = strchr(start, '+');
-    if (plus != nullptr && plus - start < end) end = plus - start;
+    if (plus != nullptr && plus - start < end) end = static_cast<int>(plus - start);
     STRING lang_code(start);
     lang_code.truncate_at(end);
     STRING next(start + end);

--- a/src/ccstruct/blamer.cpp
+++ b/src/ccstruct/blamer.cpp
@@ -149,7 +149,7 @@ void BlamerBundle::FillDebugString(const STRING &msg,
 // Sets up the norm_truth_word from truth_word using the given DENORM.
 void BlamerBundle::SetupNormTruthWord(const DENORM& denorm) {
   // TODO(rays) Is this the last use of denorm in WERD_RES and can it go?
-  norm_box_tolerance_ = kBlamerBoxTolerance * denorm.x_scale();
+  norm_box_tolerance_ = static_cast<int>(kBlamerBoxTolerance * denorm.x_scale());
   TPOINT topleft;
   TPOINT botright;
   TPOINT norm_topleft;

--- a/src/ccstruct/blobbox.cpp
+++ b/src/ccstruct/blobbox.cpp
@@ -260,7 +260,7 @@ bool BLOBNBOX::DefiniteIndividualFlow() {
     // A complex shape such as a joined word should have a much larger value.
     int perimeter = cblob()->perimeter();
     if (vert_stroke_width() > 0 || perimeter <= 0)
-      perimeter -= 2 * vert_stroke_width();
+      perimeter -= static_cast<int>(2 * vert_stroke_width());
     else
       perimeter -= 4 * cblob()->area() / perimeter;
     perimeter -= 2 * box.width();
@@ -275,7 +275,7 @@ bool BLOBNBOX::DefiniteIndividualFlow() {
     // As above, but for a putative vertical word vs a I/1/l.
     int perimeter = cblob()->perimeter();
     if (horz_stroke_width() > 0 || perimeter <= 0)
-      perimeter -= 2 * horz_stroke_width();
+      perimeter -= static_cast<int>(2 * horz_stroke_width());
     else
       perimeter -= 4 * cblob()->area() / perimeter;
     perimeter -= 2 * box.height();
@@ -309,10 +309,10 @@ bool BLOBNBOX::MatchingStrokeWidth(const BLOBNBOX& other,
   // no information in the blob.
   double p_width = area_stroke_width();
   double n_p_width = other.area_stroke_width();
-  float h_tolerance = horz_stroke_width_ * fractional_tolerance
-                     + constant_tolerance;
-  float v_tolerance = vert_stroke_width_ * fractional_tolerance
-                     + constant_tolerance;
+  float h_tolerance = static_cast<float>(horz_stroke_width_ * fractional_tolerance
+                     + constant_tolerance);
+  float v_tolerance = static_cast<float>(vert_stroke_width_ * fractional_tolerance
+                     + constant_tolerance);
   double p_tolerance = p_width * fractional_tolerance
                      + constant_tolerance;
   bool h_zero = horz_stroke_width_ == 0.0f || other.horz_stroke_width_ == 0.0f;
@@ -344,8 +344,8 @@ TBOX BLOBNBOX::BoundsWithinLimits(int left, int right) {
     top = box.top();
     bottom = box.bottom();
   }
-  FCOORD bot_left(left, bottom);
-  FCOORD top_right(right, top);
+  FCOORD bot_left(static_cast<float>(left), bottom);
+  FCOORD top_right(static_cast<float>(right), top);
   TBOX shrunken_box(bot_left);
   TBOX shrunken_box2(top_right);
   shrunken_box += shrunken_box2;

--- a/src/ccstruct/blobs.cpp
+++ b/src/ccstruct/blobs.cpp
@@ -361,9 +361,9 @@ TBLOB* TBLOB::ClassifyNormalizeIfNeeded() const {
     // Move the rotated blob back to the same y-position so that we
     // can still distinguish similar glyphs with differeny y-position.
     float target_y =
-        kBlnBaselineOffset +
-        (rotation.y() > 0 ? x_middle - box.left() : box.right() - x_middle);
-    rotated_blob->Normalize(nullptr, &rotation, &denorm_, x_middle, y_middle,
+        static_cast<float>(kBlnBaselineOffset +
+        (rotation.y() > 0 ? x_middle - box.left() : box.right() - x_middle));
+    rotated_blob->Normalize(nullptr, &rotation, &denorm_, static_cast<float>(x_middle), static_cast<float>(y_middle),
                             1.0f, 1.0f, 0.0f, target_y, denorm_.inverse(),
                             denorm_.pix());
   }
@@ -535,8 +535,8 @@ int TBLOB::ComputeMoments(FCOORD* center, FCOORD* second_moments) const {
   double y2nd = sqrt(accumulator.y_variance());
   if (x2nd < 1.0) x2nd = 1.0;
   if (y2nd < 1.0) y2nd = 1.0;
-  second_moments->set_x(x2nd);
-  second_moments->set_y(y2nd);
+  second_moments->set_x(static_cast<float>(x2nd));
+  second_moments->set_y(static_cast<float>(y2nd));
   return accumulator.count();
 }
 
@@ -729,9 +729,9 @@ static void CollectEdgesOfRun(const EDGEPT* startpt, const EDGEPT* lastpt,
     const EDGEPT* endpt = lastpt->next;
     const EDGEPT* pt = startpt;
     do {
-      FCOORD next_pos(pt->next->pos.x - box.left(),
-                      pt->next->pos.y - box.bottom());
-      FCOORD pos(pt->pos.x - box.left(), pt->pos.y - box.bottom());
+      FCOORD next_pos(static_cast<float>(pt->next->pos.x - box.left()),
+                      static_cast<float>(pt->next->pos.y - box.bottom()));
+      FCOORD pos(static_cast<float>(pt->pos.x - box.left()), static_cast<float>(pt->pos.y - box.bottom()));
       if (bounding_box != nullptr) {
         SegmentBBox(next_pos, pos, bounding_box);
       }

--- a/src/ccstruct/boxread.cpp
+++ b/src/ccstruct/boxread.cpp
@@ -107,7 +107,7 @@ STRING BoxFileName(const STRING& image_filename) {
   STRING box_filename = image_filename;
   const char *lastdot = strrchr(box_filename.string(), '.');
   if (lastdot != nullptr)
-    box_filename.truncate_at(lastdot - box_filename.string());
+    box_filename.truncate_at(static_cast<int32_t>(lastdot - box_filename.string()));
 
   box_filename += ".box";
   return box_filename;
@@ -217,7 +217,7 @@ bool ParseBoxFileStr(const char* boxfile_str, int* page_number,
     strncpy(uch, buffptr + 1, kBoxReadBufSize - 1);
     uch[kBoxReadBufSize - 1] = '\0';  // Prevent buffer overrun.
     chomp_string(uch);
-    uch_len = strlen(uch);
+    uch_len = static_cast<int>(strlen(uch));
   }
   // Validate UTF8 by making unichars with it.
   int used = 0;

--- a/src/ccstruct/coutln.cpp
+++ b/src/ccstruct/coutln.cpp
@@ -881,7 +881,7 @@ void C_OUTLINE::ComputeBinaryOffsets() {
         ClipToRange<int>(offset, -INT8_MAX, INT8_MAX);
     offsets[s].pixel_diff = ClipToRange<int>(best_diff, 0, UINT8_MAX);
     // The direction is just the vector from start to end of the window.
-    FCOORD direction(head_pos.x() - tail_pos.x(), head_pos.y() - tail_pos.y());
+    FCOORD direction(static_cast<float>(head_pos.x() - tail_pos.x()), static_cast<float>(head_pos.y() - tail_pos.y()));
     offsets[s].direction = direction.to_direction();
     increment_step(s - 2, -1, &tail_pos, dir_counts, pos_totals);
   }

--- a/src/ccstruct/detlinefit.cpp
+++ b/src/ccstruct/detlinefit.cpp
@@ -36,7 +36,7 @@ const int kNumEndPoints = 3;
 const int kMinPointsForErrorCount = 16;
 // The maximum real distance to use before switching to number of
 // mis-fitted points, which will get square-rooted for true distance.
-const int kMaxRealDistance = 2.0;
+const int kMaxRealDistance = 2;
 
 DetLineFit::DetLineFit() : square_length_(0.0) {
 }
@@ -189,10 +189,10 @@ double DetLineFit::ConstrainedFit(double m, float* c) {
     return 0.0;
   }
   double cos = 1.0 / sqrt(1.0 + m * m);
-  FCOORD direction(cos, m * cos);
+  FCOORD direction(static_cast<float>(cos), static_cast<float>(m * cos));
   ICOORD line_pt;
   double error = ConstrainedFit(direction, -FLT_MAX, FLT_MAX, false, &line_pt);
-  *c = line_pt.y() - line_pt.x() * m;
+  *c = static_cast<float>(line_pt.y() - line_pt.x() * m);
   return error;
 }
 

--- a/src/ccstruct/dppoint.cpp
+++ b/src/ccstruct/dppoint.cpp
@@ -72,10 +72,10 @@ int64_t DPPoint::CostWithVariance(const DPPoint* prev) {
     return 0;
   }
 
-  int delta = this - prev;
+  int delta = static_cast<int>(this - prev);
   int32_t n = prev->n_ + 1;
   int32_t sig_x = prev->sig_x_ + delta;
-  int64_t sig_xsq = prev->sig_xsq_ + delta * delta;
+  int64_t sig_xsq = prev->sig_xsq_ + static_cast<int64_t>(delta) * static_cast<int64_t>(delta);
   int64_t cost = (sig_xsq - sig_x * sig_x / n) / n;
   cost += prev->total_cost_;
   UpdateIfBetter(cost, prev->total_steps_ + 1, prev, n, sig_x, sig_xsq);
@@ -86,7 +86,7 @@ int64_t DPPoint::CostWithVariance(const DPPoint* prev) {
 void DPPoint::UpdateIfBetter(int64_t cost, int32_t steps, const DPPoint* prev,
                              int32_t n, int32_t sig_x, int64_t sig_xsq) {
   if (cost < total_cost_) {
-    total_cost_ = cost;
+    total_cost_ = static_cast<int32_t>(cost);
     total_steps_ = steps;
     best_prev_ = prev;
     n_ = n;

--- a/src/ccstruct/fontinfo.cpp
+++ b/src/ccstruct/fontinfo.cpp
@@ -161,7 +161,7 @@ bool read_info(TFile* f, FontInfo* fi) {
 }
 
 bool write_info(FILE* f, const FontInfo& fi) {
-  int32_t size = strlen(fi.name);
+  int32_t size = static_cast<int32_t>(strlen(fi.name));
   return tesseract::Serialize(f, &size) &&
          tesseract::Serialize(f, &fi.name[0], size) &&
          tesseract::Serialize(f, &fi.properties);

--- a/src/ccstruct/imagedata.cpp
+++ b/src/ccstruct/imagedata.cpp
@@ -102,9 +102,9 @@ void FloatWordFeature::FromWordFeatures(
     GenericVector<FloatWordFeature>* float_features) {
   for (int i = 0; i < word_features.size(); ++i) {
     FloatWordFeature f;
-    f.x = word_features[i].x();
-    f.y = word_features[i].y();
-    f.dir = word_features[i].dir();
+    f.x = static_cast<float>(word_features[i].x());
+    f.y = static_cast<float>(word_features[i].y());
+    f.dir = static_cast<float>(word_features[i].dir());
     f.x_bucket = 0;  // Will set it later.
     float_features->push_back(f);
   }
@@ -116,7 +116,7 @@ int FloatWordFeature::SortByXBucket(const void* v1, const void* v2) {
   const auto* f1 = static_cast<const FloatWordFeature*>(v1);
   const auto* f2 = static_cast<const FloatWordFeature*>(v2);
   int x_diff = f1->x_bucket - f2->x_bucket;
-  if (x_diff == 0) return f1->y - f2->y;
+  if (x_diff == 0) return static_cast<int>(f1->y - f2->y);
   return x_diff;
 }
 
@@ -261,7 +261,7 @@ Pix* ImageData::PreScale(int target_height, int max_height, float* scale_factor,
     }
     if (boxes->empty()) {
       // Make a single box for the whole image.
-      TBOX box(0, 0, im_factor * input_width, target_height);
+      TBOX box(0, 0, static_cast<int16_t>(im_factor * input_width), target_height);
       boxes->push_back(box);
     }
   }
@@ -336,7 +336,7 @@ void ImageData::SetPixInternal(Pix* pix, GenericVector<char>* image_data) {
     ret = pixWriteMem(&data, &size, pix, IFF_PNM);
   }
   pixDestroy(&pix);
-  image_data->resize_no_init(size);
+  image_data->resize_no_init(static_cast<int>(size));
   memcpy(&(*image_data)[0], data, size);
   lept_free(data);
 }

--- a/src/ccstruct/linlsq.cpp
+++ b/src/ccstruct/linlsq.cpp
@@ -165,7 +165,7 @@ double LLSQ::pearson() const {  // get correlation
 // Returns the x,y means as an FCOORD.
 FCOORD LLSQ::mean_point() const {
   if (total_weight > 0.0) {
-    return FCOORD(sigx / total_weight, sigy / total_weight);
+    return FCOORD(static_cast<float>(sigx / total_weight), static_cast<float>(sigy / total_weight));
   } else {
     return FCOORD(0.0f, 0.0f);
   }
@@ -253,6 +253,6 @@ FCOORD LLSQ::vector_fit() const {
   double y_var = y_variance();
   double covar = covariance();
   double theta = 0.5 * atan2(2.0 * covar, x_var - y_var);
-  FCOORD result(cos(theta), sin(theta));
+  FCOORD result(static_cast<float>(cos(theta)), static_cast<float>(sin(theta)));
   return result;
 }

--- a/src/ccstruct/normalis.cpp
+++ b/src/ccstruct/normalis.cpp
@@ -243,10 +243,10 @@ static void ComputeEdgeDensityProfiles(const TBOX& box,
   // Normalize each profile to sum to 1.
   if (total > 0.0) {
     for (int ix = 0; ix < width; ++ix) {
-      (*hx)[ix] /= total;
+      (*hx)[ix] /= static_cast<float>(total);
     }
     for (int iy = 0; iy < height; ++iy) {
-      (*hy)[iy] /= total;
+      (*hy)[iy] /= static_cast<float>(total);
     }
   }
   // There is an extra element in each array, so initialize to 1.
@@ -453,8 +453,8 @@ void DENORM::XHeightRange(int unichar_id, const UNICHARSET& unicharset,
   // Calculate the scale factor we'll use to get to image y-pixels
   double midx = (bbox.left() + bbox.right()) / 2.0;
   double ydiff = (bbox.top() - bbox.bottom()) + 2.0;
-  FCOORD mid_bot(midx, bbox.bottom()), tmid_bot;
-  FCOORD mid_high(midx, bbox.bottom() + ydiff), tmid_high;
+  FCOORD mid_bot(static_cast<float>(midx), static_cast<float>(bbox.bottom())), tmid_bot;
+  FCOORD mid_high(static_cast<float>(midx), static_cast<float>(bbox.bottom() + ydiff)), tmid_high;
   DenormTransform(nullptr, mid_bot, &tmid_bot);
   DenormTransform(nullptr, mid_high, &tmid_high);
 
@@ -477,7 +477,7 @@ void DENORM::XHeightRange(int unichar_id, const UNICHARSET& unicharset,
       (top_shift < 0 && bottom_shift < 0)) {
     bln_yshift = (top_shift + bottom_shift) / 2;
   }
-  *yshift = bln_yshift * yscale;
+  *yshift = static_cast<float>(bln_yshift * yscale);
 
   // To help very high cap/xheight ratio fonts accept the correct x-height,
   // and to allow the large caps in small caps to accept the xheight of the
@@ -494,9 +494,9 @@ void DENORM::XHeightRange(int unichar_id, const UNICHARSET& unicharset,
   // We shouldn't try calculations if the characters are very short (for example
   // for punctuation).
   if (min_height > kBlnXHeight / 8 && height > 0) {
-    float result = height * kBlnXHeight * yscale / min_height;
+    float result = static_cast<float>(height * kBlnXHeight * yscale / min_height);
     *max_xht = result + kFinalPixelTolerance;
-    result = height * kBlnXHeight * yscale / max_height;
+    result = static_cast<float>(height * kBlnXHeight * yscale / max_height);
     *min_xht = result - kFinalPixelTolerance;
   }
 }

--- a/src/ccstruct/ocrblock.cpp
+++ b/src/ccstruct/ocrblock.cpp
@@ -45,7 +45,7 @@ BLOCK::BLOCK(const char *name,                ///< filename
 
   proportional = prop;
   right_to_left_ = false;
-  kerning = kern;
+  kerning = static_cast<int8_t>(kern);
   spacing = space;
   font_class = -1;               //not assigned
   cell_over_xheight_ = 2.0f;
@@ -373,7 +373,7 @@ void BLOCK::compute_row_margins() {
   for (r_it.mark_cycle_pt(); !r_it.cycled_list(); r_it.forward()) {
     ROW *row = r_it.data();
     TBOX row_box = row->bounding_box();
-    int left_y = row->base_line(row_box.left()) + row->x_height();
+    int left_y = static_cast<int>(row->base_line(row_box.left()) + row->x_height());
     int left_margin;
     const std::unique_ptr</*non-const*/ ICOORDELT_LIST> segments_left(
         lines.get_line(left_y));
@@ -387,7 +387,7 @@ void BLOCK::compute_row_margins() {
         left_margin = drop_cap_distance;
     }
 
-    int right_y = row->base_line(row_box.right()) + row->x_height();
+    int right_y = static_cast<int>(row->base_line(static_cast<float>(row_box.right()) + row->x_height()));
     int right_margin;
     const std::unique_ptr</*non-const*/ ICOORDELT_LIST> segments_right(
         lines.get_line(right_y));

--- a/src/ccstruct/pageres.cpp
+++ b/src/ccstruct/pageres.cpp
@@ -524,8 +524,8 @@ void WERD_RES::FilterWordChoices(int debug_level) {
   int index = 0;
   for (it.forward(); !it.at_first(); it.forward(), ++index) {
     WERD_CHOICE* choice = it.data();
-    float threshold = StopperAmbigThreshold(best_choice->adjust_factor(),
-                                            choice->adjust_factor());
+    float threshold = static_cast<float>(StopperAmbigThreshold(best_choice->adjust_factor(),
+                                            choice->adjust_factor()));
     // i, j index the blob choice in choice, best_choice.
     // chunk is an index into the chopped_word blobs (AKA chunks).
     // Since the two words may use different segmentations of the chunks, we
@@ -591,7 +591,7 @@ void WERD_RES::ComputeAdaptionThresholds(float certainty_scale,
 
     if (num_error_chunks > 0) {
       avg_rating /= num_error_chunks;
-      *thresholds = (avg_rating / -certainty_scale) * (1.0 - rating_margin);
+      *thresholds = (avg_rating / -certainty_scale) * (1.0f - rating_margin);
     } else {
       *thresholds = max_rating;
     }
@@ -630,8 +630,8 @@ bool WERD_RES::LogNewCookedChoice(int max_num_choices, bool debug,
     // undesirable behavior. It would be better to keep all the choices and
     // prune them later when more information is available.
     float max_certainty_delta =
-        StopperAmbigThreshold(best_choice->adjust_factor(),
-                              word_choice->adjust_factor());
+        static_cast<float>(StopperAmbigThreshold(best_choice->adjust_factor(),
+                              word_choice->adjust_factor()));
     if (max_certainty_delta > -kStopperAmbiguityThresholdOffset)
       max_certainty_delta = -kStopperAmbiguityThresholdOffset;
     if (word_choice->certainty() - best_choice->certainty() <
@@ -905,8 +905,8 @@ void WERD_RES::FakeWordFromRatings(PermuterType permuter) {
   word_choice->set_permuter(permuter);
   for (int b = 0; b < num_blobs; ++b) {
     UNICHAR_ID unichar_id = UNICHAR_SPACE;
-    float rating = INT32_MAX;
-    float certainty = -INT32_MAX;
+    float rating = INT32_MAX * 1.f;
+    float certainty = -INT32_MAX * 1.f;
     BLOB_CHOICE_LIST* choices = ratings->get(b, b);
     if (choices != nullptr && !choices->empty()) {
       BLOB_CHOICE_IT bc_it(choices);
@@ -1012,8 +1012,8 @@ static int is_simple_quote(const char* signed_str, int length) {
 UNICHAR_ID WERD_RES::BothQuotes(UNICHAR_ID id1, UNICHAR_ID id2) {
   const char *ch = uch_set->id_to_unichar(id1);
   const char *next_ch = uch_set->id_to_unichar(id2);
-  if (is_simple_quote(ch, strlen(ch)) &&
-      is_simple_quote(next_ch, strlen(next_ch)))
+  if (is_simple_quote(ch, static_cast<int>(strlen(ch))) &&
+      is_simple_quote(next_ch, static_cast<int>(strlen(next_ch))))
     return uch_set->unichar_to_id("\"");
   return INVALID_UNICHAR_ID;
 }

--- a/src/ccstruct/points.cpp
+++ b/src/ccstruct/points.cpp
@@ -111,8 +111,8 @@ uint8_t FCOORD::to_direction() const {
 // Sets this with a unit vector in the given standard feature direction.
 void FCOORD::from_direction(uint8_t direction) {
   double radians = angle_from_direction(direction);
-  xcoord = cos(radians);
-  ycoord = sin(radians);
+  xcoord = static_cast<float>(cos(radians));
+  ycoord = static_cast<float>(sin(radians));
 }
 
 // Converts an angle in radians (from ICOORD::angle or FCOORD::angle) to a
@@ -138,5 +138,5 @@ FCOORD FCOORD::nearest_pt_on_line(const FCOORD& line_point,
   // to add to line1 to get the appropriate point, so
   // result = line1 + lambda dir_vector.
   double lambda = point_vector % dir_vector / dir_vector.sqlength();
-  return line_point + (dir_vector * lambda);
+  return line_point + (dir_vector * static_cast<float>(lambda));
 }

--- a/src/ccstruct/points.h
+++ b/src/ccstruct/points.h
@@ -71,7 +71,7 @@ class ICOORD
 
     ///find sq length
     float sqlength() const {
-      return xcoord * xcoord + ycoord * ycoord;
+      return static_cast<float>(xcoord * xcoord + ycoord * ycoord);
     }
 
     ///find length
@@ -95,7 +95,7 @@ class ICOORD
 
     ///find angle
     float angle() const {
-      return std::atan2(ycoord, xcoord);
+      return static_cast<float>(std::atan2(ycoord, xcoord));
     }
 
     ///test equality

--- a/src/ccstruct/polyblk.cpp
+++ b/src/ccstruct/polyblk.cpp
@@ -289,7 +289,7 @@ void POLY_BLOCK::fill(ScrollView* window, ScrollView::Color colour) {
         // Last pixel is start pixel + length.
         width = s_it.data ()->y ();
         window->SetCursor(s_it.data ()->x (), y);
-        window->DrawTo(s_it.data()->x() + static_cast<float>(width), y);
+        window->DrawTo(s_it.data()->x() + width, y);
       }
     }
   }

--- a/src/ccstruct/quspline.cpp
+++ b/src/ccstruct/quspline.cpp
@@ -51,8 +51,8 @@ QSPLINE::QSPLINE(                 //constructor
                                  //copy them
     xcoords[index] = xstarts[index];
     quadratics[index] = QUAD_COEFFS (coeffs[index * 3],
-      coeffs[index * 3 + 1],
-      coeffs[index * 3 + 2]);
+      static_cast<float>(coeffs[index * 3 + 1]),
+      static_cast<float>(coeffs[index * 3 + 2]));
   }
                                  //right edge
   xcoords[index] = xstarts[index];
@@ -121,8 +121,8 @@ int degree                       //fit required
         / (xpts[pointindex] - xpts[pointindex - 1]));
     qlsq.fit (degree);
     quadratics[segment].a = qlsq.get_a ();
-    quadratics[segment].b = qlsq.get_b ();
-    quadratics[segment].c = qlsq.get_c ();
+    quadratics[segment].b = static_cast<float>(qlsq.get_b ());
+    quadratics[segment].c = static_cast<float>(qlsq.get_c ());
   }
   delete[] ptcounts;
 }
@@ -212,7 +212,7 @@ double QSPLINE::y(          //evaluate
   int32_t index;                   //segment index
 
   index = spline_index (x);
-  return quadratics[index].y (x);//in correct segment
+  return quadratics[index].y (static_cast<float>(x));//in correct segment
 }
 
 
@@ -309,8 +309,8 @@ void QSPLINE::extrapolate(                  //linear extrapolation
   if (xmin < xcoords[0]) {
     xstarts[0] = xmin;
     quads[0].a = 0;
-    quads[0].b = gradient;
-    quads[0].c = y (xcoords[0]) - quads[0].b * xcoords[0];
+    quads[0].b = static_cast<float>(gradient);
+    quads[0].c = static_cast<float>(y (xcoords[0]) - quads[0].b * xcoords[0]);
     dest_segment = 1;
   }
   else
@@ -323,9 +323,9 @@ void QSPLINE::extrapolate(                  //linear extrapolation
   xstarts[dest_segment] = xcoords[segment];
   if (xmax > xcoords[segments]) {
     quads[dest_segment].a = 0;
-    quads[dest_segment].b = gradient;
-    quads[dest_segment].c = y (xcoords[segments])
-      - quads[dest_segment].b * xcoords[segments];
+    quads[dest_segment].b = static_cast<float>(gradient);
+    quads[dest_segment].c = static_cast<float>(y (xcoords[segments])
+      - quads[dest_segment].b * xcoords[segments]);
     dest_segment++;
     xstarts[dest_segment] = xmax + 1;
   }
@@ -361,9 +361,9 @@ void QSPLINE::plot(                //draw it
     x = xcoords[segment];
     for (step = 0; step <= QSPLINE_PRECISION; step++) {
       if (segment == 0 && step == 0)
-        window->SetCursor(x, quadratics[segment].y (x));
+        window->SetCursor(static_cast<int>(x), static_cast<int>(quadratics[segment].y (static_cast<float>(x))));
       else
-        window->DrawTo(x, quadratics[segment].y (x));
+        window->DrawTo(static_cast<int>(x), static_cast<int>(quadratics[segment].y (static_cast<float>(x))));
       x += increment;
     }
   }
@@ -388,8 +388,8 @@ void QSPLINE::plot(Pix *pix) const {
         xcoords[segment])) / QSPLINE_PRECISION;
     x = xcoords[segment];
     for (step = 0; step <= QSPLINE_PRECISION; step++) {
-      double y = height - quadratics[segment].y(x);
-      ptaAddPt(points, x, y);
+      double y = height - quadratics[segment].y(static_cast<float>(x));
+      ptaAddPt(points, static_cast<l_float32>(x), static_cast<l_float32>(y));
       x += increment;
     }
   }

--- a/src/ccstruct/ratngs.cpp
+++ b/src/ccstruct/ratngs.cpp
@@ -247,11 +247,11 @@ void WERD_CHOICE::init(const char *src_string,
                        float src_rating,
                        float src_certainty,
                        uint8_t src_permuter) {
-  int src_string_len = strlen(src_string);
+  int src_string_len = static_cast<int>(strlen(src_string));
   if (src_string_len == 0) {
     this->init(8);
   } else {
-    this->init(src_lengths ? strlen(src_lengths): src_string_len);
+    this->init(src_lengths ? static_cast<int>(strlen(src_lengths)): src_string_len);
     length_ = reserved_;
     int offset = 0;
     for (int i = 0; i < length_; ++i) {
@@ -454,7 +454,7 @@ void WERD_CHOICE::string_and_lengths(STRING *word_str,
     const char *ch = unicharset_->id_to_unichar_ext(unichar_ids_[i]);
     *word_str += ch;
     if (word_lengths_str != nullptr) {
-      *word_lengths_str += strlen(ch);
+      *word_lengths_str += static_cast<char>(strlen(ch));
     }
   }
 }
@@ -778,7 +778,7 @@ void WERD_CHOICE::DisplaySegmentation(TWERD* word) {
   // Create the window if needed.
   if (segm_window == nullptr) {
     segm_window = new ScrollView("Segmentation", 5, 10, 500, 256,
-                                 2000.0, 256.0, true);
+                                 2000, 256, true);
   } else {
     segm_window->Clear();
   }

--- a/src/ccstruct/split.cpp
+++ b/src/ccstruct/split.cpp
@@ -97,16 +97,16 @@ float SPLIT::FullPriority(int xmin, int xmax, double overlap_knob,
     grade += 100.0f;  // Total overlap.
   } else {
     if (2 * overlap > min_width) overlap += 2 * overlap - min_width;
-    if (overlap > 0) grade += overlap_knob * overlap;
+    if (overlap > 0) grade += static_cast<float>(overlap_knob * overlap);
   }
   // grade_center_of_blob.
   if (width1 <= centered_maxwidth || width2 <= centered_maxwidth) {
-    grade += std::min(static_cast<double>(kCenterGradeCap), center_knob * abs(width1 - width2));
+    grade += static_cast<float>(std::min(static_cast<double>(kCenterGradeCap), center_knob * abs(width1 - width2)));
   }
   // grade_width_change.
-  float width_change_grade = 20 - (max_right - min_left - std::max(width1, width2));
+  float width_change_grade = static_cast<float>(20 - (max_right - min_left - std::max(width1, width2)));
   if (width_change_grade > 0.0f)
-    grade += width_change_grade * width_change_knob;
+    grade += width_change_grade * static_cast<float>(width_change_knob);
   return grade;
 }
 
@@ -146,8 +146,8 @@ EDGEPT *make_edgept(int x, int y, EDGEPT *next, EDGEPT *prev) {
   C_OUTLINE* prev_ol = prev->src_outline;
   if (prev_ol != nullptr && prev->next == next) {
     // Compute the fraction of the segment that is being cut.
-    FCOORD segment_vec(next->pos.x - prev->pos.x, next->pos.y - prev->pos.y);
-    FCOORD target_vec(x - prev->pos.x, y - prev->pos.y);
+    FCOORD segment_vec(static_cast<float>(next->pos.x - prev->pos.x), static_cast<float>(next->pos.y - prev->pos.y));
+    FCOORD target_vec(static_cast<float>(x - prev->pos.x), static_cast<float>(y - prev->pos.y));
     double cut_fraction = target_vec.length() / segment_vec.length();
     // Get the start and end at the step level.
     ICOORD step_start = prev_ol->position_at_index(prev->start_step);

--- a/src/ccstruct/statistc.cpp
+++ b/src/ccstruct/statistc.cpp
@@ -592,9 +592,9 @@ void STATS::plot(ScrollView* window,  // to draw in
   window->Pen(colour);
 
   for (int index = 0; index < rangemax_ - rangemin_; index++) {
-    window->Rectangle(xorigin + xscale * index, yorigin,
-      xorigin + xscale * (index + 1),
-      yorigin + yscale * buckets_[index]);
+    window->Rectangle(static_cast<int>(xorigin + xscale * index), static_cast<int>(yorigin),
+                      static_cast<int>(xorigin + xscale * (index + 1)),
+                      static_cast<int>(yorigin + yscale * buckets_[index]));
   }
 }
 #endif
@@ -617,10 +617,10 @@ void STATS::plotline(ScrollView* window,  // to draw in
     return;
   }
   window->Pen(colour);
-  window->SetCursor(xorigin, yorigin + yscale * buckets_[0]);
+  window->SetCursor(static_cast<int>(xorigin), static_cast<int>(yorigin + yscale * buckets_[0]));
   for (int index = 0; index < rangemax_ - rangemin_; index++) {
-    window->DrawTo(xorigin + xscale * index,
-                   yorigin + yscale * buckets_[index]);
+    window->DrawTo(static_cast<int>(xorigin + xscale * index),
+                   static_cast<int>(yorigin + yscale * buckets_[index]));
   }
 }
 #endif

--- a/src/ccutil/basedir.cpp
+++ b/src/ccutil/basedir.cpp
@@ -31,10 +31,10 @@ TESS_API void truncate_path(const char *code_path, STRING* trunc_path) {
   if (code_path != nullptr) {
     const char* last_slash = strrchr(code_path, '/');
     if (last_slash != nullptr && last_slash + 1 - code_path > trunc_index)
-      trunc_index = last_slash + 1 - code_path;
+      trunc_index = static_cast<int>(last_slash + 1 - code_path);
     last_slash = strrchr(code_path, '\\');
     if (last_slash != nullptr && last_slash + 1 - code_path > trunc_index)
-      trunc_index = last_slash + 1 - code_path;
+      trunc_index = static_cast<int>(last_slash + 1 - code_path);
   }
   *trunc_path = code_path;
   if (trunc_index >= 0)

--- a/src/ccutil/fileio.cpp
+++ b/src/ccutil/fileio.cpp
@@ -154,7 +154,7 @@ InputBuffer::~InputBuffer() {
 bool InputBuffer::Read(std::string* out) {
   char buf[BUFSIZ + 1];
   int l;
-  while ((l = fread(buf, 1, BUFSIZ, stream_)) > 0) {
+  while ((l = static_cast<int>(fread(buf, 1, BUFSIZ, stream_))) > 0) {
     if (ferror(stream_)) {
       clearerr(stream_);
       return false;

--- a/src/ccutil/genericheap.h
+++ b/src/ccutil/genericheap.h
@@ -180,7 +180,7 @@ class GenericHeap {
   // its first element. Reshuffles the heap to maintain the invariant.
   // Time = O(log n).
   void Reshuffle(Pair* pair) {
-    int index = pair - &heap_[0];
+    int index = static_cast<int>(pair - &heap_[0]);
     Pair hole_pair = heap_[index];
     index = SiftDown(index, hole_pair);
     index = SiftUp(index, hole_pair);

--- a/src/ccutil/genericvector.h
+++ b/src/ccutil/genericvector.h
@@ -28,6 +28,7 @@
 #include "serialis.h"
 #include "strngs.h"
 #include "tesscallback.h"
+#include "platform.h"
 
 // Use PointerVector<T> below in preference to GenericVector<T*>, as that
 // provides automatic deletion of pointers, [De]Serialize that works, and

--- a/src/ccutil/ocrclass.h
+++ b/src/ccutil/ocrclass.h
@@ -150,7 +150,7 @@ class ETEXT_DESC {  // output header
       std::chrono::steady_clock::time_point chrono_point, struct timeval* tv) {
     auto millisecs = std::chrono::duration_cast<std::chrono::milliseconds>(
         chrono_point.time_since_epoch());
-    tv->tv_sec = millisecs.count() / 1000;
+    tv->tv_sec = static_cast<long>(millisecs.count() / 1000);
     tv->tv_usec = (millisecs.count() % 1000) * 1000;
   }
 

--- a/src/ccutil/scanutils.cpp
+++ b/src/ccutil/scanutils.cpp
@@ -28,6 +28,8 @@
 
 #include "scanutils.h"
 
+#pragma warning(disable: 4146)
+
 enum Flags {
   FL_SPLAT  = 0x01,   // Drop the value, do not assign
   FL_INV    = 0x02,   // Character-set with inverse

--- a/src/ccutil/serialis.cpp
+++ b/src/ccutil/serialis.cpp
@@ -101,95 +101,95 @@ TFile::~TFile() {
 }
 
 bool TFile::DeSerialize(char* buffer, size_t count) {
-  return FRead(buffer, sizeof(*buffer), count) == count;
+  return FRead(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::DeSerialize(double* buffer, size_t count) {
-  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+  return FReadEndian(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::DeSerialize(float* buffer, size_t count) {
-  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+  return FReadEndian(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::DeSerialize(int8_t* buffer, size_t count) {
-  return FRead(buffer, sizeof(*buffer), count) == count;
+  return FRead(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::DeSerialize(int16_t* buffer, size_t count) {
-  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+  return FReadEndian(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::DeSerialize(int32_t* buffer, size_t count) {
-  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+  return FReadEndian(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::DeSerialize(int64_t* buffer, size_t count) {
-  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+  return FReadEndian(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::DeSerialize(uint8_t* buffer, size_t count) {
-  return FRead(buffer, sizeof(*buffer), count) == count;
+  return FRead(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::DeSerialize(uint16_t* buffer, size_t count) {
-  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+  return FReadEndian(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::DeSerialize(uint32_t* buffer, size_t count) {
-  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+  return FReadEndian(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::DeSerialize(uint64_t* buffer, size_t count) {
-  return FReadEndian(buffer, sizeof(*buffer), count) == count;
+  return FReadEndian(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const char* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const double* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const float* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const int8_t* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const int16_t* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const int32_t* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const int64_t* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const uint8_t* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const uint16_t* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const uint32_t* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Serialize(const uint64_t* buffer, size_t count) {
-  return FWrite(buffer, sizeof(*buffer), count) == count;
+  return FWrite(buffer, sizeof(*buffer), static_cast<int>(count)) == count;
 }
 
 bool TFile::Skip(size_t count) {
-  offset_ += count;
+  offset_ += static_cast<int>(count);
   return true;
 }
 
@@ -234,7 +234,7 @@ bool TFile::Open(FILE* fp, int64_t end_offset) {
     if (fseek(fp, current_pos, SEEK_SET))
       return false;
   }
-  int size = end_offset - current_pos;
+  int size = static_cast<int>(end_offset - current_pos);
   is_writing_ = false;
   swap_ = false;
   if (!data_is_owned_) {
@@ -261,7 +261,7 @@ int TFile::FReadEndian(void* buffer, size_t size, int count) {
   if (swap_) {
     char* char_buffer = static_cast<char*>(buffer);
     for (int i = 0; i < num_read; ++i, char_buffer += size) {
-      ReverseN(char_buffer, size);
+      ReverseN(char_buffer, static_cast<int>(size));
     }
   }
   return num_read;
@@ -283,8 +283,8 @@ int TFile::FRead(void* buffer, size_t size, int count) {
   }
   if (required_size > 0 && buffer != nullptr)
     memcpy(buffer, &(*data_)[offset_], required_size);
-  offset_ += required_size;
-  return required_size / size;
+  offset_ += static_cast<int>(required_size);
+  return static_cast<int>(required_size / size);
 }
 
 void TFile::Rewind() {

--- a/src/ccutil/strngs.cpp
+++ b/src/ccutil/strngs.cpp
@@ -96,7 +96,7 @@ char* STRING::ensure_cstr(int32_t min_capacity) {
 void STRING::FixHeader() const {
   const STRING_HEADER* header = GetHeader();
   if (header->used_ < 0)
-    header->used_ = strlen(GetCStr()) + 1;
+    header->used_ = static_cast<int>(strlen(GetCStr()) + 1);
 }
 
 
@@ -119,7 +119,7 @@ STRING::STRING(const char* cstr) {
     // Empty STRINGs contain just the "\0".
     memcpy(AllocData(1, kMinCapacity), "", 1);
   } else {
-    const int len = strlen(cstr) + 1;
+    const int len = static_cast<int>(strlen(cstr) + 1);
     char* this_cstr = AllocData(len, len);
     memcpy(this_cstr, cstr, len);
   }
@@ -329,7 +329,7 @@ bool STRING::operator!=(const char* cstr) const {
   if (cstr == nullptr)
     return this_header->used_ > 1;  // either '\0' or nullptr
   else {
-    const int32_t length = strlen(cstr) + 1;
+    const int32_t length = static_cast<int32_t>(strlen(cstr) + 1);
     return (this_header->used_ != length)
             || (memcmp(GetCStr(), cstr, length) != 0);
   }
@@ -399,7 +399,7 @@ void STRING::add_str_double(const char* str, double number) {
 STRING & STRING::operator=(const char* cstr) {
   STRING_HEADER* this_header = GetHeader();
   if (cstr) {
-    const int len = strlen(cstr) + 1;
+    const int len = static_cast<int>(strlen(cstr) + 1);
 
     this_header->used_ = 0;  // don't bother copying data if need to realloc
     char* this_cstr = ensure_cstr(len);
@@ -464,7 +464,7 @@ STRING&  STRING::operator+=(const char *str) {
     return *this;
 
   FixHeader();
-  const int len = strlen(str) + 1;
+  const int len = static_cast<int>(strlen(str) + 1);
   const int this_used = GetHeader()->used_;
   char* this_cstr = ensure_cstr(this_used + len);
   STRING_HEADER* this_header = GetHeader();  // after ensure for realloc

--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -73,7 +73,7 @@ bool TessdataManager::LoadArchiveFile(const char *filename) {
           if (TessdataTypeFromFileName(component, &type)) {
             int64_t size = archive_entry_size(ae);
             if (size > 0) {
-              entries_[type].resize_no_init(size);
+              entries_[type].resize_no_init(static_cast<int>(size));
               if (archive_read_data(a, &entries_[type][0], size) == size) {
                 is_loaded_ = true;
               }
@@ -130,7 +130,7 @@ bool TessdataManager::LoadMemBuffer(const char *name, const char *data,
       unsigned j = i + 1;
       while (j < num_entries && offset_table[j] == -1) ++j;
       if (j < num_entries) entry_size = offset_table[j] - offset_table[i];
-      entries_[i].resize_no_init(entry_size);
+      entries_[i].resize_no_init(static_cast<int>(entry_size));
       if (!fp.DeSerialize(&entries_[i][0], entry_size)) return false;
     }
   }
@@ -177,7 +177,7 @@ void TessdataManager::Serialize(GenericVector<char> *data) const {
       offset += entries_[i].size();
     }
   }
-  data->init_to_size(offset, 0);
+  data->init_to_size(static_cast<int>(offset), 0);
   int32_t num_entries = TESSDATA_NUM_ENTRIES;
   TFile fp;
   fp.OpenWrite(data);
@@ -237,7 +237,7 @@ std::string TessdataManager::VersionString() const {
 
 // Sets the version string to the given v_str.
 void TessdataManager::SetVersionString(const std::string &v_str) {
-  entries_[TESSDATA_VERSION].resize_no_init(v_str.size());
+  entries_[TESSDATA_VERSION].resize_no_init(static_cast<int>(v_str.size()));
   memcpy(&entries_[TESSDATA_VERSION][0], v_str.data(), v_str.size());
 }
 

--- a/src/ccutil/unichar.cpp
+++ b/src/ccutil/unichar.cpp
@@ -213,7 +213,7 @@ UNICHAR::const_iterator UNICHAR::end(const char* utf8_str, int len) {
 // Returns an empty vector if the input contains invalid UTF-8.
 /* static */
 std::vector<char32> UNICHAR::UTF8ToUTF32(const char* utf8_str) {
-  const int utf8_length = strlen(utf8_str);
+  const int utf8_length = static_cast<int>(strlen(utf8_str));
   std::vector<char32> unicodes;
   unicodes.reserve(utf8_length);
   const_iterator end_it(end(utf8_str, utf8_length));

--- a/src/ccutil/unicharcompress.cpp
+++ b/src/ccutil/unicharcompress.cpp
@@ -39,7 +39,7 @@ static int RadicalPreHash(const std::vector<int>& rs) {
     result *= kRadicalRadix;
     result += radical;
   }
-  return result;
+  return static_cast<int>(result);
 }
 
 // A hash map to convert unicodes to radical encoding.
@@ -142,7 +142,7 @@ bool UnicharCompress::ComputeEncoding(const UNICHARSET& unicharset, int null_id,
       auto it = radical_map.find(unicode);
       if (it != radical_map.end()) {
         // This is Han. Use the radical codes directly.
-        int num_radicals = it->second->size();
+        int num_radicals = static_cast<int>(it->second->size());
         for (int c = 0; c < num_radicals; ++c) {
           code.Set(c, han_offset + (*it->second)[c]);
         }

--- a/src/ccutil/unicharmap.cpp
+++ b/src/ccutil/unicharmap.cpp
@@ -104,7 +104,7 @@ int UNICHARMAP::minmatch(const char* const unichar_repr) const {
 
   while (current_nodes != nullptr && *current_char != '\0') {
     if (current_nodes[static_cast<unsigned char>(*current_char)].id >= 0)
-      return current_char + 1 - unichar_repr;
+      return static_cast<int>(current_char + 1 - unichar_repr);
     current_nodes =
         current_nodes[static_cast<unsigned char>(*current_char)].children;
     ++current_char;

--- a/src/ccutil/unicharset.cpp
+++ b/src/ccutil/unicharset.cpp
@@ -210,8 +210,8 @@ UNICHAR_ID
 UNICHARSET::unichar_to_id(const char* const unichar_repr) const {
   std::string cleaned =
       old_style_included_ ? unichar_repr : CleanupString(unichar_repr);
-  return ids.contains(cleaned.data(), cleaned.size())
-             ? ids.unichar_to_id(cleaned.data(), cleaned.size())
+  return ids.contains(cleaned.data(), static_cast<int>(cleaned.size()))
+             ? ids.unichar_to_id(cleaned.data(), static_cast<int>(cleaned.size()))
              : INVALID_UNICHAR_ID;
 }
 
@@ -220,8 +220,8 @@ UNICHAR_ID UNICHARSET::unichar_to_id(const char* const unichar_repr,
   assert(length > 0 && length <= UNICHAR_LEN);
   std::string cleaned(unichar_repr, length);
   if (!old_style_included_) cleaned = CleanupString(unichar_repr, length);
-  return ids.contains(cleaned.data(), cleaned.size())
-             ? ids.unichar_to_id(cleaned.data(), cleaned.size())
+  return ids.contains(cleaned.data(), static_cast<int>(cleaned.size()))
+             ? ids.unichar_to_id(cleaned.data(), static_cast<int>(cleaned.size()))
              : INVALID_UNICHAR_ID;
 }
 
@@ -264,7 +264,7 @@ bool UNICHARSET::encode_string(const char* str, bool give_up_on_failure,
   GenericVector<char> working_lengths;
   GenericVector<char> best_lengths;
   encoding->truncate(0);  // Just in case str is empty.
-  int str_length = strlen(str);
+  int str_length = static_cast<int>(strlen(str));
   int str_pos = 0;
   bool perfect = true;
   while (str_pos < str_length) {
@@ -628,7 +628,7 @@ void UNICHARSET::unichar_insert(const char* const unichar_repr,
   if (old_style == OldUncleanUnichars::kTrue) old_style_included_ = true;
   std::string cleaned =
       old_style_included_ ? unichar_repr : CleanupString(unichar_repr);
-  if (!cleaned.empty() && !ids.contains(cleaned.data(), cleaned.size())) {
+  if (!cleaned.empty() && !ids.contains(cleaned.data(), static_cast<int>(cleaned.size()))) {
     const char* str = cleaned.c_str();
     GenericVector<int> encoding;
     if (!old_style_included_ &&
@@ -671,7 +671,7 @@ void UNICHARSET::unichar_insert(const char* const unichar_repr,
 bool UNICHARSET::contains_unichar(const char* const unichar_repr) const {
   std::string cleaned =
       old_style_included_ ? unichar_repr : CleanupString(unichar_repr);
-  return ids.contains(cleaned.data(), cleaned.size());
+  return ids.contains(cleaned.data(), static_cast<int>(cleaned.size()));
 }
 
 bool UNICHARSET::contains_unichar(const char* const unichar_repr,
@@ -681,7 +681,7 @@ bool UNICHARSET::contains_unichar(const char* const unichar_repr,
   }
   std::string cleaned(unichar_repr, length);
   if (!old_style_included_) cleaned = CleanupString(unichar_repr, length);
-  return ids.contains(cleaned.data(), cleaned.size());
+  return ids.contains(cleaned.data(), static_cast<int>(cleaned.size()));
 }
 
 bool UNICHARSET::eq(UNICHAR_ID unichar_id,
@@ -1096,7 +1096,7 @@ STRING CHAR_FRAGMENT::to_string(const char *unichar, int pos, int total,
 
 CHAR_FRAGMENT *CHAR_FRAGMENT::parse_from_string(const char *string) {
   const char *ptr = string;
-  int len = strlen(string);
+  int len = static_cast<int>(strlen(string));
   if (len < kMinLen || *ptr != kSeparator) {
     return nullptr;  // this string can not represent a fragment
   }

--- a/src/classify/blobclass.cpp
+++ b/src/classify/blobclass.cpp
@@ -54,7 +54,7 @@ void ExtractFontName(const STRING& filename, STRING* fontname) {
     if (firstdot != lastdot && firstdot != nullptr && lastdot != nullptr) {
       ++firstdot;
       *fontname = firstdot;
-      fontname->truncate_at(lastdot - firstdot);
+      fontname->truncate_at(static_cast<int32_t>(lastdot - firstdot));
     }
   }
 }

--- a/src/classify/classify.cpp
+++ b/src/classify/classify.cpp
@@ -232,17 +232,17 @@ void Classify::AddLargeSpeckleTo(int blob_length, BLOB_CHOICE_LIST *choices) {
     BLOB_CHOICE_IT bc_it(choices);
   // If there is no classifier result, we will use the worst possible certainty
   // and corresponding rating.
-  float certainty = -getDict().certainty_scale;
-  float rating = rating_scale * blob_length;
+  float certainty = static_cast<float>(-getDict().certainty_scale);
+  float rating = static_cast<float>(rating_scale * blob_length);
   if (!choices->empty() && blob_length > 0) {
     bc_it.move_to_last();
     BLOB_CHOICE* worst_choice = bc_it.data();
     // Add speckle_rating_penalty to worst rating, matching old value.
-    rating = worst_choice->rating() + speckle_rating_penalty;
+    rating = static_cast<float>(worst_choice->rating() + speckle_rating_penalty);
     // Compute the rating to correspond to the certainty. (Used to be kept
     // the same, but that messes up the language model search.)
-    certainty = -rating * getDict().certainty_scale /
-        (rating_scale * blob_length);
+    certainty = static_cast<float>(-rating * getDict().certainty_scale /
+        (rating_scale * blob_length));
   }
   auto* blob_choice = new BLOB_CHOICE(UNICHAR_SPACE, rating, certainty,
                                              -1, 0.0f, FLT_MAX, 0,

--- a/src/classify/cluster.cpp
+++ b/src/classify/cluster.cpp
@@ -1005,7 +1005,7 @@ static PROTOTYPE* MakeDegenerateProto(  //this was MinSample
   if (MinSamples < MINSAMPLESNEEDED)
     MinSamples = MINSAMPLESNEEDED;
 
-  if (Cluster->SampleCount < MinSamples) {
+  if (Cluster->SampleCount < static_cast<unsigned int>(MinSamples)) {
     switch (Style) {
       case spherical:
         Proto = NewSphericalProto (N, Cluster, Statistics);
@@ -1149,7 +1149,7 @@ static PROTOTYPE* MakeSphericalProto(CLUSTERER* Clusterer,
 
     FillBuckets (Buckets, Cluster, i, &(Clusterer->ParamDesc[i]),
       Cluster->Mean[i],
-      sqrt (static_cast<double>(Statistics->AvgVariance)));
+      static_cast<float>(sqrt (static_cast<double>(Statistics->AvgVariance))));
     if (!DistributionOK (Buckets))
       break;
   }
@@ -1183,8 +1183,8 @@ static PROTOTYPE* MakeEllipticalProto(CLUSTERER* Clusterer,
 
     FillBuckets (Buckets, Cluster, i, &(Clusterer->ParamDesc[i]),
       Cluster->Mean[i],
-      sqrt (static_cast<double>(Statistics->
-      CoVariance[i * (Clusterer->SampleSize + 1)])));
+      static_cast<float>(sqrt (static_cast<double>(Statistics->
+      CoVariance[i * (Clusterer->SampleSize + 1)]))));
     if (!DistributionOK (Buckets))
       break;
   }
@@ -1227,7 +1227,7 @@ static PROTOTYPE* MakeMixedProto(CLUSTERER* Clusterer,
 
     FillBuckets (NormalBuckets, Cluster, i, &(Clusterer->ParamDesc[i]),
       Proto->Mean[i],
-      sqrt (static_cast<double>(Proto->Variance.Elliptical[i])));
+      static_cast<float>(sqrt (static_cast<double>(Proto->Variance.Elliptical[i]))));
     if (DistributionOK (NormalBuckets))
       continue;
 
@@ -1272,9 +1272,9 @@ static void MakeDimRandom(uint16_t i, PROTOTYPE* Proto, PARAM_DESC* ParamDesc) {
 
   // subtract out the previous magnitude of this dimension from the total
   Proto->TotalMagnitude /= Proto->Magnitude.Elliptical[i];
-  Proto->Magnitude.Elliptical[i] = 1.0 / ParamDesc->Range;
+  Proto->Magnitude.Elliptical[i] = 1.0f / ParamDesc->Range;
   Proto->TotalMagnitude *= Proto->Magnitude.Elliptical[i];
-  Proto->LogMagnitude = log (static_cast<double>(Proto->TotalMagnitude));
+  Proto->LogMagnitude = static_cast<float>(log (static_cast<double>(Proto->TotalMagnitude)));
 
   // note that the proto Weight is irrelevant for D_random protos
 }                                // MakeDimRandom
@@ -1293,14 +1293,14 @@ static void MakeDimUniform(uint16_t i, PROTOTYPE* Proto, STATISTICS* Statistics)
   Proto->Variance.Elliptical[i] =
     (Statistics->Max[i] - Statistics->Min[i]) / 2;
   if (Proto->Variance.Elliptical[i] < MINVARIANCE)
-    Proto->Variance.Elliptical[i] = MINVARIANCE;
+    Proto->Variance.Elliptical[i] = static_cast<float>(MINVARIANCE);
 
   // subtract out the previous magnitude of this dimension from the total
   Proto->TotalMagnitude /= Proto->Magnitude.Elliptical[i];
   Proto->Magnitude.Elliptical[i] =
-    1.0 / (2.0 * Proto->Variance.Elliptical[i]);
+    1.0f / (2.0f * Proto->Variance.Elliptical[i]);
   Proto->TotalMagnitude *= Proto->Magnitude.Elliptical[i];
-  Proto->LogMagnitude = log (static_cast<double>(Proto->TotalMagnitude));
+  Proto->LogMagnitude = static_cast<float>(log (static_cast<double>(Proto->TotalMagnitude)));
 
   // note that the proto Weight is irrelevant for uniform protos
 }                                // MakeDimUniform
@@ -1382,7 +1382,7 @@ ComputeStatistics (int16_t N, PARAM_DESC ParamDesc[], CLUSTER * Cluster) {
     *CoVariance /= SampleCountAdjustedForBias;
     if (j == i) {
       if (*CoVariance < MINVARIANCE)
-        *CoVariance = MINVARIANCE;
+        *CoVariance = static_cast<float>(MINVARIANCE);
       Statistics->AvgVariance *= *CoVariance;
     }
   }
@@ -1413,14 +1413,14 @@ static PROTOTYPE* NewSphericalProto(uint16_t N, CLUSTER* Cluster,
 
   Proto->Variance.Spherical = Statistics->AvgVariance;
   if (Proto->Variance.Spherical < MINVARIANCE)
-    Proto->Variance.Spherical = MINVARIANCE;
+    Proto->Variance.Spherical = static_cast<float>(MINVARIANCE);
 
   Proto->Magnitude.Spherical =
-    1.0 / sqrt(2.0 * M_PI * Proto->Variance.Spherical);
+    static_cast<float>(1.0 / sqrt(2.0 * M_PI * Proto->Variance.Spherical));
   Proto->TotalMagnitude = static_cast<float>(pow(static_cast<double>(Proto->Magnitude.Spherical),
                                      static_cast<double>(N)));
-  Proto->Weight.Spherical = 1.0 / Proto->Variance.Spherical;
-  Proto->LogMagnitude = log (static_cast<double>(Proto->TotalMagnitude));
+  Proto->Weight.Spherical = 1.0f / Proto->Variance.Spherical;
+  Proto->LogMagnitude = static_cast<float>(log (static_cast<double>(Proto->TotalMagnitude)));
 
   return (Proto);
 }                                // NewSphericalProto
@@ -1451,14 +1451,14 @@ static PROTOTYPE* NewEllipticalProto(int16_t N, CLUSTER* Cluster,
   for (i = 0; i < N; i++, CoVariance += N + 1) {
     Proto->Variance.Elliptical[i] = *CoVariance;
     if (Proto->Variance.Elliptical[i] < MINVARIANCE)
-      Proto->Variance.Elliptical[i] = MINVARIANCE;
+      Proto->Variance.Elliptical[i] = static_cast<float>(MINVARIANCE);
 
     Proto->Magnitude.Elliptical[i] =
-      1.0 / sqrt(2.0 * M_PI * Proto->Variance.Elliptical[i]);
-    Proto->Weight.Elliptical[i] = 1.0 / Proto->Variance.Elliptical[i];
+      static_cast<float>(1.0 / sqrt(2.0 * M_PI * Proto->Variance.Elliptical[i]));
+    Proto->Weight.Elliptical[i] = 1.0f / Proto->Variance.Elliptical[i];
     Proto->TotalMagnitude *= Proto->Magnitude.Elliptical[i];
   }
-  Proto->LogMagnitude = log (static_cast<double>(Proto->TotalMagnitude));
+  Proto->LogMagnitude = static_cast<float>(log (static_cast<double>(Proto->TotalMagnitude)));
   Proto->Style = elliptical;
   return (Proto);
 }                                // NewEllipticalProto
@@ -1949,7 +1949,7 @@ static uint16_t NormalBucket(PARAM_DESC *ParamDesc,
       x += ParamDesc->Range;
   }
 
-  X = ((x - Mean) / StdDev) * kNormalStdDev + kNormalMean;
+  X = static_cast<float>(((x - Mean) / StdDev) * kNormalStdDev + kNormalMean);
   if (X < 0)
     return 0;
   if (X > BUCKETTABLESIZE - 1)
@@ -1982,7 +1982,7 @@ static uint16_t UniformBucket(PARAM_DESC *ParamDesc,
       x += ParamDesc->Range;
   }
 
-  X = ((x - Mean) / (2 * StdDev) * BUCKETTABLESIZE + BUCKETTABLESIZE / 2.0);
+  X = static_cast<float>(((x - Mean) / (2 * StdDev) * BUCKETTABLESIZE + BUCKETTABLESIZE / 2.0));
   if (X < 0)
     return 0;
   if (X > BUCKETTABLESIZE - 1)
@@ -2097,7 +2097,7 @@ static void AdjustBuckets(BUCKETS *Buckets, uint32_t NewSampleCount) {
     (static_cast<double>(Buckets->SampleCount)));
 
   for (i = 0; i < Buckets->NumberOfBuckets; i++) {
-    Buckets->ExpectedCount[i] *= AdjustFactor;
+    Buckets->ExpectedCount[i] *= static_cast<float>(AdjustFactor);
   }
 
   Buckets->SampleCount = NewSampleCount;
@@ -2306,11 +2306,11 @@ MultipleCharSamples(CLUSTERER* Clusterer,
   InitSampleSearch(SearchState, Cluster);
   while ((Sample = NextSample (&SearchState)) != nullptr) {
     CharID = Sample->CharID;
-    if (CharFlags[CharID] == false) {
-      CharFlags[CharID] = true;
+    if (CharFlags[CharID] == 0) {
+      CharFlags[CharID] = 1;
     }
     else {
-      if (CharFlags[CharID] == true) {
+      if (CharFlags[CharID] == 1) {
         NumIllegalInCluster++;
         CharFlags[CharID] = ILLEGAL_CHAR;
       }
@@ -2399,7 +2399,7 @@ static double InvertMatrix(const float* input, int size, float* inv) {
       for (int k = row; k < size; ++k) {
         sum += U_inv[row][k] * L[k][col];
       }
-      inv[row*size + col] = sum;
+      inv[row*size + col] = static_cast<float>(sum);
     }
   }
   // Check matrix product.

--- a/src/classify/clusttool.cpp
+++ b/src/classify/clusttool.cpp
@@ -216,10 +216,10 @@ PROTOTYPE *ReadPrototype(TFile *fp, uint16_t N) {
     case spherical:
       ASSERT_HOST(ReadNFloats(fp, 1, &(Proto->Variance.Spherical)) != nullptr);
       Proto->Magnitude.Spherical =
-          1.0 / sqrt(2.0 * M_PI * Proto->Variance.Spherical);
+          static_cast<float>(1.0 / sqrt(2.0 * M_PI * Proto->Variance.Spherical));
       Proto->TotalMagnitude = pow(Proto->Magnitude.Spherical, static_cast<float>(N));
-      Proto->LogMagnitude = log(static_cast<double>(Proto->TotalMagnitude));
-      Proto->Weight.Spherical = 1.0 / Proto->Variance.Spherical;
+      Proto->LogMagnitude = static_cast<float>(log(static_cast<double>(Proto->TotalMagnitude)));
+      Proto->Weight.Spherical = 1.0f / Proto->Variance.Spherical;
       Proto->Distrib = nullptr;
       break;
     case elliptical:
@@ -230,11 +230,11 @@ PROTOTYPE *ReadPrototype(TFile *fp, uint16_t N) {
       Proto->TotalMagnitude = 1.0;
       for (i = 0; i < N; i++) {
         Proto->Magnitude.Elliptical[i] =
-            1.0 / sqrt(2.0 * M_PI * Proto->Variance.Elliptical[i]);
-        Proto->Weight.Elliptical[i] = 1.0 / Proto->Variance.Elliptical[i];
+            static_cast<float>(1.0 / sqrt(2.0 * M_PI * Proto->Variance.Elliptical[i]));
+        Proto->Weight.Elliptical[i] = 1.0f / Proto->Variance.Elliptical[i];
         Proto->TotalMagnitude *= Proto->Magnitude.Elliptical[i];
       }
-      Proto->LogMagnitude = log(static_cast<double>(Proto->TotalMagnitude));
+      Proto->LogMagnitude = static_cast<float>(log(static_cast<double>(Proto->TotalMagnitude)));
       Proto->Distrib = nullptr;
       break;
     default:

--- a/src/classify/featdefs.cpp
+++ b/src/classify/featdefs.cpp
@@ -79,7 +79,7 @@ DefineFeature(GeoFeatDesc, 3, 0, kGeoFeatureType, GeoFeatParams)
 
 // Define all of the parameters for the PicoFeature type
 // define knob that can be used to adjust pico-feature length.
-float PicoFeatureLength = PICO_FEATURE_LENGTH;
+float PicoFeatureLength = static_cast<float>(PICO_FEATURE_LENGTH);
 StartParamDesc(PicoFeatParams)
 DefineParam(0, 0, -0.25, 0.75)
 DefineParam(1, 0, 0.0, 1.0)

--- a/src/classify/fpoint.cpp
+++ b/src/classify/fpoint.cpp
@@ -29,7 +29,7 @@
 float DistanceBetween(FPOINT A, FPOINT B) {
   const double xd = XDelta(A, B);
   const double yd = YDelta(A, B);
-  return sqrt(static_cast<double>(xd * xd + yd * yd));
+  return static_cast<float>(sqrt(static_cast<double>(xd * xd + yd * yd)));
 }
 
 /**
@@ -42,9 +42,9 @@ float DistanceBetween(FPOINT A, FPOINT B) {
  * @return angle
  */
 float NormalizedAngleFrom(FPOINT *Point1, FPOINT *Point2, float FullScale) {
-  float NumRadsInCircle = 2.0 * M_PI;
+  float NumRadsInCircle = static_cast<float>(2.0 * M_PI);
 
-  float Angle = AngleFrom (*Point1, *Point2);
+  float Angle = static_cast<float>(AngleFrom (*Point1, *Point2));
   if (Angle < 0.0)
     Angle += NumRadsInCircle;
   Angle *= FullScale / NumRadsInCircle;

--- a/src/classify/intfx.cpp
+++ b/src/classify/intfx.cpp
@@ -53,8 +53,8 @@ void InitIntegerFX() {
   atan_table_mutex.Lock();
   if (!atan_table_init) {
     for (int i = 0; i < INT_CHAR_NORM_RANGE; ++i) {
-      cos_table[i] = cos(i * 2 * M_PI / INT_CHAR_NORM_RANGE + M_PI);
-      sin_table[i] = sin(i * 2 * M_PI / INT_CHAR_NORM_RANGE + M_PI);
+      cos_table[i] = static_cast<float>(cos(i * 2 * M_PI / INT_CHAR_NORM_RANGE + M_PI));
+      sin_table[i] = static_cast<float>(sin(i * 2 * M_PI / INT_CHAR_NORM_RANGE + M_PI));
     }
     atan_table_init = true;
   }
@@ -246,7 +246,7 @@ static int ComputeFeatures(const FCOORD& start_pt, const FCOORD& end_pt,
   double lambda = lambda_step / 2.0;
   for (int f = 0; f < num_features; ++f, lambda += lambda_step) {
     FCOORD feature_pt(start_pt);
-    feature_pt += feature_vector * lambda;
+    feature_pt += feature_vector * static_cast<float>(lambda);
     INT_FEATURE_STRUCT feature(feature_pt, theta);
     features->push_back(feature);
   }
@@ -478,8 +478,8 @@ void Classify::ExtractFeatures(const TBLOB& blob,
   }
   results->NumBL = bl_features->size();
   results->NumCN = cn_features->size();
-  results->YBottom = blob.bounding_box().bottom();
-  results->YTop = blob.bounding_box().top();
+  results->YBottom = static_cast<uint8_t>(blob.bounding_box().bottom());
+  results->YTop = static_cast<uint8_t>(blob.bounding_box().top());
   results->Width = blob.bounding_box().width();
 }
 

--- a/src/classify/intmatcher.cpp
+++ b/src/classify/intmatcher.cpp
@@ -44,8 +44,8 @@ using tesseract::UnicharRating;
 // Parameters of the sigmoid used to convert similarity to evidence in the
 // similarity_evidence_table_ that is used to convert distance metric to an
 // 8 bit evidence value in the secondary matcher. (See IntMatcher::Init).
-const float IntegerMatcher::kSEExponentialMultiplier = 0.0;
-const float IntegerMatcher::kSimilarityCenter = 0.0075;
+const float IntegerMatcher::kSEExponentialMultiplier = 0.0f;
+const float IntegerMatcher::kSimilarityCenter = 0.0075f;
 
 static const uint8_t offset_table[] = {
   255, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3,
@@ -402,8 +402,8 @@ class ClassPruner {
     results->init_to_size(num_classes_, empty);
     for (int c = 0; c < num_classes_; ++c) {
       (*results)[c].Class = sort_index_[num_classes_ - c];
-      (*results)[c].Rating = 1.0 - sort_key_[num_classes_ - c] /
-        (static_cast<float>(CLASS_PRUNER_CLASS_MASK) * num_features_);
+      (*results)[c].Rating = static_cast<float>(1.0 - sort_key_[num_classes_ - c] /
+        (static_cast<float>(CLASS_PRUNER_CLASS_MASK) * num_features_));
     }
     return num_classes_;
   }
@@ -1075,7 +1075,7 @@ void IntegerMatcher::DisplayProtoDebugInfo(
       temp /= ClassTemplate->ProtoLengths[ActualProtoNum];
 
       if ((ProtoSet->Protos[ProtoNum]).Configs[0] & (*ConfigMask)) {
-        DisplayIntProto(ClassTemplate, ActualProtoNum, temp / 255.0);
+        DisplayIntProto(ClassTemplate, ActualProtoNum, temp / 255.0f);
       }
     }
   }
@@ -1120,7 +1120,7 @@ void IntegerMatcher::DisplayFeatureDebugInfo(
       else
         DisplayIntFeature(&Features[Feature], 1.0);
     } else {
-      DisplayIntFeature(&Features[Feature], best / 255.0);
+      DisplayIntFeature(&Features[Feature], best / 255.0f);
     }
   }
 

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -204,8 +204,8 @@ static double_VAR(classify_pp_side_pad, 2.5, "Proto Pruner Side Pad");
 /// Builds a feature from an FCOORD for position with all the necessary
 /// clipping and rounding.
 INT_FEATURE_STRUCT::INT_FEATURE_STRUCT(const FCOORD& pos, uint8_t theta)
-  : X(ClipToRange<int16_t>(static_cast<int16_t>(pos.x() + 0.5), 0, 255)),
-    Y(ClipToRange<int16_t>(static_cast<int16_t>(pos.y() + 0.5), 0, 255)),
+  : X(static_cast<uint8_t>(ClipToRange<int16_t>(static_cast<int16_t>(pos.x() + 0.5), 0, 255))),
+    Y(static_cast<uint8_t>(ClipToRange<int16_t>(static_cast<int16_t>(pos.y() + 0.5), 0, 255))),
     Theta(theta),
     CP_misses(0) {
 }
@@ -385,27 +385,27 @@ void AddProtoToProtoPruner(PROTO Proto, int ProtoId,
 #endif
 
   FillPPCircularBits (ProtoSet->ProtoPruner[PRUNER_ANGLE], Index,
-                      Angle + ANGLE_SHIFT, classify_pp_angle_pad / 360.0,
+                      static_cast<float>(Angle + ANGLE_SHIFT), static_cast<float>(classify_pp_angle_pad / 360.0),
                       debug);
 
-  Angle *= 2.0 * M_PI;
+  Angle *= static_cast<float>(2.0 * M_PI);
   Length = Proto->Length;
 
-  X = Proto->X + X_SHIFT;
-  Pad = std::max(fabs (cos (Angle)) * (Length / 2.0 +
+  X = static_cast<float>(Proto->X + X_SHIFT);
+  Pad = static_cast<float>(std::max(fabs (cos (Angle)) * (Length / 2.0 +
                                    classify_pp_end_pad *
                                    GetPicoFeatureLength ()),
              fabs (sin (Angle)) * (classify_pp_side_pad *
-                                   GetPicoFeatureLength ()));
+                                   GetPicoFeatureLength ())));
 
   FillPPLinearBits(ProtoSet->ProtoPruner[PRUNER_X], Index, X, Pad, debug);
 
-  Y = Proto->Y + Y_SHIFT;
-  Pad = std::max(fabs (sin (Angle)) * (Length / 2.0 +
+  Y = static_cast<float>(Proto->Y + Y_SHIFT);
+  Pad = static_cast<float>(std::max(fabs (sin (Angle)) * (Length / 2.0 +
                                    classify_pp_end_pad *
                                    GetPicoFeatureLength ()),
              fabs (cos (Angle)) * (classify_pp_side_pad *
-                                   GetPicoFeatureLength ()));
+                                   GetPicoFeatureLength ())));
 
   FillPPLinearBits(ProtoSet->ProtoPruner[PRUNER_Y], Index, Y, Pad, debug);
 }                                /* AddProtoToProtoPruner */
@@ -509,7 +509,7 @@ void Classify::ConvertProto(PROTO Proto, int ProtoId, INT_CLASS Class) {
     P->Angle = static_cast<uint8_t>(Param);
 
   /* round proto length to nearest integer number of pico-features */
-  Param = (Proto->Length / GetPicoFeatureLength()) + 0.5;
+  Param = (Proto->Length / GetPicoFeatureLength()) + 0.5f;
   Class->ProtoLengths[ProtoId] = TruncateParam(Param, 1, 255, nullptr);
   if (classify_learning_debug_level >= 2)
     cprintf("Converted ffeat to (A=%d,B=%d,C=%d,L=%d)",
@@ -991,17 +991,17 @@ void ClearFeatureSpaceWindow(NORM_METHOD norm_method, ScrollView* window) {
   // Draw the feature space limit rectangle.
   window->Rectangle(0, 0, INT_MAX_X, INT_MAX_Y);
   if (norm_method == baseline) {
-    window->SetCursor(0, INT_DESCENDER);
-    window->DrawTo(INT_MAX_X, INT_DESCENDER);
-    window->SetCursor(0, INT_BASELINE);
-    window->DrawTo(INT_MAX_X, INT_BASELINE);
-    window->SetCursor(0, INT_XHEIGHT);
-    window->DrawTo(INT_MAX_X, INT_XHEIGHT);
-    window->SetCursor(0, INT_CAPHEIGHT);
-    window->DrawTo(INT_MAX_X, INT_CAPHEIGHT);
+    window->SetCursor(0, static_cast<int>(INT_DESCENDER));
+    window->DrawTo(INT_MAX_X, static_cast<int>(INT_DESCENDER));
+    window->SetCursor(0, static_cast<int>(INT_BASELINE));
+    window->DrawTo(INT_MAX_X, static_cast<int>(INT_BASELINE));
+    window->SetCursor(0, static_cast<int>(INT_XHEIGHT));
+    window->DrawTo(INT_MAX_X, static_cast<int>(INT_XHEIGHT));
+    window->SetCursor(0, static_cast<int>(INT_CAPHEIGHT));
+    window->DrawTo(INT_MAX_X, static_cast<int>(INT_CAPHEIGHT));
   } else {
-    window->Rectangle(INT_XCENTER - INT_XRADIUS, INT_YCENTER - INT_YRADIUS,
-                      INT_XCENTER + INT_XRADIUS, INT_YCENTER + INT_YRADIUS);
+    window->Rectangle(static_cast<int>(INT_XCENTER - INT_XRADIUS), static_cast<int>(INT_YCENTER - INT_YRADIUS),
+                      static_cast<int>(INT_XCENTER + INT_XRADIUS), static_cast<int>(INT_YCENTER + INT_YRADIUS));
   }
 }
 #endif
@@ -1334,27 +1334,27 @@ void GetCPPadsForLevel(int Level,
                        float *AnglePad) {
   switch (Level) {
     case 0:
-      *EndPad = classify_cp_end_pad_loose * GetPicoFeatureLength ();
-      *SidePad = classify_cp_side_pad_loose * GetPicoFeatureLength ();
-      *AnglePad = classify_cp_angle_pad_loose / 360.0;
+      *EndPad = static_cast<float>(classify_cp_end_pad_loose) * GetPicoFeatureLength ();
+      *SidePad = static_cast<float>(classify_cp_side_pad_loose) * GetPicoFeatureLength ();
+      *AnglePad = static_cast<float>(classify_cp_angle_pad_loose) / 360.0f;
       break;
 
     case 1:
-      *EndPad = classify_cp_end_pad_medium * GetPicoFeatureLength ();
-      *SidePad = classify_cp_side_pad_medium * GetPicoFeatureLength ();
-      *AnglePad = classify_cp_angle_pad_medium / 360.0;
+      *EndPad = static_cast<float>(classify_cp_end_pad_medium) * GetPicoFeatureLength ();
+      *SidePad = static_cast<float>(classify_cp_side_pad_medium) * GetPicoFeatureLength ();
+      *AnglePad = static_cast<float>(classify_cp_angle_pad_medium) / 360.0f;
       break;
 
     case 2:
-      *EndPad = classify_cp_end_pad_tight * GetPicoFeatureLength ();
-      *SidePad = classify_cp_side_pad_tight * GetPicoFeatureLength ();
-      *AnglePad = classify_cp_angle_pad_tight / 360.0;
+      *EndPad = static_cast<float>(classify_cp_end_pad_tight) * GetPicoFeatureLength ();
+      *SidePad = static_cast<float>(classify_cp_side_pad_tight) * GetPicoFeatureLength ();
+      *AnglePad = static_cast<float>(classify_cp_angle_pad_tight) / 360.0f;
       break;
 
     default:
-      *EndPad = classify_cp_end_pad_tight * GetPicoFeatureLength ();
-      *SidePad = classify_cp_side_pad_tight * GetPicoFeatureLength ();
-      *AnglePad = classify_cp_angle_pad_tight / 360.0;
+      *EndPad = static_cast<float>(classify_cp_end_pad_tight) * GetPicoFeatureLength ();
+      *SidePad = static_cast<float>(classify_cp_side_pad_tight) * GetPicoFeatureLength ();
+      *AnglePad = static_cast<float>(classify_cp_angle_pad_tight) / 360.0f;
       break;
   }
   if (*AnglePad > 0.5)
@@ -1454,7 +1454,7 @@ void InitTableFiller (float EndPad, float SidePad,
   Angle = Proto->Angle;
   X = Proto->X;
   Y = Proto->Y;
-  HalfLength = Proto->Length / 2.0;
+  HalfLength = Proto->Length / 2.0f;
 
   Filler->AngleStart = CircBucketFor(Angle - AnglePad, AS, NB);
   Filler->AngleEnd = CircBucketFor(Angle + AnglePad, AS, NB);
@@ -1484,19 +1484,19 @@ void InitTableFiller (float EndPad, float SidePad,
 
     if ((Angle > 0.0 && Angle < 0.25) || (Angle > 0.5 && Angle < 0.75)) {
       /* rising diagonal proto */
-      Angle *= 2.0 * M_PI;
+      Angle *= static_cast<float>(2.0 * M_PI);
       Cos = fabs(cos(Angle));
       Sin = fabs(sin(Angle));
 
       /* compute the positions of the corners of the acceptance region */
       Start.x = X - (HalfLength + EndPad) * Cos - SidePad * Sin;
       Start.y = Y - (HalfLength + EndPad) * Sin + SidePad * Cos;
-      End.x = 2.0 * X - Start.x;
-      End.y = 2.0 * Y - Start.y;
+      End.x = 2.0f * X - Start.x;
+      End.y = 2.0f * Y - Start.y;
       Switch1.x = X - (HalfLength + EndPad) * Cos + SidePad * Sin;
       Switch1.y = Y - (HalfLength + EndPad) * Sin - SidePad * Cos;
-      Switch2.x = 2.0 * X - Switch1.x;
-      Switch2.y = 2.0 * Y - Switch1.y;
+      Switch2.x = 2.0f * X - Switch1.x;
+      Switch2.y = 2.0f * Y - Switch1.y;
 
       if (Switch1.x > Switch2.x) {
         S1 = 1;
@@ -1534,19 +1534,19 @@ void InitTableFiller (float EndPad, float SidePad,
       Filler->Switch[2].X = Bucket8For(End.x, XS, NB);
     } else {
       /* falling diagonal proto */
-      Angle *= 2.0 * M_PI;
+      Angle *= static_cast<float>(2.0 * M_PI);
       Cos = fabs(cos(Angle));
       Sin = fabs(sin(Angle));
 
       /* compute the positions of the corners of the acceptance region */
       Start.x = X - (HalfLength + EndPad) * Cos - SidePad * Sin;
       Start.y = Y + (HalfLength + EndPad) * Sin - SidePad * Cos;
-      End.x = 2.0 * X - Start.x;
-      End.y = 2.0 * Y - Start.y;
+      End.x = 2.0f * X - Start.x;
+      End.y = 2.0f * Y - Start.y;
       Switch1.x = X - (HalfLength + EndPad) * Cos + SidePad * Sin;
       Switch1.y = Y + (HalfLength + EndPad) * Sin + SidePad * Cos;
-      Switch2.x = 2.0 * X - Switch1.x;
-      Switch2.y = 2.0 * Y - Switch1.y;
+      Switch2.x = 2.0f * X - Switch1.x;
+      Switch2.y = 2.0f * Y - Switch1.y;
 
       if (Switch1.x > Switch2.x) {
         S1 = 1;
@@ -1609,14 +1609,14 @@ void RenderIntFeature(ScrollView *window, const INT_FEATURE_STRUCT* Feature,
 
   X = Feature->X;
   Y = Feature->Y;
-  Length = GetPicoFeatureLength() * 0.7 * INT_CHAR_NORM_RANGE;
+  Length = GetPicoFeatureLength() * 0.7f * INT_CHAR_NORM_RANGE;
   // The -PI has no significant effect here, but the value of Theta is computed
   // using BinaryAnglePlusPi in intfx.cpp.
-  Dx = (Length / 2.0) * cos((Feature->Theta / 256.0) * 2.0 * M_PI - M_PI);
-  Dy = (Length / 2.0) * sin((Feature->Theta / 256.0) * 2.0 * M_PI - M_PI);
+  Dx = static_cast<float>((Length / 2.0) * cos((Feature->Theta / 256.0) * 2.0 * M_PI - M_PI));
+  Dy = static_cast<float>((Length / 2.0) * sin((Feature->Theta / 256.0) * 2.0 * M_PI - M_PI));
 
-  window->SetCursor(X, Y);
-  window->DrawTo(X + Dx, Y + Dy);
+  window->SetCursor(static_cast<int>(X), static_cast<int>(Y));
+  window->DrawTo(static_cast<int>(X + Dx), static_cast<int>(Y + Dy));
 }                                /* RenderIntFeature */
 
 /**
@@ -1673,15 +1673,15 @@ void RenderIntProto(ScrollView *window,
       UpdateRange(Bucket, &Ymin, &Ymax);
     }
   }
-  X = (Xmin + Xmax + 1) / 2.0 * PROTO_PRUNER_SCALE;
-  Y = (Ymin + Ymax + 1) / 2.0 * PROTO_PRUNER_SCALE;
+  X = static_cast<float>((Xmin + Xmax + 1) / 2.0 * PROTO_PRUNER_SCALE);
+  Y = static_cast<float>((Ymin + Ymax + 1) / 2.0 * PROTO_PRUNER_SCALE);
   // The -PI has no significant effect here, but the value of Theta is computed
   // using BinaryAnglePlusPi in intfx.cpp.
-  Dx = (Length / 2.0) * cos((Proto->Angle / 256.0) * 2.0 * M_PI - M_PI);
-  Dy = (Length / 2.0) * sin((Proto->Angle / 256.0) * 2.0 * M_PI - M_PI);
+  Dx = static_cast<float>((Length / 2.0) * cos((Proto->Angle / 256.0) * 2.0 * M_PI - M_PI));
+  Dy = static_cast<float>((Length / 2.0) * sin((Proto->Angle / 256.0) * 2.0 * M_PI - M_PI));
 
-  window->SetCursor(X - Dx, Y - Dy);
-  window->DrawTo(X + Dx, Y + Dy);
+  window->SetCursor(static_cast<int>(X - Dx), static_cast<int>(Y - Dy));
+  window->DrawTo(static_cast<int>(X + Dx), static_cast<int>(Y + Dy));
 }                                /* RenderIntProto */
 #endif
 
@@ -1703,12 +1703,12 @@ int TruncateParam(float Param, int Min, int Max, char *Id) {
     if (Id)
       cprintf("Warning: Param %s truncated from %f to %d!\n",
               Id, Param, Min);
-    Param = Min;
+    Param = static_cast<float>(Min);
   } else if (Param > Max) {
     if (Id)
       cprintf("Warning: Param %s truncated from %f to %d!\n",
               Id, Param, Max);
-    Param = Max;
+    Param = static_cast<float>(Max);
   }
   return static_cast<int>(std::floor(Param));
 }                                /* TruncateParam */

--- a/src/classify/mastertrainer.cpp
+++ b/src/classify/mastertrainer.cpp
@@ -46,7 +46,7 @@ const int kMinClusteredShapes = 1;
 // Max number of unichars in any individual cluster.
 const int kMaxUnicharsPerCluster = 2000;
 // Mean font distance below which to merge fonts and unichars.
-const float kFontMergeDistance = 0.025;
+const float kFontMergeDistance = 0.025f;
 
 MasterTrainer::MasterTrainer(NormalizationMode norm_mode,
                              bool shape_analysis,
@@ -481,7 +481,7 @@ int MasterTrainer::GetBestMatchingFontInfoId(const char* filename) {
   int best_len = 0;
   for (int f = 0; f < fontinfo_table_.size(); ++f) {
     if (strstr(filename, fontinfo_table_.get(f).name) != nullptr) {
-      int len = strlen(fontinfo_table_.get(f).name);
+      int len = static_cast<int>(strlen(fontinfo_table_.get(f).name));
       // Use the longest matching length in case a substring of a font matched.
       if (len > best_len) {
         best_len = len;

--- a/src/classify/mfoutline.cpp
+++ b/src/classify/mfoutline.cpp
@@ -247,9 +247,9 @@ void NormalizeOutline(MFOUTLINE Outline,
   MFOUTLINE EdgePoint = Outline;
   do {
     MFEDGEPT *Current = PointAt(EdgePoint);
-    Current->Point.y = MF_SCALE_FACTOR *
-        (Current->Point.y - kBlnBaselineOffset);
-    Current->Point.x = MF_SCALE_FACTOR * (Current->Point.x - XOrigin);
+    Current->Point.y = static_cast<float>(MF_SCALE_FACTOR *
+        (Current->Point.y - kBlnBaselineOffset));
+    Current->Point.x = static_cast<float>(MF_SCALE_FACTOR * (Current->Point.x - XOrigin));
     EdgePoint = NextPointAfter(EdgePoint);
   } while (EdgePoint != Outline);
 }                                /* NormalizeOutline */
@@ -336,8 +336,8 @@ void CharNormalizeOutline(MFOUTLINE Outline, const DENORM& cn_denorm) {
     CurrentPoint = PointAt(Current);
     FCOORD pos(CurrentPoint->Point.x, CurrentPoint->Point.y);
     cn_denorm.LocalNormTransform(pos, &pos);
-    CurrentPoint->Point.x = (pos.x() - UINT8_MAX / 2) * MF_SCALE_FACTOR;
-    CurrentPoint->Point.y = (pos.y() - UINT8_MAX / 2) * MF_SCALE_FACTOR;
+    CurrentPoint->Point.x = static_cast<float>((pos.x() - UINT8_MAX / 2) * MF_SCALE_FACTOR);
+    CurrentPoint->Point.y = static_cast<float>((pos.y() - UINT8_MAX / 2) * MF_SCALE_FACTOR);
 
     Current = NextPointAfter(Current);
   }

--- a/src/classify/mfx.cpp
+++ b/src/classify/mfx.cpp
@@ -76,7 +76,7 @@ MICROFEATURES BlobMicroFeatures(TBLOB* Blob, const DENORM& cn_denorm) {
     RemainingOutlines = Outlines;
     iterate(RemainingOutlines) {
       Outline = static_cast<MFOUTLINE>first_node(RemainingOutlines);
-      FindDirectionChanges(Outline, classify_min_slope, classify_max_slope);
+      FindDirectionChanges(Outline, static_cast<float>(classify_min_slope), static_cast<float>(classify_max_slope));
       MarkDirectionChanges(Outline);
       MicroFeatures = ConvertToMicroFeatures(Outline, MicroFeatures);
     }

--- a/src/classify/normfeat.cpp
+++ b/src/classify/normfeat.cpp
@@ -30,7 +30,7 @@
 
 /** Return the length of the outline in baseline normalized form. */
 float ActualOutlineLength(FEATURE Feature) {
-  return (Feature->Params[CharNormLength] * LENGTH_COMPRESSION);
+  return static_cast<float>(Feature->Params[CharNormLength] * LENGTH_COMPRESSION);
 }
 
 /**
@@ -63,11 +63,11 @@ FEATURE_SET ExtractCharNormFeatures(const INT_FX_RESULT_STRUCT& fx_info) {
   FEATURE feature = NewFeature(&CharNormDesc);
 
   feature->Params[CharNormY] =
-      MF_SCALE_FACTOR * (fx_info.Ymean - kBlnBaselineOffset);
+      static_cast<float>(MF_SCALE_FACTOR * (fx_info.Ymean - kBlnBaselineOffset));
   feature->Params[CharNormLength] =
-      MF_SCALE_FACTOR * fx_info.Length / LENGTH_COMPRESSION;
-  feature->Params[CharNormRx] = MF_SCALE_FACTOR * fx_info.Rx;
-  feature->Params[CharNormRy] = MF_SCALE_FACTOR * fx_info.Ry;
+      static_cast<float>(MF_SCALE_FACTOR * fx_info.Length / LENGTH_COMPRESSION);
+  feature->Params[CharNormRx] = static_cast<float>(MF_SCALE_FACTOR * fx_info.Rx);
+  feature->Params[CharNormRy] = static_cast<float>(MF_SCALE_FACTOR * fx_info.Ry);
 
   AddFeature(feature_set, feature);
 

--- a/src/classify/normmatch.cpp
+++ b/src/classify/normmatch.cpp
@@ -109,12 +109,12 @@ float Classify::ComputeNormMatch(CLASS_ID ClassId,
   if (ClassId == NO_CLASS) {
     /* kludge - clean up constants and make into control knobs later */
     Match = (feature.Params[CharNormLength] *
-      feature.Params[CharNormLength] * 500.0 +
+      feature.Params[CharNormLength] * 500.0f +
       feature.Params[CharNormRx] *
-      feature.Params[CharNormRx] * 8000.0 +
+      feature.Params[CharNormRx] * 8000.0f +
       feature.Params[CharNormRy] *
-      feature.Params[CharNormRy] * 8000.0);
-    return (1.0 - NormEvidenceOf(Match));
+      feature.Params[CharNormRy] * 8000.0f);
+    return static_cast<float>(1.0 - NormEvidenceOf(Match));
   }
 
   BestMatch = FLT_MAX;
@@ -162,7 +162,7 @@ float Classify::ComputeNormMatch(CLASS_ID ClassId,
 
     ProtoId++;
   }
-  return 1.0 - NormEvidenceOf(BestMatch);
+  return static_cast<float>(1.0 - NormEvidenceOf(BestMatch));
 }                                /* ComputeNormMatch */
 
 void Classify::FreeNormProtos() {

--- a/src/classify/picofeat.cpp
+++ b/src/classify/picofeat.cpp
@@ -122,8 +122,8 @@ void ConvertSegmentToPicoFeat(FPOINT *Start,
   Delta.y = YDelta (*Start, *End) / NumFeatures;
 
   /* compute position of first pico feature */
-  Center.x = Start->x + Delta.x / 2.0;
-  Center.y = Start->y + Delta.y / 2.0;
+  Center.x = Start->x + Delta.x / 2.0f;
+  Center.y = Start->y + Delta.y / 2.0f;
 
   /* compute each pico feature in segment and add to feature set */
   for (i = 0; i < NumFeatures; i++) {
@@ -255,9 +255,9 @@ FEATURE_SET Classify::ExtractIntGeoFeatures(
   FEATURE_SET feature_set = NewFeatureSet(1);
   FEATURE feature = NewFeature(&IntFeatDesc);
 
-  feature->Params[GeoBottom] = sample->geo_feature(GeoBottom);
-  feature->Params[GeoTop] = sample->geo_feature(GeoTop);
-  feature->Params[GeoWidth] = sample->geo_feature(GeoWidth);
+  feature->Params[GeoBottom] = static_cast<float>(sample->geo_feature(GeoBottom));
+  feature->Params[GeoTop] = static_cast<float>(sample->geo_feature(GeoTop));
+  feature->Params[GeoWidth] = static_cast<float>(sample->geo_feature(GeoWidth));
   AddFeature(feature_set, feature);
   delete sample;
 

--- a/src/classify/protos.cpp
+++ b/src/classify/protos.cpp
@@ -123,9 +123,9 @@ int AddProtoToClass(CLASS_TYPE Class) {
 void FillABC(PROTO Proto) {
   float Slope, Intercept, Normalizer;
 
-  Slope = tan(Proto->Angle * 2.0 * M_PI);
+  Slope = static_cast<float>(tan(Proto->Angle * 2.0 * M_PI));
   Intercept = Proto->Y - Slope * Proto->X;
-  Normalizer = 1.0 / sqrt (Slope * Slope + 1.0);
+  Normalizer = static_cast<float>(1.0 / sqrt (Slope * Slope + 1.0));
   Proto->A = Slope * Normalizer;
   Proto->B = -Normalizer;
   Proto->C = Intercept * Normalizer;

--- a/src/classify/trainingsample.cpp
+++ b/src/classify/trainingsample.cpp
@@ -138,11 +138,11 @@ TrainingSample* TrainingSample::CopyFromFeatures(
 
   // Generate the cn_feature_ from the fx_info.
   sample->cn_feature_[CharNormY] =
-      MF_SCALE_FACTOR * (fx_info.Ymean - kBlnBaselineOffset);
+      static_cast<float>(MF_SCALE_FACTOR * (fx_info.Ymean - kBlnBaselineOffset));
   sample->cn_feature_[CharNormLength] =
-      MF_SCALE_FACTOR * fx_info.Length / LENGTH_COMPRESSION;
-  sample->cn_feature_[CharNormRx] = MF_SCALE_FACTOR * fx_info.Rx;
-  sample->cn_feature_[CharNormRy] = MF_SCALE_FACTOR * fx_info.Ry;
+      static_cast<float>(MF_SCALE_FACTOR * fx_info.Length / LENGTH_COMPRESSION);
+  sample->cn_feature_[CharNormRx] = static_cast<float>(MF_SCALE_FACTOR * fx_info.Rx);
+  sample->cn_feature_[CharNormRy] = static_cast<float>(MF_SCALE_FACTOR * fx_info.Ry);
 
   sample->features_are_indexed_ = false;
   sample->features_are_mapped_ = false;
@@ -169,10 +169,10 @@ TrainingSample* TrainingSample::RandomizedCopy(int index) const {
     for (uint32_t i = 0; i < num_features_; ++i) {
       double result = (features_[i].X - kRandomizingCenter) * scaling;
       result += kRandomizingCenter;
-      sample->features_[i].X = ClipToRange<int>(result + 0.5, 0, UINT8_MAX);
+      sample->features_[i].X = ClipToRange<int>(static_cast<int>(result + 0.5), 0, UINT8_MAX);
       result = (features_[i].Y - kRandomizingCenter) * scaling;
       result += kRandomizingCenter + yshift;
-      sample->features_[i].Y = ClipToRange<int>(result + 0.5, 0, UINT8_MAX);
+      sample->features_[i].Y = ClipToRange<int>(static_cast<int>(result + 0.5), 0, UINT8_MAX);
     }
   }
   return sample;
@@ -263,9 +263,9 @@ void TrainingSample::ExtractCharDesc(int int_feature_type,
     tprintf("Error: no Geo feature to train on.\n");
   } else {
     ASSERT_HOST(char_features->NumFeatures == 1);
-    geo_feature_[GeoBottom] = char_features->Features[0]->Params[GeoBottom];
-    geo_feature_[GeoTop] = char_features->Features[0]->Params[GeoTop];
-    geo_feature_[GeoWidth] = char_features->Features[0]->Params[GeoWidth];
+    geo_feature_[GeoBottom] = static_cast<int>(char_features->Features[0]->Params[GeoBottom]);
+    geo_feature_[GeoTop] = static_cast<int>(char_features->Features[0]->Params[GeoTop]);
+    geo_feature_[GeoWidth] = static_cast<int>(char_features->Features[0]->Params[GeoWidth]);
   }
   features_are_indexed_ = false;
   features_are_mapped_ = false;

--- a/src/classify/trainingsampleset.cpp
+++ b/src/classify/trainingsampleset.cpp
@@ -287,7 +287,7 @@ float TrainingSampleSet::UnicharDistance(const UnicharAndFonts& uf1,
       return UnicharDistance(uf1, uf2, false, feature_map);
     return 0.0f;
   }
-  return dist_sum / dist_count;
+  return static_cast<float>(dist_sum / dist_count);
 }
 
 // Returns the distance between the given pair of font/class pairs.
@@ -631,7 +631,7 @@ void TrainingSampleSet::ComputeCanonicalSamples(const IntFeatureMap& map,
         ++samples_found;
         if (max_dist < min_max_dist) {
           fcinfo.canonical_sample = s1;
-          fcinfo.canonical_dist = max_dist;
+          fcinfo.canonical_dist = static_cast<float>(max_dist);
         }
         UpdateRange(max_dist, &min_max_dist, &max_max_dist);
       }

--- a/src/cutil/callcpp.cpp
+++ b/src/cutil/callcpp.cpp
@@ -55,7 +55,7 @@ ScrollView *c_create_window(                   /*create a window */
                       double ymin,       /*getting lost in */
                       double ymax        /*empty space */
                      ) {
-   return new ScrollView(name, xpos, ypos, xsize, ysize, xmax - xmin, ymax - ymin, true);
+   return new ScrollView(name, xpos, ypos, xsize, ysize, static_cast<int>(xmax - xmin), static_cast<int>(ymax - ymin), true);
 }
 
 

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -178,7 +178,7 @@ void Dawg::init(int unicharset_size) {
   unicharset_size_ = unicharset_size;
   // Set bit masks. We will use the value unicharset_size_ as a null char, so
   // the actual number of unichars is unicharset_size_ + 1.
-  flag_start_bit_ = ceil(log(unicharset_size_ + 1.0) / log(2.0));
+  flag_start_bit_ = static_cast<int>(ceil(log(unicharset_size_ + 1.0) / log(2.0)));
   next_node_start_bit_ = flag_start_bit_ + NUM_FLAG_BITS;
   letter_mask_ = ~(~0ull << flag_start_bit_);
   next_node_mask_ = ~0ull << (flag_start_bit_ + NUM_FLAG_BITS);

--- a/src/dict/dict.cpp
+++ b/src/dict/dict.cpp
@@ -724,11 +724,11 @@ void Dict::adjust_word(WERD_CHOICE* word, bool nonword,
     // Calculate x-height and y-offset consistency penalties.
     switch (xheight_consistency) {
       case XH_INCONSISTENT:
-        adjust_factor += xheight_penalty_inconsistent;
+        adjust_factor += static_cast<float>(xheight_penalty_inconsistent);
         xheight_triggered = ", xhtBAD";
         break;
       case XH_SUBNORMAL:
-        adjust_factor += xheight_penalty_subscripts;
+        adjust_factor += static_cast<float>(xheight_penalty_subscripts);
         xheight_triggered = ", xhtSUB";
         break;
       case XH_GOOD:
@@ -749,11 +749,11 @@ void Dict::adjust_word(WERD_CHOICE* word, bool nonword,
 
   if (nonword) {  // non-dictionary word
     if (case_is_ok && punc_is_ok) {
-      adjust_factor += segment_penalty_dict_nonword;
+      adjust_factor += static_cast<float>(segment_penalty_dict_nonword);
       new_rating *= adjust_factor;
       if (debug) tprintf(", W");
     } else {
-      adjust_factor += segment_penalty_garbage;
+      adjust_factor += static_cast<float>(segment_penalty_garbage);
       new_rating *= adjust_factor;
       if (debug) {
         if (!case_is_ok) tprintf(", C");
@@ -764,16 +764,16 @@ void Dict::adjust_word(WERD_CHOICE* word, bool nonword,
     if (case_is_ok) {
       if (!is_han && freq_dawg_ != nullptr && freq_dawg_->word_in_dawg(*word)) {
         word->set_permuter(FREQ_DAWG_PERM);
-        adjust_factor += segment_penalty_dict_frequent_word;
+        adjust_factor += static_cast<float>(segment_penalty_dict_frequent_word);
         new_rating *= adjust_factor;
         if (debug) tprintf(", F");
       } else {
-        adjust_factor += segment_penalty_dict_case_ok;
+        adjust_factor += static_cast<float>(segment_penalty_dict_case_ok);
         new_rating *= adjust_factor;
         if (debug) tprintf(", ");
       }
     } else {
-      adjust_factor += segment_penalty_dict_case_bad;
+      adjust_factor += static_cast<float>(segment_penalty_dict_case_bad);
       new_rating *= adjust_factor;
       if (debug) tprintf(", C");
     }

--- a/src/dict/stopper.cpp
+++ b/src/dict/stopper.cpp
@@ -39,7 +39,7 @@ namespace tesseract {
 
 bool Dict::AcceptableChoice(const WERD_CHOICE& best_choice,
                             XHeightConsistencyEnum xheight_consistency) {
-  float CertaintyThreshold = stopper_nondict_certainty_base;
+  float CertaintyThreshold = static_cast<float>(stopper_nondict_certainty_base);
   int WordSize;
 
   if (stopper_no_acceptable_choices) return false;
@@ -73,7 +73,7 @@ bool Dict::AcceptableChoice(const WERD_CHOICE& best_choice,
     WordSize -= stopper_smallword_size;
     if (WordSize < 0)
       WordSize = 0;
-    CertaintyThreshold += WordSize * stopper_certainty_per_char;
+    CertaintyThreshold += static_cast<float>(WordSize * stopper_certainty_per_char);
   }
 
   if (stopper_debug_level >= 1)
@@ -99,7 +99,7 @@ bool Dict::AcceptableChoice(const WERD_CHOICE& best_choice,
 
 bool Dict::AcceptableResult(WERD_RES *word) const {
   if (word->best_choice == nullptr) return false;
-  float CertaintyThreshold = stopper_nondict_certainty_base - reject_offset_;
+  float CertaintyThreshold = static_cast<float>(stopper_nondict_certainty_base) - reject_offset_;
   int WordSize;
 
   if (stopper_debug_level >= 1) {
@@ -118,7 +118,7 @@ bool Dict::AcceptableResult(WERD_RES *word) const {
     WordSize -= stopper_smallword_size;
     if (WordSize < 0)
       WordSize = 0;
-    CertaintyThreshold += WordSize * stopper_certainty_per_char;
+    CertaintyThreshold += static_cast<float>(WordSize * stopper_certainty_per_char);
   }
 
   if (stopper_debug_level >= 1)
@@ -360,7 +360,7 @@ void Dict::SettupStopperPass1() {
 }
 
 void Dict::SettupStopperPass2() {
-  reject_offset_ = stopper_phase2_certainty_rejection_offset;
+  reject_offset_ = static_cast<float>(stopper_phase2_certainty_rejection_offset);
 }
 
 void Dict::ReplaceAmbig(int wrong_ngram_begin_index, int wrong_ngram_size,
@@ -483,17 +483,17 @@ int Dict::UniformCertainties(const WERD_CHOICE& word) {
   TotalCertainty -= WorstCertainty;
   TotalCertaintySquared -= static_cast<double>(WorstCertainty) * WorstCertainty;
 
-  Mean = TotalCertainty / word_length;
+  Mean = static_cast<float>(TotalCertainty / word_length);
   Variance = ((word_length * TotalCertaintySquared -
     TotalCertainty * TotalCertainty) /
     (word_length * (word_length - 1)));
   if (Variance < 0.0)
     Variance = 0.0;
-  StdDev = sqrt(Variance);
+  StdDev = static_cast<float>(sqrt(Variance));
 
-  CertaintyThreshold = Mean - stopper_allowable_character_badness * StdDev;
+  CertaintyThreshold = static_cast<float>(Mean - stopper_allowable_character_badness * StdDev);
   if (CertaintyThreshold > stopper_nondict_certainty_base)
-    CertaintyThreshold = stopper_nondict_certainty_base;
+    CertaintyThreshold = static_cast<float>(stopper_nondict_certainty_base);
 
   if (word.certainty() < CertaintyThreshold) {
     if (stopper_debug_level >= 1)

--- a/src/lstm/ctc.cpp
+++ b/src/lstm/ctc.cpp
@@ -32,7 +32,7 @@ namespace tesseract {
 
 // Magic constants that keep CTC stable.
 // Minimum probability limit for softmax input to ctc_loss.
-const float CTC::kMinProb_ = 1e-12;
+const float CTC::kMinProb_ = 1e-12f;
 // Maximum absolute argument to exp().
 const double CTC::kMaxExpArg_ = 80.0;
 // Minimum probability for total prob in time normalization.
@@ -142,8 +142,8 @@ void CTC::ComputeSimpleTargets(GENERIC_2D_ARRAY<float>* targets) const {
       }
       // Make sure that no space is left unoccupied and that non-nulls always
       // peak at 1 by stretching nulls to meet their neighbors.
-      if (l > 0) left_half_width = mean - means[l - 1];
-      if (l + 1 < num_labels_) right_half_width = means[l + 1] - mean;
+      if (l > 0) left_half_width = static_cast<float>(mean - means[l - 1]);
+      if (l + 1 < num_labels_) right_half_width = static_cast<float>(means[l + 1] - mean);
     }
     if (mean >= 0 && mean < num_timesteps_) targets->put(mean, label, 1.0f);
     for (int offset = 1; offset < left_half_width && mean >= offset; ++offset) {
@@ -182,7 +182,7 @@ void CTC::ComputeWidthsAndMeans(GenericVector<float>* half_widths,
   // to have size>=1, then all are equal, otherwise plus_size=1 and star gets
   // whatever is left-over.
   float plus_size = 1.0f, star_size = 0.0f;
-  float total_floating = num_plus + num_star;
+  float total_floating = static_cast<float>(num_plus + num_star);
   if (total_floating <= num_timesteps_) {
     plus_size = star_size = num_timesteps_ / total_floating;
   } else if (num_star > 0) {
@@ -369,7 +369,7 @@ void CTC::LabelsToClasses(const GENERIC_2D_ARRAY<double>& probs,
     }
     int best_class = 0;
     for (int c = 0; c < num_classes_; ++c) {
-      targets_t[c] = class_probs[c];
+      targets_t[c] = static_cast<float>(class_probs[c]);
       if (class_probs[c] > class_probs[best_class]) best_class = c;
     }
   }
@@ -398,7 +398,7 @@ void CTC::NormalizeProbs(GENERIC_2D_ARRAY<float>* probs) {
     // Now normalize with clipping. Any additional clipping is negligible.
     total += increment;
     for (int c = 0; c < num_classes; ++c) {
-      float prob = probs_t[c] / total;
+      float prob = static_cast<float>(probs_t[c] / total);
       probs_t[c] = std::max(prob, kMinProb_);
     }
   }

--- a/src/lstm/fullyconnected.cpp
+++ b/src/lstm/fullyconnected.cpp
@@ -87,7 +87,7 @@ int FullyConnected::InitWeights(float range, TRand* randomizer) {
 int FullyConnected::RemapOutputs(int old_no, const std::vector<int>& code_map) {
   if (type_ == NT_SOFTMAX && no_ == old_no) {
     num_weights_ = weights_.RemapOutputs(code_map);
-    no_ = code_map.size();
+    no_ = static_cast<int32_t>(code_map.size());
   }
   return num_weights_;
 }

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -217,8 +217,8 @@ void LSTMRecognizer::OutputStats(const NetworkIO& outputs, float* min_output,
     *sd = 1.0f;
   } else {
     *min_output = static_cast<float>(stats.min_bucket()) / kOutputScale;
-    *mean_output = stats.mean() / kOutputScale;
-    *sd = stats.sd() / kOutputScale;
+    *mean_output = static_cast<float>(stats.mean() / kOutputScale);
+    *sd = static_cast<float>(stats.sd() / kOutputScale);
   }
 }
 

--- a/src/lstm/lstmrecognizer.h
+++ b/src/lstm/lstmrecognizer.h
@@ -104,7 +104,7 @@ class LSTMRecognizer {
   // Multiplies the all the learning rate(s) by the given factor.
   void ScaleLearningRate(double factor) {
     ASSERT_HOST(network_ != nullptr && network_->type() == NT_SERIES);
-    learning_rate_ *= factor;
+    learning_rate_ *= static_cast<float>(factor);
     if (network_->TestFlag(NF_LAYER_SPECIFIC_LR)) {
       GenericVector<STRING> layers = EnumerateLayers();
       for (int i = 0; i < layers.size(); ++i) {

--- a/src/lstm/lstmtrainer.cpp
+++ b/src/lstm/lstmtrainer.cpp
@@ -349,7 +349,7 @@ bool LSTMTrainer::MaintainCheckpoints(TestCallback tester, STRING* log_msg) {
         *log_msg += " failed to write best model:";
       } else {
         *log_msg += " wrote best model:";
-        error_rate_of_last_saved_best_ = best_error_rate_;
+        error_rate_of_last_saved_best_ = static_cast<float>(best_error_rate_);
       }
       *log_msg += best_model_name;
     }
@@ -633,8 +633,8 @@ int LSTMTrainer::ReduceLayerLearningRates(double factor, int num_samples,
     // Which way will we modify the learning rate?
     for (int ww = 0; ww < LR_COUNT; ++ww) {
       // Transfer momentum to learning rate and adjust by the ww factor.
-      float ww_factor = momentum_factor;
-      if (ww == LR_DOWN) ww_factor *= factor;
+      float ww_factor = static_cast<float>(momentum_factor);
+      if (ww == LR_DOWN) ww_factor *= static_cast<float>(factor);
       // Make a copy of *this, so we can mess about without damaging anything.
       LSTMTrainer copy_trainer;
       samples_trainer->ReadTrainingDump(orig_trainer, &copy_trainer);
@@ -667,14 +667,14 @@ int LSTMTrainer::ReduceLayerLearningRates(double factor, int num_samples,
         // Train again on the same sample, again holding back the updates.
         layer_trainer.TrainOnLine(trainingdata, true);
         // Count the sign changes in the updates in layer vs in copy_trainer.
-        float before_bad = bad_sums[ww][i];
-        float before_ok = ok_sums[ww][i];
+        float before_bad = static_cast<float>(bad_sums[ww][i]);
+        float before_ok = static_cast<float>(ok_sums[ww][i]);
         layer->CountAlternators(*copy_trainer.GetLayer(layers[i]),
                                 &ok_sums[ww][i], &bad_sums[ww][i]);
         float bad_frac =
-            bad_sums[ww][i] + ok_sums[ww][i] - before_bad - before_ok;
+            static_cast<float>(bad_sums[ww][i] + ok_sums[ww][i] - before_bad - before_ok);
         if (bad_frac > 0.0f)
-          bad_frac = (bad_sums[ww][i] - before_bad) / bad_frac;
+          bad_frac = static_cast<float>((bad_sums[ww][i] - before_bad) / bad_frac);
       }
     }
     ++iteration;
@@ -1082,7 +1082,7 @@ void LSTMTrainer::DisplayTargets(const NetworkIO& targets,
           (*window)->SetCursor(t - 1, 0);
           start_t = t;
         }
-        (*window)->DrawTo(t, target);
+        (*window)->DrawTo(t, static_cast<int>(target));
       } else if (start_t >= 0) {
         (*window)->DrawTo(t, 0);
         (*window)->DrawTo(start_t - 1, 0);

--- a/src/lstm/networkbuilder.cpp
+++ b/src/lstm/networkbuilder.cpp
@@ -348,7 +348,7 @@ Network* NetworkBuilder::ParseLSTM(const StaticShape& input_shape, char** str) {
     lstm = BuildLSTMXYQuad(input_shape.depth(), num_states);
   } else {
     if (num_outputs == 0) num_outputs = num_states;
-    STRING name(spec_start, *str - spec_start);
+    STRING name(spec_start, static_cast<int>(*str - spec_start));
     lstm = new LSTM(name, input_shape.depth(), num_states, num_outputs, false,
                     type);
     if (dir != 'f') {
@@ -431,7 +431,7 @@ Network* NetworkBuilder::ParseFullyConnected(const StaticShape& input_shape,
     tprintf("Invalid F spec!:%s\n", *str);
     return nullptr;
   }
-  STRING name(spec_start, *str - spec_start);
+  STRING name(spec_start, static_cast<int>(*str - spec_start));
   return BuildFullyConnected(input_shape, type, name, depth);
 }
 

--- a/src/lstm/networkio.cpp
+++ b/src/lstm/networkio.cpp
@@ -151,8 +151,8 @@ static void ComputeBlackWhite(Pix* pix, float* black, float* white) {
   }
   if (mins.get_total() == 0) mins.add(0, 1);
   if (maxes.get_total() == 0) maxes.add(255, 1);
-  *black = mins.ile(0.25);
-  *white = maxes.ile(0.75);
+  *black = static_cast<float>(mins.ile(0.25));
+  *white = static_cast<float>(maxes.ile(0.75));
 }
 
 // Sets up the array from the given image, using the currently set int_mode_.
@@ -191,9 +191,9 @@ void NetworkIO::FromPixes(const StaticShape& shape,
     float contrast = (white - black) / 2.0f;
     if (contrast <= 0.0f) contrast = 1.0f;
     if (shape.height() == 1) {
-      Copy1DGreyImage(b, pix, black, contrast, randomizer);
+      Copy1DGreyImage(static_cast<int>(b), pix, black, contrast, randomizer);
     } else {
-      Copy2DImage(b, pix, black, contrast, randomizer);
+      Copy2DImage(static_cast<int>(b), pix, black, contrast, randomizer);
     }
   }
 }
@@ -423,7 +423,7 @@ void NetworkIO::Randomize(int t, int offset, int num_features,
     // float mode.
     float* line = f_[t] + offset;
     for (int i = 0; i < num_features; ++i)
-      line[i] = randomizer->SignedRand(1.0);
+      line[i] = static_cast<float>(randomizer->SignedRand(1.0));
   }
 }
 
@@ -555,7 +555,7 @@ void NetworkIO::EnsureBestLabel(int t, int label) {
     float* targets = f_[t];
     for (int c = 0; c < num_classes; ++c) {
       if (c == label) {
-        targets[c] += (1.0 - targets[c]) * (2 / 3.0);
+        targets[c] += (1.0f - targets[c]) * (2.0f / 3.0f);
       } else {
         targets[c] /= 3.0;
       }
@@ -795,14 +795,14 @@ void NetworkIO::ComputeCombinerDeltas(const NetworkIO& fwd_deltas,
     if (max_base_delta >= 0.5) {
       // The base network got it wrong. The combiner should output the right
       // answer and 0 for the base network.
-      comb_line[no] = 0.0 - base_weight;
+      comb_line[no] = 0.0f - base_weight;
     } else {
       // The base network was right. The combiner should flag that.
       for (int i = 0; i < no; ++i) {
         // All other targets are 0.
         if (comb_line[i] > 0.0) comb_line[i] -= 1.0;
       }
-      comb_line[no] = 1.0 - base_weight;
+      comb_line[no] = 1.0f - base_weight;
     }
   }
 }

--- a/src/lstm/plumbing.h
+++ b/src/lstm/plumbing.h
@@ -111,7 +111,7 @@ class Plumbing : public Network {
   void ScaleLayerLearningRate(const char* id, double factor) {
     float* lr_ptr = LayerLearningRatePtr(id);
     ASSERT_HOST(lr_ptr != nullptr);
-    *lr_ptr *= factor;
+    *lr_ptr *= static_cast<float>(factor);
   }
   // Returns a pointer to the learning rate for the given layer id.
   float* LayerLearningRatePtr(const char* id) const;

--- a/src/lstm/recodebeam.cpp
+++ b/src/lstm/recodebeam.cpp
@@ -382,8 +382,8 @@ void RecodeBeamSearch::ExtractPathAsUnicharIds(
           best_nodes[t]->permuter != NO_PERM) {
         // All the rating and certainty go on the previous character except
         // for the space itself.
-        if (certainty < certs->back()) certs->back() = certainty;
-        ratings->back() += rating;
+        if (certainty < certs->back()) certs->back() = static_cast<float>(certainty);
+        ratings->back() += static_cast<float>(rating);
         certainty = 0.0;
         rating = 0.0;
       }
@@ -403,11 +403,11 @@ void RecodeBeamSearch::ExtractPathAsUnicharIds(
         }
         rating -= cert;
       } while (t < width && best_nodes[t]->duplicate);
-      certs->push_back(certainty);
-      ratings->push_back(rating);
+      certs->push_back(static_cast<float>(certainty));
+      ratings->push_back(static_cast<float>(rating));
     } else if (!certs->empty()) {
-      if (certainty < certs->back()) certs->back() = certainty;
-      ratings->back() += rating;
+      if (certainty < certs->back()) certs->back() = static_cast<float>(certainty);
+      ratings->back() += static_cast<float>(rating);
     }
     if (best_choices != nullptr) {
       best_choices->push_back(
@@ -586,18 +586,17 @@ void RecodeBeamSearch::ContinueContext(const RecodeNode* prev, int index,
     if (top_n_flags_[prev->code] == top_n_flag) {
       if (prev_cont != NC_NO_DUP) {
         float cert =
-            NetworkIO::ProbToCertainty(outputs[prev->code]) + cert_offset;
+            static_cast<float>(NetworkIO::ProbToCertainty(outputs[prev->code]) + cert_offset);
         PushDupOrNoDawgIfBetter(length, true, prev->code, prev->unichar_id,
-                                cert, worst_dict_cert, dict_ratio, use_dawgs,
+                                cert, static_cast<float>(worst_dict_cert), static_cast<float>(dict_ratio), use_dawgs,
                                 NC_ANYTHING, prev, step);
       }
       if (prev_cont == NC_ANYTHING && top_n_flag == TN_TOP2 &&
           prev->code != null_char_) {
-        float cert = NetworkIO::ProbToCertainty(outputs[prev->code] +
-                                                outputs[null_char_]) +
-                     cert_offset;
+        float cert = static_cast<float>(NetworkIO::ProbToCertainty(outputs[prev->code] +
+                                                outputs[null_char_]) + cert_offset);
         PushDupOrNoDawgIfBetter(length, true, prev->code, prev->unichar_id,
-                                cert, worst_dict_cert, dict_ratio, use_dawgs,
+                                cert, static_cast<float>(worst_dict_cert), static_cast<float>(dict_ratio), use_dawgs,
                                 NC_NO_DUP, prev, step);
       }
     }
@@ -607,9 +606,9 @@ void RecodeBeamSearch::ContinueContext(const RecodeNode* prev, int index,
       // Allow nulls within multi code sequences, as the nulls within are not
       // explicitly included in the code sequence.
       float cert =
-          NetworkIO::ProbToCertainty(outputs[null_char_]) + cert_offset;
+          static_cast<float>(NetworkIO::ProbToCertainty(outputs[null_char_]) + cert_offset);
       PushDupOrNoDawgIfBetter(length, false, null_char_, INVALID_UNICHAR_ID,
-                              cert, worst_dict_cert, dict_ratio, use_dawgs,
+                              cert, static_cast<float>(worst_dict_cert), static_cast<float>(dict_ratio), use_dawgs,
                               NC_ANYTHING, prev, step);
     }
   }
@@ -619,7 +618,7 @@ void RecodeBeamSearch::ContinueContext(const RecodeNode* prev, int index,
       int code = (*final_codes)[i];
       if (top_n_flags_[code] != top_n_flag) continue;
       if (prev != nullptr && prev->code == code && !is_simple_text_) continue;
-      float cert = NetworkIO::ProbToCertainty(outputs[code]) + cert_offset;
+      float cert = static_cast<float>(NetworkIO::ProbToCertainty(outputs[code]) + cert_offset);
       if (cert < kMinCertainty && code != null_char_) continue;
       full_code.Set(length, code);
       int unichar_id = recoder_.DecodeUnichar(full_code);
@@ -629,7 +628,7 @@ void RecodeBeamSearch::ContinueContext(const RecodeNode* prev, int index,
           charset != nullptr &&
           !charset->get_enabled(unichar_id))
         continue; // disabled by whitelist/blacklist
-      ContinueUnichar(code, unichar_id, cert, worst_dict_cert, dict_ratio,
+      ContinueUnichar(code, unichar_id, cert, static_cast<float>(worst_dict_cert), static_cast<float>(dict_ratio),
                       use_dawgs, NC_ANYTHING, prev, step);
       if (top_n_flag == TN_TOP2 && code != null_char_) {
         float prob = outputs[code] + outputs[null_char_];
@@ -639,8 +638,8 @@ void RecodeBeamSearch::ContinueContext(const RecodeNode* prev, int index,
              (code == top_code_ && prev->code == second_code_))) {
           prob += outputs[prev->code];
         }
-        float cert = NetworkIO::ProbToCertainty(prob) + cert_offset;
-        ContinueUnichar(code, unichar_id, cert, worst_dict_cert, dict_ratio,
+        float cert = static_cast<float>(NetworkIO::ProbToCertainty(prob) + cert_offset);
+        ContinueUnichar(code, unichar_id, cert, static_cast<float>(worst_dict_cert), static_cast<float>(dict_ratio),
                         use_dawgs, NC_ONLY_DUP, prev, step);
       }
     }
@@ -651,9 +650,9 @@ void RecodeBeamSearch::ContinueContext(const RecodeNode* prev, int index,
       int code = (*next_codes)[i];
       if (top_n_flags_[code] != top_n_flag) continue;
       if (prev != nullptr && prev->code == code && !is_simple_text_) continue;
-      float cert = NetworkIO::ProbToCertainty(outputs[code]) + cert_offset;
+      float cert = static_cast<float>(NetworkIO::ProbToCertainty(outputs[code]) + cert_offset);
       PushDupOrNoDawgIfBetter(length + 1, false, code, INVALID_UNICHAR_ID, cert,
-                              worst_dict_cert, dict_ratio, use_dawgs,
+                              static_cast<float>(worst_dict_cert), static_cast<float>(dict_ratio), use_dawgs,
                               NC_ANYTHING, prev, step);
       if (top_n_flag == TN_TOP2 && code != null_char_) {
         float prob = outputs[code] + outputs[null_char_];
@@ -663,9 +662,9 @@ void RecodeBeamSearch::ContinueContext(const RecodeNode* prev, int index,
              (code == top_code_ && prev->code == second_code_))) {
           prob += outputs[prev->code];
         }
-        float cert = NetworkIO::ProbToCertainty(prob) + cert_offset;
+        float cert = static_cast<float>(NetworkIO::ProbToCertainty(prob) + cert_offset);
         PushDupOrNoDawgIfBetter(length + 1, false, code, INVALID_UNICHAR_ID,
-                                cert, worst_dict_cert, dict_ratio, use_dawgs,
+                                cert, static_cast<float>(worst_dict_cert), static_cast<float>(dict_ratio), use_dawgs,
                                 NC_ONLY_DUP, prev, step);
       }
     }

--- a/src/lstm/stridemap.cpp
+++ b/src/lstm/stridemap.cpp
@@ -134,7 +134,7 @@ void StrideMap::SetStride(const std::vector<std::pair<int, int>>& h_w_pairs) {
     if (height > max_height) max_height = height;
     if (width > max_width) max_width = width;
   }
-  shape_[FD_BATCH] = heights_.size();
+  shape_[FD_BATCH] = static_cast<int>(heights_.size());
   shape_[FD_HEIGHT] = max_height;
   shape_[FD_WIDTH] = max_width;
   ComputeTIncrements();

--- a/src/lstm/weightmatrix.cpp
+++ b/src/lstm/weightmatrix.cpp
@@ -97,7 +97,7 @@ int WeightMatrix::InitWeightsFloat(int no, int ni, bool use_adam,
 int WeightMatrix::RemapOutputs(const std::vector<int>& code_map) {
   GENERIC_2D_ARRAY<double> old_wf(wf_);
   int old_no = wf_.dim1();
-  int new_no = code_map.size();
+  int new_no = static_cast<int>(code_map.size());
   int ni = wf_.dim2();
   std::vector<double> means(ni, 0.0);
   for (int c = 0; c < old_no; ++c) {

--- a/src/textord/bbgrid.cpp
+++ b/src/textord/bbgrid.cpp
@@ -110,9 +110,9 @@ void IntGrid::Rotate(const FCOORD& rotation) {
   // Iterate over the old grid, copying data to the rotated position in the new.
   int oldi = 0;
   FCOORD x_step(rotation);
-  x_step *= gridsize();
+  x_step *= static_cast<float>(gridsize());
   for (int oldy = 0; oldy < old_height; ++oldy) {
-    FCOORD line_pos(old_bleft.x(), old_bleft.y() + gridsize() * oldy);
+    FCOORD line_pos(old_bleft.x(), old_bleft.y() + static_cast<float>(gridsize() * oldy));
     line_pos.rotate(rotation);
     for (int oldx = 0; oldx < old_width; ++oldx, line_pos += x_step, ++oldi) {
       int grid_x, grid_y;

--- a/src/textord/colpartition.cpp
+++ b/src/textord/colpartition.cpp
@@ -1474,7 +1474,7 @@ void ColPartition::LineSpacingBlocks(const ICOORD& bleft, const ICOORD& tright,
   TO_BLOCK_IT to_block_it(to_blocks);
   ColPartition_LIST spacing_parts;
   ColPartition_IT sp_block_it(&spacing_parts);
-  int same_block_threshold = max_line_height * kMaxSameBlockLineSpacing;
+  int same_block_threshold = static_cast<int>(max_line_height * kMaxSameBlockLineSpacing);
   for (it.mark_cycle_pt(); !it.empty();) {
     ColPartition* part = it.extract();
     sp_block_it.add_to_end(part);
@@ -1611,7 +1611,7 @@ static TO_BLOCK* MoveBlobsToBlock(bool vertical_text, int line_spacing,
     delete to_block;
     return nullptr;
   }
-  to_block->line_size = sizes.median();
+  to_block->line_size = static_cast<float>(sizes.median());
   if (vertical_text) {
     int block_width = block->pdblk.bounding_box().width();
     if (block_width < line_spacing)

--- a/src/textord/colpartitiongrid.cpp
+++ b/src/textord/colpartitiongrid.cpp
@@ -80,7 +80,7 @@ void ColPartitionGrid::HandleClick(int x, int y) {
   radsearch.SetUniqueMode(true);
   radsearch.StartRadSearch(x, y, 1);
   ColPartition* neighbour;
-  FCOORD click(x, y);
+  FCOORD click(static_cast<float>(x), static_cast<float>(y));
   while ((neighbour = radsearch.NextRadSearch()) != nullptr) {
     const TBOX& nbox = neighbour->bounding_box();
     if (nbox.contains(click)) {

--- a/src/textord/devanagari_processing.cpp
+++ b/src/textord/devanagari_processing.cpp
@@ -200,15 +200,15 @@ int ShiroRekhaSplitter::GetXheightForCC(Box* cc_bbox) {
       // and side is row's xheight. Take the overlap of this box with the input
       // box and check if it is a 'major overlap'. If so, this box lies in this
       // row. In that case, return the xheight for this row.
-      float box_middle = 0.5 * (bbox.left() + bbox.right());
+      float box_middle = 0.5f * (bbox.left() + bbox.right());
       int baseline = static_cast<int>(row->base_line(box_middle) + 0.5);
-      TBOX test_box(box_middle - row->x_height() / 2,
+      TBOX test_box(static_cast<int16_t>(box_middle - row->x_height() / 2),
                     baseline,
-                    box_middle + row->x_height() / 2,
+                    static_cast<int16_t>(box_middle + row->x_height() / 2),
                     static_cast<int>(baseline + row->x_height()));
       // Compute overlap. If it is is a major overlap, this is the right row.
       if (bbox.major_overlap(test_box)) {
-        return row->x_height();
+        return static_cast<int>(row->x_height());
       }
     }
   }

--- a/src/textord/drawtord.cpp
+++ b/src/textord/drawtord.cpp
@@ -106,10 +106,10 @@ void plot_to_row(                 //draw a row
   to_win->Pen(colour);
   plot_pt = FCOORD (left, row->line_m () * left + row->line_c ());
   plot_pt.rotate (rotation);
-  to_win->SetCursor(plot_pt.x (), plot_pt.y ());
+  to_win->SetCursor(static_cast<int>(plot_pt.x ()), static_cast<int>(plot_pt.y ()));
   plot_pt = FCOORD (right, row->line_m () * right + row->line_c ());
   plot_pt.rotate (rotation);
-  to_win->DrawTo(plot_pt.x (), plot_pt.y ());
+  to_win->DrawTo(static_cast<int>(plot_pt.x ()), static_cast<int>(plot_pt.y ()));
 }
 
 
@@ -139,16 +139,16 @@ void plot_parallel_row(                 //draw a row
   to_win->Pen(colour);
   plot_pt = FCOORD (fleft, gradient * left + row->max_y ());
   plot_pt.rotate (rotation);
-  to_win->SetCursor(plot_pt.x (), plot_pt.y ());
+  to_win->SetCursor(static_cast<int>(plot_pt.x ()), static_cast<int>(plot_pt.y ()));
   plot_pt = FCOORD (fleft, gradient * left + row->min_y ());
   plot_pt.rotate (rotation);
-  to_win->DrawTo(plot_pt.x (), plot_pt.y ());
+  to_win->DrawTo(static_cast<int>(plot_pt.x ()), static_cast<int>(plot_pt.y ()));
   plot_pt = FCOORD (fleft, gradient * left + row->parallel_c ());
   plot_pt.rotate (rotation);
-  to_win->SetCursor(plot_pt.x (), plot_pt.y ());
+  to_win->SetCursor(static_cast<int>(plot_pt.x ()), static_cast<int>(plot_pt.y ()));
   plot_pt = FCOORD (right, gradient * right + row->parallel_c ());
   plot_pt.rotate (rotation);
-  to_win->DrawTo(plot_pt.x (), plot_pt.y ());
+  to_win->DrawTo(static_cast<int>(plot_pt.x ()), static_cast<int>(plot_pt.y ()));
 }
 
 
@@ -173,7 +173,7 @@ int32_t thresholds[]               //for drop out
 
   colour = ScrollView::WHITE;
   to_win->Pen(colour);
-  to_win->SetCursor(fleft, static_cast<float>(ybottom));
+  to_win->SetCursor(static_cast<int>(fleft), ybottom);
   for (line_index = min_y; line_index <= max_y; line_index++) {
     if (occupation[line_index - min_y] < thresholds[line_index - min_y]) {
       if (colour != ScrollView::BLUE) {
@@ -187,13 +187,13 @@ int32_t thresholds[]               //for drop out
         to_win->Pen(colour);
       }
     }
-  to_win->DrawTo(fleft + occupation[line_index - min_y] / 10.0,      static_cast<float>(line_index));
+  to_win->DrawTo(static_cast<int>(fleft + occupation[line_index - min_y] / 10.0), line_index);
   }
   colour=ScrollView::STEEL_BLUE;
   to_win->Pen(colour);
-  to_win->SetCursor(fleft, static_cast<float>(ybottom));
+  to_win->SetCursor(static_cast<int>(fleft), ybottom);
   for (line_index = min_y; line_index <= max_y; line_index++) {
-     to_win->DrawTo(fleft + thresholds[line_index - min_y] / 10.0,      static_cast<float>(line_index));
+     to_win->DrawTo(static_cast<int>(fleft + thresholds[line_index - min_y] / 10.0), line_index);
   }
 }
 
@@ -227,12 +227,12 @@ void draw_meanlines(                  //draw a block
       FCOORD (static_cast<float>(left),
       gradient * left + row->parallel_c () + row->xheight);
     plot_pt.rotate (rotation);
-  to_win->SetCursor(plot_pt.x (), plot_pt.y ());
+  to_win->SetCursor(static_cast<int>(plot_pt.x ()), static_cast<int>(plot_pt.y ()));
     plot_pt =
       FCOORD (right,
       gradient * right + row->parallel_c () + row->xheight);
     plot_pt.rotate (rotation);
-    to_win->DrawTo (plot_pt.x (), plot_pt.y ());
+    to_win->DrawTo (static_cast<int>(plot_pt.x ()), static_cast<int>(plot_pt.y ()));
   }
 }
 
@@ -274,7 +274,7 @@ void plot_word_decisions(              //draw words
           plot_fp_cells (win, colour, &start_it, pitch, blob_count,
             &row->projection, row->projection_left,
             row->projection_right,
-            row->xheight * textord_projection_scale);
+            static_cast<float>(row->xheight * textord_projection_scale));
         blob_count = 0;
         start_it = blob_it;
       }
@@ -304,7 +304,7 @@ void plot_word_decisions(              //draw words
     plot_fp_cells (win, colour, &start_it, pitch, blob_count,
       &row->projection, row->projection_left,
       row->projection_right,
-      row->xheight * textord_projection_scale);
+      static_cast<float>(row->xheight * textord_projection_scale));
 }
 
 
@@ -410,7 +410,7 @@ void plot_row_cells(                       //draw words
   win->Pen(colour);
   for (cell_it.mark_cycle_pt (); !cell_it.cycled_list (); cell_it.forward ()) {
     cell = cell_it.data ();
-    win->Line(cell->x () + xshift, word_box.bottom (), cell->x () + xshift, word_box.top ());
+    win->Line(static_cast<int>(cell->x () + xshift), word_box.bottom (), static_cast<int>(cell->x () + xshift), word_box.top ());
   }
 }
 

--- a/src/textord/edgblob.cpp
+++ b/src/textord/edgblob.cpp
@@ -233,7 +233,7 @@ int32_t OL_BUCKETS::count_children(                   // recursive count
             parent_area = outline->outer_area();
             if (parent_area < 0)
               parent_area = -parent_area;
-            max_parent_area = outline->bounding_box().area() * edges_boxarea;
+            max_parent_area = static_cast<float>(outline->bounding_box().area() * edges_boxarea);
             if (parent_area < max_parent_area)
               parent_box = false;
           }

--- a/src/textord/oldbasel.cpp
+++ b/src/textord/oldbasel.cpp
@@ -103,7 +103,7 @@ void Textord::make_old_baselines(TO_BLOCK* block,   // block to do
     }
   }
   correlate_lines(block, gradient);
-  block->block->set_xheight(block->xheight);
+  block->block->set_xheight(static_cast<int32_t>(block->xheight));
 }
 
 
@@ -140,7 +140,7 @@ void Textord::correlate_lines(TO_BLOCK *block, float gradient) {
   if (textord_really_old_xheight || textord_old_xheight) {
     block->xheight = static_cast<float>(correlate_with_stats(&rows[0], rowcount, block));
     if (block->xheight <= 0)
-      block->xheight = block->line_size * tesseract::CCStruct::kXHeightFraction;
+      block->xheight = static_cast<float>(block->line_size * tesseract::CCStruct::kXHeightFraction);
     if (block->xheight < textord_min_xheight)
       block->xheight = (float) textord_min_xheight;
   } else {
@@ -253,24 +253,24 @@ int Textord::correlate_with_stats(TO_ROW **rows,  // rows of block.
     fullheight = lineheight + ascheight / xcount;
                                  /*must be decent size */
     if (fullheight < lineheight * (1 + MIN_ASC_FRACTION))
-      fullheight = lineheight * (1 + MIN_ASC_FRACTION);
+      fullheight = static_cast<float>(lineheight * (1 + MIN_ASC_FRACTION));
   }
   else {
     fullheight /= fullcount;     /*average max height */
                                  /*guess x-height */
-    lineheight = fullheight * X_HEIGHT_FRACTION;
+    lineheight = static_cast<float>(fullheight * X_HEIGHT_FRACTION);
   }
   if (desccount > 0 && (!oldbl_corrfix || desccount >= rowcount / 2))
     descheight /= desccount;     /*average descenders */
   else
                                  /*guess descenders */
-    descheight = -lineheight * DESCENDER_FRACTION;
+    descheight = static_cast<float>(-lineheight * DESCENDER_FRACTION);
 
   if (lineheight > 0.0f)
     block->block->set_cell_over_xheight((fullheight - descheight) / lineheight);
 
-  minascheight = lineheight * MIN_ASC_FRACTION;
-  mindescheight = -lineheight * MIN_DESC_FRACTION;
+  minascheight = static_cast<float>(lineheight * MIN_ASC_FRACTION);
+  mindescheight = static_cast<float>(-lineheight * MIN_DESC_FRACTION);
   for (rowindex = 0; rowindex < rowcount; rowindex++) {
     row = rows[rowindex];        /*do each row */
     row->all_caps = false;
@@ -299,7 +299,7 @@ int Textord::correlate_with_stats(TO_ROW **rows,  // rows of block.
       }
       if (row->ascrise < minascheight)
         row->ascrise =
-          row->xheight * ((1.0 - X_HEIGHT_FRACTION) / X_HEIGHT_FRACTION);
+          static_cast<float>(row->xheight * ((1.0 - X_HEIGHT_FRACTION) / X_HEIGHT_FRACTION));
     }
     if (row->descdrop > mindescheight) {
       if (row->xheight >= lineheight * (1 - MAXHEIGHTVARIANCE)
@@ -307,7 +307,7 @@ int Textord::correlate_with_stats(TO_ROW **rows,  // rows of block.
                                  /*set to average */
           row->descdrop = descheight;
       else
-        row->descdrop = -row->xheight * DESCENDER_FRACTION;
+        row->descdrop = static_cast<float>(-row->xheight * DESCENDER_FRACTION);
     }
   }
   return static_cast<int>(lineheight);       //block xheight
@@ -351,7 +351,7 @@ void Textord::find_textlines(TO_BLOCK *block,  // block row is in
   lineheight = get_blob_coords(row, static_cast<int>(block->line_size), &blobcoords[0],
     holed_line, blobcount);
                                  /*limit for line change */
-  jumplimit = lineheight * textord_oldbl_jumplimit;
+  jumplimit = static_cast<float>(lineheight * textord_oldbl_jumplimit);
   if (jumplimit < MINASCRISE)
     jumplimit = MINASCRISE;
 
@@ -408,7 +408,7 @@ void Textord::find_textlines(TO_BLOCK *block,  // block row is in
                         blobcount, &row->baseline, jumplimit);
   } else {
     compute_row_xheight(row, block->block->classify_rotation(),
-                        row->line_m(), block->line_size);
+                        row->line_m(), static_cast<int>(block->line_size));
   }
 }
 
@@ -546,12 +546,12 @@ float jumplimit                  /*guess half descenders */
       ycount = 0;
       segment = 0;               /*no of segments */
       maxmax = minmin = 0.0f;
-      thisy = ycoords[0] - baseline->y (xcoords[0]);
-      nexty = ycoords[1] - baseline->y (xcoords[1]);
+      thisy = static_cast<float>(ycoords[0] - baseline->y (xcoords[0]));
+      nexty = static_cast<float>(ycoords[1] - baseline->y (xcoords[1]));
       for (blobindex = 2; blobindex < blobcount; blobindex++) {
         prevy = thisy;           /*shift ycoords */
         thisy = nexty;
-        nexty = ycoords[blobindex] - baseline->y (xcoords[blobindex]);
+        nexty = static_cast<float>(ycoords[blobindex] - baseline->y (xcoords[blobindex]));
                                  /*middle of smooth y */
         if (ABS (thisy - prevy) < jumplimit && ABS (thisy - nexty) < jumplimit) {
           y1 = y2;               /*shift window */
@@ -583,7 +583,7 @@ float jumplimit                  /*guess half descenders */
         }
       }
 
-      jumplimit *= 1.2;
+      jumplimit *= 1.2f;
                                  /*must be wavy */
       if (maxmax - minmin > jumplimit) {
         ycount = segment;        /*no of segments */
@@ -676,7 +676,7 @@ float gradient                   //of line
     && spline->xcoords[spline->segments - 1] >= rightedge
   - MAXOVERLAP * (rightedge - leftedge)) {
     *baseline = *spline;         /*copy it */
-    x = (leftedge + rightedge) / 2.0;
+    x = (leftedge + rightedge) / 2.0f;
     shift = ICOORD (0, static_cast<int16_t>(gradient * x + c - spline->y (x)));
     baseline->move (shift);
   }
@@ -806,13 +806,13 @@ float jumplimit                  /*allowed delta change */
         stats.clear ();
         for (test_blob = startx; test_blob < blobindex; test_blob++) {
           coord = FCOORD ((blobcoords[test_blob].left ()
-            + blobcoords[test_blob].right ()) / 2.0,
+            + blobcoords[test_blob].right ()) / 2.0f,
             blobcoords[test_blob].bottom ());
           stats.add (coord.x (), coord.y ());
         }
         stats.fit (1);
-        m = stats.get_b ();
-        c = stats.get_c ();
+        m = static_cast<float>(stats.get_b ());
+        c = static_cast<float>(stats.get_c ());
         if (textord_oldbl_debug)
           tprintf ("Fitted line y=%g x + %g\n", m, c);
         found_one = false;
@@ -826,7 +826,7 @@ float jumplimit                  /*allowed delta change */
             coord = FCOORD ((blobcoords[startx - test_blob].left ()
               + blobcoords[startx -
               test_blob].right ()) /
-              2.0,
+              2.0f,
               blobcoords[startx -
               test_blob].bottom ());
             diff = m * coord.x () + c - coord.y ();
@@ -843,7 +843,7 @@ float jumplimit                  /*allowed delta change */
             coord =
               FCOORD ((blobcoords[blobindex + test_blob - 1].
               left () + blobcoords[blobindex + test_blob -
-              1].right ()) / 2.0,
+              1].right ()) / 2.0f,
               blobcoords[blobindex + test_blob -
               1].bottom ());
             diff = m * coord.x () + c - coord.y ();
@@ -912,10 +912,10 @@ float ydiffs[]                   /*output */
                                  /*centre of blob */
     xcentre = (blobcoords[blobindex].left () + blobcoords[blobindex].right ()) >> 1;
                                  //step functions in spline
-    drift += spline->step (lastx, xcentre);
+    drift += static_cast<float>(spline->step (lastx, xcentre));
     lastx = xcentre;
     diff = blobcoords[blobindex].bottom ();
-    diff -= spline->y (xcentre);
+    diff -= static_cast<float>(spline->y (xcentre));
     diff += drift;
     ydiffs[blobindex] = diff;    /*store difference */
     if (blobindex > 2)
@@ -1183,8 +1183,8 @@ split_stepped_spline(           //make xstarts
   doneany = false;
   startindex = 0;
   for (segment = 1; segment < segments - 1; segment++) {
-    step = baseline->step ((xstarts[segment - 1] + xstarts[segment]) / 2.0,
-      (xstarts[segment] + xstarts[segment + 1]) / 2.0);
+    step = static_cast<float>(baseline->step((xstarts[segment - 1] + xstarts[segment]) / 2.0,
+                          (xstarts[segment] + xstarts[segment + 1]) / 2.0));
     if (step < 0)
       step = -step;
     if (step > jumplimit) {
@@ -1210,9 +1210,9 @@ split_stepped_spline(           //make xstarts
         leftindex = (startindex + startindex + centreindex) / 3;
         rightindex = (centreindex + endindex + endindex) / 3;
         leftcoord =
-          (xcoords[startindex] * 2 + xcoords[centreindex]) / 3.0;
+          (xcoords[startindex] * 2 + xcoords[centreindex]) / 3.0f;
         rightcoord =
-          (xcoords[centreindex] + xcoords[endindex] * 2) / 3.0;
+          (xcoords[centreindex] + xcoords[endindex] * 2) / 3.0f;
         while (xcoords[leftindex] > leftcoord
           && leftindex - startindex > textord_spline_medianwin)
           leftindex--;
@@ -1329,8 +1329,8 @@ int bestpart                     /*biggest partition */
       runlength++;               /*run of non bests */
       if (runlength > biggestrun)
         biggestrun = runlength;
-      partsteps[part_id] += blobcoords[blobindex].bottom()
-        - row->baseline.y(xcentre);
+      partsteps[part_id] += static_cast<float>(blobcoords[blobindex].bottom()
+        - row->baseline.y(xcentre));
     }
     else
       runlength = 0;
@@ -1429,7 +1429,7 @@ float jumplimit                  /*min ascender height */
   blobindex++) {
     xcentre = (blobcoords[blobindex].left ()
       + blobcoords[blobindex].right ()) / 2;
-    diff = blobcoords[blobindex].top () - baseline->y (xcentre);
+    diff = static_cast<float>(blobcoords[blobindex].top () - baseline->y (xcentre));
                                  /*is it ascender */
     if (diff > lineheight + jumplimit) {
       ascenders += diff;
@@ -1492,7 +1492,7 @@ float jumplimit                  /*min ascender height */
   for (blobindex = 0; blobindex < blobcount; blobindex++) {
     int xcenter = (blobcoords[blobindex].left () +
         blobcoords[blobindex].right ()) / 2;
-    float base = baseline->y(xcenter);
+    float base = static_cast<float>(baseline->y(xcenter));
     float bottomdiff = fabs(base - blobcoords[blobindex].bottom());
     int strength = textord_ocropus_mode &&
                    bottomdiff <= kBaselineTouch ? kGoodStrength : 1;

--- a/src/textord/pitsync1.cpp
+++ b/src/textord/pitsync1.cpp
@@ -384,7 +384,7 @@ void make_illegal_segment(                          //find segmentation
     prevpt = prevpt_it.data ();
     if (prevpt->cost_function () < best_cost) {
                                  //find least
-      best_cost = prevpt->cost_function ();
+      best_cost = static_cast<float>(prevpt->cost_function ());
       min_x = prevpt->position ();
       max_x = min_x;             //limits on coords
     }

--- a/src/textord/strokewidth.cpp
+++ b/src/textord/strokewidth.cpp
@@ -1563,7 +1563,7 @@ bool StrokeWidth::DiacriticBlob(BlobGrid* small_grid, BLOBNBOX* blob) {
   search_box.pad(x_pad, y_pad);
   BlobGridSearch rsearch(this);
   rsearch.SetUniqueMode(true);
-  int min_height = height * kMinDiacriticSizeRatio;
+  int min_height = static_cast<int>(height * kMinDiacriticSizeRatio);
   rsearch.StartRectSearch(search_box);
   BLOBNBOX* neighbour;
   while ((neighbour = rsearch.NextRectSearch()) != nullptr) {

--- a/src/textord/tablefind.cpp
+++ b/src/textord/tablefind.cpp
@@ -1828,8 +1828,8 @@ void TableFinder::RecognizeTables() {
   recognizer.Init();
   recognizer.set_line_grid(&leader_and_ruling_grid_);
   recognizer.set_text_grid(&fragmented_text_grid_);
-  recognizer.set_max_text_height(global_median_xheight_ * 2.0);
-  recognizer.set_min_height(1.5 * gridheight());
+  recognizer.set_max_text_height(global_median_xheight_ * 2);
+  recognizer.set_min_height(static_cast<int>(1.5 * gridheight()));
   // Loop over all of the tables and try to fit them.
   // Store the good tables here.
   ColSegment_CLIST good_tables;

--- a/src/textord/topitch.cpp
+++ b/src/textord/topitch.cpp
@@ -247,11 +247,11 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
       block_index++;
     }
     if (block_votes > textord_words_veto_power) {
-      bad_row->fixed_pitch = block_stats.ile (0.5);
+      bad_row->fixed_pitch = static_cast<float>(block_stats.ile (0.5));
       bad_row->pitch_decision = PITCH_CORR_FIXED;
     }
     else if (block_votes <= textord_words_veto_power && like_votes > 0) {
-      bad_row->fixed_pitch = like_stats.ile (0.5);
+      bad_row->fixed_pitch = static_cast<float>(like_stats.ile (0.5));
       bad_row->pitch_decision = PITCH_CORR_FIXED;
     }
     else {
@@ -271,9 +271,9 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
   if (bad_row->pitch_decision == PITCH_CORR_FIXED) {
     if (bad_row->fixed_pitch < textord_min_xheight) {
       if (block_votes > 0)
-        bad_row->fixed_pitch = block_stats.ile (0.5);
+        bad_row->fixed_pitch = static_cast<float>(block_stats.ile (0.5));
       else if (block_votes == 0 && like_votes > 0)
-        bad_row->fixed_pitch = like_stats.ile (0.5);
+        bad_row->fixed_pitch = static_cast<float>(like_stats.ile (0.5));
       else {
         tprintf
           ("Warning:guessing pitch as xheight on row %d, block %d\n",
@@ -331,8 +331,8 @@ void compute_block_pitch(TO_BLOCK* block,     // input list
   block->fixed_pitch = 0.0f;
   block->space_size = static_cast<float>(block->min_space);
   block->kern_size = static_cast<float>(block->max_nonspace);
-  block->pr_nonsp = block->xheight * words_default_prop_nonspace;
-  block->pr_space = block->pr_nonsp * textord_spacesize_ratioprop;
+  block->pr_nonsp = static_cast<float>(block->xheight * words_default_prop_nonspace);
+  block->pr_space = static_cast<float>(block->pr_nonsp * textord_spacesize_ratioprop);
   if (!block->get_rows ()->empty ()) {
     ASSERT_HOST (block->xheight > 0);
     find_repeated_chars(block, textord_show_initial_words && testing_on);
@@ -438,7 +438,7 @@ bool try_doc_fixed(                             //determine pitch
   // row iterator
   TO_ROW_IT row_it(block_it.data ()->get_rows());
   master_x = row_it.data ()->projection_left;
-  master_y = row_it.data ()->baseline.y (master_x);
+  master_y = static_cast<float>(row_it.data ()->baseline.y (master_x));
   projection_left = INT16_MAX;
   projection_right = -INT16_MAX;
   prop_blocks = 0;
@@ -455,7 +455,7 @@ bool try_doc_fixed(                             //determine pitch
       if (row->fixed_pitch > 0)
         pitches.add (static_cast<int32_t>(row->fixed_pitch), 1);
       //find median
-      row_y = row->baseline.y (master_x);
+      row_y = static_cast<float>(row->baseline.y (master_x));
       row_left =
         static_cast<int16_t>(row->projection_left -
         shift_factor * (master_y - row_y));
@@ -478,7 +478,7 @@ bool try_doc_fixed(                             //determine pitch
     row_it.set_to_list (block->get_rows ());
     for (row_it.mark_cycle_pt (); !row_it.cycled_list (); row_it.forward ()) {
       row = row_it.data ();
-      row_y = row->baseline.y (master_x);
+      row_y = static_cast<float>(row->baseline.y (master_x));
       row_left =
         static_cast<int16_t>(row->projection_left -
         shift_factor * (master_y - row_y));
@@ -496,11 +496,11 @@ bool try_doc_fixed(                             //determine pitch
     projection.plot (to_win, projection_left,
       row->intercept (), 1.0f, -1.0f, ScrollView::CORAL);
 #endif
-  final_pitch = pitches.ile (0.5);
+  final_pitch = static_cast<float>(pitches.ile (0.5));
   pitch = static_cast<int16_t>(final_pitch);
   pitch_sd =
     tune_row_pitch (row, &projection, projection_left, projection_right,
-    pitch * 0.75, final_pitch, sp_sd, mid_cuts,
+    pitch * 0.75f, final_pitch, sp_sd, mid_cuts,
     &row->char_cells, false);
 
   if (textord_debug_pitch_metric)
@@ -520,7 +520,7 @@ bool try_doc_fixed(                             //determine pitch
       for (row_it.mark_cycle_pt (); !row_it.cycled_list ();
       row_it.forward ()) {
         row = row_it.data ();
-        row_y = row->baseline.y (master_x);
+        row_y = static_cast<float>(row->baseline.y (master_x));
         row_shift = shift_factor * (master_y - row_y);
         plot_row_cells(to_win, ScrollView::GOLDENROD, row, row_shift, master_cells);
       }
@@ -745,13 +745,13 @@ bool row_pitch_stats(                  //find line stats
     return false;
   }
   cluster_count = 0;
-  lower = row->xheight * words_initial_lower;
-  upper = row->xheight * words_initial_upper;
+  lower = static_cast<float>(row->xheight * words_initial_lower);
+  upper = static_cast<float>(row->xheight * words_initial_upper);
   gap_stats.smooth (smooth_factor);
   do {
     prev_count = cluster_count;
     cluster_count = gap_stats.cluster (lower, upper,
-      textord_spacesize_ratioprop,
+      static_cast<float>(textord_spacesize_ratioprop),
       BLOCK_STATS_CLUSTERS, cluster_stats);
   }
   while (cluster_count > prev_count && cluster_count < BLOCK_STATS_CLUSTERS);
@@ -759,7 +759,7 @@ bool row_pitch_stats(                  //find line stats
     return false;
   }
   for (gap_index = 0; gap_index < cluster_count; gap_index++)
-    gaps[gap_index] = cluster_stats[gap_index + 1].ile (0.5);
+    gaps[gap_index] = static_cast<float>(cluster_stats[gap_index + 1].ile (0.5));
   //get medians
   if (testing_on) {
     tprintf ("cluster_count=%d:", cluster_count);
@@ -771,8 +771,8 @@ bool row_pitch_stats(                  //find line stats
   qsort (gaps, cluster_count, sizeof (float), sort_floats);
 
   //Try to find proportional non-space and space for row.
-  lower = row->xheight * words_default_prop_nonspace;
-  upper = row->xheight * textord_words_min_minspace;
+  lower = static_cast<float>(row->xheight * words_default_prop_nonspace);
+  upper = static_cast<float>(row->xheight * textord_words_min_minspace);
   for (gap_index = 0; gap_index < cluster_count
     && gaps[gap_index] < lower; gap_index++);
   if (gap_index == 0) {
@@ -794,14 +794,14 @@ bool row_pitch_stats(                  //find line stats
     if (gap_index == cluster_count) {
       if (testing_on)
         tprintf ("No clusters above nonspace threshold!!\n");
-      row->pr_space = lower * textord_spacesize_ratioprop;
+      row->pr_space = static_cast<float>(lower * textord_spacesize_ratioprop);
     }
     else
       row->pr_space = gaps[gap_index];
   }
 
   //Now try to find the fixed pitch space and non-space.
-  upper = row->xheight * words_default_fixed_space;
+  upper = static_cast<float>(row->xheight * words_default_fixed_space);
   for (gap_index = 0; gap_index < cluster_count
     && gaps[gap_index] < upper; gap_index++);
   if (gap_index == 0) {
@@ -871,41 +871,41 @@ bool find_row_pitch(                    //find lines
 
   if (!count_pitch_stats (row, &gap_stats, &pitch_stats,
   initial_pitch, min_space, true, false, dm_gap)) {
-    dm_gap_iqr = 0.0001;
+    dm_gap_iqr = 0.0001f;
     dm_pitch_iqr = maxwidth * 2.0f;
     dm_pitch = initial_pitch;
   }
   else {
-    dm_gap_iqr = gap_stats.ile (0.75) - gap_stats.ile (0.25);
-    dm_pitch_iqr = pitch_stats.ile (0.75) - pitch_stats.ile (0.25);
-    dm_pitch = pitch_stats.ile (0.5);
+    dm_gap_iqr = static_cast<float>(gap_stats.ile (0.75) - gap_stats.ile (0.25));
+    dm_pitch_iqr = static_cast<float>(pitch_stats.ile (0.75) - pitch_stats.ile (0.25));
+    dm_pitch = static_cast<float>(pitch_stats.ile (0.5));
   }
   gap_stats.clear ();
   pitch_stats.clear ();
   if (!count_pitch_stats (row, &gap_stats, &pitch_stats,
   initial_pitch, min_space, true, false, 0)) {
-    gap_iqr = 0.0001;
+    gap_iqr = 0.0001f;
     pitch_iqr = maxwidth * 3.0f;
   }
   else {
-    gap_iqr = gap_stats.ile (0.75) - gap_stats.ile (0.25);
-    pitch_iqr = pitch_stats.ile (0.75) - pitch_stats.ile (0.25);
+    gap_iqr = static_cast<float>(gap_stats.ile (0.75) - gap_stats.ile (0.25));
+    pitch_iqr = static_cast<float>(pitch_stats.ile (0.75) - pitch_stats.ile (0.25));
     if (testing_on)
       tprintf
         ("First fp iteration:initial_pitch=%g, gap_iqr=%g, pitch_iqr=%g, pitch=%g\n",
         initial_pitch, gap_iqr, pitch_iqr, pitch_stats.ile (0.5));
-    initial_pitch = pitch_stats.ile (0.5);
+    initial_pitch = static_cast<float>(pitch_stats.ile (0.5));
     if (min_space > initial_pitch
       && count_pitch_stats (row, &gap_stats, &pitch_stats,
     initial_pitch, initial_pitch, true, false, 0)) {
       min_space = initial_pitch;
-      gap_iqr = gap_stats.ile (0.75) - gap_stats.ile (0.25);
-      pitch_iqr = pitch_stats.ile (0.75) - pitch_stats.ile (0.25);
+      gap_iqr = static_cast<float>(gap_stats.ile (0.75) - gap_stats.ile (0.25));
+      pitch_iqr = static_cast<float>(pitch_stats.ile (0.75) - pitch_stats.ile (0.25));
       if (testing_on)
         tprintf
           ("Revised fp iteration:initial_pitch=%g, gap_iqr=%g, pitch_iqr=%g, pitch=%g\n",
           initial_pitch, gap_iqr, pitch_iqr, pitch_stats.ile (0.5));
-      initial_pitch = pitch_stats.ile (0.5);
+      initial_pitch = static_cast<float>(pitch_stats.ile (0.5));
     }
   }
   if (textord_debug_pitch_metric)
@@ -925,9 +925,9 @@ bool find_row_pitch(                    //find lines
       tprintf
         ("Choosing non dm version:pitch_iqr=%g, gap_iqr=%g, dm_pitch_iqr=%g, dm_gap_iqr=%g\n",
         pitch_iqr, gap_iqr, dm_pitch_iqr, dm_gap_iqr);
-    gap_iqr = gap_stats.ile (0.75) - gap_stats.ile (0.25);
-    pitch_iqr = pitch_stats.ile (0.75) - pitch_stats.ile (0.25);
-    pitch = pitch_stats.ile (0.5);
+    gap_iqr = static_cast<float>(gap_stats.ile (0.75) - gap_stats.ile (0.25));
+    pitch_iqr = static_cast<float>(pitch_stats.ile (0.75) - pitch_stats.ile (0.25));
+    pitch = static_cast<float>(pitch_stats.ile (0.5));
     used_dm_model = false;
   }
   else {
@@ -957,7 +957,7 @@ bool find_row_pitch(                    //find lines
   else
     row->pitch_decision = PITCH_MAYBE_PROP;
   row->fixed_pitch = pitch;
-  row->kern_size = gap_stats.ile (0.5);
+  row->kern_size = static_cast<float>(gap_stats.ile (0.5));
   row->min_space = static_cast<int32_t>(row->fixed_pitch + non_space) / 2;
   if (row->min_space > row->fixed_pitch)
     row->min_space = static_cast<int32_t>(row->fixed_pitch);
@@ -993,7 +993,7 @@ bool fixed_pitch_row(TO_ROW* row,       // row to do
   POLY_BLOCK* pb = block != nullptr ? block->pdblk.poly_block() : nullptr;
   if (textord_all_prop || (pb != nullptr && !pb->IsText())) {
     // Set the decision to definitely proportional.
-    pitch_sd = textord_words_def_prop * row->fixed_pitch;
+    pitch_sd = static_cast<float>(textord_words_def_prop * row->fixed_pitch);
     row->pitch_decision = PITCH_DEF_PROP;
   } else {
     pitch_sd = tune_row_pitch (row, &row->projection, row->projection_left,
@@ -1417,7 +1417,7 @@ float compute_pitch_sd(                            //find fp cells
       occupation, mid_cuts, row_cells,
       testing_on, start, end);
     sp_sd = occupation;
-    return word_sync;
+    return static_cast<float>(word_sync);
   }
   mid_cuts = 0;
   cellpos = 0;
@@ -1454,7 +1454,7 @@ float compute_pitch_sd(                            //find fp cells
       word_sync =
         check_pitch_sync2 (&start_it, blob_count, static_cast<int16_t>(initial_pitch), 2,
         projection, projection_left, projection_right,
-        row->xheight * textord_projection_scale,
+        static_cast<float>(row->xheight * textord_projection_scale),
         occupation, &seg_list, start, end);
     else
       word_sync =
@@ -1524,8 +1524,8 @@ float compute_pitch_sd(                            //find fp cells
     seg_list.clear ();
   }
   while (!blob_it.cycled_list ());
-  sp_sd = sp_count > 0 ? sqrt (spsum / sp_count) : 0;
-  return total_count > 0 ? sqrt (sqsum / total_count) : space_size * 10;
+  sp_sd = sp_count > 0 ? static_cast<float>(sqrt (spsum / sp_count)) : 0;
+  return total_count > 0 ? static_cast<float>(sqrt (sqsum / total_count)) : space_size * 10;
 }
 
 
@@ -1585,7 +1585,7 @@ float compute_pitch_sd2(                            //find fp cells
   word_sync = check_pitch_sync2 (&blob_it, blob_count, static_cast<int16_t>(initial_pitch),
     2, projection, projection_left,
     projection_right,
-    row->xheight * textord_projection_scale,
+    static_cast<float>(row->xheight * textord_projection_scale),
     occupation, &seg_list, start, end);
   if (testing_on) {
     tprintf ("Row ending at (%d,%d), len=%d, sync rating=%g, ",
@@ -1617,7 +1617,7 @@ float compute_pitch_sd2(                            //find fp cells
       mid_cuts = seg_it.data ()->cheap_cuts ();
   }
   seg_list.clear ();
-  return occupation > 0 ? sqrt (word_sync / occupation) : initial_pitch * 10;
+  return occupation > 0 ? static_cast<float>(sqrt (word_sync / occupation)) : initial_pitch * 10;
 }
 
 
@@ -1686,7 +1686,7 @@ void print_pitch_sd(                        //find fp cells
     word_sync =
       check_pitch_sync2 (&start_it, blob_count, static_cast<int16_t>(initial_pitch), 2,
       projection, projection_left, projection_right,
-      row->xheight * textord_projection_scale,
+      static_cast<float>(row->xheight * textord_projection_scale),
       occupation, &seg_list, 0, 0);
     total_blob_count += blob_count;
     seg_it.set_to_list (&seg_list);
@@ -1711,7 +1711,7 @@ void print_pitch_sd(                        //find fp cells
     seg_list.clear ();
   }
   while (!blob_it.cycled_list ());
-  sp_sd = sp_count > 0 ? sqrt (spsum / sp_count) : 0;
+  sp_sd = sp_count > 0 ? static_cast<float>(sqrt (spsum / sp_count)) : 0;
   word_sync = total_count > 0 ? sqrt (sqsum / total_count) : space_size * 10;
   tprintf ("new_sd=%g:sd/p=%g:new_sp_sd=%g:res=%c:",
     word_sync, word_sync / initial_pitch, sp_sd,
@@ -1723,7 +1723,7 @@ void print_pitch_sd(                        //find fp cells
   word_sync =
     check_pitch_sync2 (&blob_it, total_blob_count, static_cast<int16_t>(initial_pitch), 2,
     projection, projection_left, projection_right,
-    row->xheight * textord_projection_scale, occupation,
+    static_cast<float>(row->xheight * textord_projection_scale), occupation,
     &seg_list, 0, 0);
   if (occupation > 1)
     word_sync /= occupation;

--- a/src/textord/tordmain.cpp
+++ b/src/textord/tordmain.cpp
@@ -141,18 +141,18 @@ void SetBlobStrokeWidth(Pix* pix, BLOBNBOX* blob) {
   // 2*area/perimeter, as the numbers that gives do not match the numbers
   // from the distance method.
   if (h_stats.get_total() >= (width + height) / 4) {
-    blob->set_horz_stroke_width(h_stats.ile(0.5f));
+    blob->set_horz_stroke_width(static_cast<float>(h_stats.ile(0.5f)));
     if (v_stats.get_total() >= (width + height) / 4)
-      blob->set_vert_stroke_width(v_stats.ile(0.5f));
+      blob->set_vert_stroke_width(static_cast<float>(v_stats.ile(0.5f)));
     else
       blob->set_vert_stroke_width(0.0f);
   } else {
     if (v_stats.get_total() >= (width + height) / 4 ||
         v_stats.get_total() > h_stats.get_total()) {
       blob->set_horz_stroke_width(0.0f);
-      blob->set_vert_stroke_width(v_stats.ile(0.5f));
+      blob->set_vert_stroke_width(static_cast<float>(v_stats.ile(0.5f)));
     } else {
-      blob->set_horz_stroke_width(h_stats.get_total() > 2 ? h_stats.ile(0.5f)
+      blob->set_horz_stroke_width(h_stats.get_total() > 2 ? static_cast<float>(h_stats.ile(0.5f))
                                                           : 0.0f);
       blob->set_vert_stroke_width(0.0f);
     }
@@ -266,13 +266,13 @@ void Textord::filter_blobs(ICOORD page_tr,         // top right
       &block->small_blobs,
       &block->large_blobs);
     if (block->line_size == 0) block->line_size = 1;
-    block->line_spacing = block->line_size *
+    block->line_spacing = static_cast<float>(block->line_size *
         (tesseract::CCStruct::kDescenderFraction +
          tesseract::CCStruct::kXHeightFraction +
-         2 * tesseract::CCStruct::kAscenderFraction) /
-         tesseract::CCStruct::kXHeightFraction;
-    block->line_size *= textord_min_linesize;
-    block->max_blob_size = block->line_size * textord_excess_blobsize;
+         2 * tesseract::CCStruct::kAscenderFraction /
+         tesseract::CCStruct::kXHeightFraction));
+    block->line_size *= static_cast<float>(textord_min_linesize);
+    block->max_blob_size = static_cast<float>(block->line_size * textord_excess_blobsize);
 
     #ifndef GRAPHICS_DISABLED
     if (textord_show_blobs && testing_on) {
@@ -329,14 +329,14 @@ float Textord::filter_noise_blobs(
   for (src_it.mark_cycle_pt(); !src_it.cycled_list(); src_it.forward()) {
     size_stats.add(src_it.data()->bounding_box().height(), 1);
   }
-  initial_x = size_stats.ile(textord_initialx_ile);
-  max_y = ceil(initial_x *
+  initial_x = static_cast<float>(size_stats.ile(textord_initialx_ile));
+  max_y = static_cast<float>(ceil(initial_x *
                (tesseract::CCStruct::kDescenderFraction +
                 tesseract::CCStruct::kXHeightFraction +
                 2 * tesseract::CCStruct::kAscenderFraction) /
-               tesseract::CCStruct::kXHeightFraction);
+               tesseract::CCStruct::kXHeightFraction));
   min_y = floor (initial_x / 2);
-  max_x = ceil (initial_x * textord_width_limit);
+  max_x = static_cast<float>(ceil (initial_x * textord_width_limit));
   small_it.move_to_first ();
   for (small_it.mark_cycle_pt (); !small_it.cycled_list ();
   small_it.forward ()) {
@@ -357,10 +357,10 @@ float Textord::filter_noise_blobs(
     else
       size_stats.add (height, 1);
   }
-  max_height = size_stats.ile (textord_initialasc_ile);
+  max_height = static_cast<float>(size_stats.ile (textord_initialasc_ile));
   //      tprintf("max_y=%g, min_y=%g, initial_x=%g, max_height=%g,",
   //              max_y,min_y,initial_x,max_height);
-  max_height *= tesseract::CCStruct::kXHeightCapRatio;
+  max_height *= static_cast<float>(tesseract::CCStruct::kXHeightCapRatio);
   if (max_height > initial_x)
     initial_x = max_height;
   //      tprintf(" ret=%g\n",initial_x);
@@ -491,9 +491,9 @@ bool Textord::clean_noise_from_row(          //remove empties
   C_BLOB_IT blob_it;             //blob iterator
   C_OUTLINE_IT out_it;           //outline iterator
 
-  testing_on = textord_test_y > row->base_line (textord_test_x)
+  testing_on = textord_test_y > row->base_line (static_cast<float>(textord_test_x))
                && textord_show_blobs
-               && textord_test_y < row->base_line (textord_test_x) + row->x_height ();
+               && textord_test_y < row->base_line (static_cast<float>(textord_test_x)) + row->x_height ();
   dot_count = 0;
   norm_count = 0;
   super_norm_count = 0;
@@ -677,7 +677,7 @@ void Textord::clean_noise_from_words(          //remove empties
       // Previously we threw away the entire word.
       // Now just aggressively throw all small blobs into the reject list, where
       // the classifier can decide whether they are actually needed.
-      word->CleanNoise(textord_noise_sizelimit * row->x_height());
+      word->CleanNoise(static_cast<float>(textord_noise_sizelimit * row->x_height()));
     }
     word_index++;
   }
@@ -724,7 +724,7 @@ struct BlockGroup {
       : bounding_box(block->pdblk.bounding_box()),
         rotation(block->re_rotation()),
         angle(block->re_rotation().angle()),
-        min_xheight(block->x_height()) {
+        min_xheight(static_cast<float>(block->x_height())) {
     blocks.push_back(block);
   }
   // Union of block bounding boxes.
@@ -762,7 +762,7 @@ void Textord::TransferDiacriticsToBlockGroups(BLOBNBOX_LIST* diacritic_blobs,
       double angle_diff = fabs(block_angle - groups[g]->angle);
       if (angle_diff > M_PI) angle_diff = fabs(angle_diff - 2.0 * M_PI);
       if (angle_diff < best_angle_diff) {
-        best_angle_diff = angle_diff;
+        best_angle_diff = static_cast<float>(angle_diff);
         best_g = g;
       }
     }
@@ -771,7 +771,7 @@ void Textord::TransferDiacriticsToBlockGroups(BLOBNBOX_LIST* diacritic_blobs,
     } else {
       groups[best_g]->blocks.push_back(block);
       groups[best_g]->bounding_box += block->pdblk.bounding_box();
-      float x_height = block->x_height();
+      float x_height = static_cast<float>(block->x_height());
       if (x_height < groups[best_g]->min_xheight)
         groups[best_g]->min_xheight = x_height;
     }
@@ -781,7 +781,7 @@ void Textord::TransferDiacriticsToBlockGroups(BLOBNBOX_LIST* diacritic_blobs,
   for (int g = 0; g < groups.size(); ++g) {
     const BlockGroup* group = groups[g];
     if (group->bounding_box.null_box()) continue;
-    WordGrid word_grid(group->min_xheight, group->bounding_box.botleft(),
+    WordGrid word_grid(static_cast<int>(group->min_xheight), group->bounding_box.botleft(),
                        group->bounding_box.topright());
     for (int b = 0; b < group->blocks.size(); ++b) {
       ROW_IT row_it(group->blocks[b]->row_list());
@@ -931,7 +931,7 @@ void tweak_row_baseline(ROW *row,
     blob_it.forward ()) {
       blob = blob_it.data ();
       blob_box = blob->bounding_box ();
-      x_centre = (blob_box.left () + blob_box.right ()) / 2.0;
+      x_centre = (blob_box.left () + blob_box.right ()) / 2.0f;
       ydiff = blob_box.bottom () - row->base_line (x_centre);
       if (ydiff < 0)
         ydiff = -ydiff / row->x_height ();

--- a/src/textord/tospace.cpp
+++ b/src/textord/tospace.cpp
@@ -197,9 +197,9 @@ void Textord::block_spacing_stats(
   }
   else {
     /* For debug only ..... */
-    iqr_centre_to_centre = centre_to_centre_stats.ile (0.75) -
-      centre_to_centre_stats.ile (0.25);
-    iqr_all_gap_stats = all_gap_stats.ile (0.75) - all_gap_stats.ile (0.25);
+    iqr_centre_to_centre = static_cast<float>(centre_to_centre_stats.ile (0.75) -
+      centre_to_centre_stats.ile (0.25));
+    iqr_all_gap_stats = static_cast<float>(all_gap_stats.ile (0.75) - all_gap_stats.ile (0.25));
     old_text_ord_proportional =
       iqr_centre_to_centre * 2 > iqr_all_gap_stats;
     /* .......For debug only */
@@ -224,8 +224,8 @@ void Textord::block_spacing_stats(
         (row->pitch_decision == PITCH_DEF_PROP) ||
       (row->pitch_decision == PITCH_CORR_PROP))) {
         real_space_threshold =
-                std::max (tosp_init_guess_kn_mult * block_non_space_gap_width,
-          tosp_init_guess_xht_mult * row->xheight);
+                static_cast<float>(std::max (tosp_init_guess_kn_mult * block_non_space_gap_width,
+          tosp_init_guess_xht_mult * row->xheight));
         blob_it.set_to_list (row->blob_list ());
         blob_it.mark_cycle_pt ();
         end_of_row =
@@ -403,7 +403,7 @@ void Textord::row_spacing_stats(
                                  //Use block default
         row->space_size = block_space_gap_width;
         if (all_gap_stats.get_total () > tosp_redo_kern_limit)
-          row->kern_size = all_gap_stats.median ();
+          row->kern_size = static_cast<float>(all_gap_stats.median ());
         else
           row->kern_size = block_non_space_gap_width;
         row->space_threshold =
@@ -472,8 +472,8 @@ void Textord::row_spacing_stats(
     }
     /* Beware of tables - there may be NO spaces */
     if (suspected_table) {
-      sane_space = std::max(tosp_table_kn_sp_ratio * row->kern_size,
-        tosp_table_xht_sp_ratio * row->xheight);
+      sane_space = static_cast<float>(std::max(tosp_table_kn_sp_ratio * row->kern_size,
+        tosp_table_xht_sp_ratio * row->xheight));
       sane_threshold = int32_t (floor ((sane_space + row->kern_size) / 2));
 
       if ((row->space_size < sane_space) ||
@@ -596,30 +596,30 @@ void Textord::old_to_method(
   if (space_gap_stats->get_total () >= tosp_enough_space_samples_for_median) {
   //Adequate samples
     /* Set space size to median of spaces BUT limits it if it seems wildly out */
-    row->space_size = space_gap_stats->median ();
+    row->space_size = static_cast<float>(space_gap_stats->median ());
     if (row->space_size > block_space_gap_width * 1.5) {
       if (tosp_old_to_bug_fix)
-        row->space_size = block_space_gap_width * 1.5;
+        row->space_size = block_space_gap_width * 1.5f;
       else
                                  //BUG??? should be *1.5
         row->space_size = block_space_gap_width;
     }
     if (row->space_size < (block_non_space_gap_width * 2) + 1)
-      row->space_size = (block_non_space_gap_width * 2) + 1;
+      row->space_size = (block_non_space_gap_width * 2.f) + 1;
   }
                                  //Only 1 or 2 samples
   else if (space_gap_stats->get_total () >= 1) {
                                  //hence mean not median
-    row->space_size = space_gap_stats->mean ();
+    row->space_size = static_cast<float>(space_gap_stats->mean ());
     if (row->space_size > block_space_gap_width * 1.5) {
       if (tosp_old_to_bug_fix)
-        row->space_size = block_space_gap_width * 1.5;
+        row->space_size = block_space_gap_width * 1.5f;
       else
                                  //BUG??? should be *1.5
         row->space_size = block_space_gap_width;
     }
     if (row->space_size < (block_non_space_gap_width * 3) + 1)
-      row->space_size = (block_non_space_gap_width * 3) + 1;
+      row->space_size = (block_non_space_gap_width * 3.f) + 1;
   }
   else {
                                  //Use block default
@@ -629,9 +629,9 @@ void Textord::old_to_method(
   /* Next, estimate row kern size */
   if ((tosp_only_small_gaps_for_kern) &&
     (small_gap_stats->get_total () > tosp_redo_kern_limit))
-    row->kern_size = small_gap_stats->median ();
+    row->kern_size = static_cast<float>(small_gap_stats->median ());
   else if (all_gap_stats->get_total () > tosp_redo_kern_limit)
-    row->kern_size = all_gap_stats->median ();
+    row->kern_size = static_cast<float>(all_gap_stats->median ());
   else                          //old TO -SAME FOR ALL ROWS
     row->kern_size = block_non_space_gap_width;
 
@@ -663,7 +663,7 @@ void Textord::old_to_method(
        ((row->space_size - row->kern_size) <
         tosp_silly_kn_sp_gap * row->xheight))) {
     if (row->kern_size > 2.5)
-      row->kern_size = row->space_size / tosp_min_sane_kn_sp;
+      row->kern_size = static_cast<float>(row->space_size / tosp_min_sane_kn_sp);
     row->space_threshold = int32_t (floor ((row->space_size + row->kern_size) /
                                          tosp_old_sp_kn_th_factor));
   }
@@ -695,9 +695,9 @@ bool Textord::isolated_row_stats(TO_ROW* row,
   int32_t end_of_row;
   int32_t row_length;
 
-  kern_estimate = all_gap_stats->median ();
-  crude_threshold_estimate = std::max(tosp_init_guess_kn_mult * kern_estimate,
-    tosp_init_guess_xht_mult * row->xheight);
+  kern_estimate = static_cast<float>(all_gap_stats->median ());
+  crude_threshold_estimate = static_cast<float>(std::max(tosp_init_guess_kn_mult * kern_estimate,
+    tosp_init_guess_xht_mult * row->xheight));
   small_gaps_count = stats_count_under (all_gap_stats,
     static_cast<int16_t>(ceil (crude_threshold_estimate)));
   total = all_gap_stats->get_total ();
@@ -750,22 +750,22 @@ bool Textord::isolated_row_stats(TO_ROW* row,
   if (cert_space_gap_stats.get_total () >=
     tosp_enough_space_samples_for_median)
                                  //median
-    row->space_size = cert_space_gap_stats.median ();
+    row->space_size = static_cast<float>(cert_space_gap_stats.median ());
   else if (suspected_table && (cert_space_gap_stats.get_total () > 0))
                                  //to avoid spaced
-    row->space_size = cert_space_gap_stats.mean ();
+    row->space_size = static_cast<float>(cert_space_gap_stats.mean ());
   //      1's in tables
   else if (all_space_gap_stats.get_total () >=
     tosp_enough_space_samples_for_median)
                                  //median
-    row->space_size = all_space_gap_stats.median ();
+    row->space_size = static_cast<float>(all_space_gap_stats.median ());
   else
-    row->space_size = all_space_gap_stats.mean ();
+    row->space_size = static_cast<float>(all_space_gap_stats.mean ());
 
   if (tosp_only_small_gaps_for_kern)
-    row->kern_size = small_gap_stats.median ();
+    row->kern_size = static_cast<float>(small_gap_stats.median ());
   else
-    row->kern_size = all_gap_stats->median ();
+    row->kern_size = static_cast<float>(all_gap_stats->median ());
   row->space_threshold =
     int32_t (floor ((row->space_size + row->kern_size) / 2));
   /* Sanity check */
@@ -1389,9 +1389,9 @@ bool Textord::make_a_word_break(
     (current_gap > row->space_threshold)) {
       /* Heuristics to turn dubious spaces to kerns */
       if (tosp_pass_wide_fuzz_sp_to_context > 0)
-        fuzzy_sp_to_kn_limit = row->kern_size +
+        fuzzy_sp_to_kn_limit = static_cast<float>(row->kern_size +
           tosp_pass_wide_fuzz_sp_to_context *
-          (row->space_size - row->kern_size);
+          (row->space_size - row->kern_size));
       else
         fuzzy_sp_to_kn_limit = 99999.0f;
 
@@ -1591,8 +1591,8 @@ bool Textord::suspected_punct_blob(TO_ROW* row, TBOX box) {
   float baseline;
   float blob_x_centre;
   /* Find baseline of centre of blob */
-  blob_x_centre = (box.right () + box.left ()) / 2.0;
-  baseline = row->baseline.y (blob_x_centre);
+  blob_x_centre = (box.right () + box.left ()) / 2.0f;
+  baseline = static_cast<float>(row->baseline.y (blob_x_centre));
 
   result = (box.height () <= 0.66 * row->xheight) ||
            (box.top () < baseline + row->xheight / 2.0) ||
@@ -1686,12 +1686,12 @@ void Textord::mark_gap(
     else
       //interior_style(to_win, INT_HOLLOW, true);*/
                                  //x radius
-    to_win->Ellipse (current_gap / 2.0f,
-      blob.height () / 2.0f,     //y radius
+    to_win->Ellipse (current_gap / 2,
+      blob.height () / 2,        //y radius
                                  //x centre
-      blob.left () - current_gap / 2.0f,
+      blob.left () - current_gap / 2,
                                  //y centre
-      blob.bottom () + blob.height () / 2.0f);
+      blob.bottom () + blob.height () / 2);
  }
   if (tosp_debug_level > 5)
     tprintf("  (%d,%d) Sp<->Kn Rule %d %d %d %d %d %d\n",
@@ -1852,8 +1852,8 @@ TBOX Textord::reduced_box_for_blob(
   /* Find baseline of centre of blob */
 
   blob_box = blob->bounding_box ();
-  blob_x_centre = (blob_box.left () + blob_box.right ()) / 2.0;
-  baseline = row->baseline.y (blob_x_centre);
+  blob_x_centre = (blob_box.left () + blob_box.right ()) / 2.0f;
+  baseline = static_cast<float>(row->baseline.y (blob_x_centre));
 
   /*
   Find LH limit of blob ABOVE the xht. This is so that we can detect certain
@@ -1861,7 +1861,7 @@ TBOX Textord::reduced_box_for_blob(
   */
   left_limit = static_cast<float>(INT32_MAX);
   junk = static_cast<float>(-INT32_MAX);
-  find_cblob_hlimits(blob->cblob(), (baseline + 1.1 * row->xheight),
+  find_cblob_hlimits(blob->cblob(), (baseline + 1.1f * row->xheight),
                      static_cast<float>(INT16_MAX), left_limit, junk);
   if (left_limit > junk)
     *left_above_xht = INT16_MAX; //No area above xht

--- a/src/textord/underlin.cpp
+++ b/src/textord/underlin.cpp
@@ -54,7 +54,7 @@ void restore_underlined_blobs(                 //get chop points
     if (row == nullptr)
       return;  // Don't crash if there is no row.
     find_underlined_blobs (u_line, &row->baseline, row->xheight,
-      row->xheight * textord_underline_offset,
+      static_cast<float>(row->xheight * textord_underline_offset),
       &chop_cells);
     cell_it.set_to_list (&chop_cells);
     for (cell_it.mark_cycle_pt (); !cell_it.cycled_list ();
@@ -62,14 +62,14 @@ void restore_underlined_blobs(                 //get chop points
       chop_coord = cell_it.data ()->x ();
       if (cell_it.data ()->y () - chop_coord > textord_fp_chop_error + 1) {
         split_to_blob (u_line, chop_coord,
-          textord_fp_chop_error + 0.5,
+          textord_fp_chop_error + 0.5f,
           &left_coutlines,
           &right_coutlines);
         if (!left_coutlines.empty()) {
           ru_it.add_after_then_move(new BLOBNBOX(new C_BLOB(&left_coutlines)));
         }
         chop_coord = cell_it.data ()->y ();
-        split_to_blob(nullptr, chop_coord, textord_fp_chop_error + 0.5,
+        split_to_blob(nullptr, chop_coord, textord_fp_chop_error + 0.5f,
                       &left_coutlines, &right_coutlines);
         if (!left_coutlines.empty()) {
           row->insert_blob(new BLOBNBOX(new C_BLOB(&left_coutlines)));
@@ -79,7 +79,7 @@ void restore_underlined_blobs(                 //get chop points
       delete cell_it.extract();
     }
     if (!right_coutlines.empty ()) {
-      split_to_blob(nullptr, blob_box.right(), textord_fp_chop_error + 0.5,
+      split_to_blob(nullptr, blob_box.right(), textord_fp_chop_error + 0.5f,
                     &left_coutlines, &right_coutlines);
       if (!left_coutlines.empty())
         ru_it.add_after_then_move(new BLOBNBOX(new C_BLOB(&left_coutlines)));
@@ -126,20 +126,20 @@ TO_ROW *most_overlapping_row(                    //find best row
   && !row_it.cycled_list ()) {
     best_row = row;
     bestover =
-      blob->bounding_box ().top () - row->baseline.y (x) + row->descdrop;
+      static_cast<float>(blob->bounding_box ().top () - row->baseline.y (x) + row->descdrop);
     row_it.forward ();
     row = row_it.data ();
   }
   while (row->baseline.y (x) + row->xheight + row->ascrise
   >= blob->bounding_box ().bottom () && !row_it.cycled_list ()) {
-    overlap = row->baseline.y (x) + row->xheight + row->ascrise;
+    overlap = static_cast<float>(row->baseline.y (x) + row->xheight + row->ascrise);
     if (blob->bounding_box ().top () < overlap)
       overlap = blob->bounding_box ().top ();
     if (blob->bounding_box ().bottom () >
       row->baseline.y (x) + row->descdrop)
       overlap -= blob->bounding_box ().bottom ();
     else
-      overlap -= row->baseline.y (x) + row->descdrop;
+      overlap -= static_cast<float>(row->baseline.y (x) + row->descdrop);
     if (overlap > bestover) {
       bestover = overlap;
       best_row = row;

--- a/src/textord/wordseg.cpp
+++ b/src/textord/wordseg.cpp
@@ -223,17 +223,17 @@ int32_t row_words(                  //compute space size
     return 0;
   }
   gap_stats.smooth (smooth_factor);
-  lower = row->xheight * textord_words_initial_lower;
-  upper = row->xheight * textord_words_initial_upper;
+  lower = static_cast<float>(row->xheight * textord_words_initial_lower);
+  upper = static_cast<float>(row->xheight * textord_words_initial_upper);
   cluster_count = gap_stats.cluster (lower, upper,
-    textord_spacesize_ratioprop, 3,
+    static_cast<float>(textord_spacesize_ratioprop), 3,
     cluster_stats);
   while (cluster_count < 2 && ceil (lower) < floor (upper)) {
                                  //shrink gap
     upper = (upper * 3 + lower) / 4;
     lower = (lower * 3 + upper) / 4;
     cluster_count = gap_stats.cluster (lower, upper,
-      textord_spacesize_ratioprop, 3,
+      static_cast<float>(textord_spacesize_ratioprop), 3,
       cluster_stats);
   }
   if (cluster_count < 2) {
@@ -242,7 +242,7 @@ int32_t row_words(                  //compute space size
     return 0;
   }
   for (gap_index = 0; gap_index < cluster_count; gap_index++)
-    gaps[gap_index] = cluster_stats[gap_index + 1].ile (0.5);
+    gaps[gap_index] = static_cast<float>(cluster_stats[gap_index + 1].ile (0.5));
   //get medians
   if (cluster_count > 2) {
     if (testing_on && textord_show_initial_words) {
@@ -411,13 +411,13 @@ int32_t row_words2(                  //compute space size
   }
 
   cluster_count = 0;
-  lower = block->xheight * words_initial_lower;
-  upper = block->xheight * words_initial_upper;
+  lower = static_cast<float>(block->xheight * words_initial_lower);
+  upper = static_cast<float>(block->xheight * words_initial_upper);
   gap_stats.smooth (smooth_factor);
   do {
     prev_count = cluster_count;
     cluster_count = gap_stats.cluster (lower, upper,
-      textord_spacesize_ratioprop,
+      static_cast<float>(textord_spacesize_ratioprop),
       BLOCK_STATS_CLUSTERS, cluster_stats);
   }
   while (cluster_count > prev_count && cluster_count < BLOCK_STATS_CLUSTERS);
@@ -427,7 +427,7 @@ int32_t row_words2(                  //compute space size
     return 0;
   }
   for (gap_index = 0; gap_index < cluster_count; gap_index++)
-    gaps[gap_index] = cluster_stats[gap_index + 1].ile (0.5);
+    gaps[gap_index] = static_cast<float>(cluster_stats[gap_index + 1].ile (0.5));
   //get medians
   if (testing_on) {
     tprintf ("cluster_count=%d:", cluster_count);

--- a/src/training/cntraining.cpp
+++ b/src/training/cntraining.cpp
@@ -49,7 +49,7 @@ static void WriteProtos(FILE* File, uint16_t N, LIST ProtoList,
 /* global variable to hold configuration parameters to control clustering */
 //-M 0.025   -B 0.05   -I 0.8   -C 1e-3
 static const CLUSTERCONFIG CNConfig = {
-  elliptical, 0.025, 0.05, 0.8, 1e-3, 0
+  elliptical, 0.025f, 0.05f, 0.8f, 1e-3, 0
 };
 
 /*----------------------------------------------------------------------------
@@ -157,7 +157,7 @@ int main(int argc, char *argv[]) {
       if (NumberOfProtos(ProtoList, true, false) > 0) {
         break;
       } else {
-        Config.MinSamples *= 0.95;
+        Config.MinSamples *= 0.95f;
         printf("0 significant protos for %s."
                " Retrying clustering with MinSamples = %f%%\n",
                CharSample->Label, Config.MinSamples);

--- a/src/training/commandlineflags.cpp
+++ b/src/training/commandlineflags.cpp
@@ -124,7 +124,7 @@ static bool SafeAtod(const char* str, double* val) {
 
 static void PrintCommandLineFlags() {
   const char* kFlagNamePrefix = "FLAGS_";
-  const int kFlagNamePrefixLen = strlen(kFlagNamePrefix);
+  const int kFlagNamePrefixLen = static_cast<int>(strlen(kFlagNamePrefix));
   for (int i = 0; i < GlobalParams()->int_params.size(); ++i) {
     if (!strncmp(GlobalParams()->int_params[i]->name_str(),
                  kFlagNamePrefix, kFlagNamePrefixLen)) {
@@ -208,7 +208,7 @@ void ParseCommandLineFlags(const char* usage,
     if (equals_position == nullptr) {
       lhs = current_arg;
     } else {
-      lhs.assign(current_arg, equals_position - current_arg);
+      lhs.assign(current_arg, static_cast<int>(equals_position - current_arg));
     }
     if (!lhs.length()) {
       tprintf("ERROR: Bad argument: %s\n", (*argv)[i]);

--- a/src/training/commontraining.cpp
+++ b/src/training/commontraining.cpp
@@ -85,7 +85,7 @@ using tesseract::ShapeTable;
 
 // global variable to hold configuration parameters to control clustering
 // -M 0.625   -B 0.05   -I 1.0   -C 1e-6.
-CLUSTERCONFIG Config = { elliptical, 0.625, 0.05, 1.0, 1e-6, 0 };
+CLUSTERCONFIG Config = { elliptical, 0.625f, 0.05f, 1.0f, 1e-6, 0 };
 FEATURE_DEFS_STRUCT feature_defs;
 static CCUtil ccutil;
 
@@ -133,11 +133,11 @@ void ParseArguments(int* argc, char ***argv) {
   tessoptind = 1;
   // Set some global values based on the flags.
   Config.MinSamples =
-          std::max(0.0, std::min(1.0, double(FLAGS_clusterconfig_min_samples_fraction)));
+          static_cast<float>(std::max(0.0, std::min(1.0, double(FLAGS_clusterconfig_min_samples_fraction))));
   Config.MaxIllegal =
-          std::max(0.0, std::min(1.0, double(FLAGS_clusterconfig_max_illegal)));
+          static_cast<float>(std::max(0.0, std::min(1.0, double(FLAGS_clusterconfig_max_illegal))));
   Config.Independence =
-          std::max(0.0, std::min(1.0, double(FLAGS_clusterconfig_independence)));
+          static_cast<float>(std::max(0.0, std::min(1.0, double(FLAGS_clusterconfig_independence))));
   Config.Confidence =
           std::max(0.0, std::min(1.0, double(FLAGS_clusterconfig_confidence)));
   // Set additional parameters from config file if specified.
@@ -259,7 +259,7 @@ MasterTrainer* LoadTrainingData(int argc, const char* const * argv,
 
     // If there is a file with [lang].[fontname].exp[num].fontinfo present,
     // read font spacing information in to fontinfo_table.
-    int pagename_len = strlen(page_name);
+    int pagename_len = static_cast<int>(strlen(page_name));
     char* fontinfo_file_name = new char[pagename_len + 7];
     strncpy(fontinfo_file_name, page_name, pagename_len - 2);   // remove "tr"
     strcpy(fontinfo_file_name + pagename_len - 2, "fontinfo");  // +"fontinfo"
@@ -362,7 +362,7 @@ LABELEDLIST NewLabeledList(const char* Label) {
   LABELEDLIST LabeledList;
 
   LabeledList = static_cast<LABELEDLIST>(Emalloc (sizeof (LABELEDLISTNODE)));
-  LabeledList->Label = static_cast<char*>(Emalloc (strlen (Label)+1));
+  LabeledList->Label = static_cast<char*>(Emalloc (static_cast<int>(strlen (Label)+1)));
   strcpy (LabeledList->Label, Label);
   LabeledList->List = NIL_LIST;
   LabeledList->SampleCount = 0;
@@ -581,7 +581,7 @@ void MergeInsignificantProtos(LIST ProtoList, const char* label,
   iterate(pProtoList) {
     Prototype = reinterpret_cast<PROTOTYPE *>first_node (pProtoList);
     // Process insignificant protos that do not match a green one
-    if (!Prototype->Significant && Prototype->NumSamples >= min_samples &&
+    if (!Prototype->Significant && Prototype->NumSamples >= static_cast<unsigned int>(min_samples) &&
         !Prototype->Merged) {
       if (debug)
         tprintf("Red proto at %g,%g becoming green\n",
@@ -693,7 +693,7 @@ MERGE_CLASS NewLabeledClass(const char* Label) {
   MERGE_CLASS MergeClass;
 
   MergeClass = new MERGE_CLASS_NODE;
-  MergeClass->Label = static_cast<char*>(Emalloc (strlen (Label)+1));
+  MergeClass->Label = static_cast<char*>(Emalloc (static_cast<int>(strlen (Label)+1)));
   strcpy (MergeClass->Label, Label);
   MergeClass->Class = NewClass (MAX_NUM_PROTOS, MAX_NUM_CONFIGS);
   return (MergeClass);
@@ -792,9 +792,9 @@ void Normalize (
   float Intercept;
   float Normalizer;
 
-  Slope      = tan(Values [2] * 2 * M_PI);
+  Slope      = static_cast<float>(tan(Values [2] * 2 * M_PI));
   Intercept  = Values [1] - Slope * Values [0];
-  Normalizer = 1 / sqrt (Slope * Slope + 1.0);
+  Normalizer = static_cast<float>(1 / sqrt (Slope * Slope + 1.0));
 
   Values [0] = Slope * Normalizer;
   Values [1] = - Normalizer;

--- a/src/training/lstmtraining.cpp
+++ b/src/training/lstmtraining.cpp
@@ -169,9 +169,9 @@ int main(int argc, char **argv) {
       }
       // We are initializing from scratch.
       if (!trainer.InitNetwork(FLAGS_net_spec.c_str(), FLAGS_append_index,
-                               FLAGS_net_mode, FLAGS_weight_range,
-                               FLAGS_learning_rate, FLAGS_momentum,
-                               FLAGS_adam_beta)) {
+                               FLAGS_net_mode, static_cast<float>(FLAGS_weight_range),
+                               static_cast<float>(FLAGS_learning_rate), static_cast<float>(FLAGS_momentum),
+                               static_cast<float>(FLAGS_adam_beta))) {
         tprintf("Failed to create network from spec: %s\n",
                 FLAGS_net_spec.c_str());
         return EXIT_FAILURE;

--- a/src/training/mergenf.cpp
+++ b/src/training/mergenf.cpp
@@ -76,10 +76,10 @@ float CompareProtos(PROTO p1, PROTO p2) {
   Feature->Params[PicoFeatDir] = p1->Angle;
 
   /* convert angle to radians */
-  Angle = p1->Angle * 2.0 * M_PI;
+  Angle = static_cast<float>(p1->Angle * 2.0 * M_PI);
 
   /* find distance from center of p1 to 1/2 picofeat from end */
-  Length = p1->Length / 2.0 - GetPicoFeatureLength () / 2.0;
+  Length = static_cast<float>(p1->Length / 2.0 - GetPicoFeatureLength () / 2.0);
   if (Length < 0) Length = 0;
 
   /* set the dummy pico-feature at one end of p1 and match it to p2 */
@@ -165,7 +165,7 @@ int FindClosestExistingProto(CLASS_TYPE Class, int NumMerged[],
   MakeNewFromOld (&NewProto, Prototype);
 
   BestProto = NO_PROTO;
-  BestMatch = WORST_MATCH_ALLOWED;
+  BestMatch = static_cast<float>(WORST_MATCH_ALLOWED);
   for (Pid = 0; Pid < Class->NumProtos; Pid++) {
     Proto  = ProtoIn(Class, Pid);
     ComputeMergedProto(Proto, &NewProto,
@@ -212,13 +212,13 @@ float SubfeatureEvidence(FEATURE Feature, PROTO Proto) {
   Dangle   = Proto->Angle - Feature->Params[PicoFeatDir];
   if (Dangle < -0.5) Dangle += 1.0;
   if (Dangle >  0.5) Dangle -= 1.0;
-  Dangle *= training_angle_match_scale;
+  Dangle *= static_cast<float>(training_angle_match_scale);
 
   Distance = Proto->A * Feature->Params[PicoFeatX] +
     Proto->B * Feature->Params[PicoFeatY] +
     Proto->C;
 
-  return (EvidenceOf (Distance * Distance + Dangle * Dangle));
+  return (static_cast<float>(EvidenceOf (Distance * Distance + Dangle * Dangle)));
 }
 
 /**
@@ -262,17 +262,17 @@ bool DummyFastMatch(FEATURE Feature, PROTO Proto)
   float MaxAngleError;
   float AngleError;
 
-  MaxAngleError = training_angle_pad / 360.0;
+  MaxAngleError = static_cast<float>(training_angle_pad / 360.0);
   AngleError = fabs (Proto->Angle - Feature->Params[PicoFeatDir]);
-  if (AngleError > 0.5)
-    AngleError = 1.0 - AngleError;
+  if (AngleError > 0.5f)
+    AngleError = 1.0f - AngleError;
 
   if (AngleError > MaxAngleError)
     return false;
 
   ComputePaddedBoundingBox (Proto,
-    training_tangent_bbox_pad * GetPicoFeatureLength (),
-    training_orthogonal_bbox_pad * GetPicoFeatureLength (),
+    static_cast<float>(training_tangent_bbox_pad * GetPicoFeatureLength ()),
+    static_cast<float>(training_orthogonal_bbox_pad * GetPicoFeatureLength ()),
     &BoundingBox);
 
   return PointInside(&BoundingBox, Feature->Params[PicoFeatX],
@@ -292,8 +292,8 @@ bool DummyFastMatch(FEATURE Feature, PROTO Proto)
  */
 void ComputePaddedBoundingBox (PROTO Proto, float TangentPad,
                                float OrthogonalPad, FRECT *BoundingBox) {
-  float Length     = Proto->Length / 2.0 + TangentPad;
-  float Angle      = Proto->Angle * 2.0 * M_PI;
+  float Length     = Proto->Length / 2.0f + TangentPad;
+  float Angle      = static_cast<float>(Proto->Angle * 2.0 * M_PI);
   float CosOfAngle = fabs(cos(Angle));
   float SinOfAngle = fabs(sin(Angle));
 

--- a/src/training/normstrngs.cpp
+++ b/src/training/normstrngs.cpp
@@ -232,8 +232,8 @@ bool IsUTF8Whitespace(const char* text) {
 
 unsigned int SpanUTF8Whitespace(const char* text) {
   int n_white = 0;
-  for (UNICHAR::const_iterator it = UNICHAR::begin(text, strlen(text));
-       it != UNICHAR::end(text, strlen(text)); ++it) {
+  for (UNICHAR::const_iterator it = UNICHAR::begin(text, static_cast<int>(strlen(text)));
+       it != UNICHAR::end(text, static_cast<int>(strlen(text))); ++it) {
     if (!IsWhitespace(*it)) break;
     n_white += it.utf8_len();
   }
@@ -242,8 +242,8 @@ unsigned int SpanUTF8Whitespace(const char* text) {
 
 unsigned int SpanUTF8NotWhitespace(const char* text) {
   int n_notwhite = 0;
-  for (UNICHAR::const_iterator it = UNICHAR::begin(text, strlen(text));
-       it != UNICHAR::end(text, strlen(text)); ++it) {
+  for (UNICHAR::const_iterator it = UNICHAR::begin(text, static_cast<int>(strlen(text)));
+       it != UNICHAR::end(text, static_cast<int>(strlen(text))); ++it) {
     if (IsWhitespace(*it)) break;
     n_notwhite += it.utf8_len();
   }

--- a/src/training/unicharset_training_utils.cpp
+++ b/src/training/unicharset_training_utils.cpp
@@ -78,7 +78,7 @@ void SetupBasicProperties(bool report_errors, bool decompose,
     unicharset->set_script(unichar_id, uscript_getName(
         uscript_getScript(uni_vector[0], err)));
 
-    const int num_code_points = uni_vector.size();
+    const int num_code_points = static_cast<int>(uni_vector.size());
     // Obtain the lower/upper case if needed and record it in the properties.
     unicharset->set_other_case(unichar_id, unichar_id);
     if (unichar_islower || unichar_isupper) {

--- a/src/training/validate_grapheme.cpp
+++ b/src/training/validate_grapheme.cpp
@@ -5,7 +5,7 @@
 namespace tesseract {
 
 bool ValidateGrapheme::ConsumeGraphemeIfValid() {
-  const unsigned num_codes = codes_.size();
+  const unsigned num_codes = static_cast<unsigned>(codes_.size());
   char32 prev_prev_ch = ' ';
   char32 prev_ch = ' ';
   CharClass prev_cc = CharClass::kWhitespace;

--- a/src/training/validate_indic.cpp
+++ b/src/training/validate_indic.cpp
@@ -101,7 +101,7 @@ Validator::CharClass ValidateIndic::UnicodeToCharClass(char32 ch) const {
 // representation to make it consistent by adding a ZWNJ if missing from a
 // non-linking virama. Returns false with an invalid sequence.
 bool ValidateIndic::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
-  const unsigned num_codes = codes_.size();
+  const unsigned num_codes = static_cast<unsigned>(codes_.size());
   if (joiner.first == CharClass::kOther) {
     CodeOnlyToOutput();
     if (codes_used_ < num_codes &&
@@ -120,7 +120,7 @@ bool ValidateIndic::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
         ASSERT_HOST(!CodeOnlyToOutput());
       } else {
         // Half-form with optional Nukta.
-        unsigned len = output_.size() + 1 - output_used_;
+        unsigned len = static_cast<unsigned>(output_.size() + 1 - output_used_);
         if (UseMultiCode(len)) return true;
       }
       if (codes_used_ < num_codes &&
@@ -173,12 +173,12 @@ bool ValidateIndic::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
 // Helper consumes/copies a series of consonants separated by viramas while
 // valid, but not any vowel or other modifiers.
 bool ValidateIndic::ConsumeConsonantHeadIfValid() {
-  const unsigned num_codes = codes_.size();
+  const unsigned num_codes = static_cast<unsigned>(codes_.size());
   // Consonant aksara
   do {
     CodeOnlyToOutput();
     // Special Sinhala case of [H Z Yayana/Rayana].
-    int index = output_.size() - 3;
+    int index = static_cast<int>(output_.size() - 3);
     if (output_used_ + 3 <= output_.size() &&
         (output_.back() == kYayana || output_.back() == kRayana) &&
         IsVirama(output_[index]) && output_[index + 1] == kZeroWidthJoiner) {
@@ -191,7 +191,7 @@ bool ValidateIndic::ConsumeConsonantHeadIfValid() {
       CodeOnlyToOutput();
     }
     // Test for subscript conjunct.
-    index = output_.size() - 2 - have_nukta;
+    index = static_cast<int>(output_.size() - 2 - have_nukta);
     if (output_used_ + 2 + have_nukta <= output_.size() && IsSubscriptScript() &&
         IsVirama(output_[index])) {
       // Output previous virama, consonant + optional nukta.

--- a/src/training/validate_javanese.cpp
+++ b/src/training/validate_javanese.cpp
@@ -70,7 +70,7 @@ bool ValidateJavanese::ConsumeGraphemeIfValid() {
 // representation to make it consistent by adding a ZWNJ if missing from a
 // non-linking virama. Returns false with an invalid sequence.
 bool ValidateJavanese::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
-  const unsigned num_codes = codes_.size();
+  const unsigned num_codes = static_cast<unsigned>(codes_.size());
   if (joiner.first == CharClass::kOther) {
     CodeOnlyToOutput();
     if (codes_used_ < num_codes &&
@@ -89,7 +89,7 @@ bool ValidateJavanese::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
         ASSERT_HOST(!CodeOnlyToOutput());
       } else {
         // Half-form with optional Nukta.
-        unsigned len = output_.size() + 1 - output_used_;
+        unsigned len = static_cast<unsigned>(output_.size() + 1 - output_used_);
         if (UseMultiCode(len)) return true;
       }
       if (codes_used_ < num_codes &&
@@ -142,12 +142,12 @@ bool ValidateJavanese::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
 // Helper consumes/copies a series of consonants separated by viramas while
 // valid, but not any vowel or other modifiers.
 bool ValidateJavanese::ConsumeConsonantHeadIfValid() {
-  const unsigned num_codes = codes_.size();
+  const unsigned num_codes = static_cast<unsigned>(codes_.size());
   // Consonant aksara
   do {
     CodeOnlyToOutput();
     // Special Sinhala case of [H Z Yayana/Rayana].
-    int index = output_.size() - 3;
+    int index = static_cast<int>(output_.size() - 3);
     if (output_used_ + 3 <= output_.size() &&
         (output_.back() == kPengkal || output_.back() == kCakra) &&
         IsVirama(output_[index]) && output_[index + 1] == kZeroWidthJoiner) {
@@ -160,7 +160,7 @@ bool ValidateJavanese::ConsumeConsonantHeadIfValid() {
       CodeOnlyToOutput();
     }
     // Test for subscript conjunct.
-    index = output_.size() - 2 - have_nukta;
+    index = static_cast<int>(output_.size() - 2 - have_nukta);
     if (output_used_ + 2 + have_nukta <= output_.size() && IsSubscriptScript() &&
         IsVirama(output_[index])) {
       // Output previous virama, consonant + optional nukta.

--- a/src/training/validate_khmer.cpp
+++ b/src/training/validate_khmer.cpp
@@ -18,7 +18,7 @@ namespace tesseract {
 // HC and the {Z|z}M The unicode chapter on Khmer only mentions the joiners in
 // the BNF syntax, so who knows what they do.
 bool ValidateKhmer::ConsumeGraphemeIfValid() {
-  const unsigned num_codes = codes_.size();
+  const unsigned num_codes = static_cast<unsigned>(codes_.size());
   if (codes_used_ == num_codes) return false;
   if (codes_[codes_used_].first == CharClass::kOther) {
     UseMultiCode(1);

--- a/src/training/validate_myanmar.cpp
+++ b/src/training/validate_myanmar.cpp
@@ -11,7 +11,7 @@ namespace tesseract {
 // Taken directly from the unicode table 16-3.
 // See http://www.unicode.org/versions/Unicode9.0.0/ch16.pdf
 bool ValidateMyanmar::ConsumeGraphemeIfValid() {
-  const unsigned num_codes = codes_.size();
+  const unsigned num_codes = static_cast<unsigned>(codes_.size());
   if (codes_used_ == num_codes) return true;
   // Other.
   if (IsMyanmarOther(codes_[codes_used_].second)) {
@@ -61,7 +61,7 @@ Validator::CharClass ValidateMyanmar::UnicodeToCharClass(char32 ch) const {
 // Returns true if the end of input is reached.
 bool ValidateMyanmar::ConsumeSubscriptIfPresent() {
   // Subscript consonant. It appears there can be only one.
-  const unsigned num_codes = codes_.size();
+  const unsigned num_codes = static_cast<unsigned>(codes_.size());
   if (codes_used_ + 1 < num_codes &&
       codes_[codes_used_].second == kMyanmarVirama) {
     if (IsMyanmarLetter(codes_[codes_used_ + 1].second)) {

--- a/src/viewer/scrollview.cpp
+++ b/src/viewer/scrollview.cpp
@@ -483,7 +483,7 @@ SVEvent* ScrollView::AwaitEventAnyWindow() {
 void ScrollView::SendPolygon() {
   if (!points_->empty) {
     points_->empty = true;  // Allows us to use SendMsg.
-    int length = points_->xcoords.size();
+    int length = static_cast<int>(points_->xcoords.size());
     // length == 1 corresponds to 2 SetCursors in a row and only the
     // last setCursor has any effect.
     if (length == 2) {
@@ -766,7 +766,7 @@ void ScrollView::Image(struct Pix* image, int x_pos, int y_pos) {
   l_uint8* data;
   size_t size;
   pixWriteMem(&data, &size, image, IFF_PNG);
-  int base64_len = (size + 2) / 3 * 4;
+  int base64_len = static_cast<int>((size + 2) / 3 * 4);
   y_pos = TranslateYCoordinate(y_pos);
   SendMsg("readImage(%d,%d,%d)", x_pos, y_pos, base64_len);
   // Base64 encode the data.
@@ -813,7 +813,7 @@ char* ScrollView::AddEscapeChars(const char* input) {
   int pos = 0;
   while (nextptr != nullptr) {
     strncpy(message+pos, lastptr, nextptr-lastptr);
-    pos += nextptr - lastptr;
+    pos += static_cast<int>(nextptr - lastptr);
     message[pos] = '\\';
     pos += 1;
     lastptr = nextptr;

--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -373,20 +373,22 @@ SVNetwork::SVNetwork(const char* hostname, int port) {
     for (;;) {
       stream_ = socket(addr_info->ai_family, addr_info->ai_socktype,
                        addr_info->ai_protocol);
-      if (stream_ >= 0) {
-        if (connect(stream_, addr_info->ai_addr, static_cast<int>(addr_info->ai_addrlen)) == 0) {
-          break;
-        }
-
-        Close();
-
-        std::cout << "ScrollView: Waiting for server...\n";
-#ifdef _WIN32
-        Sleep(1000);
-#else
-        sleep(1);
-#endif
+      if (stream_ < 0) {
+        continue;
       }
+      if (connect(stream_, addr_info->ai_addr,
+                  static_cast<int>(addr_info->ai_addrlen)) == 0) {
+        break;
+      }
+
+      Close();
+
+      std::cout << "ScrollView: Waiting for server...\n";
+#  ifdef _WIN32
+      Sleep(1000);
+#  else
+      sleep(1);
+#  endif
     }
   }
 #ifdef _WIN32

--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -209,7 +209,7 @@ void SVNetwork::Send(const char* msg) {
 void SVNetwork::Flush() {
   mutex_send_.Lock();
   while (!msg_buffer_out_.empty()) {
-    int i = send(stream_, msg_buffer_out_.c_str(), msg_buffer_out_.length(), 0);
+    int i = send(stream_, msg_buffer_out_.c_str(), static_cast<int>(msg_buffer_out_.length()), 0);
     msg_buffer_out_.erase(0, i);
   }
   mutex_send_.Unlock();
@@ -243,7 +243,7 @@ char* SVNetwork::Receive() {
     FD_ZERO(&readfds);
     FD_SET(stream_, &readfds);
 
-    int i = select(stream_+1, &readfds, nullptr, nullptr, &tv);
+    int i = select(static_cast<int>(stream_+1), &readfds, nullptr, nullptr, &tv);
 
     // The stream_ died.
     if (i == 0) { return nullptr; }
@@ -348,7 +348,7 @@ SVNetwork::SVNetwork(const char* hostname, int port) {
 
   if (stream_ < 0) {
     std::cerr << "Failed to open socket" << std::endl;
-  } else if (connect(stream_, addr_info->ai_addr, addr_info->ai_addrlen) < 0) {
+  } else if (connect(stream_, addr_info->ai_addr, static_cast<int>(addr_info->ai_addrlen)) < 0) {
     // If server is not there, we will start a new server as local child process.
     const char* scrollview_path = getenv("SCROLLVIEW_PATH");
     if (scrollview_path == nullptr) {
@@ -374,7 +374,7 @@ SVNetwork::SVNetwork(const char* hostname, int port) {
       stream_ = socket(addr_info->ai_family, addr_info->ai_socktype,
                        addr_info->ai_protocol);
       if (stream_ >= 0) {
-        if (connect(stream_, addr_info->ai_addr, addr_info->ai_addrlen) == 0) {
+        if (connect(stream_, addr_info->ai_addr, static_cast<int>(addr_info->ai_addrlen)) == 0) {
           break;
         }
 

--- a/src/viewer/svutil.h
+++ b/src/viewer/svutil.h
@@ -121,7 +121,7 @@ class SVNetwork {
   /// The mutex for access to Send() and Flush().
   SVMutex mutex_send_;
   /// The actual stream_ to the server.
-  int stream_;
+  size_t stream_;
   /// Stores the last received message-chunk from the server.
   char* msg_buffer_in_;
 

--- a/src/wordrec/chop.cpp
+++ b/src/wordrec/chop.cpp
@@ -118,7 +118,7 @@ EDGEPT *Wordrec::pick_close_point(EDGEPT *critical_point,
                                   int *best_dist) {
   EDGEPT *best_point = nullptr;
   int this_distance;
-  int found_better;
+  bool found_better;
 
   do {
     found_better = false;

--- a/src/wordrec/findseam.cpp
+++ b/src/wordrec/findseam.cpp
@@ -199,7 +199,7 @@ void Wordrec::combine_seam(const SeamPile& seam_pile,
                            const SEAM* seam, SeamQueue* seam_queue) {
   for (int x = 0; x < seam_pile.size(); ++x) {
     const SEAM *this_one = seam_pile.get(x).data();
-    if (seam->CombineableWith(*this_one, SPLIT_CLOSENESS, chop_ok_split)) {
+    if (seam->CombineableWith(*this_one, SPLIT_CLOSENESS, static_cast<float>(chop_ok_split))) {
       SEAM *new_one = new SEAM(*seam);
       new_one->CombineWith(*this_one);
       if (chop_debug > 1) new_one->Print("Combo priority       ");

--- a/src/wordrec/gradechop.cpp
+++ b/src/wordrec/gradechop.cpp
@@ -48,12 +48,12 @@ PRIORITY Wordrec::grade_split_length(SPLIT *split) {
   float split_length;
 
   split_length =
-      split->point1->WeightedDistance(*split->point2, chop_x_y_weight);
+      static_cast<float>(split->point1->WeightedDistance(*split->point2, chop_x_y_weight));
 
   if (split_length <= 0)
     grade = 0;
   else
-    grade = sqrt (split_length) * chop_split_dist_knob;
+    grade = static_cast<PRIORITY>(sqrt (split_length) * chop_split_dist_knob);
 
   return (std::max(0.0f, grade));
 }
@@ -76,7 +76,7 @@ PRIORITY Wordrec::grade_sharpness(SPLIT *split) {
   else
     grade += 360.0;
 
-  grade *= chop_sharpness_knob;       /* Values 0 to -360 */
+  grade *= static_cast<PRIORITY>(chop_sharpness_knob);       /* Values 0 to -360 */
 
   return (grade);
 }

--- a/src/wordrec/language_model.h
+++ b/src/wordrec/language_model.h
@@ -115,7 +115,7 @@ class LanguageModel {
       // cert is assumed to be between 0 and -dict_->certainty_scale.
       // If you enable language_model_use_sigmoidal_certainty, you
       // need to adjust language_model_ngram_nonmatch_score as well.
-      cert = -cert / dict_->certainty_scale;
+      cert = -cert / static_cast<float>(dict_->certainty_scale);
       return 1.0f / (1.0f + exp(10.0f * cert));
     } else {
       return (-1.0f / cert);
@@ -125,8 +125,8 @@ class LanguageModel {
   inline float ComputeAdjustment(int num_problems, float penalty) {
     if (num_problems == 0) return 0.0f;
     if (num_problems == 1) return penalty;
-    return (penalty + (language_model_penalty_increment *
-                       static_cast<float>(num_problems-1)));
+    return (penalty + (static_cast<float> (language_model_penalty_increment) *
+                       (static_cast<float>(num_problems - 1))));
   }
 
   // Computes the adjustment to the ratings sum based on the given
@@ -138,18 +138,18 @@ class LanguageModel {
       const LMConsistencyInfo &consistency_info) {
     if (dawg_info != nullptr) {
       return ComputeAdjustment(consistency_info.NumInconsistentCase(),
-                               language_model_penalty_case) +
+                               static_cast<float>(language_model_penalty_case)) +
           (consistency_info.inconsistent_script ?
              language_model_penalty_script : 0.0f);
     }
     return (ComputeAdjustment(consistency_info.NumInconsistentPunc(),
-                              language_model_penalty_punc) +
+                              static_cast<float>(language_model_penalty_punc)) +
             ComputeAdjustment(consistency_info.NumInconsistentCase(),
-                              language_model_penalty_case) +
+                              static_cast<float>(language_model_penalty_case)) +
             ComputeAdjustment(consistency_info.NumInconsistentChartype(),
-                              language_model_penalty_chartype) +
+                              static_cast<float>(language_model_penalty_chartype)) +
             ComputeAdjustment(consistency_info.NumInconsistentSpaces(),
-                              language_model_penalty_spacing) +
+                              static_cast<float>(language_model_penalty_spacing)) +
             (consistency_info.inconsistent_script ?
              language_model_penalty_script : 0.0f) +
             (consistency_info.inconsistent_font ?

--- a/src/wordrec/lm_pain_points.cpp
+++ b/src/wordrec/lm_pain_points.cpp
@@ -109,7 +109,7 @@ void LMPainPoints::GenerateFromPath(float rating_cert_scale,
       float ol_dif = vse->outline_length - ol_subtr;
       // priority is set to the average rating of the path per unit of outline,
       // not counting the ratings of the pieces to be joined.
-      float priority = ol_dif > 0 ? (vse->ratings_sum-rat_subtr)/ol_dif : 0.0;
+      float priority = ol_dif > 0 ? (vse->ratings_sum-rat_subtr)/ol_dif : 0.0f;
       GeneratePainPoint(pain_coord.col, pain_coord.row, LM_PPTYPE_PATH,
                         priority, true, max_char_wh_ratio_, word_res);
     } else if (debug_level_ > 3) {
@@ -190,7 +190,7 @@ bool LMPainPoints::GeneratePainPoint(
     if (pp_type == LM_PPTYPE_PATH) {
       priority = special_priority;
     } else {
-      priority = associate_stats.gap_sum;
+      priority = static_cast<float>(associate_stats.gap_sum);
     }
     MatrixCoordPair pain_point(priority, MATRIX_COORD(col, row));
     pain_points_heaps_[pp_type].Push(&pain_point);

--- a/src/wordrec/lm_pain_points.h
+++ b/src/wordrec/lm_pain_points.h
@@ -103,7 +103,7 @@ class LMPainPoints {
   bool GenerateForBlamer(double max_char_wh_ratio, WERD_RES *word_res,
                          int col, int row) {
     return GeneratePainPoint(col, row, LM_PPTYPE_BLAMER, 0.0, false,
-                             max_char_wh_ratio, word_res);
+                             static_cast<float>(max_char_wh_ratio), word_res);
   }
 
   // Adds a pain point to classify chunks_record->ratings(col, row).

--- a/src/wordrec/params_model.cpp
+++ b/src/wordrec/params_model.cpp
@@ -87,7 +87,7 @@ float ParamsModel::ComputeCost(const float features[]) const {
 }
 
 bool ParamsModel::Equivalent(const ParamsModel &that) const {
-  float epsilon = 0.0001;
+  float epsilon = 0.0001f;
   for (int p = 0; p < PTRAIN_NUM_PASSES; ++p) {
     if (weights_vec_[p].size() != that.weights_vec_[p].size()) return false;
     for (int i = 0; i < weights_vec_[p].size(); i++) {

--- a/src/wordrec/segsearch.cpp
+++ b/src/wordrec/segsearch.cpp
@@ -43,12 +43,12 @@ void Wordrec::SegSearch(WERD_RES* word_res,
                         BestChoiceBundle* best_choice_bundle,
                         BlamerBundle* blamer_bundle) {
   LMPainPoints pain_points(segsearch_max_pain_points,
-                           segsearch_max_char_wh_ratio,
+                           static_cast<float>(segsearch_max_char_wh_ratio),
                            assume_fixed_pitch_char_segment,
                            &getDict(), segsearch_debug_level);
   // Compute scaling factor that will help us recover blob outline length
   // from classifier rating and certainty for the blob.
-  float rating_cert_scale = -1.0 * getDict().certainty_scale / rating_scale;
+  float rating_cert_scale = static_cast<float>(-1.0 * getDict().certainty_scale / rating_scale);
   GenericVector<SegSearchPending> pending;
   InitialSegSearch(word_res, &pain_points, &pending, best_choice_bundle,
                    blamer_bundle);
@@ -147,11 +147,11 @@ void Wordrec::InitialSegSearch(WERD_RES* word_res, LMPainPoints* pain_points,
 
   // Compute scaling factor that will help us recover blob outline length
   // from classifier rating and certainty for the blob.
-  float rating_cert_scale = -1.0 * getDict().certainty_scale / rating_scale;
+  float rating_cert_scale = static_cast<float>(-1.0 * getDict().certainty_scale / rating_scale);
 
   language_model_->InitForWord(prev_word_best_choice_,
                                assume_fixed_pitch_char_segment,
-                               segsearch_max_char_wh_ratio, rating_cert_scale);
+                               static_cast<float>(segsearch_max_char_wh_ratio), rating_cert_scale);
 
   // Initialize blamer-related information: map character boxes recorded in
   // blamer_bundle->norm_truth_word to the corresponding i,j indices in the
@@ -294,12 +294,12 @@ void Wordrec::ProcessSegSearchPainPoint(
     if (pain_point.col > 0) {
       pain_points->GeneratePainPoint(
           pain_point.col - 1, pain_point.row, LM_PPTYPE_SHAPE, 0.0,
-          true, segsearch_max_char_wh_ratio, word_res);
+          true, static_cast<float>(segsearch_max_char_wh_ratio), word_res);
     }
     if (pain_point.row + 1 < ratings->dimension()) {
       pain_points->GeneratePainPoint(
           pain_point.col, pain_point.row + 1, LM_PPTYPE_SHAPE, 0.0,
-          true, segsearch_max_char_wh_ratio, word_res);
+          true, static_cast<float>(segsearch_max_char_wh_ratio), word_res);
     }
   }
   (*pending)[pain_point.col].SetBlobClassified(pain_point.row);

--- a/src/wordrec/tface.cpp
+++ b/src/wordrec/tface.cpp
@@ -49,7 +49,7 @@ void Wordrec::program_editup(const char *textbase,
     getDict().Load(lang, init_dict);
     getDict().FinishLoad();
   }
-  pass2_ok_split = chop_ok_split;
+  pass2_ok_split = static_cast<PRIORITY>(chop_ok_split);
 #endif  // ndef DISABLED_LEGACY_ENGINE
 }
 


### PR DESCRIPTION
Environment: Window 10 Home (x64)
Processor: Intel(R) Core(TM) i5-7200U CPU @ 2.50GHz  2.71GHz
Memory: 16GB
IDE: Microsoft Visual Studio Community 2019 (Version 16.3.4)

I built it to use tesseract, but there are a lot of warnings in my build environment that make it hard to distinguish them from the warnings I've modified. So I removed the warnings in a way that would not affect existing routines. If this PR makes sense, please merge it and ignore it if it doesn't make sense in other environments.