### PR TITLE
Require cmake 3.10 or newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 #
 # ##############################################################################
 
-cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 # In-source builds are disabled.
 if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
@@ -292,9 +292,7 @@ if(OPENMP_BUILD)
   if(OpenMP_FOUND)
     message(">> OpenMP_FOUND ${OpenMP_FOUND} ${OpenMP_VERSION}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    if(${CMAKE_VERSION} VERSION_LESS "3.9.0")
-      add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
-    endif()
+    add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
   endif()
   # https://stackoverflow.com/questions/12399422
   # how-to-set-linker-flags-for-openmp-in-cmakes-try-compile-function


### PR DESCRIPTION
CMakeLists.txt uses TREE (supported since cmake 3.8) and
check_ipo_supported (supported since cmake 3.9).

Require 3.10 which is provided by Ubuntu bionic and newer distributions.

Signed-off-by: Stefan Weil <sw@weilnetz.de>