### PR TITLE
CI: Remove Ubuntu 18.04

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,16 +21,6 @@ jobs:
           - { name: macos-11-gcc-10-cmake, os: macos-11, cxx: g++-10 } #installed
           - { name: macos-11-gcc-11-cmake, os: macos-11, cxx: g++-11 } #installed
 
-          - { name: ubuntu-18.04-clang-7-cmake, os: ubuntu-18.04, cxx: clang++-7 }
-          - { name: ubuntu-18.04-clang-8-cmake, os: ubuntu-18.04, cxx: clang++-8 } #installed
-          - { name: ubuntu-18.04-clang-9-cmake, os: ubuntu-18.04, cxx: clang++-9 } #installed
-          - { name: ubuntu-18.04-clang-10-cmake, os: ubuntu-18.04, cxx: clang++-10 }
-
-          - { name: ubuntu-18.04-gcc-7-cmake, os: ubuntu-18.04, cxx: g++-7 } #installed
-          - { name: ubuntu-18.04-gcc-8-cmake, os: ubuntu-18.04, cxx: g++-8 } #installed
-          - { name: ubuntu-18.04-gcc-9-cmake, os: ubuntu-18.04, cxx: g++-9 } #installed
-          - { name: ubuntu-18.04-gcc-10-cmake, os: ubuntu-18.04, cxx: g++-10 } #installed
-
           - { name: ubuntu-20.04-clang-7-cmake, os: ubuntu-20.04, cxx: clang++-7 }
           - { name: ubuntu-20.04-clang-8-cmake, os: ubuntu-20.04, cxx: clang++-8 } #installed
           - { name: ubuntu-20.04-clang-9-cmake, os: ubuntu-20.04, cxx: clang++-9 } #installed

--- a/.github/workflows/unittest-disablelegacy.yml
+++ b/.github/workflows/unittest-disablelegacy.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [ g++, clang++ ]
-        #os: [ ubuntu-18.04, ubuntu-20.04 ]
         os: [ ubuntu-20.04 ]
 
     steps:


### PR DESCRIPTION
Reason: https://github.com/actions/runner-images/issues/6002

I still keep Ubuntu 18.04 in autotools CIs for now.

[skip ci]