### PR TITLE
Show libcurl version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -114,9 +114,7 @@ libtesseract_api_la_CPPFLAGS += -I$(top_srcdir)/src/opencl
 libtesseract_api_la_CPPFLAGS += -I$(top_srcdir)/src/textord
 libtesseract_api_la_CPPFLAGS += -I$(top_srcdir)/src/viewer
 libtesseract_api_la_CPPFLAGS += -I$(top_srcdir)/src/wordrec
-if HAVE_LIBCURL
-libtesseract_api_la_CPPFLAGS += $(libcurl_CFLAGS) -DHAVE_LIBCURL
-endif
+libtesseract_api_la_CPPFLAGS += $(libcurl_CFLAGS)
 
 noinst_LTLIBRARIES += libtesseract_api.la
 

--- a/configure.ac
+++ b/configure.ac
@@ -428,6 +428,9 @@ AC_CHECK_TYPES([mbstate_t],,, [#include "wchar.h"])
 
 PKG_CHECK_MODULES([libcurl], [libcurl], [have_libcurl=true], [have_libcurl=false])
 AM_CONDITIONAL([HAVE_LIBCURL], $have_libcurl)
+if $have_libcurl; then
+  AC_DEFINE([HAVE_LIBCURL], [1], [Enable libcurl])
+fi
 
 PKG_CHECK_MODULES([LEPTONICA], [lept >= 1.74], [have_lept=true], [have_lept=false])
 if $have_lept; then
@@ -439,7 +442,7 @@ fi
 PKG_CHECK_MODULES([libarchive], [libarchive], [have_libarchive=true], [have_libarchive=false])
 AM_CONDITIONAL([HAVE_LIBARCHIVE], [$have_libarchive])
 if $have_libarchive; then
-  AC_DEFINE([HAVE_LIBARCHIVE], [], [Enable libarchive])
+  AC_DEFINE([HAVE_LIBARCHIVE], [1], [Enable libarchive])
   CPPFLAGS="$CPPFLAGS $libarchive_CFLAGS"
 fi
 

--- a/src/api/tesseractmain.cpp
+++ b/src/api/tesseractmain.cpp
@@ -41,6 +41,9 @@
 #if defined(HAVE_LIBARCHIVE)
 #include <archive.h>
 #endif
+#if defined(HAVE_LIBCURL)
+#include <curl/curl.h>
+#endif
 
 #if defined(_WIN32)
 #include <fcntl.h>
@@ -148,7 +151,9 @@ static void PrintVersionInfo() {
   printf(" Found %s\n", archive_version_string());
 #  endif  // ARCHIVE_VERSION_NUMBER
 #endif    // HAVE_LIBARCHIVE
-
+#if defined(HAVE_LIBCURL)
+  printf(" Found %s\n", curl_version());
+#endif
 }
 
 static void PrintHelpForPSM() {


### PR DESCRIPTION
`tesseract --version` now also shows the version of libcurl and related
libraries if it was build with libcurl.

The preprocessor macro HAVE_LIBCURL is now defined in config_auto.h.

Signed-off-by: Stefan Weil <sw@weilnetz.de>