### PR TITLE
Fix tesseract.pc from cmake to match autotools

### DIFF
--- a/tesseract.pc.cmake
+++ b/tesseract.pc.cmake
@@ -7,6 +7,7 @@ Name: @tesseract_NAME@
 Description: An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.
 URL: https://github.com/tesseract-ocr/tesseract
 Version: @tesseract_VERSION@
+Requires.private: lept
 Libs: -L${libdir} -l@tesseract_OUTPUT_NAME@ @libarchive_LIBS@ @libcurl_LIBS@ @TENSORFLOW_LIBS@
 Libs.private:
 Cflags: -I${includedir}


### PR DESCRIPTION
cf: https://github.com/tesseract-ocr/tesseract/blob/HEAD/tesseract.pc.in#L13

We found that bindings fail to compile when tesseract was built with cmake, because its pc file does not properly declare the leptonica dependency in the headers.