### PR TITLE
Training: Fix compiler warnings

### DIFF
--- a/src/training/unicharset/validate_indic.cpp
+++ b/src/training/unicharset/validate_indic.cpp
@@ -35,7 +35,8 @@ bool ValidateIndic::ConsumeGraphemeIfValid() {
       return true;
     default:
       if (report_errors_) {
-        tprintf("Invalid start of grapheme sequence:%c=0x%x\n", codes_[codes_used_].first,
+        tprintf("Invalid start of grapheme sequence:%c=0x%x\n",
+                static_cast<int>(codes_[codes_used_].first),
                 codes_[codes_used_].second);
       }
       return false;

--- a/src/training/unicharset/validate_javanese.cpp
+++ b/src/training/unicharset/validate_javanese.cpp
@@ -56,7 +56,8 @@ bool ValidateJavanese::ConsumeGraphemeIfValid() {
       return true;
     default:
       if (report_errors_) {
-        tprintf("Invalid start of grapheme sequence:%c=0x%x\n", codes_[codes_used_].first,
+        tprintf("Invalid start of grapheme sequence:%c=0x%x\n",
+                static_cast<int>(codes_[codes_used_].first),
                 codes_[codes_used_].second);
       }
       return false;


### PR DESCRIPTION
warning: format ‘%c’ expects argument of type ‘int’, but argument 2 has type ‘tesseract::Validator::CharClass’ [-Wformat=]