### PR TITLE
src/arch/simddetect.cpp: fix NEON detection on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,7 +163,7 @@ case "${host_cpu}" in
 
     ;;
 
-  aarch64)
+  aarch64|arm64)
 
     # ARMv8 always has NEON and does not need special compiler flags.
     AM_CONDITIONAL([HAVE_NEON], true)
@@ -178,6 +178,7 @@ case "${host_cpu}" in
       AC_DEFINE([HAVE_NEON], [1], [Enable NEON instructions])
       NEON_CXXFLAGS="-mfpu=neon"
       AC_SUBST([NEON_CXXFLAGS])
+      check_for_neon=1
     fi
 
     ;;
@@ -190,6 +191,16 @@ esac
 
 # check whether feenableexcept is supported. some C libraries (e.g. uclibc) don't.
 AC_CHECK_FUNCS([feenableexcept])
+
+# additional checks for NEON targets
+if test x$check_for_neon = x1; then
+  AC_MSG_NOTICE([checking how to detect NEON availability])
+  AC_CHECK_FUNCS([getauxval elf_aux_info android_getCpuFamily])
+
+  if test $ac_cv_func_getauxval = no && test $ac_cv_func_elf_aux_info = no && test $ac_cv_func_android_getCpuFamily = no; then
+      AC_MSG_WARN([NEON is available, but we don't know how to check for it.  Will not be able to use NEON.])
+  fi
+fi
 
 AX_CHECK_COMPILE_FLAG([-fopenmp-simd], [openmp_simd=true], [openmp_simd=false], [$WERROR])
 AM_CONDITIONAL([OPENMP_SIMD], $openmp_simd)

--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -53,12 +53,12 @@
 #endif
 
 #if defined(HAVE_NEON) && !defined(__aarch64__)
-#  ifdef ANDROID
+#  if HAVE_ANDROID_GETCPUFAMILY
 #    include <cpu-features.h>
-#  elif defined(__linux__)
+#  elif HAVE_GETAUXVAL
 #    include <asm/hwcap.h>
 #    include <sys/auxv.h>
-#  elif defined(__FreeBSD__)
+#  elif HAVE_ELF_AUX_INFO
 #    include <sys/auxv.h>
 #    include <sys/elf.h>
 #  endif
@@ -212,15 +212,15 @@ SIMDDetect::SIMDDetect() {
 #endif
 
 #if defined(HAVE_NEON) && !defined(__aarch64__)
-#  ifdef ANDROID
+#  if HAVE_ANDROID_GETCPUFAMILY
   {
     AndroidCpuFamily family = android_getCpuFamily();
     if (family == ANDROID_CPU_FAMILY_ARM)
       neon_available_ = (android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_NEON);
   }
-#  elif defined(__linux__)
+#  elif HAVE_GETAUXVAL
   neon_available_ = getauxval(AT_HWCAP) & HWCAP_NEON;
-#  elif defined(__FreeBSD__)
+#  elif HAVE_ELF_AUX_INFO
   unsigned long hwcap = 0;
   elf_aux_info(AT_HWCAP, &hwcap, sizeof hwcap);
   neon_available_ = hwcap & HWCAP_NEON;

--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -55,7 +55,7 @@
 #if defined(HAVE_NEON) && !defined(__aarch64__)
 #  if defined(HAVE_ANDROID_GETCPUFAMILY)
 #    include <cpu-features.h>
-#  elif HAVE_GETAUXVAL
+#  elif defined(HAVE_GETAUXVAL)
 #    include <asm/hwcap.h>
 #    include <sys/auxv.h>
 #  elif HAVE_ELF_AUX_INFO

--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -58,7 +58,7 @@
 #  elif defined(HAVE_GETAUXVAL)
 #    include <asm/hwcap.h>
 #    include <sys/auxv.h>
-#  elif HAVE_ELF_AUX_INFO
+#  elif defined(HAVE_ELF_AUX_INFO)
 #    include <sys/auxv.h>
 #    include <sys/elf.h>
 #  endif

--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -87,7 +87,7 @@ SIMDDetect SIMDDetect::detector;
 bool SIMDDetect::neon_available_ = true;
 #elif defined(HAVE_NEON)
 // If true, then Neon has been detected.
-bool SIMDDetect::neon_available_ = false;
+bool SIMDDetect::neon_available_;
 #else
 // If true, then AVX has been detected.
 bool SIMDDetect::avx_available_;
@@ -212,15 +212,15 @@ SIMDDetect::SIMDDetect() {
 #endif
 
 #if defined(HAVE_NEON) && !defined(__aarch64__)
-#  if HAVE_ANDROID_GETCPUFAMILY
+#  if defined(HAVE_ANDROID_GETCPUFAMILY)
   {
     AndroidCpuFamily family = android_getCpuFamily();
     if (family == ANDROID_CPU_FAMILY_ARM)
       neon_available_ = (android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_NEON);
   }
-#  elif HAVE_GETAUXVAL
+#  elif defined(HAVE_GETAUXVAL)
   neon_available_ = getauxval(AT_HWCAP) & HWCAP_NEON;
-#  elif HAVE_ELF_AUX_INFO
+#  elif defined(HAVE_ELF_AUX_INFO)
   unsigned long hwcap = 0;
   elf_aux_info(AT_HWCAP, &hwcap, sizeof hwcap);
   neon_available_ = hwcap & HWCAP_NEON;

--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -55,10 +55,12 @@
 #if defined(HAVE_NEON) && !defined(__aarch64__)
 #  ifdef ANDROID
 #    include <cpu-features.h>
-#  else
-/* Assume linux */
+#  elif defined(__linux__)
 #    include <asm/hwcap.h>
 #    include <sys/auxv.h>
+#  elif defined(__FreeBSD__)
+#    include <sys/auxv.h>
+#    include <sys/elf.h>
 #  endif
 #endif
 
@@ -85,7 +87,7 @@ SIMDDetect SIMDDetect::detector;
 bool SIMDDetect::neon_available_ = true;
 #elif defined(HAVE_NEON)
 // If true, then Neon has been detected.
-bool SIMDDetect::neon_available_;
+bool SIMDDetect::neon_available_ = false;
 #else
 // If true, then AVX has been detected.
 bool SIMDDetect::avx_available_;
@@ -216,9 +218,12 @@ SIMDDetect::SIMDDetect() {
     if (family == ANDROID_CPU_FAMILY_ARM)
       neon_available_ = (android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_NEON);
   }
-#  else
-  /* Assume linux */
+#  elif defined(__linux__)
   neon_available_ = getauxval(AT_HWCAP) & HWCAP_NEON;
+#  elif defined(__FreeBSD__)
+  unsigned long hwcap = 0;
+  elf_aux_info(AT_HWCAP, &hwcap, sizeof hwcap);
+  neon_available_ = hwcap & HWCAP_NEON;
 #  endif
 #endif
 

--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -53,7 +53,7 @@
 #endif
 
 #if defined(HAVE_NEON) && !defined(__aarch64__)
-#  if HAVE_ANDROID_GETCPUFAMILY
+#  if defined(HAVE_ANDROID_GETCPUFAMILY)
 #    include <cpu-features.h>
 #  elif HAVE_GETAUXVAL
 #    include <asm/hwcap.h>


### PR DESCRIPTION
FreeBSD does not have the `<asm/hwcap>` header, requiring some slightly different code to check for NEON availability.  This code might also apply to other BSD-like operating systems such as NetBSD, OpenBSD, DragonflyBSD, or iOS, but I haven't checked.