### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y cmake curl git ruby bundler wget unzip \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-RUN gem install bundler travis --no-ri --no-rdoc
+RUN gem install bundler travis -no-ri -no-rdoc
 RUN git clone --depth 1 https://github.com/travis-ci/travis-build ~/.travis/travis-build
 RUN bundle install --gemfile ~/.travis/travis-build/Gemfile
 


### PR DESCRIPTION
Change double hyphen "--" to single hyphen "-" to prevent build errors:
Fix invalid option no-ri-no-rdoc
> ERROR: While executing gem ... (OptionParser::InvalidOption) invalid option: --no-ri