### PR TITLE
Correct "NoImages" in debug pdf file

### DIFF
--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -292,7 +292,14 @@ ColumnFinder* Tesseract::SetupPageSegAndDetectOrientation(
   // Leptonica is used to find a mask of the photo regions in the input.
   *photo_mask_pix = ImageFind::FindImages(pix_binary_, &pixa_debug_);
   if (tessedit_dump_pageseg_images) {
-    pixa_debug_.AddPix(pix_binary_, "NoImages");
+    Pix* pix_no_image_ = nullptr;
+    if (*photo_mask_pix != nullptr) {
+      pix_no_image_ = pixSubtract(nullptr, pix_binary_, *photo_mask_pix);
+    } else {
+      pix_no_image_ = pixClone(pix_binary_);
+    }
+    pixa_debug_.AddPix(pix_no_image_, "NoImages");
+    pixDestroy(&pix_no_image_);
   }
   if (!PSM_COL_FIND_ENABLED(pageseg_mode)) v_lines.clear();
 


### PR DESCRIPTION
- Issues:
  - Debug information for "NoImages" just be binary image,
  it don't show up the result of photo_mask_pix to developer

- Fix:
  - Substract binary image to photo_mask_pix, the result
  are "NoImages" binary pix