### PR TITLE
Replace call of exit function by return statement in main function

### DIFF
--- a/src/training/ambiguous_words.cpp
+++ b/src/training/ambiguous_words.cpp
@@ -33,13 +33,13 @@ int main(int argc, char **argv) {
   // Parse input arguments.
   if (argc > 1 && (!strcmp(argv[1], "-v") || !strcmp(argv[1], "--version"))) {
     printf("%s\n", tesseract::TessBaseAPI::Version());
-    return 0;
+    return EXIT_SUCCESS;
   } else if (argc != 4 && (argc != 6 || strcmp(argv[1], "-l") != 0)) {
     printf(
         "Usage: %s -v | --version | %s [-l lang] tessdata_dir wordlist_file"
         " output_ambiguous_wordlist_file\n",
         argv[0], argv[0]);
-    return 1;
+    return EXIT_FAILURE;
   }
   int argv_offset = 0;
   std::string lang;
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
   FILE *input_file = fopen(input_file_str, "rb");
   if (input_file == nullptr) {
     tesseract::tprintf("Failed to open input wordlist file %s\n", input_file_str);
-    exit(1);
+    return EXIT_FAILURE;
   }
   char str[CHARS_PER_LINE];
 
@@ -78,4 +78,5 @@ int main(int argc, char **argv) {
   }
   // Clean up.
   fclose(input_file);
+  return EXIT_SUCCESS;
 }

--- a/src/training/classifier_tester.cpp
+++ b/src/training/classifier_tester.cpp
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
       InitializeClassifier(FLAGS_classifier.c_str(), trainer->unicharset(), argc, argv, &api);
   if (shape_classifier == nullptr) {
     fprintf(stderr, "Classifier init failed!:%s\n", FLAGS_classifier.c_str());
-    return 1;
+    return EXIT_FAILURE;
   }
 
   // We want to test junk as well if it is available.
@@ -123,5 +123,5 @@ int main(int argc, char **argv) {
   delete shape_classifier;
   delete api;
 
-  return 0;
+  return EXIT_SUCCESS;
 } /* main */

--- a/src/training/cntraining.cpp
+++ b/src/training/cntraining.cpp
@@ -141,7 +141,7 @@ int main(int argc, char *argv[]) {
     Clusterer = SetUpForClustering(FeatureDefs, CharSample, PROGRAM_FEATURE_TYPE);
     if (Clusterer == nullptr) { // To avoid a SIGSEGV
       fprintf(stderr, "Error: nullptr clusterer!\n");
-      return 1;
+      return EXIT_FAILURE;
     }
     float SavedMinSamples = Config.MinSamples;
     // To disable the tendency to produce a single cluster for all fonts,
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
     FreeProtoList(&freeable_proto);
   }
   printf("\n");
