### PR TITLE
Fix undefined shift with negative value (oss-fuzz issue 14658)

### DIFF
--- a/src/ccstruct/coutln.cpp
+++ b/src/ccstruct/coutln.cpp
@@ -215,13 +215,15 @@ C_OUTLINE::C_OUTLINE(C_OUTLINE* srcline, FCOORD rotation) : offsets(nullptr) {
       }
     }
     ASSERT_HOST (destpos.x () == start.x () && destpos.y () == start.y ());
-    dirdiff = step_dir (destindex - 1) - step_dir (0);
-    while ((dirdiff == 64 || dirdiff == -64) && destindex > 1) {
+    while (destindex > 1) {
+      dirdiff = step_dir(destindex - 1) - step_dir(0);
+      if (dirdiff != 64 && dirdiff != -64) {
+        break;
+      }
       start += step (0);
       destindex -= 2;
       for (int i = 0; i < destindex; ++i)
         set_step(i, step_dir(i + 1));
-      dirdiff = step_dir (destindex - 1) - step_dir (0);
     }
     if (destindex >= 4)
       break;


### PR DESCRIPTION
This fixes a bug reported by OSS Fuzz:
https://oss-fuzz.com/issue/5697280134348800

The old code passed a negative value (-1) as argument to step_dir
when destindex was 0.

Signed-off-by: Stefan Weil <sw@weilnetz.de>