### PR TITLE
[trie.h] pattern definition: fix documentation

### DIFF
--- a/src/dict/trie.h
+++ b/src/dict/trie.h
@@ -197,7 +197,7 @@ class Trie : public Dawg {
   // To denote a character class use one of:
   // \c - unichar for which UNICHARSET::get_isalpha() is true (character)
   // \d - unichar for which UNICHARSET::get_isdigit() is true
-  // \n - unichar for which UNICHARSET::get_isdigit() and
+  // \n - unichar for which UNICHARSET::get_isdigit() or
   //      UNICHARSET::isalpha() are true
   // \p - unichar for which UNICHARSET::get_ispunct() is true
   // \a - unichar for which UNICHARSET::get_islower() is true


### PR DESCRIPTION
The fix makes the definition of `\n` consistent with the examples given below the definition.  Please note that I did not check this against how it is implemented in the code.