### PR TITLE
Improve training messages (issue #3560)

### DIFF
--- a/src/training/lstmtraining.cpp
+++ b/src/training/lstmtraining.cpp
@@ -227,6 +227,7 @@ int main(int argc, char **argv) {
     tprintf("%s\n", log_str.c_str());
   } while (trainer.best_error_rate() > FLAGS_target_error_rate &&
            (trainer.training_iteration() < max_iterations));
-  tprintf("Finished! Error rate = %g\n", trainer.best_error_rate());
+  tprintf("Finished! Selected model with minimal training error rate (BCER) = %g\n",
+          trainer.best_error_rate());
   return EXIT_SUCCESS;
 } /* main */

--- a/src/training/unicharset/lstmtester.cpp
+++ b/src/training/unicharset/lstmtester.cpp
@@ -106,7 +106,7 @@ std::string LSTMTester::RunEvalSync(int iteration, const double *training_errors
         std::string ocr_text = trainer.DecodeLabels(ocr_labels);
         tprintf("OCR  :%s\n", ocr_text.c_str());
         if (verbosity > 2 || (verbosity > 1 && result != PERFECT)) {
-          tprintf("Line Char error rate=%f, Word error rate=%f\n\n",
+          tprintf("Line BCER=%f, BWER=%f\n\n",
                   trainer.NewSingleError(tesseract::ET_CHAR_ERROR),
                   trainer.NewSingleError(tesseract::ET_WORD_RECERR));
         }
@@ -118,8 +118,8 @@ std::string LSTMTester::RunEvalSync(int iteration, const double *training_errors
   std::string result;
   result += "At iteration " + std::to_string(iteration);
   result += ", stage " + std::to_string(training_stage);
-  result += ", Eval Char error rate=" + std::to_string(char_error);
-  result += ", Word error rate=" + std::to_string(word_error);
+  result += ", BCER eval=" + std::to_string(char_error);
+  result += ", BWER eval=" + std::to_string(word_error);
   return result;
 }
 

--- a/src/training/unicharset/lstmtrainer.cpp
+++ b/src/training/unicharset/lstmtrainer.cpp
@@ -396,8 +396,8 @@ void LSTMTrainer::PrepareLogMsg(std::string &log_msg) const {
   LogIterations("At", log_msg);
   log_msg += ", Mean rms=" + std::to_string(error_rates_[ET_RMS]);
   log_msg += "%, delta=" + std::to_string(error_rates_[ET_DELTA]);
-  log_msg += "%, char train=" + std::to_string(error_rates_[ET_CHAR_ERROR]);
-  log_msg += "%, word train=" + std::to_string(error_rates_[ET_WORD_RECERR]);
+  log_msg += "%, BCER train=" + std::to_string(error_rates_[ET_CHAR_ERROR]);
+  log_msg += "%, BWER train=" + std::to_string(error_rates_[ET_WORD_RECERR]);
   log_msg += "%, skip ratio=" + std::to_string(error_rates_[ET_SKIP_RATIO]);
   log_msg += "%, ";
 }


### PR DESCRIPTION
The old messages could wrongly be interpreted as CER / WER values,
but Tesseract training currently uses simple bag of characters /
bag of words error rates (see LSTMTrainer::ComputeCharError,
LSTMTrainer::ComputeWordError).

Signed-off-by: Stefan Weil <sw@weilnetz.de>