### PR TITLE
Fix memory issues in ScrollView::MessageReceiver

### DIFF
--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -1163,12 +1163,11 @@ void FillPPLinearBits(uint32_t ParamTable[NUM_PP_BUCKETS][WERDS_PER_PP_VECTOR], 
 CLASS_ID Classify::GetClassToDebug(const char *Prompt, bool *adaptive_on, bool *pretrained_on,
                                    int *shape_id) {
   tprintf("%s\n", Prompt);
-  SVEvent *ev;
   SVEventType ev_type;
   int unichar_id = INVALID_UNICHAR_ID;
   // Wait until a click or popup event.
   do {
-    ev = IntMatchWindow->AwaitEvent(SVET_ANY);
+    auto ev = IntMatchWindow->AwaitEvent(SVET_ANY);
     ev_type = ev->type;
     if (ev_type == SVET_POPUP) {
       if (ev->command_id == IDA_SHAPE_INDEX) {
@@ -1214,7 +1213,6 @@ CLASS_ID Classify::GetClassToDebug(const char *Prompt, bool *adaptive_on, bool *
         }
       }
     }
-    delete ev;
   } while (ev_type != SVET_CLICK);
   return 0;
 } /* GetClassToDebug */

--- a/src/classify/shapeclassifier.cpp
+++ b/src/classify/shapeclassifier.cpp
@@ -115,7 +115,6 @@ void ShapeClassifier::DebugDisplay(const TrainingSample &sample, Image page_pix,
   std::vector<UnicharRating> results;
   // Debug classification until the user quits.
   const UNICHARSET &unicharset = GetUnicharset();
-  SVEvent *ev;
   SVEventType ev_type;
   do {
     std::vector<ScrollView *> windows;
@@ -135,7 +134,7 @@ void ShapeClassifier::DebugDisplay(const TrainingSample &sample, Image page_pix,
     UNICHAR_ID old_unichar_id;
     do {
       old_unichar_id = unichar_id;
-      ev = debug_win->AwaitEvent(SVET_ANY);
+      auto ev = debug_win->AwaitEvent(SVET_ANY);
       ev_type = ev->type;
       if (ev_type == SVET_POPUP) {
         if (unicharset.contains_unichar(ev->parameter)) {
@@ -144,7 +143,6 @@ void ShapeClassifier::DebugDisplay(const TrainingSample &sample, Image page_pix,
           tprintf("Char class '%s' not found in unicharset", ev->parameter);
         }
       }
-      delete ev;
     } while (unichar_id == old_unichar_id && ev_type != SVET_CLICK && ev_type != SVET_DESTROY);
     for (auto window : windows) {
       delete window;

--- a/src/textord/ccnontextdetect.cpp
+++ b/src/textord/ccnontextdetect.cpp
@@ -134,7 +134,7 @@ Image CCNonTextDetect::ComputeNonTextMask(bool debug, Image photo_map, TO_BLOCK 
 #endif // !GRAPHICS_DISABLED
     pixWrite("junkccphotomask.png", pix, IFF_PNG);
 #ifndef GRAPHICS_DISABLED
-    delete win->AwaitEvent(SVET_DESTROY);
+    win->AwaitEvent(SVET_DESTROY);
     delete win;
 #endif // !GRAPHICS_DISABLED
   }

--- a/src/textord/colfind.cpp
+++ b/src/textord/colfind.cpp
@@ -440,7 +440,7 @@ int ColumnFinder::FindBlocks(PageSegMode pageseg_mode, Image scaled_color, int s
           DisplayTabVectors(window);
         }
         if (window != nullptr && textord_tabfind_show_partitions > 1) {
-          delete window->AwaitEvent(SVET_DESTROY);
+          window->AwaitEvent(SVET_DESTROY);
         }
       }
     }
@@ -476,7 +476,7 @@ int ColumnFinder::FindBlocks(PageSegMode pageseg_mode, Image scaled_color, int s
     bool waiting = false;
     do {
       waiting = false;
-      SVEvent *event = blocks_win_->AwaitEvent(SVET_ANY);
+      auto event = blocks_win_->AwaitEvent(SVET_ANY);
       if (event->type == SVET_INPUT && event->parameter != nullptr) {
         if (*event->parameter == 'd') {
           result = -1;
@@ -488,7 +488,6 @@ int ColumnFinder::FindBlocks(PageSegMode pageseg_mode, Image scaled_color, int s
       } else {
         waiting = true;
       }
-      delete event;
     } while (waiting);
   }
 #endif // !GRAPHICS_DISABLED

--- a/src/textord/strokewidth.cpp
+++ b/src/textord/strokewidth.cpp
@@ -123,7 +123,7 @@ StrokeWidth::StrokeWidth(int gridsize, const ICOORD &bleft, const ICOORD &tright
 StrokeWidth::~StrokeWidth() {
 #ifndef GRAPHICS_DISABLED
   if (widths_win_ != nullptr) {
-    delete widths_win_->AwaitEvent(SVET_DESTROY);
+    widths_win_->AwaitEvent(SVET_DESTROY);
     if (textord_tabfind_only_strokewidths) {
       exit(0);
     }

--- a/src/training/common/mastertrainer.cpp
+++ b/src/training/common/mastertrainer.cpp
@@ -785,9 +785,8 @@ void MasterTrainer::DisplaySamples(const char *unichar_str1, int cloud_font,
   ScrollView *s_window = CreateFeatureSpaceWindow("Samples", 100, 500);
   SVEventType ev_type;
   do {
-    SVEvent *ev;
     // Wait until a click or popup event.
-    ev = f_window->AwaitEvent(SVET_ANY);
+    auto ev = f_window->AwaitEvent(SVET_ANY);
     ev_type = ev->type;
     if (ev_type == SVET_CLICK) {
       int feature_index = feature_space.XYToFeatureIndex(ev->x, ev->y);
@@ -801,7 +800,6 @@ void MasterTrainer::DisplaySamples(const char *unichar_str1, int cloud_font,
         s_window->Update();
       }
     }
-    delete ev;
   } while (ev_type != SVET_DESTROY);
 }
 #endif // !GRAPHICS_DISABLED

--- a/src/training/unicharset/lstmtrainer.cpp
+++ b/src/training/unicharset/lstmtrainer.cpp
@@ -891,7 +891,7 @@ Trainability LSTMTrainer::TrainOnLine(const ImageData *trainingdata,
   }
 #ifndef GRAPHICS_DISABLED
   if (debug_interval_ == 1 && debug_win_ != nullptr) {
-    delete debug_win_->AwaitEvent(SVET_CLICK);
+    debug_win_->AwaitEvent(SVET_CLICK);
   }
 #endif // !GRAPHICS_DISABLED
   // Roll the memory of past means.

--- a/src/viewer/scrollview.cpp
+++ b/src/viewer/scrollview.cpp
@@ -158,13 +158,13 @@ void ScrollView::MessageReceiver() {
                                                                     SVET_ANY);
       waiting_for_events_mu->lock();
       if (waiting_for_events.count(awaiting_list) > 0) {
-        waiting_for_events[awaiting_list].second = cur.get();
+        waiting_for_events[awaiting_list].second = cur.release();
         waiting_for_events[awaiting_list].first->Signal();
       } else if (waiting_for_events.count(awaiting_list_any) > 0) {
-        waiting_for_events[awaiting_list_any].second = cur.get();
+        waiting_for_events[awaiting_list_any].second = cur.release();
         waiting_for_events[awaiting_list_any].first->Signal();
       } else if (waiting_for_events.count(awaiting_list_any_window) > 0) {
-        waiting_for_events[awaiting_list_any_window].second = cur.get();
+        waiting_for_events[awaiting_list_any_window].second = cur.release();
         waiting_for_events[awaiting_list_any_window].first->Signal();
       }
       waiting_for_events_mu->unlock();

--- a/src/viewer/scrollview.h
+++ b/src/viewer/scrollview.h
@@ -36,6 +36,7 @@
 #include <tesseract/export.h>
 
 #include <cstdio>
+#include <memory>
 #include <mutex>
 
 namespace tesseract {
@@ -186,7 +187,7 @@ public:
   void AddEventHandler(SVEventHandler *listener);
 
   // Block until an event of the given type is received.
-  SVEvent *AwaitEvent(SVEventType type);
+  std::unique_ptr<SVEvent> AwaitEvent(SVEventType type);
 
   /*******************************************************************************
    * Getters and Setters

--- a/src/viewer/scrollview.h
+++ b/src/viewer/scrollview.h
@@ -70,7 +70,7 @@ struct SVEvent {
   ~SVEvent() {
     delete[] parameter;
   }
-  SVEvent *copy() const;
+  std::unique_ptr<SVEvent> copy() const;
   SVEventType type = SVET_DESTROY; // What kind of event.
   ScrollView *window = nullptr;    // Window event relates to.
   char *parameter = nullptr;       // Any string that might have been passed as argument.
@@ -414,7 +414,7 @@ private:
   static SVNetwork *stream_;
 
   // Table of all the currently queued events.
-  SVEvent *event_table_[SVET_COUNT];
+  std::unique_ptr<SVEvent> event_table_[SVET_COUNT];
 
   // Mutex to access the event_table_ in a synchronized fashion.
   std::mutex mutex_;


### PR DESCRIPTION
This PR fixes memory issues that caused https://github.com/tesseract-ocr/tesseract/issues/3869. The first commit fixes the actual bug (`unique_ptr::release()` should be used instead of `unique_ptr::get()`). The second fixes the underlying problem of using plain pointers that caused the bug in the first place.

Fixes https://github.com/tesseract-ocr/tesseract/issues/3869.

Supersedes https://github.com/tesseract-ocr/tesseract/pull/3870

FYI @rmast @stweil.