### PR TITLE
Fix libdir in tesseract.pc from CMake

### DIFF
--- a/tesseract.pc.cmake
+++ b/tesseract.pc.cmake
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}/bin
-libdir=${prefix}/lib
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: @tesseract_NAME@


### PR DESCRIPTION
`tesseract.pc.cmake` was hardcoding libdir to `${prefix}/lib`, which is wrong for systems that place 64-bit libraries in `/usr/lib64/`. 

On Fedora, this was causing a CMake-generated `tesseract.pc`, installed to `/usr/lib64/pkgconfig/`, to produce library flags that included `-L/usr/lib`, potentially polluting 64-bit builds with 32-bit libs.

`CMAKE_INSTALL_LIBDIR` is already expected to contain the arch-corrected libdir path relative to the CMake install prefix, so it can be used to set the pkg-config `libdir` relative to `${prefix}`.