-  return 0;
+  return EXIT_SUCCESS;
 } // main
 
 /*----------------------------------------------------------------------------

--- a/src/training/combine_lang_model.cpp
+++ b/src/training/combine_lang_model.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
   UNICHARSET unicharset;
   if (!unicharset.load_from_file(FLAGS_input_unicharset.c_str(), false)) {
     tprintf("Failed to load unicharset from %s\n", FLAGS_input_unicharset.c_str());
-    return 1;
+    return EXIT_FAILURE;
   }
   tprintf("Loaded unicharset of size %zu from file %s\n", unicharset.size(),
           FLAGS_input_unicharset.c_str());

--- a/src/training/combine_tessdata.cpp
+++ b/src/training/combine_tessdata.cpp
@@ -269,7 +269,7 @@ int main(int argc, char **argv) {
         "Usage for compacting LSTM component to int:\n"
         "  %s -c traineddata_file\n",
         argv[0]);
-    return 1;
+    return EXIT_FAILURE;
   }
   tm.Directory();
   return EXIT_SUCCESS;

--- a/src/training/dawg2wordlist.cpp
+++ b/src/training/dawg2wordlist.cpp
@@ -60,7 +60,7 @@ static int WriteDawgAsWordlist(const UNICHARSET &unicharset, const tesseract::Da
   FILE *out = fopen(outfile_name, "wb");
   if (out == nullptr) {
     tprintf("Could not open %s for writing.\n", outfile_name);
-    return 1;
+    return EXIT_FAILURE;
   }
   WordOutputter outputter(out);
   using namespace std::placeholders; // for _1
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
         "Usage: %s -v | --version | %s <unicharset> <dawgfile> "
         "<wordlistfile>\n",
         argv[0], argv[0]);
-    return 1;
+    return EXIT_FAILURE;
   }
   const char *unicharset_file = argv[1];
   const char *dawg_file = argv[2];
@@ -88,12 +88,12 @@ int main(int argc, char *argv[]) {
   UNICHARSET unicharset;
   if (!unicharset.load_from_file(unicharset_file)) {
     tprintf("Error loading unicharset from %s.\n", unicharset_file);
-    return 1;
+    return EXIT_FAILURE;
   }
   auto dict = LoadSquishedDawg(unicharset, dawg_file);
   if (dict == nullptr) {
     tprintf("Error loading dictionary from %s.\n", dawg_file);
-    return 1;
+    return EXIT_FAILURE;
   }
   int retval = WriteDawgAsWordlist(unicharset, dict.get(), wordlist_file);
   return retval;

--- a/src/training/lstmeval.cpp
+++ b/src/training/lstmeval.cpp
@@ -34,38 +34,38 @@ int main(int argc, char **argv) {
   ParseArguments(&argc, &argv);
   if (FLAGS_model.empty()) {
     tprintf("Must provide a --model!\n");
-    return 1;
+    return EXIT_FAILURE;
   }
   if (FLAGS_eval_listfile.empty()) {
     tprintf("Must provide a --eval_listfile!\n");
-    return 1;
+    return EXIT_FAILURE;
   }
   tesseract::TessdataManager mgr;
   if (!mgr.Init(FLAGS_model.c_str())) {
     if (FLAGS_traineddata.empty()) {
       tprintf("Must supply --traineddata to eval a training checkpoint!\n");
-      return 1;
+      return EXIT_FAILURE;
     }
     tprintf("%s is not a recognition model, trying training checkpoint...\n", FLAGS_model.c_str());
     if (!mgr.Init(FLAGS_traineddata.c_str())) {
       tprintf("Failed to load language model from %s!\n", FLAGS_traineddata.c_str());
-      return 1;
+      return EXIT_FAILURE;
     }
     std::vector<char> model_data;
     if (!tesseract::LoadDataFromFile(FLAGS_model.c_str(), &model_data)) {
       tprintf("Failed to load model from: %s\n", FLAGS_model.c_str());
-      return 1;
+      return EXIT_FAILURE;
     }
     mgr.OverwriteEntry(tesseract::TESSDATA_LSTM, &model_data[0], model_data.size());
   }
   tesseract::LSTMTester tester(static_cast<int64_t>(FLAGS_max_image_MB) * 1048576);
   if (!tester.LoadAllEvalData(FLAGS_eval_listfile.c_str())) {
     tprintf("Failed to load eval data from: %s\n", FLAGS_eval_listfile.c_str());
-    return 1;
+    return EXIT_FAILURE;
   }
   double errs = 0.0;
   std::string result = tester.RunEvalSync(0, &errs, mgr,
                                           /*training_stage (irrelevant)*/ 0, FLAGS_verbosity);
   tprintf("%s\n", result.c_str());
-  return 0;
+  return EXIT_SUCCESS;
 } /* main */

