### PR TITLE
Fix use of NEON on ARMv8

### DIFF
--- a/src/api/tesseractmain.cpp
+++ b/src/api/tesseractmain.cpp
@@ -137,7 +137,7 @@ static void PrintVersionInfo() {
     }
   }
 #endif
-#if defined(HAVE_NEON)
+#if defined(HAVE_NEON) || defined(__aarch64__)
   if (tesseract::SIMDDetect::IsNEONAvailable()) printf(" Found NEON\n");
 #else
   if (tesseract::SIMDDetect::IsAVX512BWAvailable()) printf(" Found AVX512BW\n");

--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -212,7 +212,7 @@ SIMDDetect::SIMDDetect() {
     // SSE detected.
     SetDotProduct(DotProductSSE, &IntSimdMatrix::intSimdMatrixSSE);
 #endif
-#if defined(HAVE_NEON)
+#if defined(HAVE_NEON) || defined(__aarch64__)
   } else if (neon_available_) {
     // NEON detected.
     SetDotProduct(DotProduct, &IntSimdMatrix::intSimdMatrixNEON);


### PR DESCRIPTION
Flag neon_available_ is automatically set to true when __aarch64__ is defined,
but the actual check for neon_available_ required having also HAVE_NEON defined.

Now we check the flag also when only __aarch64__ is defined.