### PR TITLE
Removed unused parameters 

### DIFF
--- a/src/ccmain/pgedit.cpp
+++ b/src/ccmain/pgedit.cpp
@@ -122,13 +122,6 @@ INT_VAR(editor_image_ypos, 10, "Editor image Y Pos");
 static INT_VAR(editor_image_menuheight, 50, "Add to image height for menu bar");
 INT_VAR(editor_image_word_bb_color, ScrollView::BLUE, "Word bounding box colour");
 INT_VAR(editor_image_blob_bb_color, ScrollView::YELLOW, "Blob bounding box colour");
-INT_VAR(editor_image_text_color, ScrollView::WHITE, "Correct text colour");
-
-STRING_VAR(editor_dbwin_name, "EditorDBWin", "Editor debug window name");
-INT_VAR(editor_dbwin_xpos, 50, "Editor debug window X Pos");
-INT_VAR(editor_dbwin_ypos, 500, "Editor debug window Y Pos");
-INT_VAR(editor_dbwin_height, 24, "Editor debug window height");
-INT_VAR(editor_dbwin_width, 80, "Editor debug window width");
 
 STRING_VAR(editor_word_name, "BlnWords", "BL normalized word window");
 INT_VAR(editor_word_xpos, 60, "Word window X Pos");

--- a/src/ccmain/pgedit.h
+++ b/src/ccmain/pgedit.h
@@ -46,22 +46,13 @@ extern BLOCK_LIST *current_block_list;
 extern STRING_VAR_H(editor_image_win_name, "EditorImage", "Editor image window name");
 extern INT_VAR_H(editor_image_xpos, 590, "Editor image X Pos");
 extern INT_VAR_H(editor_image_ypos, 10, "Editor image Y Pos");
-extern INT_VAR_H(editor_image_height, 680, "Editor image height");
-extern INT_VAR_H(editor_image_width, 655, "Editor image width");
 extern INT_VAR_H(editor_image_word_bb_color, BLUE, "Word bounding box colour");
 extern INT_VAR_H(editor_image_blob_bb_color, YELLOW, "Blob bounding box colour");
-extern INT_VAR_H(editor_image_text_color, WHITE, "Correct text colour");
-extern STRING_VAR_H(editor_dbwin_name, "EditorDBWin", "Editor debug window name");
-extern INT_VAR_H(editor_dbwin_xpos, 50, "Editor debug window X Pos");
-extern INT_VAR_H(editor_dbwin_ypos, 500, "Editor debug window Y Pos");
-extern INT_VAR_H(editor_dbwin_height, 24, "Editor debug window height");
-extern INT_VAR_H(editor_dbwin_width, 80, "Editor debug window width");
 extern STRING_VAR_H(editor_word_name, "BlnWords", "BL normalised word window");
 extern INT_VAR_H(editor_word_xpos, 60, "Word window X Pos");
 extern INT_VAR_H(editor_word_ypos, 510, "Word window Y Pos");
 extern INT_VAR_H(editor_word_height, 240, "Word window height");
 extern INT_VAR_H(editor_word_width, 655, "Word window width");
-extern double_VAR_H(editor_smd_scale_factor, 1.0, "Scaling for smd image");
 
 } // namespace tesseract
 

--- a/src/ccstruct/blobbox.h
+++ b/src/ccstruct/blobbox.h
@@ -803,7 +803,6 @@ private:
 };
 
 ELISTIZEH(TO_BLOCK)
