### PR TITLE
ThresholdMethod::TiledSauvola -> ThresholdMethod::Sauvola

### DIFF
--- a/include/tesseract/publictypes.h
+++ b/include/tesseract/publictypes.h
@@ -285,7 +285,7 @@ enum OcrEngineMode {
 enum class ThresholdMethod {
   Otsu,         // Legacy Tesseract's Otsu thresholding
   AdaptiveOtsu,
-  TiledSauvola,
+  Sauvola,
 
   Max,        // Number of Thresholding methods
 };

--- a/src/ccmain/thresholder.cpp
+++ b/src/ccmain/thresholder.cpp
@@ -202,7 +202,7 @@ std::tuple<bool, Image, Image, Image> ImageThresholder::Threshold(
   auto pix_grey = GetPixRectGrey();
 
   int r;
-  if (method == ThresholdMethod::TiledSauvola) {
+  if (method == ThresholdMethod::Sauvola) {
     r = pixSauvolaBinarizeTiled(pix_grey, 25, 0.40, 300, 300, pix_thresholds,
                                 pix_binary);
   } else {


### PR DESCRIPTION
The fact that this method uses tiles is implementation detail. It does not change the result compared to Sauvola without tiles. The use of tiles minimize memory consumption.