### PR TITLE
Modernize function ObjectCache::DeleteUnusedObjects (fix issue with s…

### DIFF
--- a/src/ccutil/object_cache.h
+++ b/src/ccutil/object_cache.h
@@ -96,12 +96,16 @@ public:
 
   void DeleteUnusedObjects() {
     std::lock_guard<std::mutex> guard(mu_);
-    for (auto it = cache_.rbegin(); it != cache_.rend(); ++it) {
-      if (it->count <= 0) {
-        delete it->object;
-        cache_.erase(std::next(it).base());
-      }
-    }
+    cache_.erase(std::remove_if(cache_.begin(), cache_.end(),
+                                [](const ReferenceCount &it) {
+                                  if (it.count <= 0) {
+                                    delete it.object;
+                                    return true;
+                                  } else {
+                                    return false;
+                                  }
+                                }),
+                 cache_.end());
   }
 
 private:


### PR DESCRIPTION
…anitizers)

The old code did not work with compiler option `-fsanitize=address,undefined` and caused apiexample_test to run forever with this error message:

```
Running main() from unittest/third_party/googletest/googletest/src/gtest_main.cc
[==========] Running 4 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from EuroText
[ RUN      ] EuroText.FastLatinOCR
/usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/debug/safe_iterator.h:608:
In function:
    _Safe_iterator<type-parameter-0-0, type-parameter-0-1,
    std::bidirectional_iterator_tag>
    &__gnu_debug::_Safe_iterator<__gnu_cxx::__normal_iterator<tesseract::ObjectCache<tesseract::Dawg>::ReferenceCount
    *,
    std::__cxx1998::vector<tesseract::ObjectCache<tesseract::Dawg>::ReferenceCount,
    std::allocator<tesseract::ObjectCache<tesseract::Dawg>::ReferenceCount>>>,
[...]
```

That error message was followed by an endless sequence of newlines.

Signed-off-by: Stefan Weil <sw@weilnetz.de>