### PR TITLE
Disable more code and data with GRAPHICS_DISABLED

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -886,7 +886,7 @@ int TessBaseAPI::Recognize(ETEXT_DESC* monitor) {
   if (tesseract_->interactive_display_mode) {
     #ifndef GRAPHICS_DISABLED
     tesseract_->pgeditor_main(rect_width_, rect_height_, page_res_);
-    #endif  // GRAPHICS_DISABLED
+    #endif // !GRAPHICS_DISABLED
     // The page_res is invalid after an interactive session, so cleanup
     // in a way that lets us continue to the next page without crashing.
     delete page_res_;

--- a/src/ccmain/paramsd.cpp
+++ b/src/ccmain/paramsd.cpp
@@ -355,4 +355,4 @@ void ParamsEditor::WriteParams(char *filename,
   }
   fclose(fp);
 }
-#endif // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED

--- a/src/ccmain/paramsd.h
+++ b/src/ccmain/paramsd.h
@@ -128,5 +128,5 @@ class ParamsEditor : public SVEventHandler {
   ScrollView* sv_window_;
 };
 
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 #endif  // TESSERACT_CCMAIN_PARAMSD_H_

--- a/src/ccmain/pgedit.cpp
+++ b/src/ccmain/pgedit.cpp
@@ -690,7 +690,7 @@ void Tesseract::debug_word(PAGE_RES* page_res, const TBOX &selection_box) {
  * Blank display of word then redisplay word according to current display mode
  * settings
  */
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 namespace tesseract {
 #ifndef GRAPHICS_DISABLED
 bool Tesseract::word_blank_and_set_display(PAGE_RES_IT* pr_it) {
@@ -894,7 +894,7 @@ bool Tesseract::word_display(PAGE_RES_IT* pr_it) {
       editor_image_word_bb_color));
   return true;
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 /**
  * word_dumper()
@@ -980,6 +980,6 @@ void Tesseract::blob_feature_display(PAGE_RES* page_res,
 }
 
 
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 }  // namespace tesseract

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -566,7 +566,7 @@ class Tesseract : public Wordrec {
   SVMenuNode* build_menu_new();
 #ifndef GRAPHICS_DISABLED
   void pgeditor_main(int width, int height, PAGE_RES* page_res);
-#endif                       // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
   void process_image_event(  // action in image win
       const SVEvent& event);
   bool process_cmd_win_event(  // UI command semantics
@@ -582,7 +582,7 @@ class Tesseract : public Wordrec {
   bool word_set_display(PAGE_RES_IT* pr_it);
   // #ifndef GRAPHICS_DISABLED
   bool word_dumper(PAGE_RES_IT* pr_it);
-  // #endif  // GRAPHICS_DISABLED
+  // #endif // !GRAPHICS_DISABLED
   void blob_feature_display(PAGE_RES* page_res, const TBOX& selection_box);
   //// reject.h //////////////////////////////////////////////////////////
   // make rej map for word
@@ -1093,7 +1093,7 @@ class Tesseract : public Wordrec {
             "Sets the number of cascading iterations for the Beamsearch in "
             "lstm_choice_mode. Note that lstm_choice_mode must be set to "
             "a value greater than 0 to produce results.");
-  double_VAR_H(lstm_rating_coefficient, 5, 
+  double_VAR_H(lstm_rating_coefficient, 5,
                "Sets the rating coefficient for the lstm choices. The smaller "
                "the coefficient, the better are the ratings for each choice "
                "and less information is lost due to the cut off at 0. The "

--- a/src/ccstruct/blobbox.cpp
+++ b/src/ccstruct/blobbox.cpp
@@ -1092,4 +1092,4 @@ void plot_blob_list(ScrollView* win,                   // window to draw in
     it.data()->plot(win, body_colour, child_colour);
   }
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED

--- a/src/ccstruct/blobbox.h
+++ b/src/ccstruct/blobbox.h
@@ -846,5 +846,5 @@ void plot_blob_list(ScrollView* win,                   // window to draw in
                     BLOBNBOX_LIST *list,               // blob list
                     ScrollView::Color body_colour,     // colour to draw
                     ScrollView::Color child_colour);   // colour of child
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 #endif

--- a/src/ccstruct/blobs.cpp
+++ b/src/ccstruct/blobs.cpp
@@ -275,7 +275,7 @@ void TESSLINE::plot(ScrollView* window, ScrollView::Color color,
       window->DrawTo(pt->pos.x, pt->pos.y);
   } while (pt != loop);
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 // Returns the first non-hidden EDGEPT that has a different src_outline to
 // its predecessor, or, if all the same, the lowest indexed point.
@@ -512,7 +512,7 @@ void TBLOB::plot(ScrollView* window, ScrollView::Color color,
        outline = outline->next)
     outline->plot(window, color, child_color);
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 // Computes the center of mass and second moments for the old baseline and
 // 2nd moment normalizations. Returns the outline length.
@@ -900,7 +900,7 @@ void TWERD::plot(ScrollView* window) {
     color = WERD::NextColor(color);
   }
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 /**********************************************************************
  * divisible_blob

--- a/src/ccstruct/blobs.h
+++ b/src/ccstruct/blobs.h
@@ -261,7 +261,7 @@ struct TESSLINE {
   #ifndef GRAPHICS_DISABLED
   void plot(ScrollView* window, ScrollView::Color color,
             ScrollView::Color child_color);
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 
   // Returns the first outline point that has a different src_outline to its
   // predecessor, or, if all the same, the lowest indexed point.
@@ -366,7 +366,7 @@ struct TBLOB {
   #ifndef GRAPHICS_DISABLED
   void plot(ScrollView* window, ScrollView::Color color,
             ScrollView::Color child_color);
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 
   int BBArea() const {
     int total_area = 0;

--- a/src/ccstruct/coutln.h
+++ b/src/ccstruct/coutln.h
@@ -254,7 +254,7 @@ class DLLSYM C_OUTLINE:public ELIST_LINK {
     // making use of sub-pixel accurate information if available.
     void plot_normed(const DENORM& denorm, ScrollView::Color colour,
                      ScrollView* window) const;
-    #endif  // GRAPHICS_DISABLED
+    #endif // !GRAPHICS_DISABLED
 
     C_OUTLINE& operator=(const C_OUTLINE& source);
 

--- a/src/ccstruct/imagedata.cpp
+++ b/src/ccstruct/imagedata.cpp
@@ -285,9 +285,10 @@ int ImageData::MemoryUsed() const {
   return image_data_.size();
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Draws the data in a new window.
 void ImageData::Display() const {
-#ifndef GRAPHICS_DISABLED
   const int kTextSize = 64;
   // Draw the image.
   Pix* pix = GetPix();
@@ -319,8 +320,9 @@ void ImageData::Display() const {
   }
   win->Update();
   win->Wait();
-#endif
 }
+
+#endif
 
 // Adds the supplied boxes and transcriptions that correspond to the correct
 // page number.

--- a/src/ccstruct/ocrrow.cpp
+++ b/src/ccstruct/ocrrow.cpp
@@ -214,7 +214,7 @@ void ROW::plot(               //draw it
     word->plot (window);         //in rainbow colours
   }
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 /**********************************************************************
  * ROW::operator=

--- a/src/ccstruct/ocrrow.h
+++ b/src/ccstruct/ocrrow.h
@@ -140,7 +140,7 @@ class ROW:public ELIST_LINK
                                  //draw it
       baseline.plot (window, colour);
     }
-    #endif  // GRAPHICS_DISABLED
+    #endif // !GRAPHICS_DISABLED
     ROW& operator= (const ROW & source);
 
   private:

--- a/src/ccstruct/pdblock.h
+++ b/src/ccstruct/pdblock.h
@@ -85,7 +85,7 @@ class PDBLK {
   ///@param serial serial number
   ///@param colour colour to draw in
   void plot(ScrollView *window, int32_t serial, ScrollView::Color colour);
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
   /// assignment
   ///@param source from this

--- a/src/ccstruct/polyblk.cpp
+++ b/src/ccstruct/polyblk.cpp
@@ -414,4 +414,4 @@ ScrollView::Color POLY_BLOCK::ColorForPolyBlockType(PolyBlockType type) {
   }
   return ScrollView::WHITE;
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED

--- a/src/ccstruct/polyblk.h
+++ b/src/ccstruct/polyblk.h
@@ -62,7 +62,7 @@ class DLLSYM POLY_BLOCK {
 
   #ifndef GRAPHICS_DISABLED
   void fill(ScrollView* window, ScrollView::Color colour);
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 
   // Returns true if other is inside this.
   bool contains(POLY_BLOCK *other);
@@ -79,7 +79,7 @@ class DLLSYM POLY_BLOCK {
   // Static utility functions to handle the PolyBlockType.
   // Returns a color to draw the given type.
   static ScrollView::Color ColorForPolyBlockType(PolyBlockType type);
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 
  private:
   ICOORDELT_LIST vertices;     // vertices

--- a/src/ccstruct/ratngs.cpp
+++ b/src/ccstruct/ratngs.cpp
@@ -758,10 +758,11 @@ void WERD_CHOICE::print_state(const char *msg) const {
   tprintf("\n");
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Displays the segmentation state of *this (if not the same as the last
 // one displayed) and waits for a click in the window.
 void WERD_CHOICE::DisplaySegmentation(TWERD* word) {
-#ifndef GRAPHICS_DISABLED
   // Number of different colors to draw with.
   const int kNumColors = 6;
   static ScrollView *segm_window = nullptr;
@@ -800,9 +801,9 @@ void WERD_CHOICE::DisplaySegmentation(TWERD* word) {
                                bbox.right(), bbox.bottom());
   segm_window->Update();
   segm_window->Wait();
-#endif
 }
 
+#endif // !GRAPHICS_DISABLED
 
 bool EqualIgnoringCaseAndTerminalPunct(const WERD_CHOICE &word1,
                                        const WERD_CHOICE &word2) {

--- a/src/ccstruct/statistc.h
+++ b/src/ccstruct/statistc.h
@@ -136,7 +136,7 @@ class STATS {
                 float xscale,    // size of one unit
                 float yscale,    // size of one uint
                 ScrollView::Color colour) const;  // colour to draw in
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 
  private:
   int32_t rangemin_ = 0;            // min of range

--- a/src/ccstruct/stepblob.h
+++ b/src/ccstruct/stepblob.h
@@ -107,7 +107,7 @@ class C_BLOB:public ELIST_LINK
                      ScrollView::Color blob_colour,
                      ScrollView::Color child_colour,
                      ScrollView* window);
-    #endif  // GRAPHICS_DISABLED
+    #endif // !GRAPHICS_DISABLED
 
     C_BLOB& operator= (const C_BLOB & source) {
       if (!outlines.empty ())

--- a/src/ccstruct/werd.cpp
+++ b/src/ccstruct/werd.cpp
@@ -323,7 +323,7 @@ void WERD::plot_rej_blobs(ScrollView* window) {
     it.data()->plot(window, ScrollView::GREY, ScrollView::GREY);
   }
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 /**
  * WERD::shallow_copy()

--- a/src/ccstruct/werd.h
+++ b/src/ccstruct/werd.h
@@ -148,7 +148,7 @@ class WERD : public ELIST2_LINK {
 
   // plot rejected blobs in a rainbow of colours
   void plot_rej_blobs(ScrollView* window);
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
   // Removes noise from the word by moving small outlines to the rej_cblobs
   // list, based on the size_threshold.

--- a/src/classify/adaptmatch.cpp
+++ b/src/classify/adaptmatch.cpp
@@ -220,11 +220,12 @@ void Classify::AdaptiveClassifier(TBLOB *Blob, BLOB_CHOICE_LIST *Choices) {
   delete Results;
 }                                /* AdaptiveClassifier */
 
+#ifndef GRAPHICS_DISABLED
+
 // If *win is nullptr, sets it to a new ScrollView() object with title msg.
 // Clears the window and draws baselines.
 void Classify::RefreshDebugWindow(ScrollView **win, const char *msg,
                                   int y_offset, const TBOX &wbox) {
-  #ifndef GRAPHICS_DISABLED
   const int kSampleSpaceWidth = 500;
   if (*win == nullptr) {
     *win = new ScrollView(msg, 100, y_offset, kSampleSpaceWidth * 2, 200,
@@ -238,8 +239,9 @@ void Classify::RefreshDebugWindow(ScrollView **win, const char *msg,
                kSampleSpaceWidth, kBlnXHeight + kBlnBaselineOffset);
   (*win)->ZoomToRectangle(wbox.left(), wbox.top(),
                           wbox.right(), wbox.bottom());
-  #endif  // GRAPHICS_DISABLED
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // Learns the given word using its chopped_word, seam_array, denorm,
 // box_word, best_state, and correct_text to learn both correctly and
@@ -279,7 +281,7 @@ void Classify::LearnWord(const char* fontname, WERD_RES* word) {
     word->chopped_word->plot(learn_fragmented_word_debug_win_);
     ScrollView::Update();
   }
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 
   for (int ch = 0; ch < word_len; ++ch) {
     if (classify_debug_character_fragments) {
@@ -404,7 +406,7 @@ void Classify::LearnPieces(const char* fontname, int start, int length,
                ScrollView::BLUE, ScrollView::BROWN);
     learn_fragments_debug_win_->Update();
   }
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 
   if (fontname != nullptr) {
     classify_norm_method.set_value(character);  // force char norm spc 30/11/93
@@ -754,8 +756,10 @@ void Classify::InitAdaptedClass(TBLOB *Blob,
   if (classify_learning_debug_level >= 1) {
     tprintf("Added new class '%s' with class id %d and %d protos.\n",
             unicharset.id_to_unichar(ClassId), ClassId, NumFeatures);
+#ifndef GRAPHICS_DISABLED
     if (classify_learning_debug_level > 1)
       DisplayAdaptedChar(Blob, IClass);
+#endif
   }
 
   if (IsEmptyAdaptedClass(Class))
@@ -920,8 +924,10 @@ void Classify::AdaptToChar(TBLOB* Blob, CLASS_ID ClassId, int FontinfoId,
       if (classify_learning_debug_level >= 1) {
         tprintf("Found poor match to temp config %d = %4.1f%%.\n",
                 int_result.config, int_result.rating * 100.0);
+#ifndef GRAPHICS_DISABLED
         if (classify_learning_debug_level > 2)
           DisplayAdaptedChar(Blob, IClass);
+#endif
       }
       NewTempConfigId =
           MakeNewTemporaryConfig(adaptive_templates, ClassId, FontinfoId,
@@ -942,8 +948,9 @@ void Classify::AdaptToChar(TBLOB* Blob, CLASS_ID ClassId, int FontinfoId,
   }
 }                                /* AdaptToChar */
 
-void Classify::DisplayAdaptedChar(TBLOB* blob, INT_CLASS_STRUCT* int_class) {
 #ifndef GRAPHICS_DISABLED
+
+void Classify::DisplayAdaptedChar(TBLOB* blob, INT_CLASS_STRUCT* int_class) {
   INT_FX_RESULT_STRUCT fx_info;
   GenericVector<INT_FEATURE_STRUCT> bl_features;
   TrainingSample* sample =
@@ -970,8 +977,9 @@ void Classify::DisplayAdaptedChar(TBLOB* blob, INT_CLASS_STRUCT* int_class) {
   }
 
   delete sample;
-#endif
 }
+
+#endif
 
 /**
  * This routine adds the result of a classification into
@@ -2147,6 +2155,8 @@ void Classify::SetAdaptiveThreshold(float Threshold) {
       ClipToRange<int>(255 * Threshold, 0, 255));
 }                              /* SetAdaptiveThreshold */
 
+#ifndef GRAPHICS_DISABLED
+
 /*---------------------------------------------------------------------------*/
 /**
  * This routine displays debug information for the best config
@@ -2160,7 +2170,6 @@ void Classify::SetAdaptiveThreshold(float Threshold) {
 void Classify::ShowBestMatchFor(int shape_id,
                                 const INT_FEATURE_STRUCT* features,
                                 int num_features) {
-#ifndef GRAPHICS_DISABLED
   uint32_t config_mask;
   if (UnusedClassIdIn(PreTrainedTemplates, shape_id)) {
     tprintf("No built-in templates for class/shape %d\n", shape_id);
@@ -2187,8 +2196,9 @@ void Classify::ShowBestMatchFor(int shape_id,
             classify_adapt_feature_threshold, matcher_debug_flags,
             matcher_debug_separate_windows);
   UpdateMatchDisplay();
-#endif  // GRAPHICS_DISABLED
 }                              /* ShowBestMatchFor */
+
+#endif // !GRAPHICS_DISABLED
 
 // Returns a string for the classifier class_id: either the corresponding
 // unicharset debug_str or the shape_table_ debug str.

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -162,16 +162,18 @@ void RenderIntProto(ScrollView *window,
                     INT_CLASS Class,
                     PROTO_ID ProtoId,
                     ScrollView::Color color);
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 /*-----------------------------------------------------------------------------
         Global Data Definitions and Declarations
 -----------------------------------------------------------------------------*/
 
+#ifndef GRAPHICS_DISABLED
 /* global display lists used to display proto and feature match information*/
 static ScrollView* IntMatchWindow = nullptr;
 static ScrollView* FeatureDisplayWindow = nullptr;
 static ScrollView* ProtoDisplayWindow = nullptr;
+#endif
 
 /*-----------------------------------------------------------------------------
         Variables
@@ -1751,4 +1753,4 @@ void InitFeatureDisplayWindowIfReqd() {
 ScrollView* CreateFeatureSpaceWindow(const char* name, int xpos, int ypos) {
   return new ScrollView(name, xpos, ypos, 520, 520, 260, 260, true);
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED

--- a/src/classify/intproto.h
+++ b/src/classify/intproto.h
@@ -258,6 +258,6 @@ void InitFeatureDisplayWindowIfReqd();
 // Creates a window of the appropriate size for displaying elements
 // in feature space.
 ScrollView* CreateFeatureSpaceWindow(const char* name, int xpos, int ypos);
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 #endif

--- a/src/classify/shapeclassifier.cpp
+++ b/src/classify/shapeclassifier.cpp
@@ -88,6 +88,8 @@ const UNICHARSET& ShapeClassifier::GetUnicharset() const {
   return GetShapeTable()->unicharset();
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Visual debugger classifies the given sample, displays the results and
 // solicits user input to display other classifications. Returns when
 // the user has finished with debugging the sample.
@@ -96,7 +98,6 @@ const UNICHARSET& ShapeClassifier::GetUnicharset() const {
 void ShapeClassifier::DebugDisplay(const TrainingSample& sample,
                                    Pix* page_pix,
                                    UNICHAR_ID unichar_id) {
-#ifndef GRAPHICS_DISABLED
   static ScrollView* terminator = nullptr;
   if (terminator == nullptr) {
     terminator = new ScrollView("XIT", 0, 0, 50, 50, 50, 50, true);
@@ -152,8 +153,9 @@ void ShapeClassifier::DebugDisplay(const TrainingSample& sample,
              ev_type != SVET_CLICK && ev_type != SVET_DESTROY);
   } while (ev_type != SVET_CLICK && ev_type != SVET_DESTROY);
   delete debug_win;
-#endif  // GRAPHICS_DISABLED
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // Displays classification as the given shape_id. Creates as many windows
 // as it feels fit, using index as a guide for placement. Adds any created

--- a/src/classify/shapeclassifier.h
+++ b/src/classify/shapeclassifier.h
@@ -1,11 +1,8 @@
-// Copyright 2011 Google Inc. All Rights Reserved.
-// Author: rays@google.com (Ray Smith)
 ///////////////////////////////////////////////////////////////////////
 // File:        shapeclassifier.h
 // Description: Base interface class for classifiers that return a
 //              shape index.
 // Author:      Ray Smith
-// Created:     Tue Sep 13 11:26:32 PDT 2011
 //
 // (C) Copyright 2011, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,8 +90,8 @@ class ShapeClassifier {
   // the user has finished with debugging the sample.
   // Probably doesn't need to be overridden if the subclass provides
   // DisplayClassifyAs.
-  virtual void DebugDisplay(const TrainingSample& sample, Pix* page_pix,
-                            UNICHAR_ID unichar_id);
+  void DebugDisplay(const TrainingSample& sample, Pix* page_pix,
+                    UNICHAR_ID unichar_id);
 
 
   // Displays classification as the given unichar_id. Creates as many windows

--- a/src/classify/tessclassifier.cpp
+++ b/src/classify/tessclassifier.cpp
@@ -1,10 +1,7 @@
-// Copyright 2011 Google Inc. All Rights Reserved.
-// Author: rays@google.com (Ray Smith)
 ///////////////////////////////////////////////////////////////////////
 // File:        tessclassifier.cpp
 // Description: Tesseract implementation of a ShapeClassifier.
 // Author:      Ray Smith
-// Created:     Tue Nov 22 14:16:25 PST 2011
 //
 // (C) Copyright 2011, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,8 +74,10 @@ int TessClassifier::DisplayClassifyAs(
     tprintf("No built-in templates for class/shape %d\n", shape_id);
     return index;
   }
+#ifndef GRAPHICS_DISABLED
   classify_->ShowBestMatchFor(shape_id, sample.features(),
                               sample.num_features());
+#endif
   return index;
 }
 

--- a/src/classify/trainingsample.cpp
+++ b/src/classify/trainingsample.cpp
@@ -312,15 +312,17 @@ Pix* TrainingSample::RenderToPix(const UNICHARSET* unicharset) const {
   return pix;
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Displays the features in the given window with the given color.
 void TrainingSample::DisplayFeatures(ScrollView::Color color,
                                      ScrollView* window) const {
-  #ifndef GRAPHICS_DISABLED
   for (uint32_t f = 0; f < num_features_; ++f) {
     RenderIntFeature(window, &features_[f], color);
   }
-  #endif  // GRAPHICS_DISABLED
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // Returns a pix of the original sample image. The pix is padded all round
 // by padding wherever possible.

--- a/src/lstm/convolve.cpp
+++ b/src/lstm/convolve.cpp
@@ -4,7 +4,6 @@
 //              and pulls in random data to fill out-of-input inputs.
 //              Output is therefore same size as its input, but deeper.
 // Author:      Ray Smith
-// Created:     Tue Mar 18 16:56:06 PST 2014
 //
 // (C) Copyright 2014, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +16,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////
+
+#ifdef HAVE_CONFIG_H
+#include "config_auto.h"
+#endif
 
 #include "convolve.h"
 
@@ -76,7 +79,9 @@ void Convolve::Forward(bool debug, const NetworkIO& input,
       }
     }
   } while (dest_index.Increment());
+#ifndef GRAPHICS_DISABLED
   if (debug) DisplayForward(*output);
+#endif
 }
 
 // Runs backward propagation of errors on the deltas line.

--- a/src/lstm/fullyconnected.cpp
+++ b/src/lstm/fullyconnected.cpp
@@ -15,6 +15,10 @@
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////
 
+#ifdef HAVE_CONFIG_H
+#include "config_auto.h"
+#endif
+
 #include "fullyconnected.h"
 
 #ifdef _OPENMP
@@ -165,7 +169,9 @@ void FullyConnected::Forward(bool debug, const NetworkIO& input,
   tprintf("F Output:%s\n", name_.c_str());
   output->Print(10);
 #endif
+#ifndef GRAPHICS_DISABLED
   if (debug) DisplayForward(*output);
+#endif
 }
 
 // Components of Forward so FullyConnected can be reused inside LSTM.
@@ -220,7 +226,9 @@ void FullyConnected::ForwardTimeStep(const int8_t* i_input,
 bool FullyConnected::Backward(bool debug, const NetworkIO& fwd_deltas,
                               NetworkScratch* scratch,
                               NetworkIO* back_deltas) {
+#ifndef GRAPHICS_DISABLED
   if (debug) DisplayBackward(fwd_deltas);
+#endif
   back_deltas->Resize(fwd_deltas, ni_);
   GenericVector<NetworkScratch::FloatVec> errors;
   errors.init_to_size(kNumThreads, NetworkScratch::FloatVec());

--- a/src/lstm/lstm.cpp
+++ b/src/lstm/lstm.cpp
@@ -15,6 +15,10 @@
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////
 
+#ifdef HAVE_CONFIG_H
+#include "config_auto.h"
+#endif
+
 #include "lstm.h"
 
 #ifdef _OPENMP
@@ -432,7 +436,9 @@ void LSTM::Forward(bool debug, const NetworkIO& input,
   tprintf("Output:%s\n", name_.c_str());
   output->Print(10);
 #endif
+#ifndef GRAPHICS_DISABLED
   if (debug) DisplayForward(*output);
+#endif
 }
 
 // Runs backward propagation of errors on the deltas line.
@@ -440,7 +446,9 @@ void LSTM::Forward(bool debug, const NetworkIO& input,
 bool LSTM::Backward(bool debug, const NetworkIO& fwd_deltas,
                     NetworkScratch* scratch,
                     NetworkIO* back_deltas) {
+#ifndef GRAPHICS_DISABLED
   if (debug) DisplayBackward(fwd_deltas);
+#endif
   back_deltas->ResizeToMap(fwd_deltas.int_mode(), input_map_, ni_);
   // ======Scratch space.======
   // Output errors from deltas with recurrence from sourceerr.

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -322,7 +322,9 @@ bool LSTMRecognizer::RecognizeLine(const ImageData& image_data, bool invert,
   if (debug) {
     GenericVector<int> labels, coords;
     LabelsFromOutputs(*outputs, &labels, &coords);
+#ifndef GRAPHICS_DISABLED
     DisplayForward(*inputs, labels, coords, "LSTMForward", &debug_win_);
+#endif
     DebugActivationPath(*outputs, labels, coords);
   }
   return true;
@@ -343,6 +345,8 @@ STRING LSTMRecognizer::DecodeLabels(const GenericVector<int>& labels) {
   return result;
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Displays the forward results in a window with the characters and
 // boundaries as determined by the labels and label_coords.
 void LSTMRecognizer::DisplayForward(const NetworkIO& inputs,
@@ -350,13 +354,11 @@ void LSTMRecognizer::DisplayForward(const NetworkIO& inputs,
                                     const GenericVector<int>& label_coords,
                                     const char* window_name,
                                     ScrollView** window) {
-#ifndef GRAPHICS_DISABLED  // do nothing if there's no graphics
   Pix* input_pix = inputs.ToPix();
   Network::ClearWindow(false, window_name, pixGetWidth(input_pix),
                        pixGetHeight(input_pix), window);
   int line_height = Network::DisplayImage(input_pix, *window);
   DisplayLSTMOutput(labels, label_coords, line_height, *window);
-#endif  // GRAPHICS_DISABLED
 }
 
 // Displays the labels and cuts at the corresponding xcoords.
@@ -364,7 +366,6 @@ void LSTMRecognizer::DisplayForward(const NetworkIO& inputs,
 void LSTMRecognizer::DisplayLSTMOutput(const GenericVector<int>& labels,
                                        const GenericVector<int>& xcoords,
                                        int height, ScrollView* window) {
-#ifndef GRAPHICS_DISABLED  // do nothing if there's no graphics
   int x_scale = network_->XScaleFactor();
   window->TextAttributes("Arial", height / 4, false, false, false);
   int end = 1;
@@ -383,8 +384,9 @@ void LSTMRecognizer::DisplayLSTMOutput(const GenericVector<int>& labels,
     window->Line(xpos, 0, xpos, height * 3 / 2);
   }
   window->Update();
-#endif  // GRAPHICS_DISABLED
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // Prints debug output detailing the activation path that is implied by the
 // label_coords.

--- a/src/lstm/network.cpp
+++ b/src/lstm/network.cpp
@@ -283,31 +283,28 @@ double Network::Random(double range) {
   return randomizer_->SignedRand(range);
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // === Debug image display methods. ===
 // Displays the image of the matrix to the forward window.
 void Network::DisplayForward(const NetworkIO& matrix) {
-#ifndef GRAPHICS_DISABLED  // do nothing if there's no graphics
   Pix* image = matrix.ToPix();
   ClearWindow(false, name_.c_str(), pixGetWidth(image),
               pixGetHeight(image), &forward_win_);
   DisplayImage(image, forward_win_);
   forward_win_->Update();
-#endif  // GRAPHICS_DISABLED
 }
 
 // Displays the image of the matrix to the backward window.
 void Network::DisplayBackward(const NetworkIO& matrix) {
-#ifndef GRAPHICS_DISABLED  // do nothing if there's no graphics
   Pix* image = matrix.ToPix();
   STRING window_name = name_ + "-back";
   ClearWindow(false, window_name.c_str(), pixGetWidth(image),
               pixGetHeight(image), &backward_win_);
   DisplayImage(image, backward_win_);
   backward_win_->Update();
-#endif  // GRAPHICS_DISABLED
 }
 
-#ifndef GRAPHICS_DISABLED
 // Creates the window if needed, otherwise clears it.
 void Network::ClearWindow(bool tess_coords, const char* window_name,
                           int width, int height, ScrollView** window) {
@@ -338,6 +335,6 @@ int Network::DisplayImage(Pix* pix, ScrollView* window) {
   pixDestroy(&pix);
   return height;
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 }  // namespace tesseract.

--- a/src/lstm/parallel.cpp
+++ b/src/lstm/parallel.cpp
@@ -2,7 +2,6 @@
 // File:        parallel.cpp
 // Description: Runs networks in parallel on the same input.
 // Author:      Ray Smith
-// Created:     Thu May 02 08:06:06 PST 2013
 //
 // (C) Copyright 2013, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////
+
+#ifdef HAVE_CONFIG_H
+#include "config_auto.h"
+#endif
 
 #include "parallel.h"
 
@@ -100,9 +103,11 @@ void Parallel::Forward(bool debug, const NetworkIO& input,
       out_offset = output->CopyPacking(*result, out_offset);
     }
   }
+#ifndef GRAPHICS_DISABLED
   if (parallel_debug) {
     DisplayForward(*output);
   }
+#endif
 }
 
 // Runs backward propagation of errors on the deltas line.
@@ -113,7 +118,9 @@ bool Parallel::Backward(bool debug, const NetworkIO& fwd_deltas,
   // If this parallel is a replicator of convolvers, or holds a 1-d LSTM pair,
   // or a 2-d LSTM quad, do debug locally, and don't pass the flag on.
   if (debug && type_ != NT_PARALLEL) {
+#ifndef GRAPHICS_DISABLED
     DisplayBackward(fwd_deltas);
+#endif
     debug = false;
   }
   int stack_size = stack_.size();

--- a/src/textord/alignedblob.cpp
+++ b/src/textord/alignedblob.cpp
@@ -154,10 +154,11 @@ bool AlignedBlob::WithinTestRegion(int detail_level, int x, int y) {
          y <= textord_testregion_top && y >= textord_testregion_bottom;
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Display the tab codes of the BLOBNBOXes in this grid.
 ScrollView* AlignedBlob::DisplayTabs(const char* window_name,
                                      ScrollView* tab_win) {
-#ifndef GRAPHICS_DISABLED
   if (tab_win == nullptr)
     tab_win = MakeWindow(0, 50, window_name);
   // For every tab in the grid, display it.
@@ -196,9 +197,10 @@ ScrollView* AlignedBlob::DisplayTabs(const char* window_name,
     }
   }
   tab_win->Update();
-#endif
   return tab_win;
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // Helper returns true if the total number of line_crossings of all the blobs
 // in the list is at least 2.

--- a/src/textord/baselinedetect.cpp
+++ b/src/textord/baselinedetect.cpp
@@ -577,10 +577,11 @@ void BaselineBlock::FitBaselineSplines(bool enable_splines,
     restore_underlined_blobs(block_);
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Draws the (straight) baselines and final blobs colored according to
 // what was discarded as noise and what is associated with each row.
 void BaselineBlock::DrawFinalRows(const ICOORD& page_tr) {
-#ifndef GRAPHICS_DISABLED
   if (non_text_block_) return;
   double gradient = tan(skew_angle_);
   FCOORD rotation(1.0f, 0.0f);
@@ -601,8 +602,9 @@ void BaselineBlock::DrawFinalRows(const ICOORD& page_tr) {
   if (block_->blobs.length() > 0)
     tprintf("%d blobs discarded as noise\n", block_->blobs.length());
   draw_meanlines(block_, gradient, left_edge, ScrollView::WHITE, rotation);
-#endif
 }
+
+#endif // !GRAPHICS_DISABLED
 
 void BaselineBlock::DrawPixSpline(Pix* pix_in) {
   if (non_text_block_) return;
@@ -856,9 +858,11 @@ void BaselineDetect::ComputeBaselineSplinesAndXheights(const ICOORD& page_tr,
     if (enable_splines)
       bl_block->PrepareForSplineFitting(page_tr, remove_noise);
     bl_block->FitBaselineSplines(enable_splines, show_final_rows, textord);
+#ifndef GRAPHICS_DISABLED
     if (show_final_rows) {
       bl_block->DrawFinalRows(page_tr);
     }
+#endif
   }
 }
 

--- a/src/textord/bbgrid.h
+++ b/src/textord/bbgrid.h
@@ -583,25 +583,24 @@ template<class G> class TabEventHandler : public SVEventHandler {
   G* grid_;
 };
 
+#ifndef GRAPHICS_DISABLED
+
 // Make a window of an appropriate size to display things in the grid.
 // Position the window at the given x,y.
 template<class BBC, class BBC_CLIST, class BBC_C_IT>
 ScrollView* BBGrid<BBC, BBC_CLIST, BBC_C_IT>::MakeWindow(
     int x, int y, const char* window_name) {
-  ScrollView* tab_win = nullptr;
-#ifndef GRAPHICS_DISABLED
-  tab_win = new ScrollView(window_name, x, y,
-                           tright_.x() - bleft_.x(),
-                           tright_.y() - bleft_.y(),
-                           tright_.x() - bleft_.x(),
-                           tright_.y() - bleft_.y(),
-                           true);
+  auto tab_win = new ScrollView(window_name, x, y,
+                                tright_.x() - bleft_.x(),
+                                tright_.y() - bleft_.y(),
+                                tright_.x() - bleft_.x(),
+                                tright_.y() - bleft_.y(),
+                                true);
   auto* handler =
     new TabEventHandler<BBGrid<BBC, BBC_CLIST, BBC_C_IT> >(this);
   tab_win->AddEventHandler(handler);
   tab_win->Pen(ScrollView::GREY);
   tab_win->Rectangle(0, 0, tright_.x() - bleft_.x(), tright_.y() - bleft_.y());
-#endif
   return tab_win;
 }
 
@@ -611,7 +610,6 @@ ScrollView* BBGrid<BBC, BBC_CLIST, BBC_C_IT>::MakeWindow(
 // ScrollView::Color BBC::BoxColor() const.
 template<class BBC, class BBC_CLIST, class BBC_C_IT>
 void BBGrid<BBC, BBC_CLIST, BBC_C_IT>::DisplayBoxes(ScrollView* tab_win) {
-#ifndef GRAPHICS_DISABLED
   tab_win->Pen(ScrollView::BLUE);
   tab_win->Brush(ScrollView::NONE);
 
@@ -630,8 +628,9 @@ void BBGrid<BBC, BBC_CLIST, BBC_C_IT>::DisplayBoxes(ScrollView* tab_win) {
     tab_win->Rectangle(left_x, bottom_y, right_x, top_y);
   }
   tab_win->Update();
-#endif
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // ASSERT_HOST that every cell contains no more than one copy of each entry.
 template<class BBC, class BBC_CLIST, class BBC_C_IT>

--- a/src/textord/ccnontextdetect.cpp
+++ b/src/textord/ccnontextdetect.cpp
@@ -112,7 +112,7 @@ Pix* CCNonTextDetect::ComputeNonTextMask(bool debug, Pix* photo_map,
   if (debug) {
     win = MakeWindow(0, 400, "Photo Mask Blobs");
   }
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
   // Large and medium blobs are not text if they overlap with "a lot" of small
   // blobs.
   MarkAndDeleteNonTextBlobs(&blob_block->large_blobs,
@@ -137,12 +137,12 @@ Pix* CCNonTextDetect::ComputeNonTextMask(bool debug, Pix* photo_map,
   if (debug) {
     #ifndef GRAPHICS_DISABLED
     win->Update();
-    #endif  // GRAPHICS_DISABLED
+    #endif // !GRAPHICS_DISABLED
     pixWrite("junkccphotomask.png", pix, IFF_PNG);
     #ifndef GRAPHICS_DISABLED
     delete win->AwaitEvent(SVET_DESTROY);
     delete win;
-    #endif  // GRAPHICS_DISABLED
+    #endif // !GRAPHICS_DISABLED
   }
   return pix;
 }
@@ -262,7 +262,7 @@ void CCNonTextDetect::MarkAndDeleteNonTextBlobs(BLOBNBOX_LIST* blobs,
       #ifndef GRAPHICS_DISABLED
       if (win != nullptr)
         blob->plot(win, ok_color, ok_color);
-      #endif  // GRAPHICS_DISABLED
+      #endif // !GRAPHICS_DISABLED
     } else {
       if (noise_density_->AnyZeroInRect(box)) {
         // There is a danger that the bounding box may overlap real text, so
@@ -286,7 +286,7 @@ void CCNonTextDetect::MarkAndDeleteNonTextBlobs(BLOBNBOX_LIST* blobs,
       #ifndef GRAPHICS_DISABLED
       if (win != nullptr)
         blob->plot(win, ScrollView::RED, ScrollView::RED);
-      #endif  // GRAPHICS_DISABLED
+      #endif // !GRAPHICS_DISABLED
       // It is safe to delete the cblob now, as it isn't used by the grid
       // or BlobOverlapsTooMuch, and the BLOBNBOXes will go away with the
       // dead_blobs list.

--- a/src/textord/colpartition.cpp
+++ b/src/textord/colpartition.cpp
@@ -1787,7 +1787,7 @@ ScrollView::Color  ColPartition::BoxColor() const {
     return BLOBNBOX::TextlineColor(blob_type_, flow_);
   return POLY_BLOCK::ColorForPolyBlockType(type_);
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 // Keep in sync with BlobRegionType.
 static char kBlobTypes[BRT_COUNT + 1] = "NHSRIUVT";

--- a/src/textord/colpartition.h
+++ b/src/textord/colpartition.h
@@ -687,7 +687,7 @@ class ColPartition : public ELIST2_LINK {
   #ifndef GRAPHICS_DISABLED
   // Provides a color for BBGrid to draw the rectangle.
   ScrollView::Color  BoxColor() const;
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 
   // Prints debug information on this.
   void Print() const;

--- a/src/textord/colpartitionset.cpp
+++ b/src/textord/colpartitionset.cpp
@@ -381,18 +381,20 @@ void ColPartitionSet::GetColumnBoxes(int y_bottom, int y_top,
   }
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Display the edges of the columns at the given y coords.
 void ColPartitionSet::DisplayColumnEdges(int y_bottom, int y_top,
                                          ScrollView* win) {
-#ifndef GRAPHICS_DISABLED
   ColPartition_IT it(&parts_);
   for (it.mark_cycle_pt(); !it.cycled_list(); it.forward()) {
     ColPartition* part = it.data();
     win->Line(part->LeftAtY(y_top), y_top, part->LeftAtY(y_bottom), y_bottom);
     win->Line(part->RightAtY(y_top), y_top, part->RightAtY(y_bottom), y_bottom);
   }
-#endif  // GRAPHICS_DISABLED
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // Return the ColumnSpanningType that best explains the columns overlapped
 // by the given coords(left,right,y), with the given margins.

--- a/src/textord/drawtord.cpp
+++ b/src/textord/drawtord.cpp
@@ -34,12 +34,13 @@ BOOL_VAR (textord_show_fixed_cuts, false,
 
 ScrollView* to_win = nullptr;
 
+#ifndef GRAPHICS_DISABLED
+
 /**********************************************************************
  * create_to_win
  *
  * Create the to window used to show the fit.
  **********************************************************************/
-#ifndef GRAPHICS_DISABLED
 
 ScrollView* create_to_win(ICOORD page_tr) {
   if (to_win != nullptr) return to_win;
@@ -414,4 +415,4 @@ void plot_row_cells(                       //draw words
   }
 }
 
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED

--- a/src/textord/imagefind.cpp
+++ b/src/textord/imagefind.cpp
@@ -1354,10 +1354,12 @@ void ImageFind::FindImagePartitions(Pix* image_pix, const FCOORD& rotation,
   boxaDestroy(&boxa);
   pixaDestroy(&pixa);
   DeleteSmallImages(part_grid);
+#ifndef GRAPHICS_DISABLED
   if (textord_tabfind_show_images) {
     ScrollView* images_win_ = part_grid->MakeWindow(1000, 400, "With Images");
     part_grid->DisplayBoxes(images_win_);
   }
+#endif
 }
 
 

--- a/src/textord/tabfind.cpp
+++ b/src/textord/tabfind.cpp
@@ -443,7 +443,7 @@ bool TabFind::FindTabVectors(TabVector_LIST* hlines,
     DisplayTabs("FinalTabs", tab_win);
     tab_win = DisplayTabVectors(tab_win);
   }
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
   return true;
 }
 
@@ -481,7 +481,7 @@ void TabFind::TidyBlobs(TO_BLOCK* block) {
     block->plot_graded_blobs(rej_win);
     block->plot_noise_blobs(rej_win);
     rej_win->Update();
-    #endif  // GRAPHICS_DISABLED
+    #endif // !GRAPHICS_DISABLED
   }
   block->DeleteUnownedNoise();
 }
@@ -494,8 +494,9 @@ void TabFind::SetupTabSearch(int x, int y, int* min_key, int* max_key) {
   *max_key = std::max(key1, key2);
 }
 
-ScrollView* TabFind::DisplayTabVectors(ScrollView* tab_win) {
 #ifndef GRAPHICS_DISABLED
+
+ScrollView* TabFind::DisplayTabVectors(ScrollView* tab_win) {
   // For every vector, display it.
   TabVector_IT it(&vectors_);
   for (it.mark_cycle_pt(); !it.cycled_list(); it.forward()) {
@@ -503,9 +504,10 @@ ScrollView* TabFind::DisplayTabVectors(ScrollView* tab_win) {
     vector->Display(tab_win);
   }
   tab_win->Update();
-#endif
   return tab_win;
 }
+
+#endif
 
 // PRIVATE CODE.
 //
@@ -515,10 +517,12 @@ ScrollView* TabFind::FindInitialTabVectors(BLOBNBOX_LIST* image_blobs,
                                            int min_gutter_width,
                                            double tabfind_aligned_gap_fraction,
                                            TO_BLOCK* block) {
+#ifndef GRAPHICS_DISABLED
   if (textord_tabfind_show_initialtabs) {
     ScrollView* line_win = MakeWindow(0, 0, "VerticalLines");
     line_win = DisplayTabVectors(line_win);
   }
+#endif
   // Prepare the grid.
   if (image_blobs != nullptr)
     InsertBlobsToGrid(true, false, image_blobs, this);
@@ -530,16 +534,19 @@ ScrollView* TabFind::FindInitialTabVectors(BLOBNBOX_LIST* image_blobs,
   TabVector::MergeSimilarTabVectors(vertical_skew_, &vectors_, this);
   SortVectors();
   EvaluateTabs();
+#ifndef GRAPHICS_DISABLED
   if (textord_tabfind_show_initialtabs && initial_win != nullptr)
     initial_win = DisplayTabVectors(initial_win);
+#endif
   MarkVerticalText();
   return initial_win;
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Helper displays all the boxes in the given vector on the given window.
 static void DisplayBoxVector(const GenericVector<BLOBNBOX*>& boxes,
                              ScrollView* win) {
-  #ifndef GRAPHICS_DISABLED
   for (int i = 0; i < boxes.size(); ++i) {
     TBOX box = boxes[i]->bounding_box();
     int left_x = box.left();
@@ -551,8 +558,9 @@ static void DisplayBoxVector(const GenericVector<BLOBNBOX*>& boxes,
     win->Rectangle(left_x, bottom_y, right_x, top_y);
   }
   win->Update();
-  #endif  // GRAPHICS_DISABLED
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // For each box in the grid, decide whether it is a candidate tab-stop,
 // and if so add it to the left/right tab boxes.
@@ -588,7 +596,7 @@ ScrollView* TabFind::FindTabBoxes(int min_gutter_width,
     DisplayBoxVector(right_tab_boxes_, tab_win);
     tab_win = DisplayTabs("Tabs", tab_win);
   }
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
   return tab_win;
 }
 
@@ -952,7 +960,7 @@ void TabFind::ComputeColumnWidths(ScrollView* tab_win,
   #ifndef GRAPHICS_DISABLED
   if (tab_win != nullptr)
     tab_win->Pen(ScrollView::WHITE);
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
   // Accumulate column sections into a STATS
   int col_widths_size = (tright_.x() - bleft_.x()) / kColumnWidthFactor;
   STATS col_widths(0, col_widths_size + 1);
@@ -961,7 +969,7 @@ void TabFind::ComputeColumnWidths(ScrollView* tab_win,
   if (tab_win != nullptr) {
     tab_win->Update();
   }
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
   if (textord_debug_tabfind > 1)
     col_widths.print();
   // Now make a list of column widths.

--- a/src/textord/tablefind.h
+++ b/src/textord/tablefind.h
@@ -385,8 +385,6 @@ class TableFinder {
   void DisplayColPartitionConnections(ScrollView* win,
                                       ColPartitionGrid* grid,
                                       ScrollView::Color default_color);
-  void DisplayColSegmentGrid(ScrollView* win, ColSegmentGrid* grid,
-                             ScrollView::Color color);
 
   // Merge all colpartitions in table regions to make them a single
   // colpartition and revert types of isolated table cells not

--- a/src/textord/tablerecog.cpp
+++ b/src/textord/tablerecog.cpp
@@ -286,8 +286,9 @@ double StructuredTable::CalculateCellFilledPercentage(int row, int column) {
   return std::min(1.0, area_covered / current_area);
 }
 
-void StructuredTable::Display(ScrollView* window, ScrollView::Color color) {
 #ifndef GRAPHICS_DISABLED
+
+void StructuredTable::Display(ScrollView* window, ScrollView::Color color) {
   window->Brush(ScrollView::NONE);
   window->Pen(color);
   window->Rectangle(bounding_box_.left(), bounding_box_.bottom(),
@@ -301,8 +302,9 @@ void StructuredTable::Display(ScrollView* window, ScrollView::Color color) {
                  bounding_box_.right(), cell_y_[i]);
   }
   window->UpdateWindow();
-#endif
 }
+
+#endif
 
 // Clear structure information.
 void StructuredTable::ClearStructure() {

--- a/src/textord/tabvector.cpp
+++ b/src/textord/tabvector.cpp
@@ -535,9 +535,10 @@ void TabVector::Debug(const char* prefix) {
   }
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Draw this tabvector in place in the given window.
 void TabVector::Display(ScrollView* tab_win) {
-#ifndef GRAPHICS_DISABLED
   if (textord_debug_printable)
     tab_win->Pen(ScrollView::BLUE);
   else if (alignment_ == TA_LEFT_ALIGNED)
@@ -558,8 +559,9 @@ void TabVector::Display(ScrollView* tab_win) {
   snprintf(score_buf, sizeof(score_buf), "%d", percent_score_);
   tab_win->TextAttributes("Times", 50, false, false, false);
   tab_win->Text(startpt_.x(), startpt_.y(), score_buf);
-#endif
 }
+
+#endif
 
 // Refit the line and/or re-evaluate the vector if the dirty flags are set.
 void TabVector::FitAndEvaluateIfNeeded(const ICOORD& vertical,

--- a/src/textord/textlineprojection.cpp
+++ b/src/textord/textlineprojection.cpp
@@ -80,10 +80,11 @@ void TextlineProjection::ConstructProjection(TO_BLOCK* input_block,
   pix_ = final_pix;
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Display the blobs in the window colored according to textline quality.
 void TextlineProjection::PlotGradedBlobs(BLOBNBOX_LIST* blobs,
                                          ScrollView* win) {
-#ifndef GRAPHICS_DISABLED
   BLOBNBOX_IT it(blobs);
   for (it.mark_cycle_pt(); !it.cycled_list(); it.forward()) {
     BLOBNBOX* blob = it.data();
@@ -96,8 +97,9 @@ void TextlineProjection::PlotGradedBlobs(BLOBNBOX_LIST* blobs,
     win->Rectangle(box.left(), box.bottom(), box.right(), box.top());
   }
   win->Update();
-#endif  // GRAPHICS_DISABLED
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // Moves blobs that look like they don't sit well on a textline from the
 // input blobs list to the output small_blobs list.
@@ -119,9 +121,10 @@ void TextlineProjection::MoveNonTextlineBlobs(
   }
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Create a window and display the projection in it.
 void TextlineProjection::DisplayProjection() const {
-#ifndef GRAPHICS_DISABLED
   int width = pixGetWidth(pix_);
   int height = pixGetHeight(pix_);
   Pix* pixc = pixCreate(width, height, 32);
@@ -147,8 +150,9 @@ void TextlineProjection::DisplayProjection() const {
   win->Image(pixc, 0, 0);
   win->Update();
   pixDestroy(&pixc);
-#endif  // GRAPHICS_DISABLED
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // Compute the distance of the box from the partition using curved projection
 // space. As DistanceOfBoxFromBox, except that the direction is taken from

--- a/src/textord/tordmain.cpp
+++ b/src/textord/tordmain.cpp
@@ -256,7 +256,7 @@ void Textord::filter_blobs(ICOORD page_tr,         // top right
   #ifndef GRAPHICS_DISABLED
   if (to_win != nullptr)
     to_win->Clear();
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 
   for (block_it.mark_cycle_pt(); !block_it.cycled_list();
        block_it.forward()) {
@@ -288,7 +288,7 @@ void Textord::filter_blobs(ICOORD page_tr,         // top right
       plot_box_list(to_win, &block->large_blobs, ScrollView::WHITE);
       plot_box_list(to_win, &block->blobs, ScrollView::WHITE);
     }
-    #endif  // GRAPHICS_DISABLED
+    #endif // !GRAPHICS_DISABLED
   }
 }
 

--- a/src/training/errorcounter.cpp
+++ b/src/training/errorcounter.cpp
@@ -12,6 +12,11 @@
 // limitations under the License.
 //
 ///////////////////////////////////////////////////////////////////////
+
+#ifdef HAVE_CONFIG_H
+#include "config_auto.h"
+#endif
+
 #include <algorithm>
 #include <ctime>
 
@@ -78,7 +83,9 @@ double ErrorCounter::ComputeErrorRate(ShapeClassifier* classifier,
       tprintf("Error on sample %d: %s Classifier debug output:\n",
               it->GlobalSampleIndex(),
               it->sample_set()->SampleToString(*mutable_sample).c_str());
+#ifndef GRAPHICS_DISABLED
       classifier->DebugDisplay(*mutable_sample, page_pix, correct_id);
+#endif
       --error_samples;
     }
     ++total_samples;
@@ -141,7 +148,9 @@ void ErrorCounter::DebugNewErrors(
         new_classifier->UnicharClassifySample(*mutable_sample, page_pix, 1,
                                               correct_id, &results);
         if (results.size() > 0 && error_samples > 0) {
+#ifndef GRAPHICS_DISABLED
           new_classifier->DebugDisplay(*mutable_sample, page_pix, correct_id);
+#endif
           --error_samples;
         }
       }

--- a/src/training/lstmtrainer.cpp
+++ b/src/training/lstmtrainer.cpp
@@ -757,7 +757,7 @@ Trainability LSTMTrainer::TrainOnLine(const ImageData* trainingdata,
   if (debug_interval_ == 1 && debug_win_ != nullptr) {
     delete debug_win_->AwaitEvent(SVET_CLICK);
   }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
   // Roll the memory of past means.
   RollErrorBuffers();
   return trainable;
@@ -1026,20 +1026,23 @@ bool LSTMTrainer::DebugLSTMTraining(const NetworkIO& inputs,
       tprintf("TRAINING activation path for truth string %s\n",
               truth_text.c_str());
       DebugActivationPath(outputs, labels, xcoords);
+#ifndef GRAPHICS_DISABLED
       DisplayForward(inputs, labels, xcoords, "LSTMTraining", &align_win_);
       if (OutputLossType() == LT_CTC) {
         DisplayTargets(fwd_outputs, "CTC Outputs", &ctc_win_);
         DisplayTargets(outputs, "CTC Targets", &target_win_);
       }
+#endif
     }
   }
   return true;
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Displays the network targets as line a line graph.
 void LSTMTrainer::DisplayTargets(const NetworkIO& targets,
                                  const char* window_name, ScrollView** window) {
-#ifndef GRAPHICS_DISABLED  // do nothing if there's no graphics.
   int width = targets.Width();
   int num_features = targets.NumFeatures();
   Network::ClearWindow(true, window_name, width * kTargetXScale, kTargetYScale,
@@ -1069,8 +1072,9 @@ void LSTMTrainer::DisplayTargets(const NetworkIO& targets,
     }
   }
   (*window)->Update();
-#endif  // GRAPHICS_DISABLED
 }
+
+#endif // !GRAPHICS_DISABLED
 
 // Builds a no-compromises target where the first positions should be the
 // truth labels and the rest is padded with the null_char_.

--- a/src/training/mastertrainer.cpp
+++ b/src/training/mastertrainer.cpp
@@ -743,7 +743,7 @@ void MasterTrainer::DisplaySamples(const char* unichar_str1, int cloud_font,
     delete ev;
   } while (ev_type != SVET_DESTROY);
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 void MasterTrainer::TestClassifierVOld(bool replicate_samples,
                                        ShapeClassifier* test_classifier,

--- a/src/training/mastertrainer.h
+++ b/src/training/mastertrainer.h
@@ -209,7 +209,7 @@ class MasterTrainer {
   // will display the samples that have that feature in a separate window.
   void DisplaySamples(const char* unichar_str1, int cloud_font,
                       const char* unichar_str2, int canonical_font);
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 
   void TestClassifierVOld(bool replicate_samples,
                           ShapeClassifier* test_classifier,

--- a/src/training/mftraining.cpp
+++ b/src/training/mftraining.cpp
@@ -88,7 +88,7 @@ static void DisplayProtoList(const char* ch, LIST protolist) {
   }
   window->Update();
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 // Helper to run clustering on a single config.
 // Mostly copied from the old mftraining, but with renamed variables.
@@ -111,7 +111,7 @@ static LIST ClusterOneConfig(int shape_id, const char* class_label,
   #ifndef GRAPHICS_DISABLED
   if (strcmp(FLAGS_test_ch.c_str(), class_label) == 0)
     DisplayProtoList(FLAGS_test_ch.c_str(), proto_list);
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
   // Delete the protos that will not be used in the inttemp output file.
   proto_list = RemoveInsignificantProtos(proto_list, true,
                                          false,

--- a/src/training/shapeclustering.cpp
+++ b/src/training/shapeclustering.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
                             FLAGS_display_cloud_font,
                             FLAGS_canonical_class2.c_str(),
                             FLAGS_display_canonical_font);
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
     return 0;
   } else if (!FLAGS_canonical_class1.empty()) {
     trainer->DebugCanonical(FLAGS_canonical_class1.c_str(),

--- a/src/training/trainingsampleset.cpp
+++ b/src/training/trainingsampleset.cpp
@@ -13,6 +13,12 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
+#ifdef HAVE_CONFIG_H
+#include "config_auto.h"
+#endif
+
+#include <algorithm>
+
 #include "trainingsampleset.h"
 #include "allheaders.h"
 #include "boxread.h"
@@ -24,8 +30,6 @@
 #include "shapetable.h"
 #include "trainingsample.h"
 #include "unicity_table.h"
-
-#include <algorithm>
 
 namespace tesseract {
 
@@ -738,6 +742,8 @@ void TrainingSampleSet::AddAllFontsForClass(int class_id, Shape* shape) const {
   }
 }
 
+#ifndef GRAPHICS_DISABLED
+
 // Display the samples with the given indexed feature that also match
 // the given shape.
 void TrainingSampleSet::DisplaySamplesWithFeature(int f_index,
@@ -760,5 +766,6 @@ void TrainingSampleSet::DisplaySamplesWithFeature(int f_index,
   }
 }
 
+#endif // !GRAPHICS_DISABLED
 
 }  // namespace tesseract.

--- a/src/viewer/scrollview.cpp
+++ b/src/viewer/scrollview.cpp
@@ -356,7 +356,7 @@ void ScrollView::StartEventHandler() {
     // The thread should run as long as its associated window is alive.
   }
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 ScrollView::~ScrollView() {
   #ifndef GRAPHICS_DISABLED
@@ -385,7 +385,7 @@ ScrollView::~ScrollView() {
   for (auto & i : event_table_) {
     delete i;
   }
-  #endif  // GRAPHICS_DISABLED
+  #endif // !GRAPHICS_DISABLED
 }
 
 #ifndef GRAPHICS_DISABLED
@@ -842,4 +842,4 @@ char ScrollView::Wait() {
   return ret;
 }
 
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED

--- a/src/viewer/scrollview.h
+++ b/src/viewer/scrollview.h
@@ -409,7 +409,7 @@ class ScrollView {
 
   // Semaphore to the thread belonging to this window.
   SVSemaphore* semaphore_;
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 };
 
 #endif  // OCR_SCROLLVIEW_H__

--- a/src/viewer/svmnode.cpp
+++ b/src/viewer/svmnode.cpp
@@ -140,4 +140,4 @@ void SVMenuNode::BuildMenu(ScrollView* sv, bool menu_bar) {
   }
 }
 
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED

--- a/src/viewer/svpaint.cpp
+++ b/src/viewer/svpaint.cpp
@@ -232,4 +232,4 @@ int main(int argc, char** argv) {
   if (argc > 1) { server_name = argv[1]; } else { server_name = "localhost"; }
   SVPaint svp(server_name);
 }
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED

--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -341,4 +341,4 @@ SVNetwork::~SVNetwork() {
   delete[] msg_buffer_in_;
 }
 
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED

--- a/src/wordrec/drawfx.cpp
+++ b/src/wordrec/drawfx.cpp
@@ -67,7 +67,7 @@ void clear_fx_win() {  //make features win
                kBlnXHeight + kBlnBaselineOffset);
 }
 
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED
 
 /**********************************************************************
  * create_fxdebug_win

--- a/src/wordrec/language_model.cpp
+++ b/src/wordrec/language_model.cpp
@@ -120,7 +120,7 @@ LanguageModel::LanguageModel(const UnicityTable<FontInfo> *fontinfo_table,
                     dict->getCCUtil()->params()),
       double_MEMBER(language_model_penalty_increment, 0.01, "Penalty increment",
                     dict->getCCUtil()->params()),
-      INT_MEMBER(wordrec_display_segmentations, 0, "Display Segmentations",
+      INT_MEMBER(wordrec_display_segmentations, 0, "Display Segmentations (ScrollView)",
                  dict->getCCUtil()->params()),
       BOOL_INIT_MEMBER(language_model_use_sigmoidal_certainty, false,
                        "Use sigmoidal score for certainty",
@@ -1333,9 +1333,11 @@ void LanguageModel::UpdateBestChoice(
           vse->dawg_info != nullptr && vse->top_choice_flags);
     }
   }
+#ifndef GRAPHICS_DISABLED
   if (wordrec_display_segmentations && word_res->chopped_word != nullptr) {
     word->DisplaySegmentation(word_res->chopped_word);
   }
+#endif
 }
 
 void LanguageModel::ExtractFeaturesFromPath(

--- a/src/wordrec/plotedges.cpp
+++ b/src/wordrec/plotedges.cpp
@@ -107,4 +107,4 @@ void mark_outline(EDGEPT *edgept) {  /* Start of point list */
   window->Update();
 }
 
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED

--- a/src/wordrec/render.cpp
+++ b/src/wordrec/render.cpp
@@ -124,4 +124,4 @@ void render_outline(ScrollView* window, TESSLINE* outline,
   render_outline (window, outline->next, color);
 }
 
-#endif  // GRAPHICS_DISABLED
+#endif // !GRAPHICS_DISABLED


### PR DESCRIPTION
Some runtime parameters which are only relevant with graphics enabled
were now removed from builds when graphics was disabled.

TableFinder::DisplayColSegmentGrid is never used, so remove it completely.

Builds with --disable-graphics significantly reduce the code size and avoid
some function calls which might be important for certain applications:

   text	   data	    bss	    dec	    hex	filename
3219230	  41136	  13920	3274286	 31f62e	.libs/libtesseract.so (--disable-graphics, old)
3211347	  40976	  13600	3265923	 31d583	.libs/libtesseract.so (--disable-graphics, new)
3360942	  43656	  15392	3419990	 342f56	.libs/libtesseract.so (default)

Signed-off-by: Stefan Weil <sw@weilnetz.de>