### PR TITLE
Suppress some LeakSanitizer errors in unit tests

### DIFF
--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -15,6 +15,9 @@ TESTING_DIR=$(shell cd $(top_srcdir) && pwd)/test/testing
 # (using submodule test).
 TESTDATA_DIR=$(shell cd $(top_srcdir) && pwd)/test/testdata
 
+# Suppress some memory leaks reported by LeakSanitizer.
+export LSAN_OPTIONS=suppressions=$(top_srcdir)/unittest/tesseract_leaksanitizer.supp
+
 AM_CPPFLAGS += -DTESSBIN_DIR="\"$(abs_top_builddir)\""
 AM_CPPFLAGS += -DLANGDATA_DIR="\"$(LANGDATA_DIR)\""
 AM_CPPFLAGS += -DTESSDATA_DIR="\"$(TESSDATA_DIR)\""

--- a/unittest/tesseract_leaksanitizer.supp
+++ b/unittest/tesseract_leaksanitizer.supp
@@ -1,5 +1,6 @@
 # Suppress memory leaks.
 # Use with LSAN_OPTIONS=suppressions=tesseract_lsan.supp
+leak:FcLangSetCreate
 leak:FcPatternObjectAddWithBinding
 leak:FcPatternObjectInsertElt
 leak:FcValueListAppend
@@ -7,3 +8,4 @@ leak:FcValueListDuplicate
 leak:FcValueListPrepend
 leak:IA__FcLangSetCreate
 leak:IA__FcValueSave
+leak:libfontconfig.so

--- a/unittest/tesseract_leaksanitizer.supp
+++ b/unittest/tesseract_leaksanitizer.supp
@@ -1,0 +1,9 @@
+# Suppress memory leaks.
+# Use with LSAN_OPTIONS=suppressions=tesseract_lsan.supp
+leak:FcPatternObjectAddWithBinding
+leak:FcPatternObjectInsertElt
+leak:FcValueListAppend
+leak:FcValueListDuplicate
+leak:FcValueListPrepend
+leak:IA__FcLangSetCreate
+leak:IA__FcValueSave


### PR DESCRIPTION
The fontconfig library has some (intentional) memory leaks which
must be suppressed for unit tests with the LeakSanitizer.

This fixes the issues #3156 and #3157.

Signed-off-by: Stefan Weil <sw@weilnetz.de>