### PR TITLE
Fix spec string of convolution layer

### DIFF
--- a/src/lstm/convolve.h
+++ b/src/lstm/convolve.h
@@ -37,7 +37,7 @@ public:
   ~Convolve() override = default;
 
   std::string spec() const override {
-    return "C" + std::to_string(half_x_ * 2 + 1) + "," + std::to_string(half_y_ * 2 + 1);
+    return "C" + std::to_string(half_y_ * 2 + 1) + "," + std::to_string(half_x_ * 2 + 1);
   }
 
   // Writes to the given file. Returns false in case of error.


### PR DESCRIPTION
This PR fixes the wrong order of x window size and y window size in the spec string of the convolution layer.

From VGSL Specs https://tesseract-ocr.github.io/tessdoc/tess4/VGSLSpecs.html
>C(s|t|r|l|m)**\<y\>,\<x\>,\<d\>** Convolves using a y,x window, with no shrinkage,
  random infill, d outputs, with s|t|r|l|m non-linear layer.

In VGSL parsing, it is **\<y\>,\<x\>**,\<d\>. (correct)
https://github.com/tesseract-ocr/tesseract/blob/88d4028a5a44e3fd7d0d66fe187b197ffccccf4e/src/training/common/networkbuilder.cpp#L280-L281

However, the format of the spec string is **\<x\>,\<y\>**.
https://github.com/tesseract-ocr/tesseract/blob/88d4028a5a44e3fd7d0d66fe187b197ffccccf4e/src/lstm/convolve.h#L39-L41
