### PR TITLE
Remove unused char constant that causes a warning.

### DIFF
--- a/src/dict/dict.h
+++ b/src/dict/dict.h
@@ -60,7 +60,6 @@ using DawgVector = GenericVector<Dawg *>;
 // Constants
 //
 static const int kRatingPad = 4;
-static const char kDictWildcard[] = "\u2606";   // WHITE STAR
 static const int kDictMaxWildcards = 2;  // max wildcards for a word
 // TODO(daria): If hyphens are different in different languages and can be
 // inferred from training data we should load their values dynamically.


### PR DESCRIPTION
The kDictWildcard is never actually used, so removing it makes
no difference. It causes warnings in MSVC builds as MSVC doesn't
know how to pack a unicode value into chars.