### PR TITLE
RFC: Add option to include images in hOCR output

### DIFF
--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -261,6 +261,7 @@ Tesseract::Tesseract()
     , BOOL_MEMBER(hocr_font_info, false, "Add font info to hocr output", this->params())
     , BOOL_MEMBER(hocr_char_boxes, false, "Add coordinates for each character to hocr output",
                   this->params())
+    , BOOL_MEMBER(hocr_images, false, "Add images to hocr output", this->params())
     , BOOL_MEMBER(crunch_early_merge_tess_fails, true, "Before word crunch?", this->params())
     , BOOL_MEMBER(crunch_early_convert_bad_unlv_chs, false, "Take out ~^ early?", this->params())
     , double_MEMBER(crunch_terrible_rating, 80.0, "crunch rating lt this", this->params())

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -849,6 +849,7 @@ public:
   BOOL_VAR_H(unlv_tilde_crunching);
   BOOL_VAR_H(hocr_font_info);
   BOOL_VAR_H(hocr_char_boxes);
+  BOOL_VAR_H(hocr_images);
   BOOL_VAR_H(crunch_early_merge_tess_fails);
   BOOL_VAR_H(crunch_early_convert_bad_unlv_chs);
   double_VAR_H(crunch_terrible_rating);

--- a/tessdata/configs/hocr
+++ b/tessdata/configs/hocr
@@ -1,2 +1,3 @@
 tessedit_create_hocr 1
 hocr_font_info 0
+hocr_images 1


### PR DESCRIPTION
Written in collaboration with Aram (see commit author).

This pull request adds support to output `ocr_photo` elements in the hOCR renderer. `ocr_photo` is "Something that requires JPEG or PNG to be represented well" per the specification. `ocr_image` would be for SVG content. Since that is hard to distinguish, let's just go to `ocr_photo` unconditionally.

There are a few open questions/concerns that I can think of:

1. Do we want to render `ocrx_word` elements inside `ocr_photo`? I think per the hOCR specification this is allowed, but Tesseract seems to just "find" a word of the same bounding box with nothing but spaces as characters, in our testing.
2. If we do *not* want to have words inside `ocr_photo` elements, should we skip generating the `ocr_line` when writing hOCR even if the hocr images option is turned off, since we know the element is detected as an image block type with (apparently) no actual content?
2. If we want to skip adding `ocrx_word` elements, is the `goto` acceptable, or would you rather see the code rewritten without the `goto`?
3. Do we want to default to having this turned on?