### PR TITLE
Switch to NFC normalisation everywhere

### DIFF
--- a/src/training/pango/ligature_table.cpp
+++ b/src/training/pango/ligature_table.cpp
@@ -63,13 +63,13 @@ LigatureTable::LigatureTable()
 void LigatureTable::Init() {
   if (norm_to_lig_table_.empty()) {
     for (char32 lig = kMinLigature; lig <= kMaxLigature; ++lig) {
-      // For each char in the range, convert to utf8, nfkc normalize, and if
+      // For each char in the range, convert to utf8, nfc normalize, and if
       // the strings are different put the both mappings in the hash_maps.
       std::string lig8 = EncodeAsUTF8(lig);
       icu::UnicodeString unicode_lig8(static_cast<UChar32>(lig));
       icu::UnicodeString normed8_result;
       icu::ErrorCode status;
-      icu::Normalizer::normalize(unicode_lig8, UNORM_NFKC, 0, normed8_result, status);
+      icu::Normalizer::normalize(unicode_lig8, UNORM_NFC, 0, normed8_result, status);
       std::string normed8;
       normed8_result.toUTF8String(normed8);
       // The icu::Normalizer maps the "LONG S T" ligature to "st". Correct that

--- a/src/training/unicharset/unicharset_training_utils.cpp
+++ b/src/training/unicharset/unicharset_training_utils.cpp
@@ -128,7 +128,7 @@ void SetupBasicProperties(bool report_errors, bool decompose, UNICHARSET *unicha
     std::string normed_str;
     if (unichar_id != 0 &&
         tesseract::NormalizeUTF8String(
-            decompose ? tesseract::UnicodeNormMode::kNFKD : tesseract::UnicodeNormMode::kNFKC,
+            decompose ? tesseract::UnicodeNormMode::kNFD : tesseract::UnicodeNormMode::kNFC,
             tesseract::OCRNorm::kNormalize, tesseract::GraphemeNorm::kNone, unichar_str,
             &normed_str) &&
         !normed_str.empty()) {


### PR DESCRIPTION
Switch from NFKC to NFC normalisation (or switch from NFKD to NFD if decompose mode is requested). NFKC is not ideal for OCR, as characters which should be treated differently, such as superscripts and distinct alternative forms of letters, are treated as identical.

This is discussed in issue #1852.