### PR TITLE
Fix missing reset of best_error_history_ in LSTMTrainer::InitIterations()

### DIFF
--- a/src/training/unicharset/lstmtrainer.cpp
+++ b/src/training/unicharset/lstmtrainer.cpp
@@ -200,6 +200,8 @@ void LSTMTrainer::InitIterations() {
   worst_error_rate_ = 0.0;
   worst_iteration_ = 0;
   stall_iteration_ = kMinStallIterations;
+  best_error_history_.clear();
+  best_error_iterations_.clear();
   improvement_steps_ = kMinStallIterations;
   perfect_delay_ = 0;
   last_perfect_training_iteration_ = 0;


### PR DESCRIPTION
When training is started from `lstmtraining --continue_from ...` command, various iteration counter and  error rate variables are reset by `LSTMTrainer::InitIterations()`, but `best_error_history_` and `best_error_iterations_` are not reset from the previous training state. This may cause negative time to be reported in the training log.
This PR fixes it.
```
2 Percent improvement time=-28864, best error was 7.024 @ 39917
At iteration 11053/19300/19300, Mean rms=0.359000%, delta=1.110000%, char train=4.931000%, word train=34.318000%, skip ratio=0.000000%,  New best char error = 4.931000Previous test incomplete, skipping test at iteration 10740 wrote checkpoint.
2 Percent improvement time=-28816, best error was 7.024 @ 39917
At iteration 11101/19400/19400, Mean rms=0.357000%, delta=1.082000%, char train=4.840000%, word train=34.318000%, skip ratio=0.000000%,  New best char error = 4.840000 wrote checkpoint.

2 Percent improvement time=-42068, best error was 6.811 @ 53220
At iteration 11152/19500/19500, Mean rms=0.356000%, delta=1.062000%, char train=4.767000%, word train=33.583000%, skip ratio=0.000000%,  New best char error = 4.767000 wrote best model:./tmp/models/finetune_min2/jpn_vert_4.767000_11152_19
500.checkpoint wrote checkpoint.

2 Percent improvement time=-42184, best error was 6.719 @ 53390
At iteration 11206/19600/19600, Mean rms=0.352000%, delta=1.034000%, char train=4.677000%, word train=33.633000%, skip ratio=0.000000%,  New best char error = 4.677000 wrote checkpoint.

2 Percent improvement time=-43019, best error was 6.55 @ 54284
At iteration 11265/19700/19700, Mean rms=0.349000%, delta=1.011000%, char train=4.486000%, word train=33.201000%, skip ratio=0.000000%,  New best char error = 4.486000 wrote best model:./tmp/models/finetune_min2/jpn_vert_4.486000_11265_19
700.checkpoint wrote checkpoint.
```