--- a/src/training/merge_unicharsets.cpp
+++ b/src/training/merge_unicharsets.cpp
@@ -24,14 +24,14 @@ int main(int argc, char **argv) {
 
   if (argc > 1 && (!strcmp(argv[1], "-v") || !strcmp(argv[1], "--version"))) {
     printf("%s\n", tesseract::TessBaseAPI::Version());
-    return 0;
+    return EXIT_SUCCESS;
   } else if (argc < 4) {
     // Print usage
     printf(
         "Usage: %s -v | --version |\n"
         "       %s unicharset-in-1 ... unicharset-in-n unicharset-out\n",
         argv[0], argv[0]);
-    return 1;
+    return EXIT_FAILURE;
   }
 
   tesseract::UNICHARSET input_unicharset, result_unicharset;
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
       result_unicharset.AppendOtherUnicharset(input_unicharset);
     } else {
       printf("Failed to load unicharset from file %s!!\n", argv[arg]);
-      exit(1);
+      return EXIT_FAILURE;
     }
   }
 
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
     printf("Wrote unicharset file %s.\n", argv[argc - 1]);
   } else {
     printf("Cannot save unicharset file %s.\n", argv[argc - 1]);
-    exit(1);
+    return EXIT_FAILURE;
   }
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/src/training/mftraining.cpp
+++ b/src/training/mftraining.cpp
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
   // Load the training data.
   auto trainer = tesseract::LoadTrainingData(argv + 1, false, &shape_table, file_prefix);
   if (trainer == nullptr) {
-    return 1; // Failed.
+    return EXIT_FAILURE; // Failed.
   }
 
   // Setup an index mapping from the shapes in the shape table to the classes
@@ -269,5 +269,5 @@ int main(int argc, char **argv) {
       ;
     }
   }
-  return 0;
+  return EXIT_SUCCESS;
 } /* main */

