### PR TITLE
Fix build with unreleased leptonica 1.83

### DIFF
--- a/src/textord/devanagari_processing.cpp
+++ b/src/textord/devanagari_processing.cpp
@@ -28,6 +28,9 @@
 #include "tordmain.h"
 
 #include <allheaders.h>
+#if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || LIBLEPT_MAJOR_VERSION > 1
+#include "pix_internal.h"
+#endif
 
 namespace tesseract {
 


### PR DESCRIPTION
leptonica moved most of their type definitions to internal headers. Long term usages of internal API should be removed, but for now simply include the internal header to allow tesseract to be built.