### PR TITLE
Fixed CMakeLists.txt for the compilers without C++17 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,13 @@ else()  # minimum required standard
     set(CMAKE_CXX_STANDARD 11)
 endif()
 
+if ("${CMAKE_CXX17_STANDARD_COMPILE_OPTION}" STREQUAL "")
+    set(CMAKE_CXX_STANDARD 14)
+endif()
+if ("${CMAKE_CXX14_STANDARD_COMPILE_OPTION}" STREQUAL "")
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
 # Avoid using experimental c++1y (c++1z) standard even if the compiler announces cxx14 (cxx17)
 # in CMAKE_CXX_KNOWN_FEATURES and CMAKE_CXX_COMPILE_FEATURES
 # It is the case of clang 3.9, 4.0 (announces c++1z) and gcc 4.8 (announces c++1y)


### PR DESCRIPTION
When building with CMake and MinGW 4.9，I got these error:

> -- General configuration for Tesseract 4.1.1
> -- --------------------------------------------------------
> -- Build type: Release
> -- Compiler: GNU
> -- Used standard: C++17
> -- CXX compiler options:  -O3 -DNDEBUG

> -- Configuring done
> CMake Error in CMakeLists.txt:
>   Target "libtesseract" requires the language dialect "CXX17" , but CMake
>   does not know the compile flags to use to enable it.
> 
> CMake Error in CMakeLists.txt:
>   Target "tesseract" requires the language dialect "CXX17" , but CMake does
>   not know the compile flags to use to enable it.
> 
> -- Generating done
> CMake Generate step failed.  Build files cannot be regenerated correctly.

For MinGW 4.9，CMAKE_CXX17_STANDARD_COMPILE_OPTION is empty and CMAKE_CXX14_STANDARD_COMPILE_OPTION is "-std=c++14"
The following codes from https://github.com/tesseract-ocr/tesseract/blob/master/CMakeLists.txt#L99 can not set CMAKE_CXX_STANDARD to c++14, but the unsupported c++17
```
# Check for C++ standard to use
get_property(known_features GLOBAL PROPERTY CMAKE_CXX_KNOWN_FEATURES)
if (cxx_std_17 IN_LIST known_features)
    set(CMAKE_CXX_STANDARD 17)
elseif (cxx_std_14 IN_LIST known_features)
    set(CMAKE_CXX_STANDARD 14)
else()  # minimum required standard
    set(CMAKE_CXX_STANDARD 11)
endif()

# Avoid using experimental c++1y (c++1z) standard even if the compiler announces cxx14 (cxx17)
# in CMAKE_CXX_KNOWN_FEATURES and CMAKE_CXX_COMPILE_FEATURES
# It is the case of clang 3.9, 4.0 (announces c++1z) and gcc 4.8 (announces c++1y)
if ("${CMAKE_CXX17_STANDARD_COMPILE_OPTION}" STREQUAL "-std=c++1z")
  set(CMAKE_CXX_STANDARD 14)
endif()
if ("${CMAKE_CXX14_STANDARD_COMPILE_OPTION}" STREQUAL "-std=c++1y")
  set(CMAKE_CXX_STANDARD 11)
endif()
```

