### PR TITLE
Add missing check for __ARM_NEON

### DIFF
--- a/src/arch/dotproductneon.cpp
+++ b/src/arch/dotproductneon.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////
 
+#if defined(__ARM_NEON)
+
 #include <arm_neon.h>
 #include "dotproduct.h"
 
@@ -65,3 +67,5 @@ TFloat DotProductNEON(const TFloat *u, const TFloat *v, int n) {
 #endif
 
 } // namespace tesseract
+
+#endif /* __ARM_NEON */


### PR DESCRIPTION
This makes it consistent with intsimdmatrixneon.cpp file and allows having this file included in builds even for non-NEON platforms (simplifies build config).