### PR TITLE
Fix crash of shapeclustering (fixes #3564)

### DIFF
--- a/src/training/common/commontraining.cpp
+++ b/src/training/common/commontraining.cpp
@@ -238,7 +238,7 @@ std::unique_ptr<MasterTrainer> LoadTrainingData(int argc, const char *const *arg
   trainer->SetFeatureSpace(fs);
   const char *page_name;
   // Load training data from .tr files on the command line.
-  int tessoptind = 0;
+  int tessoptind = 1;
   while ((page_name = GetNextFilename(argc, argv, tessoptind)) != nullptr) {
     tprintf("Reading %s ...\n", page_name);
     trainer->ReadTrainingSamples(page_name, feature_defs, false);


### PR DESCRIPTION
Fixes: 4415209fd667 ("Remove tessopt. This fixes mastertrainer test in shared build")
Signed-off-by: Stefan Weil <sw@weilnetz.de>