### PR TITLE
Add new configure options --disable-doc, --with-archive and --with-curl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -475,12 +475,25 @@ else
   AC_MSG_ERROR([Leptonica 1.74 or higher is required. Try to install libleptonica-dev package.])
 fi
 
-PKG_CHECK_MODULES([libarchive], [libarchive], [have_libarchive=true], [have_libarchive=false])
-AM_CONDITIONAL([HAVE_LIBARCHIVE], [$have_libarchive])
-if $have_libarchive; then
-  AC_DEFINE([HAVE_LIBARCHIVE], [1], [Enable libarchive])
-  CPPFLAGS="$CPPFLAGS $libarchive_CFLAGS"
-fi
+AC_ARG_WITH([archive],
+            AS_HELP_STRING([--with-archive],
+                           [Build with libarchive which supports compressed model files @<:@default=check@:>@]
+))
+
+AM_CONDITIONAL([HAVE_LIBARCHIVE], false)
+AS_IF([test "x$with_archive" != xno], [
+  PKG_CHECK_MODULES([libarchive], [libarchive], [have_libarchive=true], [have_libarchive=false])
+  AM_CONDITIONAL([HAVE_LIBARCHIVE], [$have_libarchive])
+  if $have_libarchive; then
+    AC_DEFINE([HAVE_LIBARCHIVE], [1], [Enable libarchive])
+    CPPFLAGS="$CPPFLAGS $libarchive_CFLAGS"
+  else
+    AS_IF([test "x$with_archive" != xcheck], [
+      AC_MSG_FAILURE(
+        [--with-archive was given, but test for libarchive failed])
+    ])
+  fi
+])
 
 AM_CONDITIONAL([ENABLE_TRAINING], true)
 

--- a/configure.ac
+++ b/configure.ac
@@ -462,11 +462,24 @@ AC_CHECK_TYPES([long long int])
 # Test auxiliary packages
 # ----------------------------------------
 
-PKG_CHECK_MODULES([libcurl], [libcurl], [have_libcurl=true], [have_libcurl=false])
-AM_CONDITIONAL([HAVE_LIBCURL], $have_libcurl)
-if $have_libcurl; then
-  AC_DEFINE([HAVE_LIBCURL], [1], [Enable libcurl])
-fi
+AC_ARG_WITH([curl],
+            AS_HELP_STRING([--with-curl],
+                           [Build with libcurl which supports processing an image URL @<:@default=check@:>@]
+))
+
+AM_CONDITIONAL([HAVE_LIBCURL], false)
+AS_IF([test "x$with_curl" != xno], [
+  PKG_CHECK_MODULES([libcurl], [libcurl], [have_libcurl=true], [have_libcurl=false])
+  AM_CONDITIONAL([HAVE_LIBCURL], $have_libcurl)
+  if $have_libcurl; then
+    AC_DEFINE([HAVE_LIBCURL], [1], [Enable libcurl])
+  else
+    AS_IF([test "x$with_curl" != xcheck], [
+      AC_MSG_FAILURE(
+        [--with-curl was given, but test for libcurl failed])
+    ])
+  fi
+])
 
 PKG_CHECK_MODULES([LEPTONICA], [lept >= 1.74], [have_lept=true], [have_lept=false])
 if $have_lept; then

--- a/configure.ac
+++ b/configure.ac
@@ -427,29 +427,37 @@ AC_SEARCH_LIBS([pthread_create], [pthread])
 # Check for programs needed to build documentation.
 # ----------------------------------------
 
-AC_CHECK_PROG([have_asciidoc], asciidoc, true, false)
-AC_CHECK_PROG([have_xsltproc], xsltproc, true, false)
-# MacOS with Homebrew requires the environment variable
-# XML_CATALOG_FILES for xsltproc.
+AM_CONDITIONAL([ASCIIDOC], false)
 AM_CONDITIONAL([HAVE_XML_CATALOG_FILES], false)
