### PR TITLE
Fix deadlock in lstmtraining.

### DIFF
--- a/src/ccstruct/imagedata.cpp
+++ b/src/ccstruct/imagedata.cpp
@@ -435,15 +435,17 @@ void DocumentData::LoadPageInBackground(int index) {
   if (IsPageAvailable(index, &page)) {
     return;
   }
-  std::lock_guard<std::mutex> lock(pages_mutex_);
-  if (pages_offset_ == index) {
-    return;
+  {
+    std::lock_guard<std::mutex> lock(pages_mutex_);
+    if (pages_offset_ == index) {
+      return;
+    }
+    pages_offset_ = index;
+    for (auto page : pages_) {
+      delete page;
+    }
+    pages_.clear();
   }
-  pages_offset_ = index;
-  for (auto page : pages_) {
-    delete page;
-  }
-  pages_.clear();
   if (thread.joinable()) {
     thread.join();
   }


### PR DESCRIPTION
lstmtraining rarely hangs in training.

DocumentData::LoadPageInBackground() and DocumentData::ReCachePages() both tries to lock pages_mutex_.
If LoadPageInBackground() locks pages_mutex_ before previous call of ReCachePages() starts LoadPageInBackground() tries to join() blocked ReCachePages() thread and waits forever. 
It occurs in very high load (CPU or disk is busy) situation.

```cpp
void DocumentData::LoadPageInBackground(int index) {
  ImageData *page = nullptr;
  if (IsPageAvailable(index, &page)) {
    return;
  }
  std::lock_guard<std::mutex> lock(pages_mutex_);
  if (pages_offset_ == index) {
    return;
  }
  pages_offset_ = index;
  for (auto page : pages_) {
    delete page;
  }
  pages_.clear();
  if (thread.joinable()) {
    thread.join();
  }
  thread = std::thread(&tesseract::DocumentData::ReCachePages, this);
}
```
In this PR LoadPageInBackground() releases pages_mutex_ lock before join(). (I suppose this is enough scope of lock.)