### PR TITLE
Partially revert changes of list data types (fix compiler warnings)

### DIFF
--- a/src/ccstruct/matrix.h
+++ b/src/ccstruct/matrix.h
@@ -39,7 +39,7 @@
 
 namespace tesseract {
 
-struct BLOB_CHOICE_LIST;
+class BLOB_CHOICE_LIST;
 class UNICHARSET;
 
 #define NOT_CLASSIFIED static_cast<BLOB_CHOICE_LIST *>(nullptr)

--- a/src/ccutil/clst.h
+++ b/src/ccutil/clst.h
@@ -703,7 +703,7 @@ public:
 };
 
 #define CLISTIZEH(CLASSNAME)                                    \
-  struct CLASSNAME##_CLIST : X_CLIST<CLASSNAME> {               \
+  class CLASSNAME##_CLIST : public X_CLIST<CLASSNAME> {         \
     using X_CLIST<CLASSNAME>::X_CLIST;                          \
   };                                                            \
   struct CLASSNAME##_C_IT : X_ITER<CLIST_ITERATOR, CLASSNAME> { \

--- a/src/ccutil/elst.h
+++ b/src/ccutil/elst.h
@@ -800,12 +800,12 @@ inline void ELIST_ITERATOR::add_to_end( // element to add
   }
 }
 
-#define ELISTIZEH(CLASSNAME)                                           \
-  struct CLASSNAME##_LIST : X_LIST<ELIST, ELIST_ITERATOR, CLASSNAME> { \
-    using X_LIST<ELIST, ELIST_ITERATOR, CLASSNAME>::X_LIST;            \
-  };                                                                   \
-  struct CLASSNAME##_IT : X_ITER<ELIST_ITERATOR, CLASSNAME> {          \
-    using X_ITER<ELIST_ITERATOR, CLASSNAME>::X_ITER;                   \
+#define ELISTIZEH(CLASSNAME)                                                 \
+  class CLASSNAME##_LIST : public X_LIST<ELIST, ELIST_ITERATOR, CLASSNAME> { \
+    using X_LIST<ELIST, ELIST_ITERATOR, CLASSNAME>::X_LIST;                  \
+  };                                                                         \
+  class CLASSNAME##_IT : public X_ITER<ELIST_ITERATOR, CLASSNAME> {          \
+    using X_ITER<ELIST_ITERATOR, CLASSNAME>::X_ITER;                         \
   };
 
 } // namespace tesseract

--- a/src/ccutil/elst2.h
+++ b/src/ccutil/elst2.h
@@ -819,15 +819,15 @@ inline void ELIST2_ITERATOR::add_to_end( // element to add
   }
 }
 
-#define ELIST2IZEH(CLASSNAME)                                            \
-  struct CLASSNAME##_LIST : X_LIST<ELIST2, ELIST2_ITERATOR, CLASSNAME> { \
-    using X_LIST<ELIST2, ELIST2_ITERATOR, CLASSNAME>::X_LIST;            \
-  };                                                                     \
-  struct CLASSNAME##_IT : X_ITER<ELIST2_ITERATOR, CLASSNAME> {           \
-    using X_ITER<ELIST2_ITERATOR, CLASSNAME>::X_ITER;                    \
-    CLASSNAME *backward() {                                              \
-      return reinterpret_cast<CLASSNAME *>(ELIST2_ITERATOR::backward()); \
-    }                                                                    \
+#define ELIST2IZEH(CLASSNAME)                                                  \
+  class CLASSNAME##_LIST : public X_LIST<ELIST2, ELIST2_ITERATOR, CLASSNAME> { \
+    using X_LIST<ELIST2, ELIST2_ITERATOR, CLASSNAME>::X_LIST;                  \
+  };                                                                           \
+  struct CLASSNAME##_IT : X_ITER<ELIST2_ITERATOR, CLASSNAME> {                 \
+    using X_ITER<ELIST2_ITERATOR, CLASSNAME>::X_ITER;                          \
+    CLASSNAME *backward() {                                                    \
+      return reinterpret_cast<CLASSNAME *>(ELIST2_ITERATOR::backward());       \
+    }                                                                          \
   };
 
 } // namespace tesseract


### PR DESCRIPTION
Changing from class to struct causes clang compiler warnings like this one:

In file included from ../../../src/api/baseapi.cpp:63:
../../../include/tesseract/osdetect.h:29:1: warning: class 'BLOB_CHOICE_LIST' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
class BLOB_CHOICE_LIST;
^
../../../src/ccstruct/ratngs.h:228:1: note: previous use is here
ELISTIZEH(BLOB_CHOICE)
^
../../../src/ccutil/elst.h:804:10: note: expanded from macro 'ELISTIZEH'
  struct CLASSNAME##_LIST : X_LIST<ELIST, ELIST_ITERATOR, CLASSNAME> { \
         ^
<scratch space>:458:1: note: expanded from here
BLOB_CHOICE_LIST
^
../../../include/tesseract/osdetect.h:29:1: note: did you mean struct here?
class BLOB_CHOICE_LIST;
^~~~~

As it is not possible to change the API header tesseract/osdetect.h,
some of the changes from class to struct had to be reverted.

Fixes: 968d653f89d68d ("Shorten macros")
Signed-off-by: Stefan Weil <sw@weilnetz.de>