### PR TITLE
Improve CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,11 +374,11 @@ configure_file(
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
     cmake/templates/TesseractConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/TesseractConfig.cmake
-    INSTALL_DESTINATION lib/tesseract/cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/tesseract/TesseractConfig.cmake
+    INSTALL_DESTINATION lib/cmake/tesseract
     PATH_VARS INCLUDE_DIR)
 write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/TesseractConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/tesseract/TesseractConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
     COMPATIBILITY SameMajorVersion)
 

--- a/cmake/templates/TesseractConfig.cmake.in
+++ b/cmake/templates/TesseractConfig.cmake.in
@@ -22,7 +22,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/TesseractTargets.cmake)
 
 @PACKAGE_INIT@
 
-set_and_check(Tesseract_INCLUDE_DIR "@PACKAGE_INCLUDE_DIR@")
+set_and_check(Tesseract_INCLUDE_DIRS "@PACKAGE_INCLUDE_DIR@")
 set(Tesseract_LIBRARIES libtesseract)
 
 check_required_components(Tesseract)

--- a/cmake/templates/TesseractConfig.cmake.in
+++ b/cmake/templates/TesseractConfig.cmake.in
@@ -18,7 +18,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(Leptonica)
 
-include(${CMAKE_CURRENT_LIST_DIR}/tesseract/TesseractTargets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/TesseractTargets.cmake)
 
 @PACKAGE_INIT@
 

--- a/cmake/templates/TesseractConfig.cmake.in
+++ b/cmake/templates/TesseractConfig.cmake.in
@@ -15,9 +15,10 @@
 #
 # ===================================================================================
 
-include(${CMAKE_CURRENT_LIST_DIR}/tesseract/TesseractTargets.cmake)
+include(CMakeFindDependencyMacro)
+find_dependency(Leptonica)
 
-find_package(Leptonica REQUIRED)
+include(${CMAKE_CURRENT_LIST_DIR}/tesseract/TesseractTargets.cmake)
 
 @PACKAGE_INIT@
 


### PR DESCRIPTION
* Use `find_dependency` instead of `find_package`. It's recommended to use [find_dependency](https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html) for CMake config files ([official tutorial](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-a-package-configuration-file)).
* Now all CMake config files located in `lib/cmake/tesseract`. This is a more common practice. Previously `TesseractConfig.cmake` and `TesseractVersion.cmake` files was `lib/cmake/tesseract/tesseract` (additional subfolder).
* Fix typo in `Tesseract_INCLUDE_DIR` -> `Tesseract_INCLUDE_DIRS` (as noted in the description if this file).