### PR TITLE
Add TessBaseAPI::GetPageRes again

### DIFF
--- a/include/tesseract/baseapi.h
+++ b/include/tesseract/baseapi.h
@@ -800,6 +800,10 @@ class TESS_API TessBaseAPI {
   //// paragraphs.cpp ////////////////////////////////////////////////////
   TESS_LOCAL void DetectParagraphs(bool after_text_recognition);
 
+  TESS_LOCAL const PAGE_RES* GetPageRes() const {
+    return page_res_;
+  }
+
  protected:
   Tesseract* tesseract_;           ///< The underlying data object.
   Tesseract* osd_tesseract_;       ///< For orientation & script detection.

--- a/unittest/baseapi_test.cc
+++ b/unittest/baseapi_test.cc
@@ -257,10 +257,6 @@ TEST_F(TesseractTest, BasicLSTMTest) {
 // errors due to float/int conversions (e.g., see OUTLINE::move() in
 // ccstruct/poutline.h) Instead, we do a loose check.
 TEST_F(TesseractTest, LSTMGeometryTest) {
-#ifdef DISABLED_LEGACY_ENGINE
-  // Skip test because TessBaseAPI::GetPageRes is missing.
-  GTEST_SKIP();
-#else
   Pix* src_pix = pixRead(TestDataNameToPath("deslant.tif").c_str());
   FriendlyTessBaseAPI api;
   if (api.Init(TessdataPath().c_str(), "eng", tesseract::OEM_LSTM_ONLY) == -1) {
@@ -303,7 +299,6 @@ TEST_F(TesseractTest, LSTMGeometryTest) {
     }
   }
   pixDestroy(&src_pix);
-#endif
 }
 
 TEST_F(TesseractTest, InitConfigOnlyTest) {


### PR DESCRIPTION
It is now added unconditionally, so it is always available for the unittest.

Signed-off-by: Stefan Weil <sw@weilnetz.de>