### PR TITLE
allow to suppress leptonica messages by environment variables

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -368,6 +368,18 @@ int TessBaseAPI::Init(const char *data, int data_size, const char *language, Ocr
                       char **configs, int configs_size, const std::vector<std::string> *vars_vec,
                       const std::vector<std::string> *vars_values, bool set_only_non_debug_params,
                       FileReader reader) {
+  // Set Leptonica based on environment variables
+  const char * env_p = std::getenv("LEPT_MSG_SEVERITY");
+  if ( env_p != nullptr ) {
+    std::stringstream ss(env_p);
+    int i;
+    if( ss >> i ) {
+      setMsgSeverity(i);
+    } else {
+      fprintf(stderr,"Invalid LEPT_MSG_SEVERITY value: '%s'. Expected value: from %d to %d\n",
+              env_p, L_SEVERITY_EXTERNAL, L_SEVERITY_NONE);
+    }
+  }
   // Default language is "eng".
   if (language == nullptr)
     language = "eng";


### PR DESCRIPTION
Rationale: if  user intentionally built leptonica without tiff support, leptonica would  produce errors even it has no effect on tesseract:

```
> f:\win64\bin\tesseract.exe F:/Project/tesserocr/tests/eurotext.png -
Error in pixReadMemTiff: function not present
Error in pixReadMem: tiff: no pix returned
Error in pixaGenerateFontFromString: pix not made
Error in bmfCreate: font pixa not made
The (quick) [brown] {fox} jumps!
Over the $43,456.78 <lazy> #90 dog
& duck/goose, as 12.5% of E-mail
from aspammer@website.com is spam.
Der ,schnelle” braune Fuchs springt
iiber den faulen Hund. Le renard brun
«rapide» saute par-dessus le chien
paresseux. La volpe marrone rapida
salta sopra il cane pigro. El zorro
marron rdpido salta sobre el perro
perezoso. A raposa marrom ripida
salta sobre o cdo preguigoso.
```

This modification would allow user to control leptonica messaging by environment variable. E.g.
```
> set LEPT_MSG_SEVERITY=6
> f:\win64\bin\tesseract.exe F:/Project/tesserocr/tests/eurotext.png -
The (quick) [brown] {fox} jumps!
Over the $43,456.78 <lazy> #90 dog
& duck/goose, as 12.5% of E-mail
from aspammer@website.com is spam.
Der ,schnelle” braune Fuchs springt
iiber den faulen Hund. Le renard brun
«rapide» saute par-dessus le chien
paresseux. La volpe marrone rapida
salta sopra il cane pigro. El zorro
marron rdpido salta sobre el perro
perezoso. A raposa marrom ripida
salta sobre o cdo preguigoso.
```

 