### PR TITLE
Remove unused functions FontUtils::GetAllRenderableCharacters

### DIFF
--- a/src/training/pango_font_info.cpp
+++ b/src/training/pango_font_info.cpp
@@ -622,49 +622,6 @@ static void CharCoverageMapToBitmap(PangoCoverage* coverage,
   }
 }
 
-/* static */
-void FontUtils::GetAllRenderableCharacters(std::vector<bool>* unichar_bitmap) {
-  const std::vector<std::string>& all_fonts = ListAvailableFonts();
-  return GetAllRenderableCharacters(all_fonts, unichar_bitmap);
-}
-
-/* static */
-void FontUtils::GetAllRenderableCharacters(const std::string& font_name,
-                                           std::vector<bool>* unichar_bitmap) {
-  PangoFontInfo font_info(font_name);
-  PangoFont* font = font_info.ToPangoFont();
-  if (font != nullptr) {
-    // Font found.
-    PangoCoverage* coverage = pango_font_get_coverage(font, nullptr);
-    CharCoverageMapToBitmap(coverage, unichar_bitmap);
-    pango_coverage_unref(coverage);
-    g_object_unref(font);
-  }
-}
-
-/* static */
-void FontUtils::GetAllRenderableCharacters(const std::vector<std::string>& fonts,
-                                           std::vector<bool>* unichar_bitmap) {
-  // Form the union of coverage maps from the fonts
-  PangoCoverage* all_coverage = pango_coverage_new();
-  tlog(1, "Processing %u fonts\n", static_cast<unsigned>(fonts.size()));
-  for (unsigned i = 0; i < fonts.size(); ++i) {
-    PangoFontInfo font_info(fonts[i]);
-    PangoFont* font = font_info.ToPangoFont();
-    if (font != nullptr) {
-      // Font found.
-      PangoCoverage* coverage = pango_font_get_coverage(font, nullptr);
-      // Mark off characters that any font can render.
-      pango_coverage_max(all_coverage, coverage);
-      pango_coverage_unref(coverage);
-      g_object_unref(font);
-    }
-  }
-  CharCoverageMapToBitmap(all_coverage, unichar_bitmap);
-  pango_coverage_unref(all_coverage);
-}
-
-
 // Utilities written to be backward compatible with StringRender
 
 /* static */

--- a/src/training/pango_font_info.h
+++ b/src/training/pango_font_info.h
@@ -170,15 +170,6 @@ class FontUtils {
                          const std::vector<std::string>& all_fonts,
                          std::string* font_name, std::vector<std::string>* graphemes);
 
-  // Returns a bitmask where the value of true at index 'n' implies that unicode
-  // value 'n' is renderable by at least one available font.
-  static void GetAllRenderableCharacters(std::vector<bool>* unichar_bitmap);
-  // Variant of the above function that inspects only the provided font names.
-  static void GetAllRenderableCharacters(const std::vector<std::string>& font_names,
-                                         std::vector<bool>* unichar_bitmap);
-  static void GetAllRenderableCharacters(const std::string& font_name,
-                                         std::vector<bool>* unichar_bitmap);
-
   // NOTE: The following utilities were written to be backward compatible with
   // StringRender.
 

--- a/unittest/pango_font_info_test.cc
+++ b/unittest/pango_font_info_test.cc
@@ -275,6 +275,9 @@ TEST_F(FontUtilsTest, DoesFailToSelectFont) {
                                      &selected_font, &graphemes));
 }
 
+#if 0
+// Needs fix. FontUtils::GetAllRenderableCharacters was removed
+// because of deprecated pango_coverage_max.
 TEST_F(FontUtilsTest, GetAllRenderableCharacters) {
   const int32_t kHindiChar = 0x0905;
   const int32_t kArabicChar = 0x0623;
@@ -315,4 +318,6 @@ TEST_F(FontUtilsTest, GetAllRenderableCharacters) {
     unicode_mask.clear();
   }
 }
+#endif
+
 }  // namespace


### PR DESCRIPTION
They used the function pango_coverage_max which does nothing and
which has been deprecated since pango version 1.44.

Signed-off-by: Stefan Weil <sw@weilnetz.de>