### PR TITLE
Fix separator line detector

### DIFF
--- a/src/textord/alignedblob.cpp
+++ b/src/textord/alignedblob.cpp
@@ -53,7 +53,7 @@ const int kMinRaggedTabs = 5;
 // Min number of points to accept for an aligned tab stop.
 const int kMinAlignedTabs = 4;
 // Constant number of pixels minimum height of a vertical line.
-const int kVLineMinLength = 500;
+const int kVLineMinLength = 300;
 // Minimum gradient for a vertical tab vector. Used to prune away junk
 // tab vectors with what would be a ridiculously large skew angle.
 // Value corresponds to tan(90 - max allowed skew angle)

--- a/src/textord/alignedblob.cpp
+++ b/src/textord/alignedblob.cpp
@@ -26,10 +26,10 @@
 
 INT_VAR(textord_debug_tabfind, 0, "Debug tab finding");
 INT_VAR(textord_debug_bugs, 0, "Turn on output related to bugs in tab finding");
-static INT_VAR(textord_testregion_left, -1, "Left edge of debug reporting rectangle");
-static INT_VAR(textord_testregion_top, -1, "Top edge of debug reporting rectangle");
-static INT_VAR(textord_testregion_right, INT32_MAX, "Right edge of debug rectangle");
-static INT_VAR(textord_testregion_bottom, INT32_MAX, "Bottom edge of debug rectangle");
+static INT_VAR(textord_testregion_left, -1, "Left edge of debug reporting rectangle in Leptonica coords (bottom=0/top=height), with horizontal lines x/y-flipped");
+static INT_VAR(textord_testregion_top, INT32_MAX, "Top edge of debug reporting rectangle in Leptonica coords (bottom=0/top=height), with horizontal lines x/y-flipped");
+static INT_VAR(textord_testregion_right, INT32_MAX, "Right edge of debug rectangle in Leptonica coords (bottom=0/top=height), with horizontal lines x/y-flipped");
+static INT_VAR(textord_testregion_bottom, -1, "Bottom edge of debug rectangle in Leptonica coords (bottom=0/top=height), with horizontal lines x/y-flipped");
 BOOL_VAR(textord_debug_printable, false, "Make debug windows printable");
 
 namespace tesseract {

--- a/src/textord/colfind.cpp
+++ b/src/textord/colfind.cpp
@@ -1252,7 +1252,9 @@ void ColumnFinder::GridRemoveUnderlinePartitions() {
         if (line_box.bottom() <= text_bottom && text_bottom <= search_box.top())
           touched_text = true;
       } else if (covered->blob_type() == BRT_HLINE &&
-          line_box.contains(covered->bounding_box())) {
+          line_box.contains(covered->bounding_box()) &&
+          // not if same instance (identical to hline)
+          !TBOX(covered->bounding_box()).contains(line_box)) {
         line_part = covered;
       }
     }


### PR DESCRIPTION
This fixes 2 minor issues with foreground line separator detection.

Here is an example (using the ALTO renderer and PageViewer for display):
- before (misses small vertical and large horizontal line):
![fb2_-_007_-_srgb tesseract-orig](https://user-images.githubusercontent.com/38561704/91075369-3fbe0500-e63e-11ea-98c2-31468c1b9e35.png)
- after (fixed):
![fb2_-_007_-_srgb tesseract-fixed-lineseg](https://user-images.githubusercontent.com/38561704/91075447-5e240080-e63e-11ea-8315-5399b3be8bca.png)
