### PR TITLE
Remove ANDROID_BUILD macro

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -992,7 +992,6 @@ bool TessBaseAPI::ProcessPagesMultipageTiff(const l_uint8 *data,
                                             int timeout_millisec,
                                             TessResultRenderer* renderer,
                                             int tessedit_page_number) {
-#ifndef ANDROID_BUILD
   Pix *pix = nullptr;
   int page = (tessedit_page_number >= 0) ? tessedit_page_number : 0;
   size_t offset = 0;
@@ -1018,9 +1017,6 @@ bool TessBaseAPI::ProcessPagesMultipageTiff(const l_uint8 *data,
     if (!offset) break;
   }
   return true;
-#else
-  return false;
-#endif
 }
 
 // Master ProcessPages calls ProcessPagesInternal and then does any post-
@@ -1236,10 +1232,8 @@ bool TessBaseAPI::ProcessPage(Pix* pix, int page_index, const char* filename,
   }
 
   if (tesseract_->tessedit_write_images) {
-#ifndef ANDROID_BUILD
     Pix* page_pix = GetThresholdedImage();
     pixWrite("tessinput.tif", page_pix, IFF_TIFF_G4);
-#endif  // ANDROID_BUILD
   }
 
   if (failed && retry_config != nullptr && retry_config[0] != '\0') {

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -1398,7 +1398,6 @@ void Tesseract::classify_word_pass1(const WordData& word_data,
   BLOCK* block = word_data.block;
   prev_word_best_choice_ = word_data.prev_word != nullptr
       ? word_data.prev_word->word->best_choice : nullptr;
-#ifndef ANDROID_BUILD
 #ifdef DISABLED_LEGACY_ENGINE
   if (tessedit_ocr_engine_mode == OEM_LSTM_ONLY) {
 #else
@@ -1423,9 +1422,8 @@ void Tesseract::classify_word_pass1(const WordData& word_data,
                                     classify_bln_numeric_mode,
                                     textord_use_cjk_fp_model,
                                     poly_allow_detailed_fx, row, block);
-#endif  // ndef DISABLED_LEGACY_ENGINE
+  #endif  // ndef DISABLED_LEGACY_ENGINE
   }
-#endif  // ndef ANDROID_BUILD
 
 #ifndef DISABLED_LEGACY_ENGINE
   WERD_RES* word = *in_word;

--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -20,10 +20,8 @@
 #include "allheaders.h"
 #include "boxread.h"
 #include "imagedata.h"
-#ifndef ANDROID_BUILD
 #include "lstmrecognizer.h"
 #include "recodebeam.h"
-#endif
 #include "pageres.h"
 #include "tprintf.h"
 
@@ -222,7 +220,6 @@ ImageData* Tesseract::GetRectImage(const TBOX& box, const BLOCK& block,
   return new ImageData(vertical_text, box_pix);
 }
 
-#ifndef ANDROID_BUILD
 // Recognizes a word or group of words, converting to WERD_RES in *words.
 // Analogous to classify_word_pass1, but can handle a group of words as well.
 void Tesseract::LSTMRecognizeWord(const BLOCK& block, ROW *row, WERD_RES *word,
@@ -306,6 +303,5 @@ void Tesseract::SearchWords(PointerVector<WERD_RES>* words) {
     }
   }
 }
-#endif  // ANDROID_BUILD
 
 }  // namespace tesseract.

--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -36,9 +36,7 @@
 #  include "intmatcher.h"
 #  include "reject.h"
 #endif
-#ifndef ANDROID_BUILD
-#  include "lstmrecognizer.h"
-#endif
+#include "lstmrecognizer.h"
 
 namespace tesseract {
 
@@ -170,13 +168,12 @@ bool Tesseract::init_tesseract_lang_data(
 // The various OcrEngineMode settings (see tesseract/publictypes.h) determine which
 // engine-specific data files need to be loaded.
 // If LSTM_ONLY is requested, the base Tesseract files are *Not* required.
-#ifndef ANDROID_BUILD
-#  ifdef DISABLED_LEGACY_ENGINE
+#ifdef DISABLED_LEGACY_ENGINE
   if (tessedit_ocr_engine_mode == OEM_LSTM_ONLY) {
-#  else
+#else
   if (tessedit_ocr_engine_mode == OEM_LSTM_ONLY ||
       tessedit_ocr_engine_mode == OEM_TESSERACT_LSTM_COMBINED) {
-#  endif  // ndef DISABLED_LEGACY_ENGINE
+#endif  // ndef DISABLED_LEGACY_ENGINE
     if (mgr->IsComponentAvailable(TESSDATA_LSTM)) {
       lstm_recognizer_ = new LSTMRecognizer(language_data_path_prefix);
       ASSERT_HOST(lstm_recognizer_->Load(
@@ -186,14 +183,11 @@ bool Tesseract::init_tesseract_lang_data(
       tessedit_ocr_engine_mode.set_value(OEM_TESSERACT_ONLY);
     }
   }
-#endif  // ndef ANDROID_BUILD
 
   // Load the unicharset
   if (tessedit_ocr_engine_mode == OEM_LSTM_ONLY) {
     // Avoid requiring a unicharset when we aren't running base tesseract.
-#ifndef ANDROID_BUILD
     unicharset.CopyFrom(lstm_recognizer_->GetUnicharset());
-#endif  // ndef ANDROID_BUILD
   }
 #ifndef DISABLED_LEGACY_ENGINE
   else if (!mgr->GetComponent(TESSDATA_UNICHARSET, &fp) ||

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -45,9 +45,7 @@
 #ifndef DISABLED_LEGACY_ENGINE
 #include "equationdetect.h"
 #endif
-#ifndef ANDROID_BUILD
 #include "lstmrecognizer.h"
-#endif
 
 namespace tesseract {
 
@@ -546,9 +544,7 @@ Tesseract::Tesseract()
       most_recently_used_(this),
       font_table_size_(0),
       equ_detect_(nullptr),
-#ifndef ANDROID_BUILD
       lstm_recognizer_(nullptr),
-#endif
       train_line_page_num_(0) {
 }
 
@@ -559,10 +555,8 @@ Tesseract::~Tesseract() {
   for (auto* lang : sub_langs_) {
     delete lang;
   }
-#ifndef ANDROID_BUILD
   delete lstm_recognizer_;
   lstm_recognizer_ = nullptr;
-#endif
 }
 
 Dict& Tesseract::getDict() {


### PR DESCRIPTION
Build fails when ANDROID_BUILD is defined, because it removes parts of the LSTM engine, but there are still some unguarded references. But removing LSTM engine is not needed as it works perfectly fine on Android.

This macro doesn't provide any benefit anymore and is not even used in current build config. If needed, ANDROID macro should be used instead (which is already used on few places).