### PR TITLE
Specify ADD_RT for android platform, which embeds librt in libc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,6 +109,9 @@ case "${host_os}" in
     powerpc-*-darwin*)
         OPENCL_LIBS=""
         ;;
+    *android*)
+        AM_CONDITIONAL([ADD_RT], false)
+        ;;
     *)
         # default
         AM_CONDITIONAL([ADD_RT], true)


### PR DESCRIPTION
I needed this change to build tesseract 3.05.02 using the android ndk.