### PR TITLE
Fix word box boundaries in rendered PDF

### DIFF
--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -468,7 +468,9 @@ char* TessPDFRenderer::GetPDFTextObjects(TessBaseAPI* api,
     } while (!res_it->Empty(RIL_BLOCK) && !res_it->IsAtBeginningOf(RIL_WORD));
     if (res_it->IsAtBeginningOf(RIL_WORD)) {
       pdf_word += "0020";
-      pdf_word_len++;
+      // We don't increment `pdf_word_len` here because it repesents the number
+      // of characters of the word itself - the added space is not part of the
+      // word!
     }
     if (word_length > 0 && pdf_word_len > 0) {
       double h_stretch =


### PR DESCRIPTION
This addresses the dimension of the text boxes in the generated PDFs (essentially a one-off bug) that are slightly too small to accommodate the boundary of the words. Here is an example of some text selected in a sandwiched PDF:

![pre_000](https://user-images.githubusercontent.com/3911596/97059615-31825b80-1591-11eb-82d5-f7916c3c2826.png)

Sandwiched document regenerated after fix:

![post_000](https://user-images.githubusercontent.com/3911596/97059733-8625d680-1591-11eb-9940-1a087db3a9c1.png)
