### PR TITLE
Fix training tools for legacy engine (issue #3925)

### DIFF
--- a/src/training/common/trainingsampleset.cpp
+++ b/src/training/common/trainingsampleset.cpp
@@ -539,22 +539,14 @@ void TrainingSampleSet::KillSample(TrainingSample *sample) {
 // Deletes all samples with zero features marked by KillSample.
 void TrainingSampleSet::DeleteDeadSamples() {
   using namespace std::placeholders; // for _1
-  auto old_it = samples_.begin();
-  for (; old_it < samples_.end(); ++old_it) {
-    if (*old_it == nullptr || (*old_it)->class_id() < 0) {
-      break;
-    }
-  }
-  auto new_it = old_it;
-  for (; old_it < samples_.end(); ++old_it) {
-    if (*old_it == nullptr || (*old_it)->class_id() < 0) {
-      delete *old_it;
+  for (auto &&it = samples_.begin(); it < samples_.end();) {
+    if (*it == nullptr || (*it)->class_id() < 0) {
+      samples_.erase(it);
+      delete *it;
     } else {
-      *new_it = *old_it;
-      ++new_it;
+      ++it;
     }
   }
-  samples_.resize(new_it - samples_.begin() + 1);
   num_raw_samples_ = samples_.size();
   // Samples must be re-organized now we have deleted a few.
 }


### PR DESCRIPTION
Fixes: cac116dd11dc0976 ("Replace more PointerVector by std::vector [...]")
Signed-off-by: Stefan Weil <sw@weilnetz.de>