### PR TITLE
Fix division by zero during CJK training.

### DIFF
--- a/src/textord/cjkpitch.cpp
+++ b/src/textord/cjkpitch.cpp
@@ -158,10 +158,8 @@ public:
     float rc = 0;
     int vote = 0;
     for (int i = start; i < end; i++) {
-      if (values_[i].x != 0.0f) {
-        rc += values_[i].vote * x * values_[i].y / values_[i].x;
-        vote += values_[i].vote;
-      }
+      rc += values_[i].vote * x * values_[i].y / values_[i].x;
+      vote += values_[i].vote;
     }
 
     return vote == 0 ? 0.0f : rc / vote;

--- a/src/textord/cjkpitch.cpp
+++ b/src/textord/cjkpitch.cpp
@@ -158,11 +158,13 @@ public:
     float rc = 0;
     int vote = 0;
     for (int i = start; i < end; i++) {
-      rc += values_[i].vote * x * values_[i].y / values_[i].x;
-      vote += values_[i].vote;
+      if (values_[i].x != 0.0f) {
+        rc += values_[i].vote * x * values_[i].y / values_[i].x;
+        vote += values_[i].vote;
+      }
     }
 
-    return rc / vote;
+    return vote == 0 ? 0.0f : rc / vote;
   }
 
 private:


### PR DESCRIPTION
I met floating point error during training Japanese model.
Here is gdb output.
```
Program received signal SIGFPE, Arithmetic exception.
0x00007fcca7c14f5c in tesseract::LocalCorrelation::EstimateYFor (this=0x7ffdeae919d0, x=45, r=0.100000001)
    at src/textord/cjkpitch.cpp:165
165         return rc / vote;
```
This PR fixes the issue.