### PR TITLE
Tweak architecture specific SIMD files for ease of compilation.

### DIFF
--- a/src/arch/dotproductavx.cpp
+++ b/src/arch/dotproductavx.cpp
@@ -16,8 +16,10 @@
 ///////////////////////////////////////////////////////////////////////
 
 #if !defined(__AVX__)
-#error Implementation only for AVX capable architectures
-#endif
+ #if defined(__i686__) || defined(__x86_64__)
+  #error Implementation only for AVX capable architectures
+ #endif
+#else
 
 #include <immintrin.h>
 #include <cstdint>
@@ -57,3 +59,5 @@ double DotProductAVX(const double* u, const double* v, int n) {
 }
 
 }  // namespace tesseract.
+
+#endif

--- a/src/arch/dotproductfma.cpp
+++ b/src/arch/dotproductfma.cpp
@@ -16,8 +16,10 @@
 ///////////////////////////////////////////////////////////////////////
 
 #if !defined(__FMA__)
-#error Implementation only for FMA capable architectures
-#endif
+ #if defined(__i686__) || defined(__x86_64__)
+  #error Implementation only for FMA capable architectures
+ #endif
+#else
 
 #include <immintrin.h>
 #include <cstdint>
@@ -55,3 +57,5 @@ double DotProductFMA(const double* u, const double* v, int n) {
 }
 
 }  // namespace tesseract.
+
+#endif

--- a/src/arch/dotproductsse.cpp
+++ b/src/arch/dotproductsse.cpp
@@ -16,8 +16,10 @@
 ///////////////////////////////////////////////////////////////////////
 
 #if !defined(__SSE4_1__)
-#error Implementation only for SSE 4.1 capable architectures
-#endif
+ #if defined(__i686__) || defined(__x86_64__)
+  #error Implementation only for SSE 4.1 capable architectures
+ #endif
+#else
 
 #include <emmintrin.h>
 #include <smmintrin.h>
@@ -79,3 +81,5 @@ double DotProductSSE(const double* u, const double* v, int n) {
 }
 
 }  // namespace tesseract.
+
+#endif

--- a/src/arch/intsimdmatrixavx2.cpp
+++ b/src/arch/intsimdmatrixavx2.cpp
@@ -17,8 +17,10 @@
 ///////////////////////////////////////////////////////////////////////
 
 #if !defined(__AVX2__)
-#error Implementation only for AVX2 capable architectures
-#endif
+ #if defined(__i686__) || defined(__x86_64__)
+  #error Implementation only for AVX2 capable architectures
+ #endif
+#else
 
 #include "intsimdmatrix.h"
 
@@ -340,3 +342,5 @@ const IntSimdMatrix IntSimdMatrix::intSimdMatrixAVX2 = {
 };
 
 }  // namespace tesseract.
+
+#endif

--- a/src/arch/intsimdmatrixsse.cpp
+++ b/src/arch/intsimdmatrixsse.cpp
@@ -16,8 +16,10 @@
 ///////////////////////////////////////////////////////////////////////
 
 #if !defined(__SSE4_1__)
-#error Implementation only for SSE 4.1 capable architectures
-#endif
+ #if defined(__i686__) || defined(__x86_64__)
+  #error Implementation only for SSE 4.1 capable architectures
+ #endif
+#else
 
 #include "intsimdmatrix.h"
 
@@ -102,3 +104,5 @@ const IntSimdMatrix IntSimdMatrix::intSimdMatrixSSE = {
 };
 
 }  // namespace tesseract.
+
+#endif


### PR DESCRIPTION
This won't affect anything using the supplied build system. For
other projects that include tesseract within them, however, this
may make their life easier.

For example, I have an integration of Tesseract with Ghostscript,
in which tesseract is built as part of the Ghostscript build,
without using the tesseract build system.

The Ghostscript build system is makefile based, and has to work
on a range of make systems, including unix make, gnu make and
nmake. As such we have to avoid conditionals in the common
makefiles. It therefore becomes hard to build one set of files on
x86 systems, and another on (say) ARM systems.

Accordingly, this commit makes small tweaks to the architecture
specific files, so that they compile on EVERY platform; just they
only compile to anything useful on the appropriate platform.

Thus the makefiles can build all the files on all the systems, and
the preprocessor flags mean that the correct functions are actually
built.