### PR TITLE
Allow line images with larger width (depending on height)

### DIFF
--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -266,7 +266,7 @@ bool LSTMRecognizer::RecognizeLine(const ImageData& image_data, bool invert,
                                    float* scale_factor, NetworkIO* inputs,
                                    NetworkIO* outputs) {
   // Maximum width of image to train on.
-  const int kMaxImageWidth = 2560;
+  const int kMaxImageWidth = 4096;
   // This ensures consistent recognition results.
   SetRandomSeed();
   int min_width = network_->XScaleFactor();

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -265,8 +265,6 @@ bool LSTMRecognizer::RecognizeLine(const ImageData& image_data, bool invert,
                                    bool debug, bool re_invert, bool upside_down,
                                    float* scale_factor, NetworkIO* inputs,
                                    NetworkIO* outputs) {
-  // Maximum width of image to train on.
-  const int kMaxImageWidth = 4096;
   // This ensures consistent recognition results.
   SetRandomSeed();
   int min_width = network_->XScaleFactor();
@@ -276,6 +274,8 @@ bool LSTMRecognizer::RecognizeLine(const ImageData& image_data, bool invert,
     tprintf("Line cannot be recognized!!\n");
     return false;
   }
+  // Maximum width of image to train on.
+  const int kMaxImageWidth = 128 * pixGetHeight(pix);
   if (network_->IsTraining() && pixGetWidth(pix) > kMaxImageWidth) {
     tprintf("Image too large to learn!! Size = %dx%d\n", pixGetWidth(pix),
             pixGetHeight(pix));


### PR DESCRIPTION
The limit was increased from 2048 to 2560 in the past. I now had to increase it to 4096
for training from some newspaper lines, but even that was not enough when training
models with line images normalized to 64 px height.