### PR TITLE
Null check for GetSourceYResolution

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -956,7 +956,7 @@ const char *TessBaseAPI::GetDatapath() {
 
 int TessBaseAPI::GetSourceYResolution() {
   if (thresholder_ == nullptr)
-    return;
+    return -1;
   return thresholder_->GetSourceYResolution();
 }
 

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -955,6 +955,8 @@ const char *TessBaseAPI::GetDatapath() {
 }
 
 int TessBaseAPI::GetSourceYResolution() {
+  if (thresholder_ == nullptr)
+    return;
   return thresholder_->GetSourceYResolution();
 }
 


### PR DESCRIPTION
Added missing NULL check to avoid crash when we read property in our tesseract wrapper.