### PR TITLE
Use set instead of set_and_check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,7 +361,7 @@ include(Configure)
 
 configure_file(${AUTOCONFIG_SRC} ${AUTOCONFIG} @ONLY)
 
-set(INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include" "${CMAKE_INSTALL_PREFIX}/include/tesseract")
+set(INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include")
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/include/tesseract/version.h.in


### PR DESCRIPTION
`set_and_check` can't work with lists and regular `check` should be used instead (see [CMake issue](https://gitlab.kitware.com/cmake/cmake/-/issues/16219)). Partially fixes #3269.

**Updated:** I removed extra include from `INCLUDE_DIR` and it works now.