### PR TITLE
Remove warning C4312 (casting integers to pointers)

### DIFF
--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -51,9 +51,9 @@ namespace tesseract {
 
 // Special "weak" ParagraphModels.
 const ParagraphModel *kCrownLeft
-    = reinterpret_cast<ParagraphModel *>(0xDEAD111F);
+    = reinterpret_cast<ParagraphModel *>(static_cast<uintptr_t>(0xDEAD111F));
 const ParagraphModel *kCrownRight
-    = reinterpret_cast<ParagraphModel *>(0xDEAD888F);
+    = reinterpret_cast<ParagraphModel *>(static_cast<uintptr_t>(0xDEAD888F));
 
 // Do the text and geometry of two rows support a paragraph break between them?
 static bool LikelyParagraphStart(const RowScratchRegisters &before,


### PR DESCRIPTION
Environment: Window 10 Home (x64)
Processor: Intel(R) Core(TM) i5-7200U CPU @ 2.50GHz 2.71GHz
Memory: 16GB
IDE: Microsoft Visual Studio Community 2019 (Version 16.3.4)