-if $have_asciidoc && $have_xsltproc; then
-  AM_CONDITIONAL([ASCIIDOC], true)
-  XML_CATALOG_FILES=
-  AC_CHECK_PROG([have_brew], brew, true, false)
-  if $have_brew; then
-    brew_prefix=$(brew --prefix)
-    catalog_file=$brew_prefix/etc/xml/catalog
-    if test -f $catalog_file; then
-      AM_CONDITIONAL([HAVE_XML_CATALOG_FILES], true)
-      XML_CATALOG_FILES=file:$catalog_file
-    else
-      AC_MSG_WARN([Missing file $catalog_file.])
+AC_ARG_ENABLE([doc],
+              AS_HELP_STRING([--disable-doc], [disable build of documentation]))
+AS_IF([test "$enable_doc" != "no"], [
+  AC_CHECK_PROG([have_asciidoc], asciidoc, true, false)
+  AC_CHECK_PROG([have_xsltproc], xsltproc, true, false)
+  # MacOS with Homebrew requires the environment variable
+  # XML_CATALOG_FILES for xsltproc.
+  if $have_asciidoc && $have_xsltproc; then
+    AM_CONDITIONAL([ASCIIDOC], true)
+    XML_CATALOG_FILES=
+    AC_CHECK_PROG([have_brew], brew, true, false)
+    if $have_brew; then
+      brew_prefix=$(brew --prefix)
+      catalog_file=$brew_prefix/etc/xml/catalog
+      if test -f $catalog_file; then
+        AM_CONDITIONAL([HAVE_XML_CATALOG_FILES], true)
+        XML_CATALOG_FILES=file:$catalog_file
+      else
+        AC_MSG_WARN([Missing file $catalog_file.])
+      fi
     fi
+    AC_SUBST([XML_CATALOG_FILES])
+  else
+    AS_IF([test "x$enable_doc" != xcheck], [
+      AC_MSG_FAILURE(
+        [--enable-doc was given, but test for asciidoc and xsltproc failed])
+    ])
   fi
-  AC_SUBST([XML_CATALOG_FILES])
-else
-  AM_CONDITIONAL([ASCIIDOC], false)
-fi
+])
 
 # ----------------------------------------
 # Checks for typedefs, structures, and compiler characteristics.
@@ -568,13 +576,15 @@ echo "$ sudo make install"
 echo "$ sudo ldconfig"
 echo ""
 
-AM_COND_IF([ASCIIDOC],
-  [
-   echo "This will also build the documentation."
+AM_COND_IF([ASCIIDOC], [
+  echo "This will also build the documentation."
+], [
+  AS_IF([test "$enable_doc" = "no"], [
+    echo "Documentation will not be built because it was disabled."
   ], [
-   echo "Documentation will not be built because asciidoc or xsltproc is missing."
-  ]
-)
+    echo "Documentation will not be built because asciidoc or xsltproc is missing."
+  ])
+])
 
 # echo "$ sudo make install LANGS=\"eng ara deu\""
 # echo "  Or:"

--- a/configure.ac
+++ b/configure.ac
@@ -243,11 +243,21 @@ if test "$enable_opencl" = "yes"; then
   ])
 fi
 
-# Check whether to build with support for TensorFlow.
+# Configure arguments which allow disabling some optional libraries.
+AC_ARG_WITH([archive],
+            AS_HELP_STRING([--with-archive],
+                           [Build with libarchive which supports compressed model files @<:@default=check@:>@]
+))
+AC_ARG_WITH([curl],
+            AS_HELP_STRING([--with-curl],
+                           [Build with libcurl which supports processing an image URL @<:@default=check@:>@]
+))
 AC_ARG_WITH([tensorflow],
   AS_HELP_STRING([--with-tensorflow],
                  [support TensorFlow @<:@default=check@:>@]),
   [], [with_tensorflow=check])
+
+# Check whether to build with support for TensorFlow.
 AM_CONDITIONAL([TENSORFLOW], false)
 TENSORFLOW_LIBS=
 AS_IF([test "x$with_tensorflow" != xno],
@@ -470,11 +480,6 @@ AC_CHECK_TYPES([long long int])
 # Test auxiliary packages
 # ----------------------------------------
 
-AC_ARG_WITH([curl],
-            AS_HELP_STRING([--with-curl],
-                           [Build with libcurl which supports processing an image URL @<:@default=check@:>@]
-))
-
 AM_CONDITIONAL([HAVE_LIBCURL], false)
 AS_IF([test "x$with_curl" != xno], [
   PKG_CHECK_MODULES([libcurl], [libcurl], [have_libcurl=true], [have_libcurl=false])
@@ -495,11 +500,6 @@ if $have_lept; then
 else
   AC_MSG_ERROR([Leptonica 1.74 or higher is required. Try to install libleptonica-dev package.])
 fi
-
-AC_ARG_WITH([archive],
-            AS_HELP_STRING([--with-archive],
-                           [Build with libarchive which supports compressed model files @<:@default=check@:>@]
-))
 
 AM_CONDITIONAL([HAVE_LIBARCHIVE], false)
 AS_IF([test "x$with_archive" != xno], [


### PR DESCRIPTION
The new options allow overriding the default behaviour which checks whether the documentation can be build and whether libarchive and libcurl are available.