### PR TITLE
Reduce number of INFO messages from lstm_test

### DIFF
--- a/unittest/lstm_test.h
+++ b/unittest/lstm_test.h
@@ -119,9 +119,9 @@ class LSTMTrainerTest : public testing::Test {
       trainer_->MaintainCheckpoints(nullptr, &log_str);
       iteration = trainer_->training_iteration();
       mean_error *= 100.0 / kBatchIterations;
-      LOG(INFO) << log_str.c_str();
-      LOG(INFO) << "Best error = " << best_error << "\n" ;
-      LOG(INFO) << "Mean error = " << mean_error << "\n" ;
+      //LOG(INFO) << log_str.c_str();
+      //LOG(INFO) << "Best error = " << best_error << "\n" ;
+      //LOG(INFO) << "Mean error = " << mean_error << "\n" ;
       if (mean_error < best_error) best_error = mean_error;
     } while (iteration < iteration_limit);
     LOG(INFO) << "Trainer error rate = " << best_error << "\n";

--- a/unittest/lstm_test.h
+++ b/unittest/lstm_test.h
@@ -119,9 +119,6 @@ class LSTMTrainerTest : public testing::Test {
       trainer_->MaintainCheckpoints(nullptr, &log_str);
       iteration = trainer_->training_iteration();
       mean_error *= 100.0 / kBatchIterations;
-      //LOG(INFO) << log_str.c_str();
-      //LOG(INFO) << "Best error = " << best_error << "\n" ;
-      //LOG(INFO) << "Mean error = " << mean_error << "\n" ;
       if (mean_error < best_error) best_error = mean_error;
     } while (iteration < iteration_limit);
     LOG(INFO) << "Trainer error rate = " << best_error << "\n";


### PR DESCRIPTION
Some more of these messages can be reduced. Attached log from run after this change.

[lstm_test.log](https://github.com/tesseract-ocr/tesseract/files/5840764/lstm_test.log)