### PR TITLE
Add pageseg_apply_music_mask option to allow disabling the music mask

### DIFF
--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -209,7 +209,7 @@ int Tesseract::AutoPageSeg(PageSegMode pageseg_mode, BLOCK_LIST* blocks,
 
   ColumnFinder* finder = SetupPageSegAndDetectOrientation(
       pageseg_mode, blocks, osd_tess, osr, &temp_blocks, &photomask_pix,
-      &musicmask_pix);
+      pageseg_apply_music_mask ? &musicmask_pix : nullptr);
   int result = 0;
   if (finder != nullptr) {
     TO_BLOCK_IT to_block_it(&temp_blocks);

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -526,6 +526,8 @@ Tesseract::Tesseract()
           "coefficient, the better are the ratings for each choice and less "
           "information is lost due to the cut off at 0. The standard value is "
           "5", this->params()),
+      BOOL_MEMBER(pageseg_apply_music_mask, true,
+                "Detect music staff and remove intersecting components", this->params()),
 
       backup_config_file_(nullptr),
       pix_binary_(nullptr),

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -1092,6 +1092,8 @@ class Tesseract : public Wordrec {
                "the coefficient, the better are the ratings for each choice "
                "and less information is lost due to the cut off at 0. The "
                "standard value is 5.");
+  BOOL_VAR_H(pageseg_apply_music_mask, true,
+             "Detect music staff and remove intersecting components");
 
   //// ambigsrecog.cpp /////////////////////////////////////////////////////////
   FILE* init_recog_training(const STRING& fname);


### PR DESCRIPTION
I have an image with a very large, lined table where most of the text was being dropped by the FilterMusic function, which was falsely recognizing parts of the table as a music staff.

I have added a new parameter called pageseg_apply_music_mask (default of true to preserve the current behavior) to allow this function to be disabled.

I am a little unsure of the proper name for the parameter so suggestions are welcome.