### PR TITLE
Suppress resolution warning if no resolution was given

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -2020,8 +2020,11 @@ bool TessBaseAPI::Threshold(Pix **pix) {
   if (user_dpi) {
     thresholder_->SetSourceYResolution(user_dpi);
   } else if (y_res < kMinCredibleResolution || y_res > kMaxCredibleResolution) {
-    tprintf("Warning: Invalid resolution %d dpi. Using %d instead.\n", y_res,
-            kMinCredibleResolution);
+    if (y_res != 0) {
+      // Show warning only if a resolution was given.
+      tprintf("Warning: Invalid resolution %d dpi. Using %d instead.\n",
+              y_res, kMinCredibleResolution);
+    }
     thresholder_->SetSourceYResolution(kMinCredibleResolution);
   }
   auto pageseg_mode = static_cast<PageSegMode>(static_cast<int>(tesseract_->tessedit_pageseg_mode));


### PR DESCRIPTION
Tesseract reported confusing information for images without resolution:

    Warning: Invalid resolution 0 dpi. Using 70 instead.
    Estimating resolution as 642

The warning is also shown when the resolution is not used at all
when preparing data for training.

It is now suppressed when there is no resolution information
(resolution == 0).

Signed-off-by: Stefan Weil <sw@weilnetz.de>