### PR TITLE
master branch: missing changes that are needed too

### DIFF
--- a/src/wordrec/wordrec.h
+++ b/src/wordrec/wordrec.h
@@ -49,7 +49,7 @@ class TESS_API Wordrec : public Classify {
   virtual ~Wordrec() = default;
 
   // tface.cpp
-  void program_editup(const char *textbase, TessdataManager *init_classifier,
+  void program_editup(const std::string &textbase, TessdataManager *init_classifier,
                       TessdataManager *init_dict);
   void program_editdown(int32_t elasped_time);
   int end_recog();

--- a/src/wordrec/wordrec.h
+++ b/src/wordrec/wordrec.h
@@ -49,7 +49,7 @@ class TESS_API Wordrec : public Classify {
   virtual ~Wordrec() = default;
 
   // tface.cpp
-  void program_editup(const std::string &textbase, TessdataManager *init_classifier,
+  void program_editup(const std::string& textbase, TessdataManager* init_classifier,
                       TessdataManager *init_dict);
   void program_editdown(int32_t elasped_time);
   int end_recog();


### PR DESCRIPTION
to make this codebase compile on Windows.

Just a minor glitch.

---

Your latest changes around `std::string` parameters missed this bit, which popped up as a compile error in my own (custom) tesseract build for Windows.

