### PR TITLE
Fix a number of performance issues (reported by Coverity Scan)

### DIFF
--- a/src/api/hocrrenderer.cpp
+++ b/src/api/hocrrenderer.cpp
@@ -412,7 +412,7 @@ char *TessBaseAPI::GetHOCRText(ETEXT_DESC *monitor, int page_number) {
                    << " id='"
                    << "timestep" << page_id << "_" << wcnt << "_" << tcnt
                    << "'>";
-          for (auto conf : timestep) {
+          for (auto &&conf : timestep) {
             hocr_str << "\n         <span class='ocrx_cinfo'"
                      << " id='"
                      << "choice_" << page_id << "_" << wcnt << "_" << ccnt

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -1191,7 +1191,7 @@ bool Tesseract::SelectGoodDiacriticOutlines(int pass, float certainty_threshold,
     *ok_outlines = best_outlines;
     if (debug_noise_removal) {
       tprintf("%s noise combination ", blob ? "Adding" : "New");
-      for (auto best_outline : best_outlines) {
+      for (auto &&best_outline : best_outlines) {
         tprintf("%c", best_outline ? 'T' : 'F');
       }
       tprintf(" yields certainty %g, beating target of %g\n", best_cert, target_cert);

--- a/src/ccstruct/fontinfo.cpp
+++ b/src/ccstruct/fontinfo.cpp
@@ -67,7 +67,7 @@ bool FontInfoTable::DeSerialize(TFile *fp) {
 bool FontInfoTable::SetContainsFontProperties(int font_id,
                                               const std::vector<ScoredFont> &font_set) const {
   uint32_t properties = at(font_id).properties;
-  for (auto f : font_set) {
+  for (auto &&f : font_set) {
     if (at(f.fontinfo_id).properties == properties) {
       return true;
     }

--- a/src/ccstruct/points.h
+++ b/src/ccstruct/points.h
@@ -269,11 +269,11 @@ public:
   bool normalise();
 
   /// test equality
-  bool operator==(const FCOORD &other) {
+  bool operator==(const FCOORD &other) const {
     return xcoord == other.xcoord && ycoord == other.ycoord;
   }
   /// test inequality
-  bool operator!=(const FCOORD &other) {
+  bool operator!=(const FCOORD &other) const {
     return xcoord != other.xcoord || ycoord != other.ycoord;
   }
   /// rotate 90 deg anti

--- a/src/ccutil/params.h
+++ b/src/ccutil/params.h
@@ -253,7 +253,7 @@ public:
   bool empty() const {
     return value_.empty();
   }
-  bool operator==(const std::string &other) {
+  bool operator==(const std::string &other) const {
     return value_ == other;
   }
   void operator=(const std::string &value) {

--- a/src/ccutil/serialis.h
+++ b/src/ccutil/serialis.h
@@ -157,7 +157,7 @@ public:
       return false;
     } else if constexpr (std::is_same<T, std::string>::value) {
       // Serialize strings.
-      for (auto string : data) {
+      for (auto &&string : data) {
         if (!Serialize(string)) {
           return false;
         }

--- a/src/classify/adaptmatch.cpp
+++ b/src/classify/adaptmatch.cpp
@@ -1079,7 +1079,7 @@ void Classify::MasterMatcher(INT_TEMPLATES_STRUCT *templates, int16_t num_featur
   int top = blob_box.top();
   int bottom = blob_box.bottom();
   UnicharRating int_result;
-  for (auto result : results) {
+  for (auto &&result : results) {
     CLASS_ID class_id = result.Class;
     BIT_VECTOR protos = classes != nullptr ? classes[class_id]->PermProtos : AllProtosOn;
     BIT_VECTOR configs = classes != nullptr ? classes[class_id]->PermConfigs : AllConfigsOn;

--- a/src/classify/shapeclassifier.cpp
+++ b/src/classify/shapeclassifier.cpp
@@ -174,7 +174,7 @@ void ShapeClassifier::UnicharPrintResults(const char *context,
             GetUnicharset().id_to_unichar(result.unichar_id));
     if (!result.fonts.empty()) {
       tprintf(" Font Vector:");
-      for (auto font : result.fonts) {
+      for (auto &&font : result.fonts) {
         tprintf(" %d", font.fontinfo_id);
       }
     }

--- a/src/dict/dawg.h
+++ b/src/dict/dawg.h
@@ -361,7 +361,7 @@ struct DawgPosition {
         dawg_index(dawg_idx),
         punc_index(punc_idx),
         back_to_punc(backtopunc) {}
-  bool operator==(const DawgPosition &other) {
+  bool operator==(const DawgPosition &other) const {
     return dawg_index == other.dawg_index && dawg_ref == other.dawg_ref &&
            punc_index == other.punc_index && punc_ref == other.punc_ref &&
            back_to_punc == other.back_to_punc;

--- a/src/dict/dawg.h
+++ b/src/dict/dawg.h
@@ -382,7 +382,7 @@ public:
   /// true otherwise.
   inline bool add_unique(const DawgPosition &new_pos, bool debug,
                          const char *debug_msg) {
-    for (auto position : *this) {
+    for (auto &&position : *this) {
       if (position == new_pos) {
         return false;
       }

--- a/src/lstm/networkio.cpp
+++ b/src/lstm/networkio.cpp
@@ -173,7 +173,7 @@ void NetworkIO::FromPixes(const StaticShape &shape, const std::vector<Image> &pi
   int target_height = shape.height();
   int target_width = shape.width();
   std::vector<std::pair<int, int>> h_w_pairs;
-  for (auto pix : pixes) {
+  for (auto &&pix : pixes) {
     Image var_pix = pix;
     int width = pixGetWidth(var_pix);
     if (target_width != 0) {

--- a/src/lstm/recodebeam.cpp
+++ b/src/lstm/recodebeam.cpp
@@ -322,7 +322,7 @@ void RecodeBeamSearch::ExtractBestPathAsWords(const TBOX &line_box,
 }
 
 struct greater_than {
-  inline bool operator()(const RecodeNode *&node1, const RecodeNode *&node2) {
+  inline bool operator()(const RecodeNode *&node1, const RecodeNode *&node2) const {
     return (node1->score > node2->score);
   }
 };

--- a/src/lstm/recodebeam.cpp
+++ b/src/lstm/recodebeam.cpp
@@ -341,7 +341,7 @@ void RecodeBeamSearch::PrintBeam2(bool uids, int num_outputs,
   // fill the topology with depths first
   for (int step = beam.size() - 1; step >= 0; --step) {
     std::vector<tesseract::RecodePair> &heaps = beam.at(step)->beams_->heap();
-    for (auto node : heaps) {
+    for (auto &&node : heaps) {
       int backtracker = 0;
       const RecodeNode *curr = &node.data();
       while (curr != nullptr && !visited.count(curr)) {
@@ -426,7 +426,7 @@ void RecodeBeamSearch::extractSymbolChoices(const UNICHARSET *unicharset) {
     std::vector<const RecodeNode *> best_nodes;
     std::vector<const RecodeNode *> best;
     // Scan the segmented node chain for valid unichar ids.
-    for (auto entry : heaps) {
+    for (auto &&entry : heaps) {
       bool validChar = false;
       int backcounter = 0;
       const RecodeNode *node = &entry.data();

--- a/src/training/pango/pango_font_info.cpp
+++ b/src/training/pango/pango_font_info.cpp
@@ -591,7 +591,7 @@ int FontUtils::FontScore(const std::unordered_map<char32, int64_t> &ch_map,
   }
   *raw_score = 0;
   int ok_chars = 0;
-  for (auto it : ch_map) {
+  for (auto &&it : ch_map) {
     bool covered =
         (coverage != nullptr) && (IsWhitespace(it.first) ||
                                   (pango_coverage_get(coverage, it.first) == PANGO_COVERAGE_EXACT));

--- a/src/wordrec/chopper.cpp
+++ b/src/wordrec/chopper.cpp
@@ -283,7 +283,7 @@ SEAM *Wordrec::chop_overlapping_blob(const std::vector<TBOX> &boxes, bool italic
 
     bool almost_equal_box = false;
     int num_overlap = 0;
-    for (auto boxe : boxes) {
+    for (auto &&boxe : boxes) {
       if (original_box.overlap_fraction(boxe) > 0.125) {
         num_overlap++;
       }

--- a/src/wordrec/lm_pain_points.cpp
+++ b/src/wordrec/lm_pain_points.cpp
@@ -130,7 +130,7 @@ void LMPainPoints::GenerateFromAmbigs(const DANGERR &fixpt, ViterbiStateEntry *v
                                       WERD_RES *word_res) {
   // Begins and ends in DANGERR vector now record the blob indices as used
   // by the ratings matrix.
-  for (auto danger : fixpt) {
+  for (auto &&danger : fixpt) {
     // Only use dangerous ambiguities.
     if (danger.dangerous) {
       GeneratePainPoint(danger.begin, danger.end - 1, LM_PPTYPE_AMBIG, vse->cost, true,
@@ -203,7 +203,7 @@ bool LMPainPoints::GeneratePainPoint(int col, int row, LMPainPointsType pp_type,
 void LMPainPoints::RemapForSplit(int index) {
   for (auto &pain_points_heap : pain_points_heaps_) {
     std::vector<MatrixCoordPair> &heap = pain_points_heap.heap();
-    for (auto entry : heap) {
+    for (auto &&entry : heap) {
       entry.data().MapForSplit(index);
     }
   }


### PR DESCRIPTION
The latest scan reported a number of performance issues because
several `for` loops used expensive copy operations.

After adding the `const` attribute to compare operators, `const`
could also be used in most `for` loops.