### PR TITLE
Adding SVMutex and SVSemaphore destructors to avoid system objects leaks

### DIFF
--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -61,6 +61,14 @@ SVMutex::SVMutex() {
 #endif
 }
 
+SVMutex::~SVMutex() {
+#ifdef _WIN32
+  CloseHandle(mutex_);
+#else
+  pthread_mutex_destroy(&mutex_);
+#endif
+}
+
 void SVMutex::Lock() {
 #ifdef _WIN32
   WaitForSingleObject(mutex_, INFINITE);
@@ -176,6 +184,16 @@ SVSemaphore::SVSemaphore() {
   }
 #else
   sem_init(&semaphore_, 0, 0);
+#endif
+}
+
+SVSemaphore::~SVSemaphore() {
+#ifdef _WIN32
+  CloseHandle(semaphore_);
+#elif defined(__APPLE__)
+  sem_close(semaphore_);
+#else
+  sem_close(&semaphore_);
 #endif
 }
 

--- a/src/viewer/svutil.h
+++ b/src/viewer/svutil.h
@@ -49,6 +49,8 @@ class SVSemaphore {
  public:
   /// Sets up a semaphore.
   SVSemaphore();
+  /// Cleans up the mutex
+  ~SVSemaphore();
   /// Signal a semaphore.
   void Signal();
   /// Wait on a semaphore.
@@ -69,6 +71,8 @@ class SVMutex {
  public:
   /// Sets up a new mutex.
   SVMutex();
+  /// Destroys the mutex
+  ~SVMutex();
   /// Locks on a mutex.
   void Lock();
   /// Unlocks on a mutex.


### PR DESCRIPTION
Operating system object leak when using LSTMRecognizer (that is tessdata ver 4). Each time you initialize a TessBaseAPI object you lose four mutexes.

Added destructors to SVMutex and SVSemaphore to cleanup mutex and semaphore objects.

issue [https://github.com/tesseract-ocr/tesseract/issues/3397](https://github.com/tesseract-ocr/tesseract/issues/3397)