### PR TITLE
lstm: Include missing header

### DIFF
--- a/src/lstm/recodebeam.h
+++ b/src/lstm/recodebeam.h
@@ -28,6 +28,7 @@
 #include "dawg.h"
 #include "dict.h"
 #include "genericheap.h"
+#include "genericvector.h"
 #include "kdpair.h"
 #include "networkio.h"
 #include "ratngs.h"


### PR DESCRIPTION
lstm/recodebeam.h was using PointerVector from ccutil/genericvector.h without including it.