### PR TITLE
Add benchmark test with disable-openmp

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -2,11 +2,10 @@ name: autotools
 # autotools build of tesseract and training tools on Ubuntu.
 # run command line tests, basicapitest and unittests. '--disable-openmp'
 on:
-  #push:
+  push:
   schedule:
     - cron: 0 20 * * *
 jobs:
-
 
   linux:
     runs-on: ${{ matrix.config.os }}
@@ -108,6 +107,29 @@ jobs:
            cd test
            ${{ matrix.config.cxx }} -o basicapitest testing/basicapitest.cpp -I/usr/local/include -L/usr/local/lib `pkg-config --cflags --libs tesseract lept ` -pthread -std=c++11
            ./basicapitest
+
+    - name: Setup for Tesseract benchmark using image from issue 263 fifteen times in a list file
+      run: |
+           wget -O i263_speed.jpg https://cloud.githubusercontent.com/assets/9968625/13674495/ac261db4-e6ab-11e5-9b4a-ad91d5b4ff87.jpg
+           printf 'i263_speed.jpg\n%.0s' {1..15} > benchmarks.list
+           lscpu
+           free
+           tesseract -v
+
+    - name: Run Tesseract using image from issue 263 with tessdata_fast
+      run: |
+           time tesseract benchmarks.list - --tessdata-dir ../tessdata_fast > /dev/null 2>&1
+           echo "tessdata_fast - disable-openmp"
+
+    - name: Run Tesseract using image from issue 263 with tessdata_best
+      run: |
+           time tesseract benchmarks.list - --tessdata-dir ../tessdata_best > /dev/null 2>&1
+           echo "tessdata_best - disable-openmp"
+
+    - name: Run Tesseract using image from issue 263 with tessdata_fast
+      run: |
+           time tesseract benchmarks.list - --tessdata-dir ../tessdata > /dev/null 2>&1
+           echo "tessdata - disable-openmp"
 
     - name: Display Compiler Version
       run: |


### PR DESCRIPTION
Using same image list as in https://github.com/tesseract-ocr/tesseract/pull/3774
This PR adds it to tesseract built with diable-openmp