### PR TITLE
Check OpenMP target in CMake (issue #3751)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,9 @@ if(OPENMP_BUILD)
   if(OpenMP_FOUND)
     message(">> OpenMP_FOUND ${OpenMP_FOUND} ${OpenMP_VERSION}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+	if (NOT TARGET OpenMP::OpenMP_CXX)
+      add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+	endif()
   endif()
   # https://stackoverflow.com/questions/12399422
   # how-to-set-linker-flags-for-openmp-in-cmakes-try-compile-function


### PR DESCRIPTION
When building Tesseract, an error message appears in CMake. Depending on the CMake version, the target OpenMP::OpenMP_CXX is apparently already defined. In any case it is already present in 3.22.2. Therefore you should check if the target already exists.

Solves issue #3751