### PR TITLE
cmake: Improve configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,16 +431,7 @@ configure_file(
 
 include(CMakePackageConfigHelpers)
 include(GenerateExportHeader)
-configure_package_config_file(
-    cmake/templates/TesseractConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/tesseract/TesseractConfig.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tesseract
-    PATH_VARS INCLUDE_DIR LIBRARY_DIRS)
-write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/tesseract/TesseractConfigVersion.cmake
-    VERSION ${PACKAGE_VERSION}
-    COMPATIBILITY SameMajorVersion)
-
+    
 # show summary of configuration
 if(${CMAKE_BUILD_TYPE} MATCHES Debug)
     set(COMPILER_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}")
@@ -758,7 +749,19 @@ endif()
 get_target_property(tesseract_NAME libtesseract NAME)
 get_target_property(tesseract_VERSION libtesseract VERSION)
 get_target_property(tesseract_OUTPUT_NAME libtesseract OUTPUT_NAME)
+
 configure_file(tesseract.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/tesseract.pc @ONLY)
+
+configure_package_config_file(
+    cmake/templates/TesseractConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/tesseract/TesseractConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tesseract
+    PATH_VARS INCLUDE_DIR LIBRARY_DIRS)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/tesseract/TesseractConfigVersion.cmake
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY SameMajorVersion)
+
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tesseract.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 install(TARGETS tesseract DESTINATION bin)
 install(TARGETS libtesseract EXPORT TesseractTargets RUNTIME DESTINATION bin LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/cmake/templates/TesseractConfig.cmake.in
+++ b/cmake/templates/TesseractConfig.cmake.in
@@ -13,6 +13,10 @@
 #      - Tesseract_LIBRARIES             : The list of all imported targets.
 #      - Tesseract_INCLUDE_DIRS          : The Tesseract include directories.
 #      - Tesseract_LIBRARY_DIRS          : The Tesseract library directories.
+#      - Tesseract_VERSION               : The version of this Tesseract build: "@VERSION_PLAIN@"
+#      - Tesseract_VERSION_MAJOR         : Major version part of Tesseract_VERSION: "@VERSION_MAJOR@"
+#      - Tesseract_VERSION_MINOR         : Minor version part of Tesseract_VERSION: "@VERSION_MINOR@"
+#      - Tesseract_VERSION_PATCH         : Patch version part of Tesseract_VERSION: "@VERSION_PATCH@"
 #
 # ===================================================================================
 
@@ -23,8 +27,13 @@ include(${CMAKE_CURRENT_LIST_DIR}/TesseractTargets.cmake)
 
 @PACKAGE_INIT@
 
+SET(Tesseract_VERSION           @VERSION_PLAIN@)
+SET(Tesseract_VERSION_MAJOR     @VERSION_MAJOR@)
+SET(Tesseract_VERSION_MINOR     @VERSION_MINOR@)
+SET(Tesseract_VERSION_PATCH     @VERSION_PATCH@)
+
 set_and_check(Tesseract_INCLUDE_DIRS "@PACKAGE_INCLUDE_DIR@")
 set_and_check(Tesseract_LIBRARY_DIRS "@PACKAGE_LIBRARY_DIRS@")
-set(Tesseract_LIBRARIES tesseract)
+set(Tesseract_LIBRARIES @tesseract_OUTPUT_NAME@)
 
 check_required_components(Tesseract)


### PR DESCRIPTION
- Use correct library name in TesseractConfig.cmake on all platforms
- Expose Tesseract_VERSION and Tesseract_VERSION_* variables in TesseractConfig.cmake