--- a/src/training/set_unicharset_properties.cpp
+++ b/src/training/set_unicharset_properties.cpp
@@ -29,14 +29,14 @@ int main(int argc, char **argv) {
   // Check validity of input flags.
   if (FLAGS_U.empty() || FLAGS_O.empty()) {
     tprintf("Specify both input and output unicharsets!\n");
-    exit(1);
+    return EXIT_FAILURE;
   }
   if (FLAGS_script_dir.empty()) {
     tprintf("Must specify a script_dir!\n");
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   tesseract::SetPropertiesForInputFile(FLAGS_script_dir.c_str(), FLAGS_U.c_str(), FLAGS_O.c_str(),
                                        FLAGS_X.c_str());
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/src/training/shapeclustering.cpp
+++ b/src/training/shapeclustering.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
   auto trainer = tesseract::LoadTrainingData(argv + 1, false, nullptr, file_prefix);
 
   if (!trainer) {
-    return 1;
+    return EXIT_FAILURE;
   }
 
   if (FLAGS_display_cloud_font >= 0) {
@@ -58,13 +58,13 @@ int main(int argc, char **argv) {
     trainer->DisplaySamples(FLAGS_canonical_class1.c_str(), FLAGS_display_cloud_font,
                             FLAGS_canonical_class2.c_str(), FLAGS_display_canonical_font);
 #endif // !GRAPHICS_DISABLED
-    return 0;
+    return EXIT_SUCCESS;
   } else if (!FLAGS_canonical_class1.empty()) {
     trainer->DebugCanonical(FLAGS_canonical_class1.c_str(), FLAGS_canonical_class2.c_str());
-    return 0;
+    return EXIT_SUCCESS;
   }
   trainer->SetupMasterShapes();
   WriteShapeTable(file_prefix, trainer->master_shapes());
 
-  return 0;
+  return EXIT_SUCCESS;
 } /* main */

--- a/src/training/text2image.cpp
+++ b/src/training/text2image.cpp
@@ -458,15 +458,15 @@ static int Main() {
   // Check validity of input flags.
   if (FLAGS_text.empty()) {
     tprintf("'--text' option is missing!\n");
-    exit(1);
+    return EXIT_FAILURE;
   }
   if (FLAGS_outputbase.empty()) {
     tprintf("'--outputbase' option is missing!\n");
-    exit(1);
+    return EXIT_FAILURE;
   }
   if (!FLAGS_unicharset_file.empty() && FLAGS_render_ngrams) {
     tprintf("Use '--unicharset_file' only if '--render_ngrams' is set.\n");
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   std::string font_name = FLAGS_font.c_str();
@@ -479,7 +479,7 @@ static int Main() {
         tprintf("Pango suggested font '%s'.\n", pango_name.c_str());
       }
       tprintf("Please correct --font arg.\n");
-      exit(1);
+      return EXIT_FAILURE;
     }
   }
 
@@ -525,14 +525,14 @@ static int Main() {
     render.set_render_fullwidth_latin(true);
   } else {
     tprintf("Invalid writing mode: %s\n", FLAGS_writing_mode.c_str());
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   std::string src_utf8;
   // This c_str is NOT redundant!
   if (!File::ReadFileToString(FLAGS_text.c_str(), &src_utf8)) {
     tprintf("Failed to read file: %s\n", FLAGS_text.c_str());
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   // Remove the unicode mark if present.
@@ -554,7 +554,7 @@ static int Main() {
     if (FLAGS_render_ngrams && !FLAGS_unicharset_file.empty() &&
         !unicharset.load_from_file(FLAGS_unicharset_file.c_str())) {
       tprintf("Failed to load unicharset from file %s\n", FLAGS_unicharset_file.c_str());
-      exit(1);
+      return EXIT_FAILURE;
     }
 
     // If we are rendering ngrams that will be OCRed later, shuffle them so that
@@ -604,7 +604,7 @@ static int Main() {
     tprintf("Extracting font properties only\n");
     ExtractFontProperties(src_utf8, &render, FLAGS_outputbase.c_str());
     tprintf("Done!\n");
-    return 0;
+    return EXIT_SUCCESS;
   }
 
   int im = 0;
@@ -708,7 +708,7 @@ static int Main() {
     }
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 int main(int argc, char **argv) {

--- a/src/training/wordlist2dawg.cpp
+++ b/src/training/wordlist2dawg.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
 
   if (argc > 1 && (!strcmp(argv[1], "-v") || !strcmp(argv[1], "--version"))) {
     printf("%s\n", tesseract::TessBaseAPI::Version());
-    return 0;
+    return EXIT_SUCCESS;
   } else if (!(argc == 4 || (argc == 5 && strcmp(argv[1], "-t") == 0) ||
                (argc == 6 && strcmp(argv[1], "-r") == 0))) {
     printf(
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
         "       %s [-t | -r [reverse policy] ] word_list_file"
         " dawg_file unicharset_file\n",
         argv[0], argv[0]);
-    return 1;
+    return EXIT_FAILURE;
   }
   tesseract::Classify classify;
   int argv_index = 0;
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
   tprintf("Loading unicharset from '%s'\n", unicharset_file);
   if (!classify.getDict().getUnicharset().load_from_file(unicharset_file)) {
     tprintf("Failed to load unicharset from '%s'\n", unicharset_file);
-    return 1;
+    return EXIT_FAILURE;
   }
   const UNICHARSET &unicharset = classify.getDict().getUnicharset();
   if (argc == 4 || argc == 6) {
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
     tprintf("Reading word list from '%s'\n", wordlist_filename);
     if (!trie.read_and_add_word_list(wordlist_filename, unicharset, reverse_policy)) {
       tprintf("Failed to add word list from '%s'\n", wordlist_filename);
-      exit(1);
+      return EXIT_FAILURE;
     }
     tprintf("Reducing Trie to SquishedDawg\n");
     std::unique_ptr<tesseract::SquishedDawg> dawg(trie.trie_to_dawg());
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
     words.check_for_words(wordlist_filename, unicharset, true);
   } else { // should never get here
     tprintf("Invalid command-line options\n");
-    exit(1);
+    return EXIT_FAILURE;
   }
-  return 0;
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Add also a missing return statement and use EXIT_FAILURE
and EXIT_SUCCESS instead of 1 and 0 as return values.

Signed-off-by: Stefan Weil <sw@weilnetz.de>