### PR TITLE
Add RowAttributes getter to PageIterator

### DIFF
--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -145,14 +145,6 @@ float LTRResultIterator::Confidence(PageIteratorLevel level) const {
   return 0.0f;
 }
 
-void LTRResultIterator::RowAttributes(float* row_height, float* descenders,
-                                      float* ascenders) const {
-  *row_height = it_->row()->row->x_height() + it_->row()->row->ascenders() -
-                it_->row()->row->descenders();
-  *descenders = it_->row()->row->descenders();
-  *ascenders = it_->row()->row->ascenders();
-}
-
 // Returns the font attributes of the current word. If iterating at a higher
 // level object than words, eg textlines, then this will return the
 // attributes of the first word in that textline.

--- a/src/ccmain/ltrresultiterator.h
+++ b/src/ccmain/ltrresultiterator.h
@@ -94,10 +94,6 @@ class TESS_API LTRResultIterator : public PageIterator {
   // The number should be interpreted as a percent probability. (0.0f-100.0f)
   float Confidence(PageIteratorLevel level) const;
 
-  // Returns the attributes of the current row.
-  void RowAttributes(float* row_height, float* descenders,
-                     float* ascenders) const;
-
   // ============= Functions that refer to words only ============.
 
   // Returns the font attributes of the current word. If iterating at a higher

--- a/src/ccmain/pageiterator.cpp
+++ b/src/ccmain/pageiterator.cpp
@@ -516,6 +516,14 @@ bool PageIterator::Baseline(PageIteratorLevel level,
   return true;
 }
 
+void PageIterator::RowAttributes(float* row_height, float* descenders,
+                                 float* ascenders) const {
+  *row_height = it_->row()->row->x_height() + it_->row()->row->ascenders() -
+                it_->row()->row->descenders();
+  *descenders = it_->row()->row->descenders();
+  *ascenders = it_->row()->row->ascenders();
+}
+
 void PageIterator::Orientation(tesseract::Orientation *orientation,
                                tesseract::WritingDirection *writing_direction,
                                tesseract::TextlineOrder *textline_order,

--- a/src/ccmain/pageiterator.h
+++ b/src/ccmain/pageiterator.h
@@ -264,6 +264,10 @@ class TESS_API PageIterator {
   bool Baseline(PageIteratorLevel level,
                 int* x1, int* y1, int* x2, int* y2) const;
 
+  // Returns the attributes of the current row.
+  void RowAttributes(float* row_height, float* descenders,
+                     float* ascenders) const;
+
   /**
    * Returns orientation for the block the iterator points to.
    *   orientation, writing_direction, textline_order: see publictypes.h


### PR DESCRIPTION
Allows row attributes to be accessed via PageIterator without runnning full recognition - in https://github.com/sirfz/tesserocr terms, by running only `AnalyseLayout` and not `Recognize`. 

If one is only interested in baselines and row attributes, but not text detection, this reduces the runtime by about a factor of 10, which is a big deal for processing big collections of 100 000s of pages.

Here's some results for extracting baselines and row attributes from the same page, v1 is with this PR (hash codes in the second line are on extracted baseline and row data which show that the results are identical).

`
v1: using AnalyseLayout: 
bbe705a10940601631c9a5f26f3f421a
time elapsed 2.9205799102783203

v2: using Recognize: 
bbe705a10940601631c9a5f26f3f421a
time elapsed 25.913426399230957
`

Test code used: 
[demo.py.zip](https://github.com/tesseract-ocr/tesseract/files/4588552/demo.py.zip)
