### PR TITLE
Print command line options if run_command() failed.

### DIFF
--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -79,7 +79,7 @@ run_command() {
     shift
     tlog "[$(date)] ${cmd} $@"
     if ! "${cmd}" "$@" 2>&1 | tee -a "${LOG_FILE}"; then
-        err_exit "Program $(basename ${cmd}) failed. Abort."
+        err_exit "Program $(basename ${cmd}) failed. Abort. Command line: ${cmd} $@"
     fi
 }
 


### PR DESCRIPTION
It helps to reproduce failed command execution during training.