### PR TITLE
Fix "tesseract.exe not flushing stdout/stderr" (Issue #2859)

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -1015,7 +1015,6 @@ bool TessBaseAPI::ProcessPagesFileList(FILE *flist,
       return false;
     }
     tprintf("Page %d : %s\n", page, pagename);
-    fflush(stderr);
     bool r = ProcessPage(pix, page, pagename, retry_config,
                          timeout_millisec, renderer);
     pixDestroy(&pix);

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -1015,6 +1015,7 @@ bool TessBaseAPI::ProcessPagesFileList(FILE *flist,
       return false;
     }
     tprintf("Page %d : %s\n", page, pagename);
+    fflush(stderr);
     bool r = ProcessPage(pix, page, pagename, retry_config,
                          timeout_millisec, renderer);
     pixDestroy(&pix);

--- a/src/api/renderer.cpp
+++ b/src/api/renderer.cpp
@@ -105,6 +105,7 @@ void TessResultRenderer::AppendString(const char* s) {
 
 void TessResultRenderer::AppendData(const char* s, int len) {
   if (!tesseract::Serialize(fout_, s, len)) happy_ = false;
+  fflush(fout_);
 }
 
 bool TessResultRenderer::BeginDocumentHandler() {


### PR DESCRIPTION
In my application, I spawn tesseract.exe from java and continuously send request (path to image) / receive response  (tokens) through standard pipe-stdio.

For example, tesseract is launched with following args.
```
tesseract.exe stdin stdout -c stream_filelist=true
```

Problem with the existing code, **tokens are never flushed from  tesseract.exe** when OCR is finished for the image (token is fully-buffered).  In other words, tokens will not be flushed until tesseract.exe is killed, because they are only buffered.

Based on research, this is due to the way buffering behaves differently for following streams:
![buffering](https://user-images.githubusercontent.com/55756666/72619873-3af8dc00-390c-11ea-8e22-d0f1fb21de69.png)
Since Java communicates with the child process over a pipe, it falls into the “stdout (not a TTY)” category.
More ref: https://eklitzke.org/stdout-buffering

I was able to resolve by adding flush command in source code.

Reference: https://github.com/tesseract-ocr/tesseract/issues/2859