### PR TITLE
lstmeval: Print char and word error rates for each line tested

### DIFF
--- a/src/training/unicharset/lstmtester.cpp
+++ b/src/training/unicharset/lstmtester.cpp
@@ -105,9 +105,11 @@ std::string LSTMTester::RunEvalSync(int iteration, const double *training_errors
         trainer.LabelsFromOutputs(fwd_outputs, &ocr_labels, &xcoords);
         std::string ocr_text = trainer.DecodeLabels(ocr_labels);
         tprintf("OCR  :%s\n", ocr_text.c_str());
-        tprintf("Line Char error rate=%f, Word error rate=%f\n\n",
-                trainer.NewSingleError(tesseract::ET_CHAR_ERROR),
-                trainer.NewSingleError(tesseract::ET_WORD_RECERR));
+        if (verbosity > 2 || (verbosity > 1 && result != PERFECT)) {
+          tprintf("Line Char error rate=%f, Word error rate=%f\n\n",
+                  trainer.NewSingleError(tesseract::ET_CHAR_ERROR),
+                  trainer.NewSingleError(tesseract::ET_WORD_RECERR));
+        }
       }
     }
   }

--- a/src/training/unicharset/lstmtester.cpp
+++ b/src/training/unicharset/lstmtester.cpp
@@ -105,6 +105,9 @@ std::string LSTMTester::RunEvalSync(int iteration, const double *training_errors
         trainer.LabelsFromOutputs(fwd_outputs, &ocr_labels, &xcoords);
         std::string ocr_text = trainer.DecodeLabels(ocr_labels);
         tprintf("OCR  :%s\n", ocr_text.c_str());
+        tprintf("Line Char error rate=%f, Word error rate=%f\n\n",
+                trainer.NewSingleError(tesseract::ET_CHAR_ERROR),
+                trainer.NewSingleError(tesseract::ET_WORD_RECERR));
       }
     }
   }


### PR DESCRIPTION
It can be handy when evaluating a new training set to see the character and word error rates for each line, rather than just the average over a set.