### PR TITLE
Ensure PACKAGE_VERSION is defined, even without config.h

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -57,7 +57,6 @@
 #include "blobclass.h"         // for ExtractFontName
 #endif
 #include "boxword.h"           // for BoxWord
-#include "config_auto.h"       // for PACKAGE_VERSION
 #include "coutln.h"            // for C_OUTLINE_IT, C_OUTLINE_LIST
 #include "dawg_cache.h"        // for DawgCache
 #include "dict.h"              // for Dict
@@ -235,7 +234,7 @@ TessBaseAPI::~TessBaseAPI() {
  * Returns the version identifier as a static string. Do not delete.
  */
 const char* TessBaseAPI::Version() {
-  return PACKAGE_VERSION;
+  return TESSERACT_VERSION_STR;
 }
 
 /**

--- a/src/api/hocrrenderer.cpp
+++ b/src/api/hocrrenderer.cpp
@@ -460,7 +460,7 @@ bool TessHOcrRenderer::BeginDocumentHandler() {
       "</title>\n"
       "  <meta http-equiv=\"Content-Type\" content=\"text/html;"
       "charset=utf-8\"/>\n"
-      "  <meta name='ocr-system' content='tesseract " PACKAGE_VERSION
+      "  <meta name='ocr-system' content='tesseract " TESSERACT_VERSION_STR
       "' />\n"
       "  <meta name='ocr-capabilities' content='ocr_page ocr_carea ocr_par"
       " ocr_line ocrx_word ocrp_wconf");

--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -34,20 +34,21 @@
 #include <tesseract/helpers.h>
 #include <tesseract/serialis.h>
 #include <tesseract/strngs.h>
+#include <tesseract/version.h>
 #include "tprintf.h"
 #include "params.h"
 
 namespace tesseract {
 
 TessdataManager::TessdataManager() : reader_(nullptr), is_loaded_(false), swap_(false) {
-  SetVersionString(PACKAGE_VERSION);
+  SetVersionString(TESSERACT_VERSION_STR);
 }
 
 TessdataManager::TessdataManager(FileReader reader)
   : reader_(reader),
     is_loaded_(false),
     swap_(false) {
-  SetVersionString(PACKAGE_VERSION);
+  SetVersionString(TESSERACT_VERSION_STR);
 }
 
 // Lazily loads from the the given filename. Won't actually read the file


### PR DESCRIPTION
If we aren't using config.h, then PACKAGE_VERSION is not
defined. Spot this, and include tess_version.h to get
TESSERACT_VERSION_STR instead.