### PR TITLE
Fix linking Tesseract to project using CMake on Linux

### DIFF
--- a/cmake/templates/TesseractConfig.cmake.in
+++ b/cmake/templates/TesseractConfig.cmake.in
@@ -23,6 +23,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/TesseractTargets.cmake)
 @PACKAGE_INIT@
 
 set_and_check(Tesseract_INCLUDE_DIRS "@PACKAGE_INCLUDE_DIR@")
-set(Tesseract_LIBRARIES libtesseract)
+set(Tesseract_LIBRARIES tesseract)
 
 check_required_components(Tesseract)


### PR DESCRIPTION
In the past Tesseract library was wrongly named as "liblibtesseract" so it was needed to use "-llibtesseract" as argument for linker. The name was fixed in commit 52cac3a42ef2b823b9367b9ee2d1d84f8eda4ea0 but the ${Tesseract_LIBRARIES} variable still wrongly holds "libtesseract" and causes linker error when one is using it in target_link_libraries(...). This commit fixes that.