### PR TITLE
make BlockPolygon usable

### DIFF
--- a/src/ccmain/pageiterator.cpp
+++ b/src/ccmain/pageiterator.cpp
@@ -370,7 +370,13 @@ Pta* PageIterator::BlockPolygon() const {
     return nullptr;  // Already at the end!
   if (it_->block()->block->pdblk.poly_block() == nullptr)
     return nullptr;  // No layout analysis used - no polygon.
-  ICOORDELT_IT it(it_->block()->block->pdblk.poly_block()->points());
+  // Copy polygon, so we can unrotate it to image coordinates.
+  POLY_BLOCK* internal_poly = it_->block()->block->pdblk.poly_block();
+  ICOORDELT_LIST vertices;
+  vertices.deep_copy(internal_poly->points(), ICOORDELT::deep_copy);
+  POLY_BLOCK poly(&vertices, internal_poly->isA());
+  poly.rotate(it_->block()->block->re_rotation());
+  ICOORDELT_IT it(poly.points());
   Pta* pta = ptaCreate(it.length());
   int num_pts = 0;
   for (it.mark_cycle_pt(); !it.cycled_list(); it.forward(), ++num_pts) {

--- a/src/ccmain/pageiterator.cpp
+++ b/src/ccmain/pageiterator.cpp
@@ -382,8 +382,10 @@ Pta* PageIterator::BlockPolygon() const {
   for (it.mark_cycle_pt(); !it.cycled_list(); it.forward(), ++num_pts) {
     ICOORD* pt = it.data();
     // Convert to top-down coords within the input image.
-    float x = static_cast<float>(pt->x()) / scale_ + rect_left_;
-    float y = rect_top_ + rect_height_ - static_cast<float>(pt->y()) / scale_;
+    int x = static_cast<float>(pt->x()) / scale_ + rect_left_;
+    int y = rect_top_ + rect_height_ - static_cast<float>(pt->y()) / scale_;
+    x = ClipToRange(x, rect_left_, rect_left_ + rect_width_);
+    y = ClipToRange(y, rect_top_, rect_top_ + rect_height_);
     ptaAddPt(pta, x, y);
   }
   return pta;


### PR DESCRIPTION
Layout analysis delivers segments that often need to be non-rectangular to accomodate close neighbours, image near text, ragged/unaligned lines etc. The CLI builds on the internal, polygon-based data structures, which allow for that without conflicts/overlaps. But API users up until now could only use bounding boxes, because `BlockPolygon` did not deliver correct coordinates:

1. unlike `BoundingBox`, they were not "unrotated" (i.e. the internal deskewing has not been compensated for, giving coordinates widely out of scope)
2. unlike `BoundingBox`, they were not clipped (i.e. forced into the interval of the image/rectangle)

Both issues have been fixed here. 

But there is a third problem that I have not tackled yet: Polygon paths are often self-intersecting or otherwise unusable. This even confuses Tesseract itself when it tries to provide `GetImage()` on the raw image (i.e. when passed non-null `original_img`). It's not even enough to take the convex hull of these invalid paths. (My guess is that there is a bug in the incremental aggregation of the polyblock segments, in how it orders them, depending on their orientation.)

Anyway, this is already much more usable than before. I can provide example images if necessary.