### PR TITLE
Fix crash in ObjectCache::DeleteUnusedObjects

### DIFF
--- a/src/ccutil/object_cache.h
+++ b/src/ccutil/object_cache.h
@@ -95,7 +95,7 @@ public:
 
   void DeleteUnusedObjects() {
     std::lock_guard<std::mutex> guard(mu_);
-    for (auto i = cache_.size() - 1; i >= 0; i--) {
+    for (int i = (int)cache_.size() - 1; i >= 0; i--) {
       if (cache_[i].count <= 0) {
         delete cache_[i].object;
         cache_.erase(cache_.begin() + i);


### PR DESCRIPTION
>for (auto i = cache_.size() - 1; i >= 0; i--) {
https://github.com/tesseract-ocr/tesseract/commit/4b5dd25b845d2ebf5ef7b15a86589d52f7b12495

The return type of .size() is unsigned, so the condition `i >= 0` will never be false and will crash.
This issue occurs when importing the Python `tesserocr` module.

```
% gdb --args bash python3
(gdb) run
>>> import tesserocr

Program received signal SIGSEGV, Segmentation fault.
tesseract::ObjectCache<tesseract::Dawg>::DeleteUnusedObjects (this=0x7ffff60d2c00 <tesseract::Dict::GlobalDawgCache()::cache>) at ./src/ccutil/object_cache.h:99
99            if (cache_[i].count <= 0) {
```