### PR TITLE
Add configure based detection for NEON runtime detection.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -188,6 +188,9 @@ libtesseract_neon_la_CXXFLAGS = -mfpu=neon
 libtesseract_neon_la_SOURCES = src/arch/intsimdmatrixneon.cpp
 libtesseract_la_LIBADD += libtesseract_neon.la
 noinst_LTLIBRARIES += libtesseract_neon.la
+if HAVE_HWCAP_BASED_NEON_RUNTIME_DETECTION
+libtesseract_neon_la_CXXFLAGS += -DHAVE_HWCAP_BASED_NEON_RUNTIME_DETECTION
+endif
 endif
 
 libtesseract_la_SOURCES += src/arch/intsimdmatrix.cpp

--- a/configure.ac
+++ b/configure.ac
@@ -200,6 +200,16 @@ have_tiff=false
 # Note that the first usage of AC_CHECK_HEADERS must be unconditional.
 AC_CHECK_HEADERS([tiffio.h], [have_tiff=true], [have_tiff=false])
 
+# Check whether we have the runtime neon detection headers:
+AC_MSG_CHECKING([runtime neon detection])
+have_hwcap_based_neon_runtime_detection=true
+AC_CHECK_HEADERS([sys/auxv.h], [], [have_hwcap_based_neon_runtime_detection=false])
+AC_CHECK_HEADERS([asm/hwcap.h], [], [have_hwcap_based_neon_runtime_detection=false])
+AM_CONDITIONAL([HAVE_HWCAP_BASED_NEON_RUNTIME_DETECTION], $have_hwcap_based_neon_runtime_detection)
+if $have_hwcap_based_neon_runtime_detection; then
+  AC_DEFINE([HAVE_HWCAP_BASED_NEON_RUNTIME_DETECTION], [1], [Enable runtime NEON detection using asm/hwcap.h])
+fi
+
 # check whether to build opencl version
 AC_MSG_CHECKING([--enable-opencl argument])
 AC_ARG_ENABLE([opencl],

--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -40,8 +40,7 @@
 #ifdef HAVE_NEON
 #ifdef ANDROID
 #include <cpufeatures.h>
-#else
-/* Assume linux */
+#elif defined(HAVE_HWCAP_BASED_NEON_RUNTIME_DETECTION)
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
 #endif
@@ -192,9 +191,13 @@ SIMDDetect::SIMDDetect() {
                          ANDROID_CPU_ARM64_FEATURE_ASIMD);
 #endif
   }
-#else
+#elif defined(HAVE_HWCAP_BASED_NEON_RUNTIME_DETECTION)
   /* Assume linux */
   neon_available_ = getauxval(AT_HWCAP) & HWCAP_NEON;
+#elif defined(NEON_ALWAYS_AVAILABLE)
+  neon_available = 1;
+#else
+  neon_available = 0;
 #endif
 #endif
 


### PR DESCRIPTION
Previously, we assumed that if the compiler accepted
-mfpu=neon that we'd either be on ANDROID, or asm/hwcap.h
would be available to us.

There will be non-Android systems where asm/hwcap.h is not
available (indeed, the OS-FUZZ target seems to be one).

So, extend the checks to see whether asm/hwcap.h etc is
available. If it is not, then we don't attempt to use it,
and instead look at NEON_ALWAYS_AVAILABLE to decide whether
to hardwire support on/off.