### PR TITLE
lstm.train: allow .box from .raw.png too

### DIFF
--- a/src/ccstruct/boxread.cpp
+++ b/src/ccstruct/boxread.cpp
@@ -43,7 +43,7 @@ static std::string BoxFileName(const char *image_filename) {
   std::string box_filename = image_filename;
   size_t length = box_filename.length();
   std::string last = (length > 8) ? box_filename.substr(length - 8) : "";
-  if (last == ".bin.png" || last == ".nrm.png") {
+  if (last == ".bin.png" || last == ".nrm.png" || last == ".raw.png") {
     box_filename.resize(length - 8);
   } else {
     size_t lastdot = box_filename.find_last_of('.');


### PR DESCRIPTION
(typical for ocropy / kraken and GT without binarization)