### PR TITLE
Fix runtime error caused by too large TBOX

### DIFF
--- a/src/lstm/recodebeam.cpp
+++ b/src/lstm/recodebeam.cpp
@@ -615,11 +615,12 @@ WERD_RES* RecodeBeamSearch::InitializeWord(bool leading_space,
   C_BLOB_IT b_it(&blobs);
   for (int i = word_start; i < word_end; ++i) {
     if (character_boundaries_.size() > (i + 1)) {
-      TBOX box(character_boundaries_[i], 0, character_boundaries_[i + 1],
-               line_box.height());
-      box.scale(scale_factor);
-      box.move(ICOORD(line_box.left(), line_box.bottom()));
-      box.set_top(line_box.top());
+      TBOX box(static_cast<int16_t>(std::floor(character_boundaries_[i] *
+                                               scale_factor)) + line_box.left(),
+               line_box.bottom(),
+               static_cast<int16_t>(std::ceil(character_boundaries_[i + 1] *
+                                              scale_factor)) + line_box.left(),
+               line_box.top());
       b_it.add_after_then_move(C_BLOB::FakeBlob(box));
     }
   }


### PR DESCRIPTION
Runtime error reported by sanitizer:

    src/ccstruct/rect.h:191:44: runtime error: 50961 is outside the range of representable values of type 'short'
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/ccstruct/rect.h:191:44 in

Signed-off-by: Stefan Weil <sw@weilnetz.de>