### PR TITLE
Simplify intsimdmatrixavx2

### DIFF
--- a/src/arch/intsimdmatrixavx2.cpp
+++ b/src/arch/intsimdmatrixavx2.cpp
@@ -29,7 +29,7 @@
 #include <algorithm>
 #include <vector>
 
-#include <string.h>
+#include <cstring> // memcpy
 
 namespace tesseract {
 


### PR DESCRIPTION
intsimdmatrixavx2 has some strange code in the
PartialMatrixDocVectorXX functions, whereby the final
ExtractResults can be run more than kNumOutputsPerRegister
times.

There *are* only kNumOutputsPerRegister result values to
extract, so all this ends up doing is pulling extra 0's out
and writing them to memory.

That memory is then overwritten by subsequent calls to
later PartialMatrixDocVectorXX calls, so it actually serves
no purpose.

Remove this special code. This should not only speed up the
runtimes as fewer needless operationations are happening, but
may also help due to improved compile time optimisation (as
the loop sizes are fixed).