### PR TITLE
Add --vertical_fontlist option to tesstrain.sh

### DIFF
--- a/src/training/language-specific.sh
+++ b/src/training/language-specific.sh
@@ -1179,6 +1179,10 @@ set_lang_specific_parameters() {
 
   # Default to 0 exposure if it hasn't been set
   test -z "$EXPOSURES" && EXPOSURES=0
+
+  # Overrides VERTICAL_FONTS if --vertical_fontlist option have been set
+  test -n "${OPTIONAL_VERTICAL_FONTS:-}" && VERTICAL_FONTS=( "${OPTIONAL_VERTICAL_FONTS[@]}" )
+
   # Set right-to-left and normalization mode.
   case "${LANG_CODE}" in
     ara | div| fas | pus | snd | syr | uig | urd | kur_ara | heb | yid )

--- a/src/training/tesstrain.sh
+++ b/src/training/tesstrain.sh
@@ -19,6 +19,7 @@ display_usage() {
 echo -e 'USAGE: tesstrain.sh
      --exposures EXPOSURES      # A list of exposure levels to use (e.g. "-1 0 1").
      --fontlist FONTS           # A list of fontnames to train on.
+     --vertical_fontlist FONTS  # A list of fontnames to render vertical text.
      --fonts_dir FONTS_PATH     # Path to font files.
      --lang LANG_CODE           # ISO 639 code.
      --langdata_dir DATADIR     # Path to tesseract/training/langdata directory.

--- a/src/training/tesstrain_utils.sh
+++ b/src/training/tesstrain_utils.sh
@@ -129,6 +129,17 @@ parse_flags() {
                     j=$((j+1))
                 done
                 i=$((j-1)) ;;
+            --vertical_fontlist)
+                fn=0
+                OPTIONAL_VERTICAL_FONTS=""
+                while test $j -lt ${#ARGV[@]}; do
+                    test -z "${ARGV[$j]}" && break
+                    test $(echo ${ARGV[$j]} | cut -c -2) = "--" && break
+                    OPTIONAL_VERTICAL_FONTS[$fn]="${ARGV[$j]}"
+                    fn=$((fn+1))
+                    j=$((j+1))
+                done
+                i=$((j-1)) ;;
             --exposures)
                 exp=""
                 while test $j -lt ${#ARGV[@]}; do


### PR DESCRIPTION
This Pull Request adds `--vertical_fontlist` option to `tesstrain.sh` to specify a list of fontnames to render vertical text.
The format for specifying a list of fontnames is the same as for `--font_list` option.
If `--vertical_fontlist <FONTS>` option is specified, it will override the `VERTICLA_FONTS` variable(defined in `language-specific.sh`) with the specified list of fontnames.

In the current version, the `VERTICAL_FONTS` variable is hardcoded in `language-specific.sh`. So, when creating training data for vertical text such as Japanese, users need to edit the source code even if they specify a list of fontnames with `--fontlist` and `--font_dir`.
