### PR TITLE
Make several functions inline for improved performance

### DIFF
--- a/src/ccstruct/rect.cpp
+++ b/src/ccstruct/rect.cpp
@@ -55,17 +55,6 @@ TBOX::TBOX(            // constructor
   }
 }
 
-/**********************************************************************
- * TBOX::TBOX()  Constructor from 4 integer values.
- *  Note: It is caller's responsibility to provide values in the right
- *        order.
- **********************************************************************/
-
-TBOX::TBOX(                    //constructor
-    int16_t left, int16_t bottom, int16_t right, int16_t top)
-    : bot_left(left, bottom), top_right(right, top) {
-}
-
 // rotate_large constructs the containing bounding box of all 4
 // corners after rotating them. It therefore guarantees that all
 // original content is contained within, but also slightly enlarges the box.

--- a/src/ccstruct/rect.h
+++ b/src/ccstruct/rect.h
@@ -41,8 +41,15 @@ class DLLSYM TBOX  {  // bounding box
         const ICOORD pt1,   // one corner
         const ICOORD pt2);  // the other corner
 
-    TBOX(                    // constructor
-        int16_t left, int16_t bottom, int16_t right, int16_t top);
+    //*********************************************************************
+    // TBOX::TBOX()  Constructor from 4 integer values.
+    //  Note: It is caller's responsibility to provide values
+    //        in the right order.
+    //*********************************************************************
+    TBOX(                    //constructor
+        int16_t left, int16_t bottom, int16_t right, int16_t top)
+        : bot_left(left, bottom), top_right(right, top) {
+    }
 
     TBOX(  // box around FCOORD
         const FCOORD pt);

--- a/src/ccstruct/seam.cpp
+++ b/src/ccstruct/seam.cpp
@@ -35,30 +35,6 @@ TBOX SEAM::bounding_box() const {
   return box;
 }
 
-// Returns true if other can be combined into *this.
-bool SEAM::CombineableWith(const SEAM& other, int max_x_dist,
-                           float max_total_priority) const {
-  int dist = location_.x - other.location_.x;
-  if (-max_x_dist < dist && dist < max_x_dist &&
-      num_splits_ + other.num_splits_ <= kMaxNumSplits &&
-      priority_ + other.priority_ < max_total_priority &&
-      !OverlappingSplits(other) && !SharesPosition(other)) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
-// Combines other into *this. Only works if CombinableWith returned true.
-void SEAM::CombineWith(const SEAM& other) {
-  priority_ += other.priority_;
-  location_ += other.location_;
-  location_ /= 2;
-
-  for (uint8_t s = 0; s < other.num_splits_ && num_splits_ < kMaxNumSplits; ++s)
-    splits_[num_splits_++] = other.splits_[s];
-}
-
 // Returns true if the splits in *this SEAM appear OK in the sense that they
 // do not cross any outlines and do not chop off any ridiculously small
 // pieces.

--- a/src/ccstruct/seam.h
+++ b/src/ccstruct/seam.h
@@ -64,9 +64,23 @@ class SEAM {
 
   // Returns true if other can be combined into *this.
   bool CombineableWith(const SEAM& other, int max_x_dist,
-                       float max_total_priority) const;
+                       float max_total_priority) const {
+    int dist = location_.x - other.location_.x;
+    return -max_x_dist < dist && dist < max_x_dist &&
+      num_splits_ + other.num_splits_<= kMaxNumSplits &&
+      priority_+ other.priority_ < max_total_priority &&
+      !OverlappingSplits(other) && !SharesPosition(other);
+  }
+
   // Combines other into *this. Only works if CombinableWith returned true.
-  void CombineWith(const SEAM& other);
+  void CombineWith(const SEAM& other) {
+    priority_ += other.priority_;
+    location_ += other.location_;
+    location_ /= 2;
+
+    for (uint8_t s = 0; s < other.num_splits_ && num_splits_ < kMaxNumSplits; ++s)
+      splits_[num_splits_++] = other.splits_[s];
+  }
 
   // Returns true if the given blob contains all splits of *this SEAM.
   bool ContainedByBlob(const TBLOB& blob) const {

--- a/src/ccstruct/split.cpp
+++ b/src/ccstruct/split.cpp
@@ -39,13 +39,6 @@ const double kBadPriority = 999.0;
 
 BOOL_VAR(wordrec_display_splits, 0, "Display splits");
 
-// Returns the bounding box of all the points in the split.
-TBOX SPLIT::bounding_box() const {
-  return TBOX(
-      std::min(point1->pos.x, point2->pos.x), std::min(point1->pos.y, point2->pos.y),
-      std::max(point1->pos.x, point2->pos.x), std::max(point1->pos.y, point2->pos.y));
-}
-
 // Hides the SPLIT so the outlines appear not to be cut by it.
 void SPLIT::Hide() const {
   EDGEPT* edgept = point1;

--- a/src/ccstruct/split.h
+++ b/src/ccstruct/split.h
@@ -37,7 +37,13 @@ struct SPLIT {
   SPLIT(EDGEPT* pt1, EDGEPT* pt2) : point1(pt1), point2(pt2) {}
 
   // Returns the bounding box of all the points in the split.
-  TBOX bounding_box() const;
+  TBOX bounding_box() const {
+    return TBOX(std::min(point1->pos.x, point2->pos.x),
+                std::min(point1->pos.y, point2->pos.y),
+                std::max(point1->pos.x, point2->pos.x),
+                std::max(point1->pos.y, point2->pos.y));
+  }
+
   // Returns the bounding box of the outline from point1 to point2.
   TBOX Box12() const { return point1->SegmentBox(point2); }
   // Returns the bounding box of the outline from point1 to point1.


### PR DESCRIPTION
OSS Fuzz reports a timeout in issue 19900
(https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19900).

Im my test, making some functions which are called most often in that test inline
reduces the execution time from 44 s to 39 s.