### PR TITLE
Fix linker flags for MSYS2 clang64 builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -107,7 +107,7 @@ libtesseract_la_LDFLAGS += $(libarchive_LIBS)
 libtesseract_la_LDFLAGS += $(libcurl_LIBS)
 libtesseract_la_LDFLAGS += $(TENSORFLOW_LIBS)
 if T_WIN
-libtesseract_la_LDFLAGS += -no-undefined -Wl,--as-needed -lws2_32
+libtesseract_la_LDFLAGS += -no-undefined -lws2_32
 else
 libtesseract_la_LDFLAGS += $(NOUNDEFINED)
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ case "${host_os}" in
     mingw*)
         AM_CONDITIONAL([T_WIN], true)
         AM_CONDITIONAL([ADD_RT], false)
-        AC_SUBST([AM_LDFLAGS], ['-Wl,-no-undefined -Wl,--as-needed'])
+        AC_SUBST([AM_LDFLAGS], ['-no-undefined'])
         ;;
     cygwin*)
         AM_CONDITIONAL([ADD_RT], false)


### PR DESCRIPTION
MSYS2 clang64 uses the lld linker which does not support --as-needed.
The normal GNU ld uses that linker option with ELF targets but ignores
it for PE targets (.exe, .dll), so it can be removed.

Remove also the -Wl, which is only needed when linker options are
passed to the compiler but not when they are directly passed to the
linker.

Signed-off-by: Stefan Weil <sw@weilnetz.de>