### PR TITLE
fix compile error: PrintFontsTable() is for legacy builds only

### DIFF
--- a/include/tesseract/baseapi.h
+++ b/include/tesseract/baseapi.h
@@ -150,10 +150,14 @@ public:
    */
   const char *GetStringVariable(const char *name) const;
 
+#ifndef DISABLED_LEGACY_ENGINE
+
   /**
    * Print Tesseract fonts table to the given file.
    */
   void PrintFontsTable(FILE* fp) const;
+
+#endif
 
   /**
    * Print Tesseract parameters to the given file.

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -330,6 +330,8 @@ bool TessBaseAPI::GetVariableAsString(const char *name, std::string *val) const 
   return ParamUtils::GetParamAsString(name, tesseract_->params(), val);
 }
 
+#ifndef DISABLED_LEGACY_ENGINE
+
 /** Print Tesseract fonts table to the given file. */
 void TessBaseAPI::PrintFontsTable(FILE *fp) const {
   const int fontinfo_size = tesseract_->get_fontinfo_table().size();
@@ -345,6 +347,8 @@ void TessBaseAPI::PrintFontsTable(FILE *fp) const {
                 font.is_fraktur() ? "true" : "false");
   }
 }
+
+#endif
 
 /** Print Tesseract parameters to the given file. */
 void TessBaseAPI::PrintVariables(FILE *fp) const {


### PR DESCRIPTION
When compiling tesseract master branch with legacy engine DISABLED, these bits of code would throw a tantrum as they are for legacy only.

(Cherrypicked commit back onto mainline master.)

\# Conflicts:
\#	googletest