### PR TITLE
remove legacy parameter disable_character_fragments from lstm.train

### DIFF
--- a/tessdata/configs/lstm.train
+++ b/tessdata/configs/lstm.train
@@ -1,4 +1,3 @@
-disable_character_fragments T
 file_type                   .bl
 textord_fast_pitch_test	T
 tessedit_zero_rejection T


### PR DESCRIPTION
fixes https://github.com/tesseract-ocr/tesseract/issues/2665

`il1_adaption_test` has already been removed by earlier commit.

