### PR TITLE
Fix build with gcc 13 by including <cstdint>

### DIFF
--- a/src/ccutil/params.h
+++ b/src/ccutil/params.h
@@ -21,6 +21,7 @@
 
 #include <tesseract/export.h> // for TESS_API
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <string>


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for int32_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Khem Raj <raj.khem@gmail.com>