### PR TITLE
Abort LSTM training with integer model (fixes issue #1573)

### DIFF
--- a/src/training/unicharset/lstmtrainer.cpp
+++ b/src/training/unicharset/lstmtrainer.cpp
@@ -105,6 +105,10 @@ bool LSTMTrainer::TryLoadingCheckpoint(const char *filename, const char *old_tra
   if (!ReadTrainingDump(data, *this)) {
     return false;
   }
+  if (IsIntMode()) {
+    tprintf("Error, %s is an integer (fast) model, cannot continue training\n", filename);
+    return false;
+  }
   if (((old_traineddata == nullptr || *old_traineddata == '\0') &&
        network_->NumOutputs() == recoder_.code_range()) ||
       filename == old_traineddata) {


### PR DESCRIPTION
Tesseract currently cannot continue LSTM training from an
integer (fast) model.

Report this to users who try it nevertheless instead of crashing
with an assertion.

Signed-off-by: Stefan Weil <sw@weilnetz.de>