### PR TITLE
Add a mechanism to avoid creating debug fonts.

### DIFF
--- a/src/ccstruct/debugpixa.h
+++ b/src/ccstruct/debugpixa.h
@@ -12,7 +12,11 @@ class DebugPixa {
   // TODO(rays) add another constructor with size control.
   DebugPixa() {
     pixa_ = pixaCreate(0);
+#ifdef TESSERACT_DISABLE_DEBUG_FONTS
+    fonts_ = NULL;
+#else
     fonts_ = bmfCreate(nullptr, 14);
+#endif
   }
   // If the filename_ has been set and there are any debug images, they are
   // written to the set filename_.


### PR DESCRIPTION
If TESSERACT_DISABLE_DEBUG_FONTS is defined, tesseract doesn't
atetmpt to create any debug fonts. This not only saves memory,
but it (combined with the change to optionally use Pix as
internal storage for the ImageData) allows us to use an
embedded Leptonica library with no format handlers at all.