### PR TITLE
Check input for `AppendString` to avoid `strlen(nullptr)`.

### DIFF
--- a/src/api/renderer.cpp
+++ b/src/api/renderer.cpp
@@ -109,6 +109,9 @@ bool TessResultRenderer::EndDocument() {
 }
 
 void TessResultRenderer::AppendString(const char *s) {
+  if (s == nullptr) {
+    return;
+  }
   AppendData(s, strlen(s));
 }
 


### PR DESCRIPTION
Fix #3788.