### PR TITLE
Check if platform supports feenableexcept

### DIFF
--- a/cmake/Configure.cmake
+++ b/cmake/Configure.cmake
@@ -104,6 +104,13 @@ set(types_list
 )
 check_types(types_list)
 
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+list(APPEND CMAKE_REQUIRED_LIBRARIES -lm)
+set(functions_list
+    feenableexcept
+)
+check_functions(functions_list)
+
 file(APPEND ${AUTOCONFIG_SRC} "
 /* Version number */
 #cmakedefine PACKAGE_VERSION \"${PACKAGE_VERSION}\"

--- a/configure.ac
+++ b/configure.ac
@@ -188,6 +188,9 @@ case "${host_cpu}" in
 
 esac
 
+# check whether feenableexcept is supported. some C libraries (e.g. uclibc) don't.
+AC_CHECK_FUNCS([feenableexcept])
+
 AX_CHECK_COMPILE_FLAG([-fopenmp-simd], [openmp_simd=true], [openmp_simd=false], [$WERROR])
 AM_CONDITIONAL([OPENMP_SIMD], $openmp_simd)
 

--- a/src/tesseract.cpp
+++ b/src/tesseract.cpp
@@ -629,7 +629,7 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
  **********************************************************************/
 
 int main(int argc, char **argv) {
-#if defined(__USE_GNU)
+#if defined(__USE_GNU) && defined(HAVE_FEENABLEEXCEPT)
   // Raise SIGFPE.
 #  if defined(__clang__)
   // clang creates code which causes some FP exceptions, so don't enable those.


### PR DESCRIPTION
feenableexcept is not supported by uclibc

Signed-off-by: Gilles Talis <gilles.talis@gmail.com>
[Retrieved (and updated to add cmake support and simplify configure.ac)
from
https://git.buildroot.net/buildroot/tree/package/tesseract-ocr/0001-Check-if-platform-supports-feenableexcept.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>