### PR TITLE
Change LATIN_FONTS to use replacement fonts from TeX Gyre collection

### DIFF
--- a/src/training/language-specific.sh
+++ b/src/training/language-specific.sh
@@ -65,13 +65,13 @@ LATIN_FONTS=(
     "Verdana Italic" \
     "Verdana" \
     "Verdana Bold Italic" \
-    "URW Bookman L Bold" \
-    "URW Bookman L Italic" \
-    "URW Bookman L Bold Italic" \
-    "Century Schoolbook L Bold" \
-    "Century Schoolbook L Italic" \
-    "Century Schoolbook L Bold Italic" \
-    "Century Schoolbook L Medium" \
+    "Tex Gyre Bonum Bold" \
+    "Tex Gyre Bonum Italic" \
+    "Tex Gyre Bonum Bold Italic" \
+    "Tex Gyre Schola Bold" \
+    "Tex Gyre Schola Italic" \
+    "Tex Gyre Schola Bold Italic" \
+    "Tex Gyre Schola Regular" \
     "DejaVu Sans Ultra-Light" \
 )
 


### PR DESCRIPTION
Changed

URW Bookman L -> Bonum

Century Schoolbook L -> Schola

as per suggestion by @amitdo in https://github.com/tesseract-ocr/tesseract/pull/3071#issuecomment-772792181