### PR TITLE
Adding --print-fonts-table parameter & tessedit_font_id configuration option

### DIFF
--- a/include/tesseract/baseapi.h
+++ b/include/tesseract/baseapi.h
@@ -170,6 +170,11 @@ class TESS_API TessBaseAPI {
   const char* GetStringVariable(const char* name) const;
 
   /**
+   * Print Tesseract fonts table to the given file.
+   */
+  void PrintFontsTable(FILE* fp) const;
+
+  /**
    * Print Tesseract parameters to the given file.
    */
   void PrintVariables(FILE* fp) const;

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -321,6 +321,22 @@ bool TessBaseAPI::GetVariableAsString(const char *name, STRING *val) {
   return ParamUtils::GetParamAsString(name, tesseract_->params(), val);
 }
 
+/** Print Tesseract fonts table to the given file. */
+void TessBaseAPI::PrintFontsTable(FILE *fp) const {
+  const int fontinfo_size = tesseract_->get_fontinfo_table().size();
+  for (int font_index = 1; font_index < fontinfo_size; ++font_index) {
+    FontInfo font = tesseract_->get_fontinfo_table().get(font_index);
+    fprintf(fp, "ID=%3d: %s is_italic=%s is_bold=%s"
+                " is_fixed_pitch=%s is_serif=%s is_fraktur=%s\n",
+                font_index, font.name,
+                font.is_italic() ? "true" : "false",
+                font.is_bold() ? "true" : "false",
+                font.is_fixed_pitch() ? "true" : "false",
+                font.is_serif() ? "true" : "false",
+                font.is_fraktur() ? "true" : "false");
+  }
+}
+
 /** Print Tesseract parameters to the given file. */
 void TessBaseAPI::PrintVariables(FILE *fp) const {
   ParamUtils::PrintParams(fp, tesseract_->params());

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -1965,8 +1965,20 @@ void Tesseract::set_word_fonts(WERD_RES *word) {
   ASSERT_HOST(word->best_choice != nullptr);
 
 #ifndef DISABLED_LEGACY_ENGINE
-  const int fontinfo_size = get_fontinfo_table().size();
+  const int fontinfo_size = fontinfo_table_.size();
   if (fontinfo_size == 0) return;
+  if (tessedit_font_id > 0) {
+    if (tessedit_font_id >= fontinfo_size) {
+      tprintf("Error, invalid font ID provided: must be below %d.\n"
+              "Falling back to font auto-detection.\n", fontinfo_size);
+    } else {
+      word->fontinfo = &fontinfo_table_.get(tessedit_font_id);
+      word->fontinfo2 = nullptr;
+      word->fontinfo_id_count = INT8_MAX;
+      word->fontinfo_id2_count = 0;
+      return;
+    }
+  }
   GenericVector<int> font_total_score;
   font_total_score.init_to_size(fontinfo_size, 0);
 

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -143,6 +143,7 @@ Tesseract::Tesseract()
                   "Add words to the document dictionary", this->params()),
       BOOL_MEMBER(tessedit_debug_fonts, false, "Output font info per char",
                   this->params()),
+      INT_MEMBER(tessedit_font_id, 0, "Font ID to use or zero", this->params()),
       BOOL_MEMBER(tessedit_debug_block_rejection, false, "Block and Row stats",
                   this->params()),
       BOOL_MEMBER(tessedit_enable_bigram_correction, true,

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -843,6 +843,8 @@ class Tesseract : public Wordrec {
   BOOL_VAR_H(tessedit_enable_doc_dict, true,
              "Add words to the document dictionary");
   BOOL_VAR_H(tessedit_debug_fonts, false, "Output font info per char");
+  INT_VAR_H(tessedit_font_id, 0, "Disable font detection and use the font"
+                                 " corresponding to the ID specified instead");
   BOOL_VAR_H(tessedit_debug_block_rejection, false, "Block and Row stats");
   BOOL_VAR_H(tessedit_enable_bigram_correction, true,
              "Enable correction based on the word bigram dictionary.");


### PR DESCRIPTION
The ability to "force select" the font has been requested a few times in the past, for example there on StackOverflow : https://stackoverflow.com/questions/13154150/explicitly-set-the-font-to-be-used-for-recognition-by-tesseract-ocr?rq=1

The new `--print-fonts-table` argument is helpful to select the value to set to the new `tessedit_font_id` configuration option.