### PR TITLE
Use strtok_s for MSVC in class SVNetwork

### DIFF
--- a/src/viewer/svutil.h
+++ b/src/viewer/svutil.h
@@ -95,9 +95,8 @@ class SVNetwork {
   /// Stores the messages which are supposed to go out.
   std::string msg_buffer_out_;
 
-  bool has_content;  // Win32 (strtok)
   /// Where we are at in our msg_buffer_in_
-  char* buffer_ptr_;  // Unix (strtok_r)
+  char* buffer_ptr_;  // strtok_r, strtok_s
 };
 
 #endif  // TESSERACT_VIEWER_SVUTIL_H_


### PR DESCRIPTION
strtok_s can be used with MSVC as a replacement for strtok_r, so less
special handling is needed in the code and class SVNetwork can be
made smaller by removing member has_content.

Signed-off-by: Stefan Weil <sw@weilnetz.de>