### PR TITLE
Fix Memory leak when using TESSERACT_IMAGEDATA_AS_PIX

### DIFF
--- a/src/ccstruct/imagedata.cpp
+++ b/src/ccstruct/imagedata.cpp
@@ -125,6 +125,9 @@ ImageData::ImageData(bool vertical, Pix* pix)
   SetPix(pix);
 }
 ImageData::~ImageData() {
+#ifdef TESSERACT_IMAGEDATA_AS_PIX
+  pixDestroy(&internal_pix_);
+#endif
 }
 
 // Builds and returns an ImageData from the basic data. Note that imagedata,


### PR DESCRIPTION
If building with TESSERACT_IMAGEDATA_AS_PIX, then tesseract
doesn't compress/decompress images, but rather holds the
data as internal Pix structures. Unfortunately, I forgot to
make the ImageData destructor free these, so memory leaked
during use. Fixed here.