### PR TITLE
configure.ac: fix build on aarch64_be

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -170,7 +170,7 @@ case "${host_cpu}" in
 
     ;;
 
-  aarch64|arm64)
+  aarch64*|arm64)
 
     # ARMv8 always has NEON and does not need special compiler flags.
     AM_CONDITIONAL([HAVE_NEON], true)


### PR DESCRIPTION
Fix the following build failure on `aarch64_be`:

`/home/buildroot/autobuild/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/aarch64_be-none-linux-gnu/10.3.1/../../../../aarch64_be-none-linux-gnu/bin/ld: ./.libs/libtesseract.so: undefined reference to `tesseract::IntSimdMatrix::intSimdMatrixNEON'`

Fixes:
 - http://autobuild.buildroot.org/results/b9246a37fcf6be4fabfc491daddadfb09e0a320a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>