### PR TITLE
Remove duplicate parameter certainty_scale

### DIFF
--- a/src/classify/adaptmatch.cpp
+++ b/src/classify/adaptmatch.cpp
@@ -276,7 +276,7 @@ void Classify::LearnWord(const char *fontname, WERD_RES *word) {
       tprintf("\n\nAdapting to word = %s\n", word->best_choice->debug_string().c_str());
     }
     thresholds = new float[word_len];
-    word->ComputeAdaptionThresholds(certainty_scale, matcher_perfect_threshold,
+    word->ComputeAdaptionThresholds(getDict().certainty_scale, matcher_perfect_threshold,
                                     matcher_good_threshold, matcher_rating_margin, thresholds);
   }
   int start_blob = 0;

--- a/src/classify/classify.cpp
+++ b/src/classify/classify.cpp
@@ -101,7 +101,6 @@ Classify::Classify()
                     "its expected textline position",
                     this->params())
     , double_MEMBER(rating_scale, 1.5, "Rating scaling factor", this->params())
-    , double_MEMBER(certainty_scale, 20.0, "Certainty scaling factor", this->params())
     , double_MEMBER(tessedit_class_miss_scale, 0.00390625, "Scale factor for features not used",
                     this->params())
     , double_MEMBER(classify_adapted_pruning_factor, 2.5,

--- a/src/classify/classify.h
+++ b/src/classify/classify.h
@@ -394,7 +394,6 @@ public:
   double_VAR_H(matcher_clustering_max_angle_delta);
   double_VAR_H(classify_misfit_junk_penalty);
   double_VAR_H(rating_scale);
-  double_VAR_H(certainty_scale);
   double_VAR_H(tessedit_class_miss_scale);
   double_VAR_H(classify_adapted_pruning_factor);
   double_VAR_H(classify_adapted_pruning_threshold);


### PR DESCRIPTION
It was also declared in class Dict and mostly used from that class.
Setting it via API or command line never changed that used value.

Signed-off-by: Stefan Weil <sw@weilnetz.de>