### PR TITLE
Guard #include "config_auto.h" with HAVE_CONFIG_H.

### DIFF
--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -15,7 +15,9 @@
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////
 
+#ifdef HAVE_CONFIG_H
 #include "config_auto.h"     // for HAVE_AVX, ...
+#endif
 #include <numeric>           // for std::inner_product
 #include "simddetect.h"
 #include "dotproduct.h"


### PR DESCRIPTION
Every other file already does this.