-extern double_VAR_H(textord_error_weight, 3, "Weighting for error in believability");
 void find_cblob_limits( // get y limits
     C_BLOB *blob,       // blob to search
     float leftx,        // x limits

--- a/src/textord/blkocc.h
+++ b/src/textord/blkocc.h
@@ -234,10 +234,6 @@ public:
 
 #define END_OF_WERD_CODE 255
 
-extern BOOL_VAR_H(blockocc_show_result, false, "Show intermediate results");
-extern INT_VAR_H(blockocc_desc_height, 0, "Descender height after normalisation");
-extern INT_VAR_H(blockocc_asc_height, 255, "Ascender height after normalisation");
-extern INT_VAR_H(blockocc_band_count, 4, "Number of bands used");
 extern double_VAR_H(textord_underline_threshold, 0.9, "Fraction of width occupied");
 
 bool test_underline(  // look for underlines

--- a/src/textord/drawtord.h
+++ b/src/textord/drawtord.h
@@ -29,8 +29,6 @@ namespace tesseract {
 #define NO_SMD "none"
 
 extern BOOL_VAR_H(textord_show_fixed_cuts, false, "Draw fixed pitch cell boundaries");
-extern STRING_VAR_H(to_debugfile, DEBUG_WIN_NAME, "Name of debugfile");
-extern STRING_VAR_H(to_smdfile, NO_SMD, "Name of SMD file");
 extern ScrollView *to_win;
 extern FILE *to_debug;
 // Creates a static display window for textord, and returns a pointer to it.

--- a/src/textord/fpchop.cpp
+++ b/src/textord/fpchop.cpp
@@ -32,7 +32,6 @@
 namespace tesseract {
 
 INT_VAR(textord_fp_chop_error, 2, "Max allowed bending of chop cells");
-double_VAR(textord_fp_chop_snap, 0.5, "Max distance of chop pt from vertex");
 
 static WERD *add_repeated_word(WERD_IT *rep_it, int16_t &rep_left, int16_t &prev_chop_coord,
                                uint8_t &blanks, float pitch, WERD_IT *word_it);

--- a/src/textord/fpchop.h
+++ b/src/textord/fpchop.h
@@ -59,7 +59,6 @@ private:
 ELISTIZEH(C_OUTLINE_FRAG)
 
 extern INT_VAR_H(textord_fp_chop_error, 2, "Max allowed bending of chop cells");
-extern double_VAR_H(textord_fp_chop_snap, 0.5, "Max distance of chop pt from vertex");
 
 ROW *fixed_pitch_words( // find lines
     TO_ROW *row,        // row to do

--- a/src/textord/makerow.cpp
+++ b/src/textord/makerow.cpp
@@ -68,7 +68,6 @@ INT_VAR(textord_spline_medianwin, 6, "Size of window for spline segmentation");
 static INT_VAR(textord_max_blob_overlaps, 4, "Max number of blobs a big blob can overlap");
 INT_VAR(textord_min_xheight, 10, "Min credible pixel xheight");
 double_VAR(textord_spline_shift_fraction, 0.02, "Fraction of line spacing for quad");
-double_VAR(textord_spline_outlier_fraction, 0.1, "Fraction of line spacing for outlier");
 double_VAR(textord_skew_ile, 0.5, "Ile of gradients for page skew");
 double_VAR(textord_skew_lag, 0.02, "Lag for skew on row accumulation");
 double_VAR(textord_linespace_iqrlimit, 0.2, "Max iqr/median for linespace");

--- a/src/textord/makerow.h
+++ b/src/textord/makerow.h
@@ -49,12 +49,10 @@ extern BOOL_VAR_H(textord_show_final_blobs, false, "Display blob bounds after pr
 extern BOOL_VAR_H(textord_test_landscape, false, "Tests refer to land/port");
 extern BOOL_VAR_H(textord_parallel_baselines, true, "Force parallel baselines");
 extern BOOL_VAR_H(textord_straight_baselines, false, "Force straight baselines");
-extern BOOL_VAR_H(textord_quadratic_baselines, false, "Use quadratic splines");
 extern BOOL_VAR_H(textord_old_baselines, true, "Use old baseline algorithm");
 extern BOOL_VAR_H(textord_old_xheight, true, "Use old xheight algorithm");
 extern BOOL_VAR_H(textord_fix_xheight_bug, true, "Use spline baseline");
 extern BOOL_VAR_H(textord_fix_makerow_bug, true, "Prevent multiple baselines");
-extern BOOL_VAR_H(textord_cblob_blockocc, true, "Use new projection for underlines");
 extern BOOL_VAR_H(textord_debug_xheights, false, "Test xheight algorithms");
 extern INT_VAR_H(textord_test_x, -INT32_MAX, "coord of test pt");
 extern INT_VAR_H(textord_test_y, -INT32_MAX, "coord of test pt");
@@ -63,7 +61,6 @@ extern INT_VAR_H(textord_spline_minblobs, 8, "Min blobs in each spline segment")
 extern INT_VAR_H(textord_spline_medianwin, 6, "Size of window for spline segmentation");
 extern INT_VAR_H(textord_min_xheight, 10, "Min credible pixel xheight");
 extern double_VAR_H(textord_spline_shift_fraction, 0.02, "Fraction of line spacing for quad");
-extern double_VAR_H(textord_spline_outlier_fraction, 0.1, "Fraction of line spacing for outlier");
 extern double_VAR_H(textord_skew_ile, 0.5, "Ile of gradients for page skew");
 extern double_VAR_H(textord_skew_lag, 0.75, "Lag for skew on row accumulation");
 extern double_VAR_H(textord_linespace_iqrlimit, 0.2, "Max iqr/median for linespace");

--- a/src/textord/pitsync1.cpp
+++ b/src/textord/pitsync1.cpp
@@ -26,7 +26,6 @@ namespace tesseract {
 INT_VAR(pitsync_linear_version, 6, "Use new fast algorithm");
 double_VAR(pitsync_joined_edge, 0.75, "Dist inside big blob for chopping");
 double_VAR(pitsync_offset_freecut_fraction, 0.25, "Fraction of cut for free cuts");
-INT_VAR(pitsync_fake_depth, 1, "Max advance fake generation");
 
 /**********************************************************************
  * FPSEGPT::FPSEGPT

--- a/src/textord/pitsync1.h
+++ b/src/textord/pitsync1.h
@@ -83,7 +83,6 @@ CLISTIZEH(FPSEGPT_LIST)
 extern INT_VAR_H(pitsync_linear_version, 0, "Use new fast algorithm");
 extern double_VAR_H(pitsync_joined_edge, 0.75, "Dist inside big blob for chopping");
 extern double_VAR_H(pitsync_offset_freecut_fraction, 0.25, "Fraction of cut for free cuts");
-extern INT_VAR_H(pitsync_fake_depth, 1, "Max advance fake generation");
 double check_pitch_sync(   // find segmentation
     BLOBNBOX_IT *blob_it,  // blobs to do
     int16_t blob_count,    // no of blobs

--- a/src/textord/topitch.cpp
+++ b/src/textord/topitch.cpp
@@ -45,7 +45,6 @@ BOOL_VAR(textord_fast_pitch_test, false, "Do even faster pitch algorithm");
 BOOL_VAR(textord_debug_pitch_metric, false, "Write full metric stuff");
 BOOL_VAR(textord_show_row_cuts, false, "Draw row-level cuts");
 BOOL_VAR(textord_show_page_cuts, false, "Draw page-level cuts");
-BOOL_VAR(textord_pitch_cheat, false, "Use correct answer for fixed/prop");
 BOOL_VAR(textord_blockndoc_fixed, false, "Attempt whole doc/block fixed pitch");
 double_VAR(textord_projection_scale, 0.200, "Ding rate for mid-cuts");
 double_VAR(textord_balance_factor, 1.0, "Ding rate for unbalanced char cells");

--- a/src/textord/topitch.h
+++ b/src/textord/topitch.h
@@ -29,7 +29,6 @@ extern BOOL_VAR_H(textord_debug_pitch_test, false, "Debug on fixed pitch test");
 extern BOOL_VAR_H(textord_debug_pitch_metric, false, "Write full metric stuff");
 extern BOOL_VAR_H(textord_show_row_cuts, false, "Draw row-level cuts");
 extern BOOL_VAR_H(textord_show_page_cuts, false, "Draw page-level cuts");
-extern BOOL_VAR_H(textord_pitch_cheat, false, "Use correct answer for fixed/prop");
 extern BOOL_VAR_H(textord_blockndoc_fixed, true, "Attempt whole doc/block fixed pitch");
 extern BOOL_VAR_H(textord_fast_pitch_test, false, "Do even faster pitch algorithm");
 extern double_VAR_H(textord_projection_scale, 0.125, "Ding rate for mid-cuts");

--- a/src/textord/tovars.cpp
+++ b/src/textord/tovars.cpp
@@ -23,18 +23,12 @@
 namespace tesseract {
 
 BOOL_VAR(textord_show_initial_words, false, "Display separate words");
-BOOL_VAR(textord_show_new_words, false, "Display separate words");
-BOOL_VAR(textord_show_fixed_words, false, "Display forced fixed pitch words");
 BOOL_VAR(textord_blocksall_fixed, false, "Moan about prop blocks");
 BOOL_VAR(textord_blocksall_prop, false, "Moan about fixed pitch blocks");
-BOOL_VAR(textord_blocksall_testing, false, "Dump stats when moaning");
-BOOL_VAR(textord_test_mode, false, "Do current test");
 INT_VAR(textord_dotmatrix_gap, 3, "Max pixel gap for broken pixed pitch");
 INT_VAR(textord_debug_block, 0, "Block to do debug on");
 INT_VAR(textord_pitch_range, 2, "Max range test on pitch");
 double_VAR(textord_wordstats_smooth_factor, 0.05, "Smoothing gap stats");
-double_VAR(textord_width_smooth_factor, 0.10, "Smoothing width stats");
-double_VAR(textord_words_width_ile, 0.4, "Ile of blob widths for space est");
 double_VAR(textord_words_maxspace, 4.0, "Multiple of xheight");
 double_VAR(textord_words_default_maxspace, 3.5, "Max believable third space");
 double_VAR(textord_words_default_minspace, 0.6, "Fraction of xheight");
@@ -55,10 +49,8 @@ double_VAR(words_default_prop_nonspace, 0.25, "Fraction of xheight");
 double_VAR(words_default_fixed_space, 0.75, "Fraction of xheight");
 double_VAR(words_default_fixed_limit, 0.6, "Allowed size variance");
 double_VAR(textord_words_definite_spread, 0.30, "Non-fuzzy spacing region");
-double_VAR(textord_spacesize_ratiofp, 2.8, "Min ratio space/nonspace");
 double_VAR(textord_spacesize_ratioprop, 2.0, "Min ratio space/nonspace");
 double_VAR(textord_fpiqr_ratio, 1.5, "Pitch IQR/Gap IQR threshold");
 double_VAR(textord_max_pitch_iqr, 0.20, "Xh fraction noise in pitch");
-double_VAR(textord_fp_min_width, 0.5, "Min width of decent blobs");
 
 } // namespace tesseract

--- a/src/textord/tovars.h
+++ b/src/textord/tovars.h
@@ -25,18 +25,12 @@
 namespace tesseract {
 
 extern BOOL_VAR_H(textord_show_initial_words, false, "Display separate words");
-extern BOOL_VAR_H(textord_show_new_words, false, "Display separate words");
-extern BOOL_VAR_H(textord_show_fixed_words, false, "Display forced fixed pitch words");
 extern BOOL_VAR_H(textord_blocksall_fixed, false, "Moan about prop blocks");
 extern BOOL_VAR_H(textord_blocksall_prop, false, "Moan about fixed pitch blocks");
-extern BOOL_VAR_H(textord_blocksall_testing, false, "Dump stats when moaning");
-extern BOOL_VAR_H(textord_test_mode, false, "Do current test");
 extern INT_VAR_H(textord_dotmatrix_gap, 3, "Max pixel gap for broken pixed pitch");
 extern INT_VAR_H(textord_debug_block, 0, "Block to do debug on");
 extern INT_VAR_H(textord_pitch_range, 2, "Max range test on pitch");
 extern double_VAR_H(textord_wordstats_smooth_factor, 0.05, "Smoothing gap stats");
-extern double_VAR_H(textord_width_smooth_factor, 0.10, "Smoothing width stats");
-extern double_VAR_H(textord_words_width_ile, 0.4, "Ile of blob widths for space est");
 extern double_VAR_H(textord_words_maxspace, 4.0, "Multiple of xheight");
 extern double_VAR_H(textord_words_default_maxspace, 3.5, "Max believable third space");
 extern double_VAR_H(textord_words_default_minspace, 0.6, "Fraction of xheight");
@@ -57,11 +51,9 @@ extern double_VAR_H(words_default_prop_nonspace, 0.25, "Fraction of xheight");
 extern double_VAR_H(words_default_fixed_space, 0.75, "Fraction of xheight");
 extern double_VAR_H(words_default_fixed_limit, 0.6, "Allowed size variance");
 extern double_VAR_H(textord_words_definite_spread, 0.30, "Non-fuzzy spacing region");
-extern double_VAR_H(textord_spacesize_ratiofp, 2.8, "Min ratio space/nonspace");
 extern double_VAR_H(textord_spacesize_ratioprop, 2.0, "Min ratio space/nonspace");
 extern double_VAR_H(textord_fpiqr_ratio, 1.5, "Pitch IQR/Gap IQR threshold");
 extern double_VAR_H(textord_max_pitch_iqr, 0.20, "Xh fraction noise in pitch");
-extern double_VAR_H(textord_fp_min_width, 0.5, "Min width of decent blobs");
 
 } // namespace tesseract
 

--- a/src/textord/wordseg.cpp
+++ b/src/textord/wordseg.cpp
@@ -36,7 +36,6 @@
 
 namespace tesseract {
 
-BOOL_VAR(textord_fp_chopping, true, "Do fixed pitch chopping");
 BOOL_VAR(textord_force_make_prop_words, false, "Force proportional word segmentation on all rows");
 BOOL_VAR(textord_chopper_test, false, "Chopper is being tested.");
 

--- a/src/textord/wordseg.h
+++ b/src/textord/wordseg.h
@@ -26,7 +26,6 @@
 namespace tesseract {
 class Tesseract;
 
-extern BOOL_VAR_H(textord_fp_chopping, true, "Do fixed pitch chopping");
 extern BOOL_VAR_H(textord_force_make_prop_words, false,
                   "Force proportional word segmentation on all rows");
 extern BOOL_VAR_H(textord_chopper_test, false, "Chopper is being tested.");

--- a/src/wordrec/drawfx.cpp
+++ b/src/wordrec/drawfx.cpp
@@ -39,8 +39,6 @@ namespace tesseract {
 // title of window
 #  define DEBUG_WIN_NAME "FXDebug"
 
-STRING_VAR(fx_debugfile, DEBUG_WIN_NAME, "Name of debugfile");
-
 ScrollView *fx_win = nullptr;
 FILE *fx_debug = nullptr;
 

--- a/src/wordrec/drawfx.h
+++ b/src/wordrec/drawfx.h
@@ -24,7 +24,6 @@
 
 namespace tesseract {
 
-extern STRING_VAR_H(fx_debugfile, DEBUG_WIN_NAME, "Name of debugfile");
 #ifndef GRAPHICS_DISABLED
 extern ScrollView *fx_win;
 #endif // !GRAPHICS_DISABLED


### PR DESCRIPTION
The following parameters are not used anywhere anymore:
* editor_image_text_color
* editor_dbwin_name
* editor_dbwin_xpos
* editor_dbwin_ypos
* editor_dbwin_height
* editor_dbwin_width
* editor_image_height
* editor_image_width
* editor_smd_scale_factor
* textord_error_weight
* blockocc_show_result
* blockocc_desc_height
* blockocc_asc_height
* blockocc_band_count
* to_debugfile
* to_smdfile
* textord_fp_chop_snap
* textord_spline_outlier_fraction
* textord_quadratic_baselines
* textord_cblob_blockocc
* textord_spline_outlier_fraction
* pitsync_fake_depth
* textord_pitch_cheat
* textord_show_new_words
* textord_show_fixed_words
* textord_width_smooth_factor
* textord_words_width_ile
* textord_spacesize_ratiofp
* textord_blocksall_testing
* textord_test_mode
* textord_fp_min_width
* textord_fp_chopping
* fx_debugfile

Found with a python script and reviewed individually.