### PR TITLE
Destroy box before potentially exiting function (preventing a memory leak)

### DIFF
--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -196,8 +196,8 @@ ImageData* Tesseract::GetRectImage(const TBOX& box, const BLOCK& block,
   Box* clip_box = boxCreate(revised_box->left(), height - revised_box->top(),
                             revised_box->width(), revised_box->height());
   Pix* box_pix = pixClipRectangle(pix, clip_box, nullptr);
-  if (box_pix == nullptr) return nullptr;
   boxDestroy(&clip_box);
+  if (box_pix == nullptr) return nullptr;
   if (num_rotations > 0) {
     Pix* rot_pix = pixRotateOrth(box_pix, num_rotations);
     pixDestroy(&box_pix);


### PR DESCRIPTION
At present, `Tesseract::GetRectImage` checks to see whether the `pixClipRectangle` function has failed, and returns if it has.  But in such a case, the created `clip_box` is not boxDestroyed.  Swapping the order of these two lines, as in this patch, fixes this potential small problem.