### PR TITLE
Fix linkage of icu libs

### DIFF
--- a/src/training/CMakeLists.txt
+++ b/src/training/CMakeLists.txt
@@ -264,7 +264,7 @@ if(ICU_FOUND)
                                                        PkgConfig::ICU)
     else()
       target_link_libraries(unicharset_training PUBLIC common_training
-                                                       ${ICU_LIBRARIES})
+                                                       ${ICU_LINK_LIBRARIES})
     endif()
   endif()
   target_include_directories(unicharset_training


### PR DESCRIPTION
`ICU_LIBRARIES` is only a list of library names, but the libraries are not necessary on the default compiler search path. So use `ICU_LINK_LIBRARIES` (See https://cmake.org/cmake/help/latest/module/FindPkgConfig.html#command:pkg_check_modules)