### PR TITLE
Fix possible UB when accessing empty vector's data

### DIFF
--- a/src/lstm/networkscratch.h
+++ b/src/lstm/networkscratch.h
@@ -148,7 +148,8 @@ public:
       vec_ = scratch_space_->vec_stack_.Borrow();
       vec_->reserve(reserve);
       vec_->resize(size);
-      data_ = &(*vec_)[0];
+      // use vector.at(0) to make sure we do not trigger UB on an empty vector
+      data_ = &vec_->at(0);
     }
 
     void Init(int size, NetworkScratch *scratch) {


### PR DESCRIPTION
Make sure that the empty vector's data is never used, `at()` will throw an exception in that case.

This may allow compilers to better optimize code.