### PR TITLE
Remove redundant method from class GenericVector

### DIFF
--- a/include/tesseract/genericvector.h
+++ b/include/tesseract/genericvector.h
@@ -82,10 +82,6 @@ class GenericVector {
     return size_reserved_;
   }
 
-  int length() const {
-    return size_used_;
-  }
-
   // Return true if empty.
   bool empty() const {
     return size_used_ == 0;

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -721,9 +721,9 @@ void Tesseract::blamer_pass(PAGE_RES* page_res) {
         static_cast<IncorrectResultReason>(bl)),
         page_res->blame_reasons[bl]);
   }
-  if (page_res->misadaption_log.length() > 0) {
+  if (page_res->misadaption_log.size() > 0) {
     tprintf("Misadaption log:\n");
-    for (int i = 0; i < page_res->misadaption_log.length(); ++i) {
+    for (int i = 0; i < page_res->misadaption_log.size(); ++i) {
       tprintf("%s\n", page_res->misadaption_log[i].c_str());
     }
   }

--- a/src/ccstruct/blamer.cpp
+++ b/src/ccstruct/blamer.cpp
@@ -130,7 +130,7 @@ void BlamerBundle::FillDebugString(const STRING &msg,
                                    const WERD_CHOICE *choice,
                                    STRING *debug) {
   (*debug) += "Truth ";
-  for (int i = 0; i < this->truth_text_.length(); ++i) {
+  for (int i = 0; i < this->truth_text_.size(); ++i) {
     (*debug) += this->truth_text_[i];
   }
   if (!this->truth_has_char_boxes_) (*debug) += " (no char boxes)";
@@ -451,12 +451,12 @@ void BlamerBundle::SetupCorrectSegmentation(const TWERD* word, bool debug) {
     }
   }
   if (blob_index < num_blobs ||  // trailing blobs
-      correct_segmentation_cols_.length() != norm_truth_word_.length()) {
+      correct_segmentation_cols_.size() != norm_truth_word_.length()) {
     debug_str.add_str_int("Blamer failed to find correct segmentation"
                           " (tolerance=", norm_box_tolerance_);
     if (blob_index >= num_blobs) debug_str += " blob == nullptr";
     debug_str += ")\n";
-    debug_str.add_str_int(" path length ", correct_segmentation_cols_.length());
+    debug_str.add_str_int(" path length ", correct_segmentation_cols_.size());
     debug_str.add_str_int(" vs. truth ", norm_truth_word_.length());
     debug_str += "\n";
     SetBlame(IRR_UNKNOWN, debug_str, nullptr, debug);
@@ -488,7 +488,7 @@ void BlamerBundle::InitForSegSearch(const WERD_CHOICE* best_choice,
   // Fill pain points for any unclassifed blob corresponding to the
   // correct segmentation state.
   *debug_str += "Correct segmentation:\n";
-  for (int idx = 0; idx < correct_segmentation_cols_.length(); ++idx) {
+  for (int idx = 0; idx < correct_segmentation_cols_.size(); ++idx) {
     debug_str->add_str_int("col=", correct_segmentation_cols_[idx]);
     debug_str->add_str_int(" row=", correct_segmentation_rows_[idx]);
     *debug_str += "\n";

--- a/src/ccstruct/blamer.h
+++ b/src/ccstruct/blamer.h
@@ -114,7 +114,7 @@ struct BlamerBundle {
   // Accessors.
   STRING TruthString() const {
     STRING truth_str;
-    for (int i = 0; i < truth_text_.length(); ++i)
+    for (int i = 0; i < truth_text_.size(); ++i)
       truth_str += truth_text_[i];
     return truth_str;
   }
@@ -139,7 +139,7 @@ struct BlamerBundle {
       best_correctly_segmented_rating_ = rating;
   }
   int correct_segmentation_length() const {
-    return correct_segmentation_cols_.length();
+    return correct_segmentation_cols_.size();
   }
   // Returns true if the given ratings matrix col,row position is included
   // in the correct segmentation path at the given index.

--- a/src/ccstruct/pageres.cpp
+++ b/src/ccstruct/pageres.cpp
@@ -797,7 +797,7 @@ void WERD_RES::ReplaceBestChoice(WERD_CHOICE* choice) {
   SetupBoxWord();
   // Make up a fake reject map of the right length to keep the
   // rejection pass happy.
-  reject_map.initialise(best_state.length());
+  reject_map.initialise(best_state.size());
   done = tess_accepted = tess_would_adapt = true;
   SetScriptPositions();
 }
@@ -975,7 +975,7 @@ void WERD_RES::MergeAdjacentBlobs(int index) {
   best_choice->remove_unichar_id(index + 1);
   rebuild_word->MergeBlobs(index, index + 2);
   box_word->MergeBoxes(index, index + 2);
-  if (index + 1 < best_state.length()) {
+  if (index + 1 < best_state.size()) {
     best_state[index] += best_state[index + 1];
     best_state.remove(index + 1);
   }

--- a/src/dict/dict.cpp
+++ b/src/dict/dict.cpp
@@ -190,7 +190,7 @@ DawgCache* Dict::GlobalDawgCache() {
 
 // Sets up ready for a Load or LoadLSTM.
 void Dict::SetupForLoad(DawgCache* dawg_cache) {
-  if (dawgs_.length() != 0) this->End();
+  if (dawgs_.size() != 0) this->End();
 
   apostrophe_unichar_id_ = getUnicharset().unichar_to_id(kApostropheSymbol);
   question_unichar_id_ = getUnicharset().unichar_to_id(kQuestionSymbol);
@@ -353,11 +353,11 @@ bool Dict::FinishLoad() {
   // Construct a list of corresponding successors for each dawg. Each entry, i,
   // in the successors_ vector is a vector of integers that represent the
   // indices into the dawgs_ vector of the successors for dawg i.
-  successors_.reserve(dawgs_.length());
-  for (int i = 0; i < dawgs_.length(); ++i) {
+  successors_.reserve(dawgs_.size());
+  for (int i = 0; i < dawgs_.size(); ++i) {
     const Dawg* dawg = dawgs_[i];
     auto* lst = new SuccessorList();
-    for (int j = 0; j < dawgs_.length(); ++j) {
+    for (int j = 0; j < dawgs_.size(); ++j) {
       const Dawg* other = dawgs_[j];
       if (dawg != nullptr && other != nullptr &&
           (dawg->lang() == other->lang()) &&
@@ -370,7 +370,7 @@ bool Dict::FinishLoad() {
 }
 
 void Dict::End() {
-  if (dawgs_.length() == 0) return;  // Not safe to call twice.
+  if (dawgs_.size() == 0) return;  // Not safe to call twice.
   for (int i = 0; i < dawgs_.size(); i++) {
     if (!dawg_cache_->FreeDawg(dawgs_[i])) {
       delete dawgs_[i];
@@ -403,7 +403,7 @@ int Dict::def_letter_is_okay(void* void_dawg_args, const UNICHARSET& unicharset,
         "def_letter_is_okay: current unichar=%s word_end=%d"
         " num active dawgs=%d\n",
         getUnicharset().debug_str(unichar_id).c_str(), word_end,
-        dawg_args->active_dawgs->length());
+        dawg_args->active_dawgs->size());
   }
 
   // Do not accept words that contain kPatternUnicharID.
@@ -423,7 +423,7 @@ int Dict::def_letter_is_okay(void* void_dawg_args, const UNICHARSET& unicharset,
   // Go over the active_dawgs vector and insert DawgPosition records
   // with the updated ref (an edge with the corresponding unichar id) into
   // dawg_args->updated_pos.
-  for (int a = 0; a < dawg_args->active_dawgs->length(); ++a) {
+  for (int a = 0; a < dawg_args->active_dawgs->size(); ++a) {
     const DawgPosition& pos = (*dawg_args->active_dawgs)[a];
     const Dawg* punc_dawg =
         pos.punc_index >= 0 ? dawgs_[pos.punc_index] : nullptr;
@@ -442,7 +442,7 @@ int Dict::def_letter_is_okay(void* void_dawg_args, const UNICHARSET& unicharset,
       if (punc_transition_edge != NO_EDGE) {
         // Find all successors, and see which can transition.
         const SuccessorList& slist = *(successors_[pos.punc_index]);
-        for (int s = 0; s < slist.length(); ++s) {
+        for (int s = 0; s < slist.size(); ++s) {
           int sdawg_index = slist[s];
           const Dawg* sdawg = dawgs_[sdawg_index];
           UNICHAR_ID ch = char_for_dawg(unicharset, unichar_id, sdawg);
@@ -620,7 +620,7 @@ void Dict::default_dawgs(DawgPositionVector* dawg_pos_vec,
       (punc_dawg_ != nullptr) &&
       punc_dawg_->edge_char_of(0, Dawg::kPatternUnicharID, true) != NO_EDGE;
 
-  for (int i = 0; i < dawgs_.length(); i++) {
+  for (int i = 0; i < dawgs_.size(); i++) {
     if (dawgs_[i] != nullptr &&
         !(suppress_patterns && (dawgs_[i])->type() == DAWG_TYPE_PATTERN)) {
       int dawg_ty = dawgs_[i]->type();

--- a/src/dict/permdawg.cpp
+++ b/src/dict/permdawg.cpp
@@ -169,10 +169,10 @@ WERD_CHOICE *Dict::dawg_permute_and_select(
   auto *best_choice = new WERD_CHOICE(&getUnicharset());
   best_choice->make_bad();
   best_choice->set_rating(rating_limit);
-  if (char_choices.length() == 0 || char_choices.length() > MAX_WERD_LENGTH)
+  if (char_choices.size() == 0 || char_choices.size() > MAX_WERD_LENGTH)
     return best_choice;
   auto *active_dawgs =
-      new DawgPositionVector[char_choices.length() + 1];
+      new DawgPositionVector[char_choices.size() + 1];
   init_active_dawgs(&(active_dawgs[0]), true);
   DawgArgs dawg_args(&(active_dawgs[0]), &(active_dawgs[1]), NO_PERM);
   WERD_CHOICE word(&getUnicharset(), MAX_WERD_LENGTH);
@@ -210,7 +210,7 @@ void Dict::permute_choices(
             debug, char_choice_index, *limit, word->rating(),
             word->certainty(), word->debug_string().c_str());
   }
-  if (char_choice_index < char_choices.length()) {
+  if (char_choice_index < char_choices.size()) {
     BLOB_CHOICE_IT blob_choice_it;
     blob_choice_it.set_to_list(char_choices.get(char_choice_index));
     for (blob_choice_it.mark_cycle_pt(); !blob_choice_it.cycled_list();
@@ -247,7 +247,7 @@ void Dict::append_choices(
     WERD_CHOICE *best_choice,
     int *attempts_left,
     void *more_args) {
-  int word_ending = (char_choice_index == char_choices.length() - 1);
+  int word_ending = (char_choice_index == char_choices.size() - 1);
 
   // Deal with fragments.
   CHAR_FRAGMENT_INFO char_frag_info;

--- a/src/dict/stopper.cpp
+++ b/src/dict/stopper.cpp
@@ -296,7 +296,7 @@ bool Dict::NoDangerousAmbig(WERD_CHOICE *best_choice,
   if (ambigs_found) {
     if (stopper_debug_level > 2) {
       tprintf("\nResulting ambig_blob_choices:\n");
-      for (i = 0; i < ambig_blob_choices.length(); ++i) {
+      for (i = 0; i < ambig_blob_choices.size(); ++i) {
         print_ratings_list("", ambig_blob_choices.get(i), getUnicharset());
         tprintf("\n");
       }

--- a/src/dict/trie.cpp
+++ b/src/dict/trie.cpp
@@ -267,7 +267,7 @@ bool Trie::add_word_to_dawg(const WERD_CHOICE &word,
 NODE_REF Trie::new_dawg_node() {
   auto *node = new TRIE_NODE_RECORD();
   nodes_.push_back(node);
-  return nodes_.length() - 1;
+  return nodes_.size() - 1;
 }
 
 // Sort function to sort words by decreasing order of length.

--- a/src/textord/tablerecog.cpp
+++ b/src/textord/tablerecog.cpp
@@ -95,10 +95,10 @@ bool StructuredTable::is_lined() const {
   return is_lined_;
 }
 int StructuredTable::row_count() const {
-  return cell_y_.length() == 0 ? 0 : cell_y_.length() - 1;
+  return cell_y_.size() == 0 ? 0 : cell_y_.size() - 1;
 }
 int StructuredTable::column_count() const {
-  return cell_x_.length() == 0 ? 0 : cell_x_.length() - 1;
+  return cell_x_.size() == 0 ? 0 : cell_x_.size() - 1;
 }
 int StructuredTable::cell_count() const {
   return row_count() * column_count();
@@ -157,7 +157,7 @@ bool StructuredTable::FindLinedStructure() {
   // HasSignificantLines should guarantee cells.
   // Because that code is a different class, just gracefully
   // return false. This could be an assert.
-  if (cell_x_.length() < 3 || cell_y_.length() < 3)
+  if (cell_x_.size() < 3 || cell_y_.size() < 3)
     return false;
 
   cell_x_.sort();
@@ -169,9 +169,9 @@ bool StructuredTable::FindLinedStructure() {
 
   // The border should be the extents of line boxes, not middle.
   cell_x_[0] = bounding_box_.left();
-  cell_x_[cell_x_.length() - 1] = bounding_box_.right();
+  cell_x_[cell_x_.size() - 1] = bounding_box_.right();
   cell_y_[0] = bounding_box_.bottom();
-  cell_y_[cell_y_.length() - 1] = bounding_box_.top();
+  cell_y_[cell_y_.size() - 1] = bounding_box_.top();
 
   // Remove duplicates that may have occurred due to moving the borders.
   cell_x_.compact_sorted();
@@ -193,9 +193,9 @@ bool StructuredTable::FindWhitespacedStructure() {
     return false;
   } else {
     bounding_box_.set_left(cell_x_[0]);
-    bounding_box_.set_right(cell_x_[cell_x_.length() - 1]);
+    bounding_box_.set_right(cell_x_[cell_x_.size() - 1]);
     bounding_box_.set_bottom(cell_y_[0]);
-    bounding_box_.set_top(cell_y_[cell_y_.length() - 1]);
+    bounding_box_.set_top(cell_y_[cell_y_.size() - 1]);
     AbsorbNearbyLines();
     CalculateMargins();
     CalculateStats();
@@ -210,10 +210,10 @@ bool StructuredTable::FindWhitespacedStructure() {
 // throughout the code is that "0" distance is a very very small space.
 bool StructuredTable::DoesPartitionFit(const ColPartition& part) const {
   const TBOX& box = part.bounding_box();
-  for (int i = 0; i < cell_x_.length(); ++i)
+  for (int i = 0; i < cell_x_.size(); ++i)
     if (box.left() < cell_x_[i] && cell_x_[i] < box.right())
       return false;
-  for (int i = 0; i < cell_y_.length(); ++i)
+  for (int i = 0; i < cell_y_.size(); ++i)
     if (box.bottom() < cell_y_[i] && cell_y_[i] < box.top())
       return false;
   return true;
@@ -292,11 +292,11 @@ void StructuredTable::Display(ScrollView* window, ScrollView::Color color) {
   window->Pen(color);
   window->Rectangle(bounding_box_.left(), bounding_box_.bottom(),
                     bounding_box_.right(), bounding_box_.top());
-  for (int i = 0; i < cell_x_.length(); i++) {
+  for (int i = 0; i < cell_x_.size(); i++) {
     window->Line(cell_x_[i], bounding_box_.bottom(),
                  cell_x_[i], bounding_box_.top());
   }
-  for (int i = 0; i < cell_y_.length(); i++) {
+  for (int i = 0; i < cell_y_.size(); i++) {
     window->Line(bounding_box_.left(), cell_y_[i],
                  bounding_box_.right(), cell_y_[i]);
   }
@@ -321,12 +321,12 @@ void StructuredTable::ClearStructure() {
 // The following function makes sure the previous assumption is met.
 bool StructuredTable::VerifyLinedTableCells() {
   // Function only called when lines exist.
-  ASSERT_HOST(cell_y_.length() >= 2 && cell_x_.length() >= 2);
-  for (int i = 0; i < cell_y_.length(); ++i) {
+  ASSERT_HOST(cell_y_.size() >= 2 && cell_x_.size() >= 2);
+  for (int i = 0; i < cell_y_.size(); ++i) {
     if (CountHorizontalIntersections(cell_y_[i]) > 0)
       return false;
   }
-  for (int i = 0; i < cell_x_.length(); ++i) {
+  for (int i = 0; i < cell_x_.size(); ++i) {
     if (CountVerticalIntersections(cell_x_[i]) > 0)
       return false;
   }
@@ -374,7 +374,7 @@ void StructuredTable::FindWhitespacedColumns() {
     right_sides.push_back(text->bounding_box().right() + spacing);
   }
   // It causes disaster below, so avoid it!
-  if (left_sides.length() == 0 || right_sides.length() == 0)
+  if (left_sides.size() == 0 || right_sides.size() == 0)
     return;
 
   // Since data may be inserted in grid order, we sort the left/right sides.
@@ -440,7 +440,7 @@ void StructuredTable::FindWhitespacedRows() {
     top_sides.push_back(top);
   }
   // It causes disaster below, so avoid it!
-  if (bottom_sides.length() == 0 || top_sides.length() == 0)
+  if (bottom_sides.size() == 0 || top_sides.size() == 0)
     return;
 
   // Since data may be inserted in grid order, we sort the bottom/top sides.
@@ -458,7 +458,7 @@ void StructuredTable::FindWhitespacedRows() {
 
   // Recover the min/max correctly since it was shifted.
   cell_y_[0] = min_bottom;
-  cell_y_[cell_y_.length() - 1] = max_top;
+  cell_y_[cell_y_.size() - 1] = max_top;
 }
 
 void StructuredTable::CalculateMargins() {
@@ -594,12 +594,12 @@ void StructuredTable::FindCellSplitLocations(const GenericVector<int>& min_list,
                                              int max_merged,
                                              GenericVector<int>* locations) {
   locations->clear();
-  ASSERT_HOST(min_list.length() == max_list.length());
-  if (min_list.length() == 0)
+  ASSERT_HOST(min_list.size() == max_list.size());
+  if (min_list.size() == 0)
     return;
   ASSERT_HOST(min_list.get(0) < max_list.get(0));
-  ASSERT_HOST(min_list.get(min_list.length() - 1) <
-              max_list.get(max_list.length() - 1));
+  ASSERT_HOST(min_list.get(min_list.size() - 1) <
+              max_list.get(max_list.size() - 1));
 
   locations->push_back(min_list.get(0));
   int min_index = 0;
@@ -609,7 +609,7 @@ void StructuredTable::FindCellSplitLocations(const GenericVector<int>& min_list,
   // max_index will expire after min_index.
   // However, we can't "increase" the hill size if min_index expired.
   // So finish processing when min_index expires.
-  while (min_index < min_list.length()) {
+  while (min_index < min_list.size()) {
     // Increase the hill count.
     if (min_list[min_index] < max_list[max_index]) {
       ++stacked_partitions;
@@ -630,7 +630,7 @@ void StructuredTable::FindCellSplitLocations(const GenericVector<int>& min_list,
       ++max_index;
     }
   }
-  locations->push_back(max_list.get(max_list.length() - 1));
+  locations->push_back(max_list.get(max_list.size() - 1));
 }
 
 // Counts the number of partitions in the table

--- a/src/wordrec/chopper.cpp
+++ b/src/wordrec/chopper.cpp
@@ -553,7 +553,7 @@ int Wordrec::select_blob_to_split(
   }
 
   if (split_next_to_fragment && blob_choices.size() > 0) {
-    fragments = new const CHAR_FRAGMENT *[blob_choices.length()];
+    fragments = new const CHAR_FRAGMENT *[blob_choices.size()];
     if (blob_choices[0] != nullptr) {
       fragments[0] = getDict().getUnicharset().get_fragment(
           blob_choices[0]->unichar_id());

--- a/unittest/tablerecog_test.cc
+++ b/unittest/tablerecog_test.cc
@@ -52,17 +52,17 @@ class TestableStructuredTable : public tesseract::StructuredTable {
 
   void ExpectCellX(int x_min, int second, int add, int almost_done, int x_max) {
     ASSERT_EQ(0, (almost_done - second) % add);
-    EXPECT_EQ(3 + (almost_done - second) / add, cell_x_.length());
+    EXPECT_EQ(3 + (almost_done - second) / add, cell_x_.size());
     EXPECT_EQ(x_min, cell_x_.get(0));
-    EXPECT_EQ(x_max, cell_x_.get(cell_x_.length() - 1));
-    for (int i = 1; i < cell_x_.length() - 1; ++i) {
+    EXPECT_EQ(x_max, cell_x_.get(cell_x_.size() - 1));
+    for (int i = 1; i < cell_x_.size() - 1; ++i) {
       EXPECT_EQ(second + add * (i - 1), cell_x_.get(i));
     }
   }
 
   void ExpectSortedX() {
-    EXPECT_GT(cell_x_.length(), 0);
-    for (int i = 1; i < cell_x_.length(); ++i) {
+    EXPECT_GT(cell_x_.size(), 0);
+    for (int i = 1; i < cell_x_.size(); ++i) {
       EXPECT_LT(cell_x_.get(i - 1), cell_x_.get(i));
     }
   }


### PR DESCRIPTION
length() is not needed: it can be replaced by size().

Signed-off-by: Stefan Weil <sw@weilnetz.de>