### PR TITLE
Moved oss-fuzz build script to Tesseracts own repository

### DIFF
--- a/unittest/fuzzers/oss-fuzz-build.sh
+++ b/unittest/fuzzers/oss-fuzz-build.sh
@@ -1,0 +1,41 @@
+cd $SRC/leptonica
+./autogen.sh
+./configure
+make -j$(nproc)
+make install
+ldconfig
+
+cd $SRC/tesseract
+./autogen.sh
+CXXFLAGS="$CXXFLAGS -D_GLIBCXX_DEBUG" ./configure --disable-graphics --disable-shared
+make -j$(nproc)
+
+cp -R $SRC/tessdata $OUT
+
+$CXX $CXXFLAGS \
+    -I $SRC/tesseract/include \
+     $SRC/tesseract/unittest/fuzzers/fuzzer-api.cpp -o $OUT/fuzzer-api \
+     $SRC/tesseract/.libs/libtesseract.a \
+     /usr/local/lib/liblept.a \
+     /usr/lib/x86_64-linux-gnu/libtiff.a \
+     /usr/lib/x86_64-linux-gnu/libpng.a \
+     /usr/lib/x86_64-linux-gnu/libjpeg.a \
+     /usr/lib/x86_64-linux-gnu/libjbig.a \
+     /usr/lib/x86_64-linux-gnu/liblzma.a \
+     -lz \
+     $LIB_FUZZING_ENGINE
+
+$CXX $CXXFLAGS \
+    -DTESSERACT_FUZZER_WIDTH=512 \
+    -DTESSERACT_FUZZER_HEIGHT=256 \
+    -I $SRC/tesseract/include \
+     $SRC/tesseract/unittest/fuzzers/fuzzer-api.cpp -o $OUT/fuzzer-api-512x256 \
+     $SRC/tesseract/.libs/libtesseract.a \
+     /usr/local/lib/liblept.a \
+     /usr/lib/x86_64-linux-gnu/libtiff.a \
+     /usr/lib/x86_64-linux-gnu/libpng.a \
+     /usr/lib/x86_64-linux-gnu/libjpeg.a \
+     /usr/lib/x86_64-linux-gnu/libjbig.a \
+     /usr/lib/x86_64-linux-gnu/liblzma.a \
+     -lz \
+     $LIB_FUZZING_ENGINE


### PR DESCRIPTION
This PR moves the [oss-fuzz build](https://github.com/google/oss-fuzz/blob/master/projects/tesseract-ocr/build.sh) script over to Tesseracts own repository. No changes have been made to the build-script besides removing the license header that won't be necessary.

If the PR is merged, I will adjust the build script in oss-fuzz's repository accordingly to run in a similar fashion as [libreoffice's build script](https://github.com/google/oss-fuzz/blob/master/projects/libreoffice/build.sh).

Having the build script in the projects own repository is recommended for maintainers and contributors to easier maintain the oss-fuzz integration. Build scripts become outdated, and fixing a broken build is easier and faster with the current setup.

Other examples of projects on oss-fuzz having this setup are: [curl](https://github.com/google/oss-fuzz/blob/master/projects/curl/build.sh), [leptonica](https://github.com/google/oss-fuzz/blob/master/projects/leptonica/build.sh) & [lz4](https://github.com/google/oss-fuzz/blob/master/projects/lz4/build.sh)