### PR TITLE
Force fontconfig pangocairo backend for pango_font_info_test

### DIFF
--- a/src/training/pango_font_info.cpp
+++ b/src/training/pango_font_info.cpp
@@ -59,7 +59,7 @@ STRING_PARAM_FLAG(fonts_dir, "/auto/ocr-data/tesstraining/fonts",
 #else
 using std::pair;
 STRING_PARAM_FLAG(fonts_dir, "",
-                  "If empty it use system default. Otherwise it overrides"
+                  "If empty it uses system default. Otherwise it overrides"
                   " system default font location");
 #endif
 

--- a/src/training/pango_font_info.cpp
+++ b/src/training/pango_font_info.cpp
@@ -149,7 +149,7 @@ void PangoFontInfo::HardInitFontConfig(const char* fonts_dir,
            "<dir>%s</dir>\n"
            "<cachedir>%s</cachedir>\n"
            "<config></config>\n"
-           "</fontconfig>",
+           "</fontconfig>\n",
            fonts_dir, cache_dir);
   std::string fonts_conf_file = File::JoinPath(cache_dir, "fonts.conf");
   File::WriteStringToFileOrDie(fonts_conf_template, fonts_conf_file);

--- a/src/training/pango_font_info.cpp
+++ b/src/training/pango_font_info.cpp
@@ -132,8 +132,8 @@ void PangoFontInfo::SoftInitFontConfig() {
 // Re-initializes font config, whether or not already initialized.
 // If already initialized, any existing cache is deleted, just to be sure.
 /* static */
-void PangoFontInfo::HardInitFontConfig(const std::string& fonts_dir,
-                                       const std::string& cache_dir) {
+void PangoFontInfo::HardInitFontConfig(const char* fonts_dir,
+                                       const char* cache_dir) {
   if (!cache_dir_.empty()) {
     File::DeleteMatchingFiles(
         File::JoinPath(cache_dir_.c_str(), "*cache-?").c_str());
@@ -150,16 +150,16 @@ void PangoFontInfo::HardInitFontConfig(const std::string& fonts_dir,
            "<cachedir>%s</cachedir>\n"
            "<config></config>\n"
            "</fontconfig>",
-           fonts_dir.c_str(), cache_dir_.c_str());
-  std::string fonts_conf_file = File::JoinPath(cache_dir_.c_str(), "fonts.conf");
+           fonts_dir, cache_dir);
+  std::string fonts_conf_file = File::JoinPath(cache_dir, "fonts.conf");
   File::WriteStringToFileOrDie(fonts_conf_template, fonts_conf_file);
 #ifdef _WIN32
   std::string env("FONTCONFIG_PATH=");
-  env.append(cache_dir_.c_str());
+  env.append(cache_dir);
   _putenv(env.c_str());
   _putenv("LANG=en_US.utf8");
 #else
-  setenv("FONTCONFIG_PATH", cache_dir_.c_str(), true);
+  setenv("FONTCONFIG_PATH", cache_dir, true);
   // Fix the locale so that the reported font names are consistent.
   setenv("LANG", "en_US.utf8", true);
 #endif  // _WIN32

--- a/src/training/pango_font_info.h
+++ b/src/training/pango_font_info.h
@@ -92,8 +92,8 @@ class PangoFontInfo {
   static void SoftInitFontConfig();
   // Re-initializes font config, whether or not already initialized.
   // If already initialized, any existing cache is deleted, just to be sure.
-  static void HardInitFontConfig(const std::string& fonts_dir,
-                                 const std::string& cache_dir);
+  static void HardInitFontConfig(const char* fonts_dir,
+                                 const char* cache_dir);
 
   // Accessors
   std::string DescriptionName() const;

--- a/unittest/pango_font_info_test.cc
+++ b/unittest/pango_font_info_test.cc
@@ -61,11 +61,17 @@ const char* kBadlyFormedHinWords[] = {
   "प्रंात", nullptr
 };
 
+static PangoFontMap* font_map;
+
 class PangoFontInfoTest : public ::testing::Test {
  protected:
   void SetUp() override {
     static std::locale system_locale("");
     std::locale::global(system_locale);
+    if (!font_map) {
+      font_map = pango_cairo_font_map_new_for_font_type(CAIRO_FONT_TYPE_FT);
+    }
+    pango_cairo_font_map_set_default(PANGO_CAIRO_FONT_MAP(font_map));
   }
 
   // Creates a fake fonts.conf file that points to the testdata fonts for
@@ -187,6 +193,10 @@ class FontUtilsTest : public ::testing::Test {
   static void SetUpTestCase() {
     FLAGS_fonts_dir = TESTING_DIR;
     FLAGS_fontconfig_tmpdir = FLAGS_test_tmpdir;
+    if (!font_map) {
+      font_map = pango_cairo_font_map_new_for_font_type(CAIRO_FONT_TYPE_FT);
+    }
+    pango_cairo_font_map_set_default(PANGO_CAIRO_FONT_MAP(font_map));
   }
 
 #ifdef INCLUDE_TENSORFLOW


### PR DESCRIPTION
This fixes the test on platforms like MacOS (maybe also Windows) which don't use the fontconfig backend by default.
Fix and improve also some other smaller issues in the pango_font_info.cpp code.