### PR TITLE
Replace 'can not' by 'cannot'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -821,7 +821,7 @@ if DISABLED_LEGACY_ENGINE
 training_CPPFLAGS += -DDISABLED_LEGACY_ENGINE
 endif
 
-# TODO: training programs can not be linked to shared library created
+# TODO: training programs cannot be linked to shared library created
 # with -fvisibility
 if VISIBILITY
 AM_LDFLAGS += -all-static

--- a/configure.ac
+++ b/configure.ac
@@ -640,7 +640,7 @@ AM_COND_IF([ENABLE_TRAINING],
    echo "$ sudo make training-install"
    echo ""],
   [
-   echo "You can not build training tools because of missing dependency."
+   echo "You cannot build training tools because of missing dependency."
    echo "Check configure output for details."
    echo ""]
 )

--- a/src/ccstruct/boxread.cpp
+++ b/src/ccstruct/boxread.cpp
@@ -78,7 +78,7 @@ bool ReadAllBoxes(int target_page, bool skip_blanks, const char *filename, std::
                   std::vector<int> *pages) {
   std::ifstream input(BoxFileName(filename).c_str(), std::ios::in | std::ios::binary);
   if (input.fail()) {
-    tprintf("Can not read box data from '%s'.\n", BoxFileName(filename).c_str());
+    tprintf("Cannot read box data from '%s'.\n", BoxFileName(filename).c_str());
     tprintf("Does it exists?\n");
     return false;
   }

--- a/src/ccutil/unicharset.cpp
+++ b/src/ccutil/unicharset.cpp
@@ -1104,7 +1104,7 @@ CHAR_FRAGMENT *CHAR_FRAGMENT::parse_from_string(const char *string) {
   const char *ptr = string;
   int len = strlen(string);
   if (len < kMinLen || *ptr != kSeparator) {
-    return nullptr; // this string can not represent a fragment
+    return nullptr; // this string cannot represent a fragment
   }
   ptr++; // move to the next character
   int step = 0;

--- a/src/dict/dawg.h
+++ b/src/dict/dawg.h
@@ -400,7 +400,7 @@ public:
 //
 /// Concrete class that can operate on a compacted (squished) Dawg (read,
 /// search and write to file). This class is read-only in the sense that
-/// new words can not be added to an instance of SquishedDawg.
+/// new words cannot be added to an instance of SquishedDawg.
 /// The underlying representation of the nodes and edges in SquishedDawg
 /// is stored as a contiguous EDGE_ARRAY (read from file or given as an
 /// argument to the constructor).

--- a/src/dict/permdawg.cpp
+++ b/src/dict/permdawg.cpp
@@ -357,7 +357,7 @@ bool Dict::fragment_state_okay(UNICHAR_ID curr_unichar_id, float curr_rating, fl
   }
   if (word_ending && char_frag_info->fragment) {
     if (debug) {
-      tprintf("Word can not end with a fragment\n");
+      tprintf("Word cannot end with a fragment\n");
     }
     return false;
   }

--- a/src/textord/makerow.cpp
+++ b/src/textord/makerow.cpp
@@ -1336,7 +1336,7 @@ void Textord::compute_block_xheight(TO_BLOCK *block, float gradient) {
     // Try to search for two modes in row_cap_heights that could
     // be the xheight and the capheight (e.g. some of the rows
     // were lowercase, but did not have enough (a/de)scenders.
-    // If such two modes can not be found, this block is most
+    // If such two modes cannot be found, this block is most
     // likely all caps (or all small caps, in which case the code
     // still works as intended).
     compute_xheight_from_modes(

--- a/src/training/pango/pango_font_info.cpp
+++ b/src/training/pango/pango_font_info.cpp
@@ -725,7 +725,7 @@ void FontUtils::PangoFontTypeInfo() {
              CAIRO_FONT_TYPE_USER) {
     printf("Using CAIRO_FONT_TYPE_USER.\n");
   } else if (!font_map) {
-    printf("Can not create pango cairo font map!\n");
+    printf("Cannot create pango cairo font map!\n");
   }
 }
 

--- a/src/training/unicharset_extractor.cpp
+++ b/src/training/unicharset_extractor.cpp
@@ -77,7 +77,7 @@ static int Main(int argc, char **argv) {
                    /*continue_on_failure*/ false, /*boxes*/ nullptr, &texts,
                    /*box_texts*/ nullptr, /*pages*/ nullptr);
       if (!res) {
-        tprintf("Can not read box data from '%s'\n", argv[arg]);
+        tprintf("Cannot read box data from '%s'\n", argv[arg]);
         return EXIT_FAILURE;
       }
     } else {

--- a/src/wordrec/language_model.cpp
+++ b/src/wordrec/language_model.cpp
@@ -1010,7 +1010,7 @@ float LanguageModel::ComputeDenom(BLOB_CHOICE_LIST *curr_list) {
   assert(len != 0);
   // The ideal situation would be to have the classifier scores for
   // classifying each position as each of the characters in the unicharset.
-  // Since we can not do this because of speed, we add a very crude estimate
+  // Since we cannot do this because of speed, we add a very crude estimate
   // of what these scores for the "missing" classifications would sum up to.
   denom +=
       (dict_->getUnicharset().size() - len) * CertaintyScore(language_model_ngram_nonmatch_score);

--- a/src/wordrec/language_model.h
+++ b/src/wordrec/language_model.h
@@ -267,7 +267,7 @@ protected:
   // could be pruned out (i.e. is neither a system/user/frequent dictionary
   // nor a top choice path).
   // In non-space delimited languages all paths can be "somewhat" dictionary
-  // words. In such languages we can not do dictionary-driven path pruning,
+  // words. In such languages we cannot do dictionary-driven path pruning,
   // so paths with non-empty dawg_info are considered prunable.
   inline bool PrunablePath(const ViterbiStateEntry &vse) {
     if (vse.top_choice_flags) {

--- a/src/wordrec/segsearch.cpp
+++ b/src/wordrec/segsearch.cpp
@@ -242,7 +242,7 @@ void Wordrec::ProcessSegSearchPainPoint(float pain_point_priority, const MATRIX_
   if (lst == nullptr) {
     ratings->put(pain_point.col, pain_point.row, classified);
   } else {
-    // We can not delete old BLOB_CHOICEs, since they might contain
+    // We cannot delete old BLOB_CHOICEs, since they might contain
     // ViterbiStateEntries that are parents of other "active" entries.
     // Thus if the matrix cell already contains classifications we add
     // the new ones to the beginning of the list.


### PR DESCRIPTION
Both forms are used in American English, but 'cannot' is more common (also in Tesseract code), so use it always.

Signed-off-by: Stefan Weil <sw@weilnetz.de>