### PR TITLE
follow-up to dev mailing list discuss + issue #3998: RFC:  Consistent tprintf() use, ERROR: & WARNING: prefixes.

### DIFF
--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -304,7 +304,7 @@ static void ClipBaseline(int ppi, int x1, int y1, int x2, int y2, int *line_x1, 
 
 static bool CodepointToUtf16be(int code, char utf16[kMaxBytesPerCodepoint]) {
   if ((code > 0xD7FF && code < 0xE000) || code > 0x10FFFF) {
-    tprintf("Dropping invalid codepoint %d\n", code);
+    tprintf("ERROR: Dropping invalid codepoint %d\n", code);
     return false;
   }
   if (code < 0x10000) {
@@ -633,7 +633,7 @@ bool TessPDFRenderer::BeginDocumentHandler() {
     font = buffer.data();
   } else {
 #if !defined(NDEBUG)
-    tprintf("Cannot open file \"%s\"!\nUsing internal glyphless font.\n", stream.str().c_str());
+    tprintf("ERROR: Cannot open file \"%s\"!\nUsing internal glyphless font.\n", stream.str().c_str());
 #endif
     font = pdf_ttf;
     size = sizeof(pdf_ttf);

--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -323,7 +323,7 @@ void SIMDDetect::Update() {
     dotproduct_method = "std::inner_product";
   } else {
     // Unsupported value of config variable.
-    tprintf("Warning, ignoring unsupported config variable value: dotproduct=%s\n",
+    tprintf("WARNING: Ignoring unsupported config variable value: dotproduct=%s\n",
             dotproduct.c_str());
     tprintf(
         "Supported values for dotproduct: auto generic native"

--- a/src/ccmain/applybox.cpp
+++ b/src/ccmain/applybox.cpp
@@ -400,7 +400,7 @@ bool Tesseract::ResegmentCharBox(PAGE_RES *page_res, const TBOX *prev_box, const
     }
   }
   if (applybox_debug > 0) {
-    tprintf("FAIL!\n");
+    tprintf("ERROR: FAIL!\n");
   }
   return false; // Failure.
 }
@@ -485,7 +485,7 @@ bool Tesseract::ResegmentWordBox(BLOCK_LIST *block_list, const TBOX &box, const 
     }
   }
   if (new_word == nullptr && applybox_debug > 0) {
-    tprintf("FAIL!\n");
+    tprintf("ERROR: FAIL!\n");
   }
   return new_word != nullptr;
 }

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -123,7 +123,7 @@ bool Tesseract::ProcessTargetWord(const TBOX &word_box, const TBOX &target_word_
         backup_config_file_ = kBackUpConfigFile;
         FILE *config_fp = fopen(backup_config_file_, "wb");
         if (config_fp == nullptr) {
-          tprintf("Error, failed to open file \"%s\"\n", backup_config_file_);
+          tprintf("ERROR: Failed to open file \"%s\"\n", backup_config_file_);
         } else {
           ParamUtils::PrintParams(config_fp, params());
           fclose(config_fp);
@@ -472,7 +472,7 @@ void Tesseract::bigram_correction_pass(PAGE_RES *page_res) {
     }
     if (w_prev->word->flag(W_REP_CHAR) || w->word->flag(W_REP_CHAR)) {
       if (tessedit_bigram_debug) {
-        tprintf("Skipping because one of the words is W_REP_CHAR\n");
+        tprintf("WARNING: Skipping because one of the words is W_REP_CHAR\n");
       }
       continue;
     }
@@ -1678,7 +1678,7 @@ void Tesseract::fix_rep_char(PAGE_RES_IT *page_res_it) {
   // Find the best exemplar of a classifier result for maxch_id.
   BLOB_CHOICE *best_choice = FindBestMatchingChoice(maxch_id, word_res);
   if (best_choice == nullptr) {
-    tprintf("Failed to find a choice for %s, occurring %d times\n",
+    tprintf("WARNING: Failed to find a choice for %s, occurring %d times\n",
             word_res->uch_set->debug_str(maxch_id).c_str(), max_count);
     return;
   }
@@ -1737,9 +1737,9 @@ ACCEPTABLE_WERD_TYPE Tesseract::acceptable_word_string(const UNICHARSET &char_se
       goto not_a_word;
     }
     /*
-Allow a single hyphen in a lower case word
-- don't trust upper case - I've seen several cases of "H" -> "I-I"
-*/
+      Allow a single hyphen in a lower case word
+      - don't trust upper case - I've seen several cases of "H" -> "I-I"
+    */
     if (lengths[i] == 1 && s[offset] == '-') {
       hyphen_pos = i;
       offset += lengths[i++];
@@ -1939,7 +1939,7 @@ void Tesseract::set_word_fonts(WERD_RES *word) {
   }
   if (tessedit_font_id > 0) {
     if (tessedit_font_id >= fontinfo_size) {
-      tprintf("Error, invalid font ID provided: must be below %d.\n"
+      tprintf("ERROR: Invalid font ID provided: must be below %d.\n"
               "Falling back to font auto-detection.\n", fontinfo_size);
     } else {
       word->fontinfo = &fontinfo_table_.at(tessedit_font_id);

--- a/src/ccmain/equationdetect.cpp
+++ b/src/ccmain/equationdetect.cpp
@@ -106,7 +106,7 @@ EquationDetect::EquationDetect(const char *equ_datapath, const char *equ_name) {
 
   if (equ_tesseract_.init_tesseract(equ_datapath, equ_name, OEM_TESSERACT_ONLY)) {
     tprintf(
-        "Warning: equation region detection requested,"
+        "WARNING: Equation region detection requested,"
         " but %s failed to load from %s\n",
         equ_name, equ_datapath);
   }

--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -45,7 +45,7 @@ bool Tesseract::TrainLineRecognizer(const char *input_imagename, const std::stri
   if (applybox_page > 0) {
     // Load existing document for the previous pages.
     if (!images.LoadDocument(lstmf_name.c_str(), 0, 0, nullptr)) {
-      tprintf("Failed to read training data from %s!\n", lstmf_name.c_str());
+      tprintf("ERROR: Failed to read training data from %s!\n", lstmf_name.c_str());
       return false;
     }
   }
@@ -54,17 +54,17 @@ bool Tesseract::TrainLineRecognizer(const char *input_imagename, const std::stri
   // Get the boxes for this page, if there are any.
   if (!ReadAllBoxes(applybox_page, false, input_imagename, &boxes, &texts, nullptr, nullptr) ||
       boxes.empty()) {
-    tprintf("Failed to read boxes from %s\n", input_imagename);
+    tprintf("ERROR: Failed to read boxes from %s\n", input_imagename);
     return false;
   }
   TrainFromBoxes(boxes, texts, block_list, &images);
   if (images.PagesSize() == 0) {
-    tprintf("Failed to read pages from %s\n", input_imagename);
+    tprintf("ERROR: Failed to read pages from %s\n", input_imagename);
     return false;
   }
   images.Shuffle();
   if (!images.SaveDocument(lstmf_name.c_str(), nullptr)) {
-    tprintf("Failed to write training data to %s!\n", lstmf_name.c_str());
+    tprintf("ERROR: Failed to write training data to %s!\n", lstmf_name.c_str());
     return false;
   }
   return true;

--- a/src/ccmain/osdetect.cpp
+++ b/src/ccmain/osdetect.cpp
@@ -167,7 +167,7 @@ static void remove_nontext_regions(tesseract::Tesseract *tess, BLOCK_LIST *block
   int resolution;
   if (kMinCredibleResolution > pixGetXRes(pix)) {
     resolution = kMinCredibleResolution;
-    tprintf("Warning. Invalid resolution %d dpi. Using %d instead.\n", pixGetXRes(pix), resolution);
+    tprintf("WARNING: Invalid resolution %d dpi. Using %d instead.\n", pixGetXRes(pix), resolution);
   } else {
     resolution = pixGetXRes(pix);
   }

--- a/src/ccmain/pageiterator.cpp
+++ b/src/ccmain/pageiterator.cpp
@@ -648,7 +648,7 @@ void PageIterator::BeginWord(int offset) {
     word_length_ = word_res->best_choice->length();
     if (word_res->box_word != nullptr) {
       if (word_res->box_word->length() != static_cast<unsigned>(word_length_)) {
-        tprintf("Corrupted word! best_choice[len=%d] = %s, box_word[len=%d]: ",
+        tprintf("WARNING: Corrupted word! best_choice[len=%d] = %s, box_word[len=%d]: ",
                 word_length_, word_res->best_choice->unichar_string().c_str(),
                 word_res->box_word->length());
         word_res->box_word->bounding_box().print();

--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -160,7 +160,7 @@ int Tesseract::SegmentPage(const char *input_file, BLOCK_LIST *blocks, Tesseract
 
   if (blocks->empty()) {
     if (textord_debug_tabfind) {
-      tprintf("Empty page\n");
+      tprintf("WARNING: Empty page\n");
     }
     return 0; // AutoPageSeg found an empty page.
   }

--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -74,7 +74,7 @@ static bool AcceptableRowArgs(int debug_level, int min_num_rows, const char *fun
                               const std::vector<RowScratchRegisters> *rows, int row_start,
                               int row_end) {
   if (row_start < 0 || static_cast<size_t>(row_end) > rows->size() || row_start > row_end) {
-    tprintf("Invalid arguments rows[%d, %d) while rows is of size %zu.\n", row_start, row_end,
+    tprintf("ERROR: Invalid arguments rows[%d, %d) while rows is of size %zu.\n", row_start, row_end,
             rows->size());
     return false;
   }
@@ -568,7 +568,7 @@ LineType RowScratchRegisters::GetLineType() const {
         has_body = true;
         break;
       default:
-        tprintf("Encountered bad value in hypothesis list: %c\n", hypothese.ty);
+        tprintf("ERROR: Encountered bad value in hypothesis list: %c\n", hypothese.ty);
         break;
     }
   }
@@ -596,7 +596,7 @@ LineType RowScratchRegisters::GetLineType(const ParagraphModel *model) const {
         has_body = true;
         break;
       default:
-        tprintf("Encountered bad value in hypothesis list: %c\n", hypothese.ty);
+        tprintf("ERROR: Encountered bad value in hypothesis list: %c\n", hypothese.ty);
         break;
     }
   }
@@ -1327,7 +1327,7 @@ int ParagraphTheory::IndexOf(const ParagraphModel *model) const {
 bool ValidFirstLine(const std::vector<RowScratchRegisters> *rows, int row,
                     const ParagraphModel *model) {
   if (!StrongModel(model)) {
-    tprintf("ValidFirstLine() should only be called with strong models!\n");
+    tprintf("WARNING: ValidFirstLine() should only be called with strong models!\n");
   }
   return StrongModel(model) && model->ValidFirstLine((*rows)[row].lmargin_, (*rows)[row].lindent_,
                                                      (*rows)[row].rindent_, (*rows)[row].rmargin_);
@@ -1336,7 +1336,7 @@ bool ValidFirstLine(const std::vector<RowScratchRegisters> *rows, int row,
 bool ValidBodyLine(const std::vector<RowScratchRegisters> *rows, int row,
                    const ParagraphModel *model) {
   if (!StrongModel(model)) {
-    tprintf("ValidBodyLine() should only be called with strong models!\n");
+    tprintf("WARNING: ValidBodyLine() should only be called with strong models!\n");
   }
   return StrongModel(model) && model->ValidBodyLine((*rows)[row].lmargin_, (*rows)[row].lindent_,
                                                     (*rows)[row].rindent_, (*rows)[row].rmargin_);
@@ -1758,7 +1758,7 @@ static ParagraphModel InternalParagraphModelByOutline(
   cmin = cmax = 0;
   for (int i = start + 1; i < end; i++) {
     if ((*rows)[i].lmargin_ != lmargin || (*rows)[i].rmargin_ != rmargin) {
-      tprintf("Margins don't match! Software error.\n");
+      tprintf("ERROR: Margins don't match! Software error.\n");
       *consistent = false;
       return ParagraphModel();
     }
@@ -2148,7 +2148,7 @@ static void ConvertHypothesizedModelRunsToParagraphs(int debug_level,
     for (int row = start; row < end; row++) {
       if ((*row_owners)[row] != nullptr) {
         tprintf(
-            "Memory leak! ConvertHypothesizeModelRunsToParagraphs() called "
+            "ERROR: Memory leak! ConvertHypothesizeModelRunsToParagraphs() called "
             "more than once!\n");
         delete (*row_owners)[row];
       }

--- a/src/ccmain/paramsd.cpp
+++ b/src/ccmain/paramsd.cpp
@@ -336,7 +336,7 @@ void ParamsEditor::WriteParams(char *filename, bool changes_only) {
 
   fp = fopen(filename, "wb"); // can we write to it?
   if (fp == nullptr) {
-    sv_window_->AddMessage("Can't write to file {}", filename);
+    sv_window_->AddMessageF("Can't write to file %s", filename);
     return;
   }
   for (auto &iter : vcMap) {

--- a/src/ccmain/paramsd.cpp
+++ b/src/ccmain/paramsd.cpp
@@ -336,7 +336,7 @@ void ParamsEditor::WriteParams(char *filename, bool changes_only) {
 
   fp = fopen(filename, "wb"); // can we write to it?
   if (fp == nullptr) {
-    sv_window_->AddMessageF("Can't write to file %s", filename);
+    sv_window_->AddMessage("Can't write to file {}", filename);
     return;
   }
   for (auto &iter : vcMap) {

--- a/src/ccmain/recogtraining.cpp
+++ b/src/ccmain/recogtraining.cpp
@@ -49,7 +49,7 @@ FILE *Tesseract::init_recog_training(const char *filename) {
   output_fname += ".txt";
   FILE *output_file = fopen(output_fname.c_str(), "a+");
   if (output_file == nullptr) {
-    tprintf("Error: Could not open file %s\n", output_fname.c_str());
+    tprintf("ERROR: Could not open file %s\n", output_fname.c_str());
     ASSERT_HOST(output_file);
   }
   return output_file;
@@ -94,7 +94,7 @@ void Tesseract::recog_training_segmented(const char *filename, PAGE_RES *page_re
   // ReadNextBox() will close box_file
   FILE *box_file = fopen(box_fname.c_str(), "r");
   if (box_file == nullptr) {
-    tprintf("Error: Could not open file %s\n", box_fname.c_str());
+    tprintf("ERROR: Could not open file %s\n", box_fname.c_str());
     ASSERT_HOST(box_file);
   }
 

--- a/src/ccmain/reject.cpp
+++ b/src/ccmain/reject.cpp
@@ -159,7 +159,7 @@ void Tesseract::make_reject_map(WERD_RES *word, ROW *row, int16_t pass) {
       /* Ambig word rejection was here once !!*/
     }
   } else {
-    tprintf("BAD tessedit_reject_mode\n");
+    tprintf("ERROR: BAD tessedit_reject_mode\n");
     ASSERT_HOST("Fatal error encountered!" == nullptr);
   }
 

--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -88,9 +88,9 @@ bool Tesseract::init_tesseract_lang_data(const std::string &arg0,
   // Initialize TessdataManager.
   std::string tessdata_path = language_data_path_prefix + kTrainedDataSuffix;
   if (!mgr->is_loaded() && !mgr->Init(tessdata_path.c_str())) {
-    tprintf("Error opening data file %s\n", tessdata_path.c_str());
+    tprintf("ERROR: Error opening data file %s\n", tessdata_path.c_str());
     tprintf(
-        "Please make sure the TESSDATA_PREFIX environment variable is set"
+        "INFO: Please make sure the TESSDATA_PREFIX environment variable is set"
         " to your \"tessdata\" directory.\n");
     return false;
   }
@@ -131,7 +131,7 @@ bool Tesseract::init_tesseract_lang_data(const std::string &arg0,
     for (unsigned i = 0; i < vars_vec->size(); ++i) {
       if (!ParamUtils::SetParam((*vars_vec)[i].c_str(), (*vars_values)[i].c_str(),
                                 set_params_constraint, this->params())) {
-        tprintf("Warning: The parameter '%s' was not found.\n", (*vars_vec)[i].c_str());
+        tprintf("WARNING: The parameter '%s' was not found.\n", (*vars_vec)[i].c_str());
       }
     }
   }
@@ -142,7 +142,7 @@ bool Tesseract::init_tesseract_lang_data(const std::string &arg0,
       ParamUtils::PrintParams(params_file, this->params());
       fclose(params_file);
     } else {
-      tprintf("Failed to open %s for writing params.\n", tessedit_write_params_to_file.c_str());
+      tprintf("ERROR: Failed to open %s for writing params.\n", tessedit_write_params_to_file.c_str());
     }
   }
 
@@ -172,7 +172,7 @@ bool Tesseract::init_tesseract_lang_data(const std::string &arg0,
       lstm_recognizer_ = new LSTMRecognizer(language_data_path_prefix.c_str());
       ASSERT_HOST(lstm_recognizer_->Load(this->params(), lstm_use_matrix ? language : "", mgr));
     } else {
-      tprintf("Error: LSTM requested, but not present!! Loading tesseract.\n");
+      tprintf("ERROR: LSTM requested, but not present!! Loading tesseract.\n");
       tessedit_ocr_engine_mode.set_value(OEM_TESSERACT_ONLY);
     }
   }
@@ -185,14 +185,14 @@ bool Tesseract::init_tesseract_lang_data(const std::string &arg0,
 #ifndef DISABLED_LEGACY_ENGINE
   else if (!mgr->GetComponent(TESSDATA_UNICHARSET, &fp) || !unicharset.load_from_file(&fp, false)) {
     tprintf(
-        "Error: Tesseract (legacy) engine requested, but components are "
+        "ERROR: Tesseract (legacy) engine requested, but components are "
         "not present in %s!!\n",
         tessdata_path.c_str());
     return false;
   }
 #endif // ndef DISABLED_LEGACY_ENGINE
   if (unicharset.size() > MAX_NUM_CLASSES) {
-    tprintf("Error: Size of unicharset is greater than MAX_NUM_CLASSES\n");
+    tprintf("ERROR: Size of unicharset is greater than MAX_NUM_CLASSES\n");
     return false;
   }
   right_to_left_ = unicharset.major_right_to_left();
@@ -327,7 +327,7 @@ int Tesseract::init_tesseract(const std::string &arg0, const std::string &textba
 
       if (!loaded_primary) {
         if (result < 0) {
-          tprintf("Failed loading language '%s'\n", lang_str);
+          tprintf("ERROR: Failed loading language '%s'\n", lang_str);
         } else {
           ParseLanguageString(tess_to_init->tessedit_load_sublangs, &langs_to_load,
                               &langs_not_to_load);
@@ -335,7 +335,7 @@ int Tesseract::init_tesseract(const std::string &arg0, const std::string &textba
         }
       } else {
         if (result < 0) {
-          tprintf("Failed loading language '%s'\n", lang_str);
+          tprintf("ERROR: Failed loading language '%s'\n", lang_str);
           delete tess_to_init;
         } else {
           sub_langs_.push_back(tess_to_init);
@@ -347,7 +347,7 @@ int Tesseract::init_tesseract(const std::string &arg0, const std::string &textba
     }
   }
   if (!loaded_primary && !langs_to_load.empty()) {
-    tprintf("Tesseract couldn't load any languages!\n");
+    tprintf("ERROR: Tesseract couldn't load any languages!\n");
     return -1; // Couldn't load any language!
   }
 #ifndef DISABLED_LEGACY_ENGINE

--- a/src/ccmain/thresholder.cpp
+++ b/src/ccmain/thresholder.cpp
@@ -126,7 +126,7 @@ void ImageThresholder::SetImage(const unsigned char *imagedata, int width, int h
       break;
 
     default:
-      tprintf("Cannot convert RAW image to Pix with bpp = %d\n", bpp);
+      tprintf("ERROR: Cannot convert RAW image to Pix with bpp = %d\n", bpp);
   }
   SetImage(pix);
   pix.destroy();
@@ -284,7 +284,7 @@ std::tuple<bool, Image, Image, Image> ImageThresholder::Threshold(
 /// Returns false on error.
 bool ImageThresholder::ThresholdToPix(Image *pix) {
   if (image_width_ > INT16_MAX || image_height_ > INT16_MAX) {
-    tprintf("Image too large: (%d, %d)\n", image_width_, image_height_);
+    tprintf("ERROR: Image too large: (%d, %d)\n", image_width_, image_height_);
     return false;
   }
   Image original = GetPixRect();

--- a/src/ccstruct/blread.cpp
+++ b/src/ccstruct/blread.cpp
@@ -49,7 +49,7 @@ bool read_unlv_file(   // print list of sides
 
   name += UNLV_EXT; // add extension
   if ((pdfp = fopen(name.c_str(), "rb")) == nullptr) {
-    tprintf("ERROR: Cannot read UZN file %s.\n", name);
+    tprintf("ERROR: Cannot read UZN file %s.\n", name.c_str());
     return false; // didn't read one
   } else {
     while (tfscanf(pdfp, "%d %d %d %d %*s", &x, &y, &width, &height) >= 4) {

--- a/src/ccstruct/blread.cpp
+++ b/src/ccstruct/blread.cpp
@@ -49,6 +49,7 @@ bool read_unlv_file(   // print list of sides
 
   name += UNLV_EXT; // add extension
   if ((pdfp = fopen(name.c_str(), "rb")) == nullptr) {
+    tprintf("ERROR: Cannot read UZN file %s.\n", name);
     return false; // didn't read one
   } else {
     while (tfscanf(pdfp, "%d %d %d %d %*s", &x, &y, &width, &height) >= 4) {

--- a/src/ccstruct/boxread.cpp
+++ b/src/ccstruct/boxread.cpp
@@ -181,7 +181,7 @@ bool ReadNextBox(int target_page, int *line_number, FILE *box_file, std::string 
     }
     if (*buffptr != '\0') {
       if (!ParseBoxFileStr(buffptr, &page, utf8_str, bounding_box)) {
-        tprintf("Box file format error on line %i; ignored\n", *line_number);
+        tprintf("ERROR: Box file format error on line %i; ignored\n", *line_number);
         continue;
       }
       if (target_page >= 0 && target_page != page) {
@@ -244,7 +244,7 @@ bool ParseBoxFileStr(const char *boxfile_str, int *page_number, std::string &utf
   stream >> y_max;
   stream >> *page_number;
   if (x_max < x_min || y_max < y_min) {
-    tprintf("Bad box coordinates in boxfile string! %s\n", ubuf);
+    tprintf("ERROR: Bad box coordinates in boxfile string! %s\n", ubuf);
     return false;
   }
   // Test for long space-delimited string label.
@@ -260,7 +260,7 @@ bool ParseBoxFileStr(const char *boxfile_str, int *page_number, std::string &utf
     tesseract::UNICHAR ch(uch + used, uch_len - used);
     int new_used = ch.utf8_len();
     if (new_used == 0) {
-      tprintf("Bad UTF-8 str %s starts with 0x%02x at col %d\n", uch + used, uch[used], used + 1);
+      tprintf("ERROR: Bad UTF-8 str %s starts with 0x%02x at col %d\n", uch + used, uch[used], used + 1);
       return false;
     }
     used += new_used;

--- a/src/ccstruct/imagedata.cpp
+++ b/src/ccstruct/imagedata.cpp
@@ -68,7 +68,7 @@ ImageData *ImageData::Build(const char *name, int page_number, const char *lang,
   memcpy(&image_data->image_data_[0], imagedata, imagedatasize);
   if (!image_data->AddBoxes(box_text)) {
     if (truth_text == nullptr || truth_text[0] == '\0') {
-      tprintf("Error: No text corresponding to page %d from image %s!\n",
+      tprintf("ERROR: No text corresponding to page %d from image %s!\n",
               page_number, name);
       delete image_data;
       return nullptr;
@@ -234,7 +234,7 @@ Image ImageData::PreScale(int target_height, int max_height,
   // Get the scaled image.
   Image pix = pixScale(src_pix, im_factor, im_factor);
   if (pix == nullptr) {
-    tprintf("Scaling pix of size %d, %d by factor %g made null pix!!\n",
+    tprintf("ERROR: Scaling pix of size %d, %d by factor %g made null pix!!\n",
             input_width, input_height, im_factor);
     src_pix.destroy();
     return nullptr;
@@ -371,7 +371,7 @@ bool ImageData::AddBoxes(const char *box_text) {
       AddBoxes(boxes, texts, box_pages);
       return true;
     } else {
-      tprintf("Error: No boxes for page %d from image %s!\n", page_number_,
+      tprintf("ERROR: No boxes for page %d from image %s!\n", page_number_,
               imagefilename_.c_str());
     }
   }
@@ -423,7 +423,7 @@ bool DocumentData::SaveDocument(const char *filename, FileWriter writer) {
   TFile fp;
   fp.OpenWrite(nullptr);
   if (!fp.Serialize(pages_) || !fp.CloseWrite(filename, writer)) {
-    tprintf("Serialize failed: %s\n", filename);
+    tprintf("ERROR: Serialize failed: %s\n", filename);
     return false;
   }
   return true;
@@ -549,7 +549,7 @@ bool DocumentData::ReCachePages() {
   TFile fp;
   if (!fp.Open(document_name_.c_str(), reader_) ||
       !fp.DeSerializeSize(&loaded_pages) || loaded_pages <= 0) {
-    tprintf("Deserialize header failed: %s\n", document_name_.c_str());
+    tprintf("ERROR: Deserialize header failed: %s\n", document_name_.c_str());
     return false;
   }
   pages_offset_ %= loaded_pages;
@@ -584,7 +584,7 @@ bool DocumentData::ReCachePages() {
     }
   }
   if (page < loaded_pages) {
-    tprintf("Deserialize failed: %s read %d/%d lines\n", document_name_.c_str(),
+    tprintf("ERROR: Deserialize failed: %s read %d/%d lines\n", document_name_.c_str(),
             page, loaded_pages);
     for (auto page : pages_) {
       delete page;
@@ -632,7 +632,7 @@ bool DocumentCache::LoadDocuments(const std::vector<std::string> &filenames,
     if (GetPageBySerial(0) != nullptr) {
       return true;
     }
-    tprintf("Load of page 0 failed!\n");
+    tprintf("ERROR: Load of page 0 failed!\n");
   }
   return false;
 }
@@ -700,7 +700,7 @@ const ImageData *DocumentCache::GetPageSequential(int serial) {
     documents_[0]->GetPage(0);
     num_pages_per_doc_ = documents_[0]->NumPages();
     if (num_pages_per_doc_ == 0) {
-      tprintf("First document cannot be empty!!\n");
+      tprintf("ERROR: First document cannot be empty!!\n");
       ASSERT_HOST(num_pages_per_doc_ > 0);
     }
     // Get rid of zero now if we don't need it.

--- a/src/ccstruct/quadlsq.cpp
+++ b/src/ccstruct/quadlsq.cpp
@@ -75,7 +75,7 @@ void QLSQ::add(double x, double y) {
 
 void QLSQ::remove(double x, double y) {
   if (n <= 0) {
-    tprintf("Can't remove an element from an empty QLSQ accumulator!\n");
+    tprintf("ERROR: Can't remove an element from an empty QLSQ accumulator!\n");
     return;
   }
   n--;       // Count elements.

--- a/src/ccstruct/ratngs.cpp
+++ b/src/ccstruct/ratngs.cpp
@@ -560,7 +560,7 @@ void WERD_CHOICE::SetScriptPositions(bool small_caps, TWERD *word, int debug) {
       4 * position_counts[tesseract::SP_SUPERSCRIPT] > 3 * length_) {
     if (debug >= 2) {
       tprintf(
-          "Most characters of %s are subscript or superscript.\n"
+          "WARNING: Most characters of %s are subscript or superscript.\n"
           "That seems wrong, so I'll assume we got the baseline wrong\n",
           unichar_string().c_str());
     }

--- a/src/ccstruct/werd.cpp
+++ b/src/ccstruct/werd.cpp
@@ -423,7 +423,7 @@ WERD *WERD::ConstructWerdWithNewBlobs(C_BLOB_LIST *all_blobs, C_BLOB_LIST *orpha
       // be added to the new blobs list.
       TBOX a_blob_box = a_blob->bounding_box();
       if (a_blob_box.null_box()) {
-        tprintf("Bounding box couldn't be ascertained\n");
+        tprintf("WARNING: Bounding box couldn't be ascertained\n");
       }
       if (werd_blob_box.contains(a_blob_box) || werd_blob_box.major_overlap(a_blob_box)) {
         // Old blobs are from minimal splits, therefore are expected to be

--- a/src/ccutil/ambigs.cpp
+++ b/src/ccutil/ambigs.cpp
@@ -31,8 +31,8 @@
 namespace tesseract {
 
 static const char kAmbigDelimiters[] = "\t ";
-static const char kIllegalMsg[] = "Illegal ambiguity specification on line %d\n";
-static const char kIllegalUnicharMsg[] = "Illegal unichar %s in ambiguity specification\n";
+static const char kIllegalMsg[] = "ERROR: Illegal ambiguity specification on line %d\n";
+static const char kIllegalUnicharMsg[] = "ERROR: Illegal unichar %s in ambiguity specification\n";
 
 // Maximum line size:
 //   10 for sizes of ambigs, tabs, abmig type and newline
@@ -240,7 +240,7 @@ bool UnicharAmbigs::ParseAmbiguityLine(int line_num, int version, int debug_leve
     *test_ambig_part_size = unichars.size();
     if (*test_ambig_part_size > MAX_AMBIG_SIZE) {
       if (debug_level) {
-        tprintf("Too many unichars in ambiguity on line %d\n", line_num);
+        tprintf("ERROR: Too many unichars in ambiguity on line %d\n", line_num);
       }
       return false;
     }
@@ -256,7 +256,7 @@ bool UnicharAmbigs::ParseAmbiguityLine(int line_num, int version, int debug_leve
     *replacement_ambig_part_size = unichars.size();
     if (*replacement_ambig_part_size > MAX_AMBIG_SIZE) {
       if (debug_level) {
-        tprintf("Too many unichars in ambiguity on line %d\n", line_num);
+        tprintf("ERROR: Too many unichars in ambiguity on line %d\n", line_num);
       }
       return false;
     }
@@ -281,7 +281,7 @@ bool UnicharAmbigs::ParseAmbiguityLine(int line_num, int version, int debug_leve
   }
   if (*test_ambig_part_size > MAX_AMBIG_SIZE) {
     if (debug_level) {
-      tprintf("Too many unichars in ambiguity on line %d\n", line_num);
+      tprintf("ERROR: Too many unichars in ambiguity on line %d\n", line_num);
     }
     return false;
   }
@@ -308,7 +308,7 @@ bool UnicharAmbigs::ParseAmbiguityLine(int line_num, int version, int debug_leve
   }
   if (*replacement_ambig_part_size > MAX_AMBIG_SIZE) {
     if (debug_level) {
-      tprintf("Too many unichars in ambiguity on line %d\n", line_num);
+      tprintf("ERROR: Too many unichars in ambiguity on line %d\n", line_num);
     }
     return false;
   }

--- a/src/ccutil/errcode.cpp
+++ b/src/ccutil/errcode.cpp
@@ -49,7 +49,7 @@ void ERRCODE::error(         // handle error
     msgptr += sprintf(msgptr, "%s:", caller);
   }
   // actual message
-  msgptr += sprintf(msgptr, "Error:%s", message);
+  msgptr += sprintf(msgptr, "ERROR: %s", message);
   if (format != nullptr) {
     msgptr += sprintf(msgptr, ":");
     va_start(args, format); // variable list

--- a/src/ccutil/params.cpp
+++ b/src/ccutil/params.cpp
@@ -42,7 +42,7 @@ bool ParamUtils::ReadParamsFile(const char *file, SetParamConstraint constraint,
                                 ParamsVectors *member_params) {
   TFile fp;
   if (!fp.Open(file, nullptr)) {
-    tprintf("read_params_file: Can't open %s\n", file);
+    tprintf("ERROR: read_params_file: Can't open file %s\n", file);
     return true;
   }
   return ReadParamsFromFp(constraint, &fp, member_params);
@@ -71,7 +71,7 @@ bool ParamUtils::ReadParamsFromFp(SetParamConstraint constraint, TFile *fp,
 
       if (!foundit) {
         anyerr = true; // had an error
-        tprintf("Warning: Parameter not found: %s\n", line);
+        tprintf("WARNING: Parameter not found: %s\n", line);
       }
     }
   }

--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -267,7 +267,7 @@ bool TessdataManager::CombineDataFiles(const char *language_data_path_prefix,
     if (fp != nullptr) {
       fclose(fp);
       if (!LoadDataFromFile(filename.c_str(), &entries_[type])) {
-        tprintf("Load of file %s failed!\n", filename.c_str());
+        tprintf("ERROR: Load of file %s failed!\n", filename.c_str());
         return false;
       }
     }
@@ -277,7 +277,7 @@ bool TessdataManager::CombineDataFiles(const char *language_data_path_prefix,
   // Make sure that the required components are present.
   if (!IsBaseAvailable() && !IsLSTMAvailable()) {
     tprintf(
-        "Error: traineddata file must contain at least (a unicharset file"
+        "ERROR: traineddata file must contain at least (a unicharset file"
         " and inttemp) OR an lstm file.\n");
     return false;
   }
@@ -293,7 +293,7 @@ bool TessdataManager::OverwriteComponents(const char *new_traineddata_filename,
     TessdataType type;
     if (TessdataTypeFromFileName(component_filenames[i], &type)) {
       if (!LoadDataFromFile(component_filenames[i], &entries_[type])) {
-        tprintf("Failed to read component file:%s\n", component_filenames[i]);
+        tprintf("ERROR: Failed to read component file:%s\n", component_filenames[i]);
         return false;
       }
     }
@@ -321,7 +321,7 @@ bool TessdataManager::TessdataTypeFromFileSuffix(const char *suffix, TessdataTyp
   }
 #if !defined(NDEBUG)
   tprintf(
-      "TessdataManager can't determine which tessdata"
+      "ERROR: TessdataManager can't determine which tessdata"
       " component is represented by %s\n",
       suffix);
 #endif

--- a/src/ccutil/unichar.cpp
+++ b/src/ccutil/unichar.cpp
@@ -161,7 +161,7 @@ UNICHAR::const_iterator &UNICHAR::const_iterator::operator++() {
   if (step == 0) {
     tprintf("ERROR: Illegal UTF8 encountered.\n");
     for (int i = 0; i < 5 && it_[i] != '\0'; ++i) {
-      tprintf("Index %d char = 0x%x\n", i, it_[i]);
+      tprintf("  Index %d char = 0x%x\n", i, it_[i]);
     }
     step = 1;
   }

--- a/src/ccutil/unicharcompress.cpp
+++ b/src/ccutil/unicharcompress.cpp
@@ -80,7 +80,7 @@ static bool DecodeRadicalTable(std::string &radical_data, RSMap *radical_map) {
   std::vector<std::string> lines = split(radical_data, '\n');
   for (unsigned i = 0; i < lines.size(); ++i) {
     if (!DecodeRadicalLine(lines[i], radical_map)) {
-      tprintf("Invalid format in radical table at line %d: %s\n", i, lines[i].c_str());
+      tprintf("ERROR: Invalid format in radical table at line %d: %s\n", i, lines[i].c_str());
       return false;
     }
   }
@@ -182,7 +182,7 @@ bool UnicharCompress::ComputeEncoding(const UNICHARSET &unicharset, int null_id,
         for (int uni : unicodes) {
           int position = code.length();
           if (position >= RecodedCharID::kMaxCodeLen) {
-            tprintf("Unichar %d=%s is too long to encode!!\n", u, unicharset.id_to_unichar(u));
+            tprintf("ERROR: Unichar %d=%s is too long to encode!!\n", u, unicharset.id_to_unichar(u));
             return false;
           }
           UNICHAR unichar(uni);

--- a/src/ccutil/unicharset.cpp
+++ b/src/ccutil/unicharset.cpp
@@ -670,7 +670,7 @@ void UNICHARSET::unichar_insert(const char *const unichar_repr,
     int index = 0;
     do {
       if (index >= UNICHAR_LEN) {
-        fprintf(stderr, "Utf8 buffer too big, size>%d for %s\n", UNICHAR_LEN,
+        tesseract::tprintf("ERROR: Utf8 buffer too big, size>%d for %s\n", UNICHAR_LEN,
                 unichar_repr);
         return;
       }
@@ -824,7 +824,7 @@ bool UNICHARSET::load_via_fgets(
     stream >> std::setw(255) >> unichar >> std::hex >> properties >> std::dec;
     // stream.flags(std::ios::dec);
     if (stream.fail()) {
-      fprintf(stderr, "%s:%u failed\n", __FILE__, __LINE__);
+      tesseract::tprintf("ERROR: stream failure. (%s:%u)\n", __FILE__, __LINE__);
       return false;
     }
     auto position = stream.tellg();

--- a/src/ccutil/unicharset.cpp
+++ b/src/ccutil/unicharset.cpp
@@ -19,6 +19,7 @@
 #include "unicharset.h"
 
 #include "params.h"
+#include "tprintf.h" // for tprintf
 
 #include <tesseract/unichar.h>
 #include "serialis.h"

--- a/src/classify/adaptmatch.cpp
+++ b/src/classify/adaptmatch.cpp
@@ -440,7 +440,7 @@ void Classify::LearnPieces(const char *fontname, int start, int length, float th
       AdaptToChar(rotated_blob, class_id, font_id, threshold, BackupAdaptedTemplates);
     }
   } else if (classify_debug_level >= 1) {
-    tprintf("Can't adapt to %s not in unicharset\n", correct_text);
+    tprintf("WARNING: Can't adapt to %s not in unicharset\n", correct_text);
   }
   if (rotated_blob != blob) {
     delete rotated_blob;
@@ -470,7 +470,7 @@ void Classify::EndAdaptiveClassifier() {
     Filename = imagefile + ADAPT_TEMPLATE_SUFFIX;
     File = fopen(Filename.c_str(), "wb");
     if (File == nullptr) {
-      tprintf("Unable to save adapted templates to %s!\n", Filename.c_str());
+      tprintf("ERROR: Unable to save adapted templates to %s!\n", Filename.c_str());
     } else {
       tprintf("\nSaving adapted templates to %s ...", Filename.c_str());
       fflush(stdout);

--- a/src/classify/cluster.cpp
+++ b/src/classify/cluster.cpp
@@ -2118,7 +2118,7 @@ static PROTOTYPE *TestEllipticalProto(CLUSTERER *Clusterer, CLUSTERCONFIG *Confi
   }
   double err = InvertMatrix(&Covariance[0], N, &Inverse[0]);
   if (err > 1) {
-    tprintf("Clustering error: Matrix inverse failed with error %g\n", err);
+    tprintf("ERROR: Clustering error: Matrix inverse failed with error %g\n", err);
   }
   int EssentialN = 0;
   for (int dim = 0; dim < N; ++dim) {

--- a/src/classify/clusttool.cpp
+++ b/src/classify/clusttool.cpp
@@ -57,7 +57,7 @@ static bool ReadNFloats(TFile *fp, uint16_t N, float Buffer[]) {
     float f = NAN;
     stream >> f;
     if (std::isnan(f)) {
-      tprintf("Read of %u floats failed!\n", N);
+      tprintf("ERROR: Read of %u floats failed!\n", N);
       return false;
     }
     Buffer[i] = f;
@@ -175,7 +175,7 @@ PROTOTYPE *ReadPrototype(TFile *fp, uint16_t N) {
   if (fp->FGets(line, kMaxLineSize) == nullptr ||
       sscanf(line, "%" QUOTED_TOKENSIZE "s %" QUOTED_TOKENSIZE "s %d", sig_token, shape_token,
              &SampleCount) != 3) {
-    tprintf("Invalid prototype: %s\n", line);
+    tprintf("ERROR: Invalid prototype: %s\n", line);
     return nullptr;
   }
   auto Proto = new PROTOTYPE;
@@ -193,7 +193,7 @@ PROTOTYPE *ReadPrototype(TFile *fp, uint16_t N) {
       Proto->Style = automatic;
       break;
     default:
-      tprintf("Invalid prototype style specification:%s\n", shape_token);
+      tprintf("ERROR: Invalid prototype style specification:%s\n", shape_token);
       Proto->Style = elliptical;
   }
 

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -346,7 +346,7 @@ void AddProtoToProtoPruner(PROTO_STRUCT *Proto, int ProtoId, INT_CLASS_STRUCT *C
   float Pad;
 
   if (ProtoId >= Class->NumProtos) {
-    tprintf("AddProtoToProtoPruner:assert failed: %d < %d", ProtoId, Class->NumProtos);
+    tprintf("ERROR: AddProtoToProtoPruner:assert failed: %d < %d", ProtoId, Class->NumProtos);
   }
   assert(ProtoId < Class->NumProtos);
 
@@ -500,7 +500,7 @@ INT_TEMPLATES_STRUCT *Classify::CreateIntTemplates(CLASSES FloatProtos,
     FClass = &(FloatProtos[ClassId]);
     if (FClass->NumProtos == 0 && FClass->NumConfigs == 0 &&
         strcmp(target_unicharset.id_to_unichar(ClassId), " ") != 0) {
-      tprintf("Warning: no protos/configs for %s in CreateIntTemplates()\n",
+      tprintf("WARNING: no protos/configs for %s in CreateIntTemplates()\n",
               target_unicharset.id_to_unichar(ClassId));
     }
     assert(UnusedClassIdIn(IntTemplates, ClassId));
@@ -648,18 +648,18 @@ INT_TEMPLATES_STRUCT *Classify::ReadIntTemplates(TFile *fp) {
   // Read Templates in parts for 64 bit compatibility.
   uint32_t unicharset_size;
   if (fp->FReadEndian(&unicharset_size, sizeof(unicharset_size), 1) != 1) {
-    tprintf("Bad read of inttemp!\n");
+    tprintf("ERROR: Bad read of inttemp!\n");
   }
   int32_t version_id = 0;
   if (fp->FReadEndian(&version_id, sizeof(version_id), 1) != 1 ||
       fp->FReadEndian(&Templates->NumClassPruners, sizeof(Templates->NumClassPruners), 1) != 1) {
-    tprintf("Bad read of inttemp!\n");
+    tprintf("ERROR: Bad read of inttemp!\n");
   }
   if (version_id < 0) {
     // This file has a version id!
     version_id = -version_id;
     if (fp->FReadEndian(&Templates->NumClasses, sizeof(Templates->NumClasses), 1) != 1) {
-      tprintf("Bad read of inttemp!\n");
+      tprintf("ERROR: Bad read of inttemp!\n");
     }
   } else {
     Templates->NumClasses = version_id;
@@ -673,11 +673,11 @@ INT_TEMPLATES_STRUCT *Classify::ReadIntTemplates(TFile *fp) {
   if (version_id < 2) {
     std::vector<int16_t> IndexFor(MAX_NUM_CLASSES);
     if (fp->FReadEndian(&IndexFor[0], sizeof(IndexFor[0]), unicharset_size) != unicharset_size) {
-      tprintf("Bad read of inttemp!\n");
+      tprintf("ERROR: Bad read of inttemp!\n");
     }
     if (fp->FReadEndian(&ClassIdFor[0], sizeof(ClassIdFor[0]), Templates->NumClasses) !=
         Templates->NumClasses) {
-      tprintf("Bad read of inttemp!\n");
+      tprintf("ERROR: Bad read of inttemp!\n");
     }
   }
 
@@ -686,7 +686,7 @@ INT_TEMPLATES_STRUCT *Classify::ReadIntTemplates(TFile *fp) {
   for (unsigned i = 0; i < Templates->NumClassPruners; i++) {
     Pruner = new CLASS_PRUNER_STRUCT;
     if (fp->FReadEndian(Pruner, sizeof(Pruner->p[0][0][0][0]), kNumBuckets) != kNumBuckets) {
-      tprintf("Bad read of inttemp!\n");
+      tprintf("ERROR: Bad read of inttemp!\n");
     }
     if (version_id < 2) {
       TempClassPruner[i] = Pruner;
@@ -761,21 +761,21 @@ INT_TEMPLATES_STRUCT *Classify::ReadIntTemplates(TFile *fp) {
     if (fp->FReadEndian(&Class->NumProtos, sizeof(Class->NumProtos), 1) != 1 ||
         fp->FRead(&Class->NumProtoSets, sizeof(Class->NumProtoSets), 1) != 1 ||
         fp->FRead(&Class->NumConfigs, sizeof(Class->NumConfigs), 1) != 1) {
-      tprintf("Bad read of inttemp!\n");
+      tprintf("ERROR: Bad read of inttemp!\n");
     }
     if (version_id == 0) {
       // Only version 0 writes 5 pointless pointers to the file.
       for (j = 0; j < 5; ++j) {
         int32_t junk;
         if (fp->FRead(&junk, sizeof(junk), 1) != 1) {
-          tprintf("Bad read of inttemp!\n");
+          tprintf("ERROR: Bad read of inttemp!\n");
         }
       }
     }
     unsigned num_configs = version_id < 4 ? MaxNumConfigs : Class->NumConfigs;
     ASSERT_HOST(num_configs <= MaxNumConfigs);
     if (fp->FReadEndian(Class->ConfigLengths, sizeof(uint16_t), num_configs) != num_configs) {
-      tprintf("Bad read of inttemp!\n");
+      tprintf("ERROR: Bad read of inttemp!\n");
     }
     if (version_id < 2) {
       ClassForClassId(Templates, ClassIdFor[i]) = Class;
@@ -789,7 +789,7 @@ INT_TEMPLATES_STRUCT *Classify::ReadIntTemplates(TFile *fp) {
       Class->ProtoLengths.resize(MaxNumIntProtosIn(Class));
       if (fp->FRead(&Class->ProtoLengths[0], sizeof(uint8_t), MaxNumIntProtosIn(Class)) !=
           MaxNumIntProtosIn(Class)) {
-        tprintf("Bad read of inttemp!\n");
+        tprintf("ERROR: Bad read of inttemp!\n");
       }
     }
 
@@ -799,18 +799,18 @@ INT_TEMPLATES_STRUCT *Classify::ReadIntTemplates(TFile *fp) {
       unsigned num_buckets = NUM_PP_PARAMS * NUM_PP_BUCKETS * WERDS_PER_PP_VECTOR;
       if (fp->FReadEndian(&ProtoSet->ProtoPruner, sizeof(ProtoSet->ProtoPruner[0][0][0]),
                           num_buckets) != num_buckets) {
-        tprintf("Bad read of inttemp!\n");
+        tprintf("ERROR: Bad read of inttemp!\n");
       }
       for (x = 0; x < PROTOS_PER_PROTO_SET; x++) {
         if (fp->FRead(&ProtoSet->Protos[x].A, sizeof(ProtoSet->Protos[x].A), 1) != 1 ||
             fp->FRead(&ProtoSet->Protos[x].B, sizeof(ProtoSet->Protos[x].B), 1) != 1 ||
             fp->FRead(&ProtoSet->Protos[x].C, sizeof(ProtoSet->Protos[x].C), 1) != 1 ||
             fp->FRead(&ProtoSet->Protos[x].Angle, sizeof(ProtoSet->Protos[x].Angle), 1) != 1) {
-          tprintf("Bad read of inttemp!\n");
+          tprintf("ERROR: Bad read of inttemp!\n");
         }
         if (fp->FReadEndian(&ProtoSet->Protos[x].Configs, sizeof(ProtoSet->Protos[x].Configs[0]),
                             WerdsPerConfigVec) != WerdsPerConfigVec) {
-          tprintf("Bad read of inttemp!\n");
+          tprintf("ERROR: Bad read of inttemp!\n");
         }
       }
       Class->ProtoSets[j] = ProtoSet;
@@ -837,7 +837,7 @@ INT_TEMPLATES_STRUCT *Classify::ReadIntTemplates(TFile *fp) {
         }
       } else {
         if (ClassForClassId(Templates, i) != nullptr) {
-          fprintf(stderr, "Class id %u exceeds NumClassesIn (Templates) %u\n", i,
+          tprintf("ERROR: Class id %u exceeds NumClassesIn (Templates) %u\n", i,
                   Templates->NumClasses);
           exit(1);
         }
@@ -924,7 +924,7 @@ void Classify::WriteIntTemplates(FILE *File, INT_TEMPLATES_STRUCT *Templates,
 
   if (Templates->NumClasses != unicharset_size) {
     tprintf(
-        "Warning: executing WriteIntTemplates() with %d classes in"
+        "WARNING: Executing WriteIntTemplates() with %d classes in"
         " Templates, while target_unicharset size is %" PRIu32 "\n",
         Templates->NumClasses, unicharset_size);
   }
@@ -1185,7 +1185,7 @@ CLASS_ID Classify::GetClassToDebug(const char *Prompt, bool *adaptive_on, bool *
           }
           tprintf("Shape index '%s' not found in shape table\n", ev->parameter);
         } else {
-          tprintf("No shape table loaded!\n");
+          tprintf("WARNING: No shape table loaded!\n");
         }
       } else {
         if (unicharset.contains_unichar(ev->parameter)) {
@@ -1211,7 +1211,7 @@ CLASS_ID Classify::GetClassToDebug(const char *Prompt, bool *adaptive_on, bool *
             }
           }
         } else {
-          tprintf("Char class '%s' not found in unicharset", ev->parameter);
+          tprintf("ERROR: Char class '%s' not found in unicharset", ev->parameter);
         }
       }
     }

--- a/src/classify/normmatch.cpp
+++ b/src/classify/normmatch.cpp
@@ -201,7 +201,7 @@ NORM_PROTOS *Classify::ReadNormProtos(TFile *fp) {
       }
       NormProtos->Protos[unichar_id] = Protos;
     } else {
-      tprintf("Error: unichar %s in normproto file is not in unichar set.\n", unichar);
+      tprintf("ERROR: unichar %s in normproto file is not in unichar set.\n", unichar);
       for (int i = 0; i < NumProtos; i++) {
         FreePrototype(ReadPrototype(fp, NormProtos->NumParams));
       }

--- a/src/classify/trainingsample.cpp
+++ b/src/classify/trainingsample.cpp
@@ -239,7 +239,7 @@ void TrainingSample::ExtractCharDesc(int int_feature_type, int micro_type, int c
   delete[] features_;
   FEATURE_SET_STRUCT *char_features = char_desc->FeatureSets[int_feature_type];
   if (char_features == nullptr) {
-    tprintf("Error: no features to train on of type %s\n", kIntFeatureType);
+    tprintf("ERROR: No features to train on of type %s\n", kIntFeatureType);
     num_features_ = 0;
     features_ = nullptr;
   } else {
@@ -256,7 +256,7 @@ void TrainingSample::ExtractCharDesc(int int_feature_type, int micro_type, int c
   delete[] micro_features_;
   char_features = char_desc->FeatureSets[micro_type];
   if (char_features == nullptr) {
-    tprintf("Error: no features to train on of type %s\n", kMicroFeatureType);
+    tprintf("ERROR: No features to train on of type %s\n", kMicroFeatureType);
     num_micro_features_ = 0;
     micro_features_ = nullptr;
   } else {
@@ -271,7 +271,7 @@ void TrainingSample::ExtractCharDesc(int int_feature_type, int micro_type, int c
   // Extract the CN feature.
   char_features = char_desc->FeatureSets[cn_type];
   if (char_features == nullptr) {
-    tprintf("Error: no CN feature to train on.\n");
+    tprintf("ERROR: No CN feature to train on.\n");
   } else {
     ASSERT_HOST(char_features->NumFeatures == 1);
     cn_feature_[CharNormY] = char_features->Features[0]->Params[CharNormY];
@@ -282,7 +282,7 @@ void TrainingSample::ExtractCharDesc(int int_feature_type, int micro_type, int c
   // Extract the Geo feature.
   char_features = char_desc->FeatureSets[geo_type];
   if (char_features == nullptr) {
-    tprintf("Error: no Geo feature to train on.\n");
+    tprintf("ERROR: No Geo feature to train on.\n");
   } else {
     ASSERT_HOST(char_features->NumFeatures == 1);
     geo_feature_[GeoBottom] = char_features->Features[0]->Params[GeoBottom];

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -78,7 +78,7 @@ int Dawg::check_for_words(const char *filename, const UNICHARSET &unicharset,
 
   word_file = fopen(filename, "r");
   if (word_file == nullptr) {
-    tprintf("Error: Could not open file %s\n", filename);
+    tprintf("ERROR: Could not open file %s\n", filename);
     ASSERT_HOST(word_file);
   }
 
@@ -88,11 +88,11 @@ int Dawg::check_for_words(const char *filename, const UNICHARSET &unicharset,
     if (word.length() > 0 && !word.contains_unichar_id(INVALID_UNICHAR_ID)) {
       if (!match_words(&word, 0, 0,
                        enable_wildcard ? wildcard : INVALID_UNICHAR_ID)) {
-        tprintf("Missing word: %s\n", string);
+        tprintf("WARNING: Missing word: %s\n", string);
         ++misses;
       }
     } else {
-      tprintf("Failed to create a valid word from %s\n", string);
+      tprintf("ERROR: Failed to create a valid word from %s\n", string);
     }
   }
   fclose(word_file);
@@ -322,7 +322,7 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
     return false;
   }
   if (magic != kDawgMagicNumber) {
-    tprintf("Bad magic number on dawg: %d vs %d\n", magic, kDawgMagicNumber);
+    tprintf("ERROR: Bad magic number on dawg: %d vs %d\n", magic, kDawgMagicNumber);
     return false;
   }
 

--- a/src/dict/dict.cpp
+++ b/src/dict/dict.cpp
@@ -253,7 +253,7 @@ void Dict::Load(const std::string &lang, TessdataManager *data_file) {
     }
     if (!trie_ptr->read_and_add_word_list(name.c_str(), getUnicharset(),
                                           Trie::RRP_REVERSE_IF_HAS_RTL)) {
-      tprintf("Error: failed to load %s\n", name.c_str());
+      tprintf("ERROR: Failed to load %s\n", name.c_str());
       delete trie_ptr;
     } else {
       dawgs_.push_back(trie_ptr);
@@ -271,7 +271,7 @@ void Dict::Load(const std::string &lang, TessdataManager *data_file) {
       name += user_patterns_suffix;
     }
     if (!trie_ptr->read_pattern_list(name.c_str(), getUnicharset())) {
-      tprintf("Error: failed to load %s\n", name.c_str());
+      tprintf("ERROR: Failed to load %s\n", name.c_str());
       delete trie_ptr;
     } else {
       dawgs_.push_back(trie_ptr);
@@ -326,7 +326,7 @@ void Dict::LoadLSTM(const std::string &lang, TessdataManager *data_file) {
     }
     if (!trie_ptr->read_and_add_word_list(name.c_str(), getUnicharset(),
                                           Trie::RRP_REVERSE_IF_HAS_RTL)) {
-      tprintf("Error: failed to load %s\n", name.c_str());
+      tprintf("ERROR: Failed to load %s\n", name.c_str());
       delete trie_ptr;
     } else {
       dawgs_.push_back(trie_ptr);
@@ -344,7 +344,7 @@ void Dict::LoadLSTM(const std::string &lang, TessdataManager *data_file) {
       name += user_patterns_suffix;
     }
     if (!trie_ptr->read_pattern_list(name.c_str(), getUnicharset())) {
-      tprintf("Error: failed to load %s\n", name.c_str());
+      tprintf("ERROR: Failed to load %s\n", name.c_str());
       delete trie_ptr;
     } else {
       dawgs_.push_back(trie_ptr);
@@ -698,7 +698,7 @@ void Dict::add_document_word(const WERD_CHOICE &best_choice) {
     filename += ".doc";
     FILE *doc_word_file = fopen(filename.c_str(), "a");
     if (doc_word_file == nullptr) {
-      tprintf("Error: Could not open file %s\n", filename.c_str());
+      tprintf("ERROR: Could not open file %s\n", filename.c_str());
       ASSERT_HOST(doc_word_file);
     }
     fprintf(doc_word_file, "%s\n", best_choice.debug_string().c_str());

--- a/src/dict/permdawg.cpp
+++ b/src/dict/permdawg.cpp
@@ -59,7 +59,7 @@ void Dict::go_deeper_dawg_fxn(const char *debug, const BLOB_CHOICE_LIST_VECTOR &
   bool checked_unigrams = false;
   if (getUnicharset().get_isngram(orig_uch_id)) {
     if (dawg_debug_level) {
-      tprintf("checking unigrams in an ngram %s\n", getUnicharset().debug_str(orig_uch_id).c_str());
+      tprintf("Checking unigrams in an ngram %s\n", getUnicharset().debug_str(orig_uch_id).c_str());
     }
     int num_unigrams = 0;
     word->remove_last_unichar_id();
@@ -106,13 +106,13 @@ void Dict::go_deeper_dawg_fxn(const char *debug, const BLOB_CHOICE_LIST_VECTOR &
     // Add a new word choice
     if (word_ending) {
       if (dawg_debug_level) {
-        tprintf("found word = %s\n", word->debug_string().c_str());
+        tprintf("Found word = %s\n", word->debug_string().c_str());
       }
       if (strcmp(output_ambig_words_file.c_str(), "") != 0) {
         if (output_ambig_words_file_ == nullptr) {
           output_ambig_words_file_ = fopen(output_ambig_words_file.c_str(), "wb+");
           if (output_ambig_words_file_ == nullptr) {
-            tprintf("Failed to open output_ambig_words_file %s\n", output_ambig_words_file.c_str());
+            tprintf("ERROR: Failed to open output_ambig_words_file %s\n", output_ambig_words_file.c_str());
             exit(1);
           }
           std::string word_str;
@@ -142,7 +142,7 @@ void Dict::go_deeper_dawg_fxn(const char *debug, const BLOB_CHOICE_LIST_VECTOR &
     }
   } else {
     if (dawg_debug_level) {
-      tprintf("last unichar not OK at index %d in %s\n", word_index, word->debug_string().c_str());
+      tprintf("Last unichar not OK at index %d in %s\n", word_index, word->debug_string().c_str());
     }
   }
 }
@@ -311,7 +311,7 @@ bool Dict::fragment_state_okay(UNICHAR_ID curr_unichar_id, float curr_rating, fl
   char_frag_info->num_fragments = 1;
   if (prev_fragment && !this_fragment) {
     if (debug) {
-      tprintf("Skip choice with incomplete fragment\n");
+      tprintf("WARNING: Skip choice with incomplete fragment\n");
     }
     return false;
   }
@@ -349,7 +349,7 @@ bool Dict::fragment_state_okay(UNICHAR_ID curr_unichar_id, float curr_rating, fl
         }
       } else {
         if (debug) {
-          tprintf("Non-starting fragment piece with no prev_fragment\n");
+          tprintf("WARNING: Non-starting fragment piece with no prev_fragment\n");
         }
         return false;
       }
@@ -357,7 +357,7 @@ bool Dict::fragment_state_okay(UNICHAR_ID curr_unichar_id, float curr_rating, fl
   }
   if (word_ending && char_frag_info->fragment) {
     if (debug) {
-      tprintf("Word cannot end with a fragment\n");
+      tprintf("WARNING: Word cannot end with a fragment\n");
     }
     return false;
   }

--- a/src/dict/stopper.cpp
+++ b/src/dict/stopper.cpp
@@ -224,7 +224,7 @@ bool Dict::NoDangerousAmbig(WERD_CHOICE *best_choice, DANGERR *fixpt, bool fix_r
           UnicharIdArrayUtils::print(wrong_ngram, getUnicharset());
           tprintf("current ngram from spec: ");
           UnicharIdArrayUtils::print(ambig_spec->wrong_ngram, getUnicharset());
-          tprintf("comparison result: %d\n", compare);
+          tprintf("Comparison result: %d\n", compare);
         }
         if (compare == 0) {
           // Record the place where we found an ambiguity.
@@ -242,7 +242,7 @@ bool Dict::NoDangerousAmbig(WERD_CHOICE *best_choice, DANGERR *fixpt, bool fix_r
 
           if (replace) {
             if (stopper_debug_level > 2) {
-              tprintf("replace ambiguity with %s : ",
+              tprintf("Replace ambiguity with %s : ",
                       getUnicharset().id_to_unichar(ambig_spec->correct_ngram_id));
               UnicharIdArrayUtils::print(ambig_spec->correct_fragments, getUnicharset());
             }

--- a/src/dict/trie.cpp
+++ b/src/dict/trie.cpp
@@ -196,7 +196,7 @@ bool Trie::add_word_to_dawg(const WERD_CHOICE &word, const std::vector<bool> *re
       found = edge_char_of(last_node, NO_EDGE, FORWARD_EDGE, word_end, unichar_id, &edge_ptr,
                            &edge_index);
       if (found && debug_level_ > 1) {
-        tprintf("exploring edge " REFFORMAT " in node " REFFORMAT "\n", edge_index, last_node);
+        tprintf("Exploring edge " REFFORMAT " in node " REFFORMAT "\n", edge_index, last_node);
       }
       if (!found) {
         still_finding_chars = false;
@@ -222,7 +222,7 @@ bool Trie::add_word_to_dawg(const WERD_CHOICE &word, const std::vector<bool> *re
     if (!still_finding_chars) {
       the_next_node = new_dawg_node();
       if (debug_level_ > 1) {
-        tprintf("adding node " REFFORMAT "\n", the_next_node);
+        tprintf("Adding node " REFFORMAT "\n", the_next_node);
       }
       if (the_next_node == 0) {
         add_failed = true;
@@ -321,7 +321,7 @@ bool Trie::add_word_list(const std::vector<std::string> &words, const UNICHARSET
     if (!word_in_dawg(word)) {
       add_word_to_dawg(word);
       if (!word_in_dawg(word)) {
-        tprintf("Error: word '%s' not in DAWG after adding it\n", i.c_str());
+        tprintf("ERROR: Word '%s' not in DAWG after adding it\n", i.c_str());
         return false;
       }
     }
@@ -389,13 +389,13 @@ UNICHAR_ID Trie::character_class_to_pattern(char ch) {
 
 bool Trie::read_pattern_list(const char *filename, const UNICHARSET &unicharset) {
   if (!initialized_patterns_) {
-    tprintf("please call initialize_patterns() before read_pattern_list()\n");
+    tprintf("WARNING: Please call initialize_patterns() before read_pattern_list()\n");
     return false;
   }
 
   FILE *pattern_file = fopen(filename, "rb");
   if (pattern_file == nullptr) {
-    tprintf("Error opening pattern file %s\n", filename);
+    tprintf("ERROR: Error opening pattern file %s\n", filename);
     return false;
   }
 
@@ -420,7 +420,7 @@ bool Trie::read_pattern_list(const char *filename, const UNICHARSET &unicharset)
 #if 0 // TODO: This code should be enabled if kSaneNumConcreteChars != 0.
           if (word.length() < kSaneNumConcreteChars) {
             tprintf(
-                "Please provide at least %d concrete characters at the"
+                "ERROR: Please provide at least %d concrete characters at the"
                 " beginning of the pattern\n",
                 kSaneNumConcreteChars);
             failed = true;
@@ -449,7 +449,7 @@ bool Trie::read_pattern_list(const char *filename, const UNICHARSET &unicharset)
       }
     }
     if (failed) {
-      tprintf("Invalid user pattern %s\n", string);
+      tprintf("ERROR: Invalid user pattern %s\n", string);
       continue;
     }
     // Insert the pattern into the trie.
@@ -459,7 +459,7 @@ bool Trie::read_pattern_list(const char *filename, const UNICHARSET &unicharset)
     if (!this->word_in_dawg(word)) {
       this->add_word_to_dawg(word, &repetitions_vec);
       if (!this->word_in_dawg(word)) {
-        tprintf("Error: failed to insert pattern '%s'\n", string);
+        tprintf("ERROR: Failed to insert pattern '%s'\n", string);
       }
     }
     ++pattern_count;
@@ -477,7 +477,7 @@ void Trie::remove_edge_linkage(NODE_REF node1, NODE_REF node2, int direction, bo
   EDGE_INDEX edge_index = 0;
   ASSERT_HOST(edge_char_of(node1, node2, direction, word_end, unichar_id, &edge_ptr, &edge_index));
   if (debug_level_ > 1) {
-    tprintf("removed edge in nodes_[" REFFORMAT "]: ", node1);
+    tprintf("Removed edge in nodes_[" REFFORMAT "]: ", node1);
     print_edge_rec(*edge_ptr);
     tprintf("\n");
   }
@@ -585,7 +585,7 @@ bool Trie::eliminate_redundant_edges(NODE_REF node, const EDGE_RECORD &edge1,
   int next_node2_num_edges =
       (next_node2_ptr->forward_edges.size() + next_node2_ptr->backward_edges.size());
   if (debug_level_ > 1) {
-    tprintf("removed %d edges from node " REFFORMAT "\n", next_node2_num_edges, next_node2);
+    tprintf("Removed %d edges from node " REFFORMAT "\n", next_node2_num_edges, next_node2);
   }
   next_node2_ptr->forward_edges.clear();
   next_node2_ptr->backward_edges.clear();

--- a/src/lstm/input.cpp
+++ b/src/lstm/input.cpp
@@ -70,7 +70,7 @@ void Input::Forward(bool debug, const NetworkIO &input, const TransposedArray *i
 // See NetworkCpp for a detailed discussion of the arguments.
 bool Input::Backward(bool debug, const NetworkIO &fwd_deltas, NetworkScratch *scratch,
                      NetworkIO *back_deltas) {
-  tprintf("Input::Backward should not be called!!\n");
+  tprintf("ERROR: Input::Backward should not be called!!\n");
   return false;
 }
 
@@ -86,11 +86,11 @@ Image Input::PrepareLSTMInputs(const ImageData &image_data, const Network *netwo
   Image pix =
       image_data.PreScale(target_height, kMaxInputHeight, image_scale, &width, &height, nullptr);
   if (pix == nullptr) {
-    tprintf("Bad pix from ImageData!\n");
+    tprintf("ERROR: Bad pix from ImageData!\n");
     return nullptr;
   }
   if (width < min_width || height < min_width) {
-    tprintf("Image too small to scale!! (%dx%d vs min width of %d)\n", width, height, min_width);
+    tprintf("ERROR: Image too small to scale!! (%dx%d vs min width of %d)\n", width, height, min_width);
     pix.destroy();
     return nullptr;
   }

--- a/src/lstm/lstm.cpp
+++ b/src/lstm/lstm.cpp
@@ -117,7 +117,7 @@ LSTM::LSTM(const std::string &name, int ni, int ns, int no, bool two_dimensional
     nf_ = type_ == NT_LSTM_SOFTMAX ? no_ : ceil_log2(no_);
     softmax_ = new FullyConnected("LSTM Softmax", ns_, no_, NT_SOFTMAX);
   } else {
-    tprintf("%d is invalid type of LSTM!\n", type);
+    tprintf("ERROR: %d is invalid type of LSTM!\n", type);
     ASSERT_HOST(false);
   }
   na_ += nf_;

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -203,7 +203,7 @@ bool LSTMRecognizer::LoadRecoder(TFile *fp) {
     RecodedCharID code;
     recoder_.EncodeUnichar(UNICHAR_SPACE, &code);
     if (code(0) != UNICHAR_SPACE) {
-      tprintf("Space was garbled in recoding!!\n");
+      tprintf("ERROR: Space was garbled in recoding!!\n");
       return false;
     }
   } else {
@@ -235,7 +235,7 @@ bool LSTMRecognizer::LoadDictionary(const ParamsVectors *params, const std::stri
     return true; // Success.
   }
   if (log_level <= 0) {
-    tprintf("Failed to load any lstm-specific dictionaries for lang %s!!\n", lang.c_str());
+    tprintf("ERROR: Failed to load any lstm-specific dictionaries for lang %s!!\n", lang.c_str());
   }
   delete dict_;
   dict_ = nullptr;
@@ -327,13 +327,13 @@ bool LSTMRecognizer::RecognizeLine(const ImageData &image_data,
   int min_width = network_->XScaleFactor();
   Image pix = Input::PrepareLSTMInputs(image_data, network_, min_width, &randomizer_, scale_factor);
   if (pix == nullptr) {
-    tprintf("Line cannot be recognized!!\n");
+    tprintf("ERROR: Line cannot be recognized!!\n");
     return false;
   }
   // Maximum width of image to train on.
   const int kMaxImageWidth = 128 * pixGetHeight(pix);
   if (network_->IsTraining() && pixGetWidth(pix) > kMaxImageWidth) {
-    tprintf("Image too large to learn!! Size = %dx%d\n", pixGetWidth(pix), pixGetHeight(pix));
+    tprintf("ERROR: Image too large to learn!! Size = %dx%d\n", pixGetWidth(pix), pixGetHeight(pix));
     pix.destroy();
     return false;
   }

--- a/src/lstm/network.cpp
+++ b/src/lstm/network.cpp
@@ -204,7 +204,7 @@ static NetworkType getNetworkType(TFile *fp) {
     for (data = 0; data < NT_COUNT && type_name != kTypeNames[data]; ++data) {
     }
     if (data == NT_COUNT) {
-      tprintf("Invalid network layer type:%s\n", type_name.c_str());
+      tprintf("ERROR: Invalid network layer type:%s\n", type_name.c_str());
       return NT_NONE;
     }
   }
@@ -290,7 +290,7 @@ Network *Network::CreateFromFile(TFile *fp) {
 #ifdef INCLUDE_TENSORFLOW
       network = new TFNetwork(name.c_str());
 #else
-      tprintf("TensorFlow not compiled in! -DINCLUDE_TENSORFLOW\n");
+      tprintf("WARNING: TensorFlow not compiled in! -DINCLUDE_TENSORFLOW\n");
 #endif
       break;
     // All variants of FullyConnected.

--- a/src/lstm/series.cpp
+++ b/src/lstm/series.cpp
@@ -164,7 +164,7 @@ void Series::SplitAt(unsigned last_start, Series **start, Series **end) {
   *start = nullptr;
   *end = nullptr;
   if (last_start >= stack_.size()) {
-    tprintf("Invalid split index %u must be in range [0,%zu]!\n", last_start, stack_.size() - 1);
+    tprintf("ERROR: Invalid split index %u must be in range [0,%zu]!\n", last_start, stack_.size() - 1);
     return;
   }
   auto *master_series = new Series("MasterSeries");

--- a/src/lstm/tfnetwork.cpp
+++ b/src/lstm/tfnetwork.cpp
@@ -103,7 +103,7 @@ void TFNetwork::Forward(bool debug, const NetworkIO &input, const TransposedArra
   std::vector<Tensor> outputs;
   Status s = session_->Run(tf_inputs, target_layers, {}, &outputs);
   if (!s.ok())
-    tprintf("session->Run failed:%s\n", s.error_message().c_str());
+    tprintf("ERROR: session->Run failed:%s\n", s.error_message().c_str());
   ASSERT_HOST(s.ok());
   ASSERT_HOST(outputs.size() == 1);
   const Tensor &output_tensor = outputs[0];

--- a/src/opencl/openclwrapper.cpp
+++ b/src/opencl/openclwrapper.cpp
@@ -645,11 +645,11 @@ static Image mapOutputCLBuffer(const KernelEnv &rEnv, cl_mem clbuffer, Image pix
   if (!pixd) {
     if (memcopy) {
       if ((pixd = pixCreateTemplate(pixs)) == nullptr)
-        tprintf("pixd not made\n");
+        tprintf("ERROR: pixd not made.\n");
     } else {
       if ((pixd = pixCreateHeader(pixGetWidth(pixs), pixGetHeight(pixs), pixGetDepth(pixs))) ==
           nullptr)
-        tprintf("pixd not made\n");
+        tprintf("ERROR: pixd not made.\n");
     }
   }
   l_uint32 *pValues =
@@ -999,7 +999,7 @@ int OpenclDevice::CompileKernelFile(GPUEnv *gpuInfo, const char *buildOption) {
                               nullptr, nullptr);
   }
   if (clStatus != CL_SUCCESS) {
-    tprintf("BuildProgram error!\n");
+    tprintf("ERROR: BuildProgram error!\n");
     size_t length;
     if (!gpuInfo->mnIsUserCreated) {
       clStatus = clGetProgramBuildInfo(gpuInfo->mpArryPrograms[idx], gpuInfo->mpArryDevsID[0],
@@ -1009,7 +1009,7 @@ int OpenclDevice::CompileKernelFile(GPUEnv *gpuInfo, const char *buildOption) {
                                        CL_PROGRAM_BUILD_LOG, 0, nullptr, &length);
     }
     if (clStatus != CL_SUCCESS) {
-      tprintf("opencl create build log fail\n");
+      tprintf("ERROR: opencl create build log fail.\n");
       return 0;
     }
     std::vector<char> buildLog(length);
@@ -1021,7 +1021,7 @@ int OpenclDevice::CompileKernelFile(GPUEnv *gpuInfo, const char *buildOption) {
                                        CL_PROGRAM_BUILD_LOG, length, &buildLog[0], &length);
     }
     if (clStatus != CL_SUCCESS) {
-      tprintf("opencl program build info fail\n");
+      tprintf("ERROR: opencl program build info fail.\n");
       return 0;
     }
 

--- a/src/tesseract.cpp
+++ b/src/tesseract.cpp
@@ -368,7 +368,7 @@ static void FixPageSegMode(tesseract::TessBaseAPI &api, tesseract::PageSegMode p
 
 static bool checkArgValues(int arg, const char *mode, int count) {
   if (arg >= count || arg < 0) {
-    trintf("ERROR: Invalid %s value, please enter a number between 0-%d\n", mode, count - 1);
+    tprintf("ERROR: Invalid %s value, please enter a number between 0-%d\n", mode, count - 1);
     return false;
   }
   return true;

--- a/src/tesseract.cpp
+++ b/src/tesseract.cpp
@@ -61,7 +61,10 @@
 
 static void Win32ErrorHandler(const char *module, const char *fmt, va_list ap) {
   if (module != nullptr) {
-    fprintf(stderr, "%s: ", module);
+    fprintf(stderr, "ERROR: %s: ", module);
+  }
+  else {
+    fprintf(stderr, "ERROR: ");
   }
   vfprintf(stderr, fmt, ap);
   fprintf(stderr, ".\n");
@@ -69,7 +72,10 @@ static void Win32ErrorHandler(const char *module, const char *fmt, va_list ap) {
 
 static void Win32WarningHandler(const char *module, const char *fmt, va_list ap) {
   if (module != nullptr) {
-    fprintf(stderr, "%s: ", module);
+    fprintf(stderr, "WARNING: %s: ", module);
+  }
+  else {
+    fprintf(stderr, "WARNING: ");
   }
   fprintf(stderr, "Warning, ");
   vfprintf(stderr, fmt, ap);
@@ -312,7 +318,7 @@ static bool SetVariablesFromCLArgs(tesseract::TessBaseAPI &api, int argc, char *
       opt1[255] = '\0';
       char *p = strchr(opt1, '=');
       if (!p) {
-        fprintf(stderr, "Missing = in configvar assignment\n");
+        tprintf("ERROR: Missing '=' in configvar assignment for '%s'\n", opt1);
         success = false;
         break;
       }
@@ -322,7 +328,7 @@ static bool SetVariablesFromCLArgs(tesseract::TessBaseAPI &api, int argc, char *
       ++i;
 
       if (!api.SetVariable(opt1, opt2)) {
-        fprintf(stderr, "Could not set option: %s=%s\n", opt1, opt2);
+        tprintf("ERROR: Could not set option: %s=%s\n", opt1, opt2);
       }
     }
   }
@@ -362,7 +368,7 @@ static void FixPageSegMode(tesseract::TessBaseAPI &api, tesseract::PageSegMode p
 
 static bool checkArgValues(int arg, const char *mode, int count) {
   if (arg >= count || arg < 0) {
-    printf("Invalid %s value, please enter a number between 0-%d\n", mode, count - 1);
+    trintf("ERROR: Invalid %s value, please enter a number between 0-%d\n", mode, count - 1);
     return false;
   }
   return true;
@@ -425,7 +431,7 @@ static bool ParseArgs(int argc, char **argv, const char **lang, const char **ima
         log_level = loglevel;
       } catch (const std::out_of_range &e) {
         // TODO: Allow numeric argument?
-        tprintf("Error, unsupported --loglevel %s\n", loglevel_string.c_str());
+        tprintf("ERROR: Unsupported --loglevel %s\n", loglevel_string.c_str());
         return false;
       }
     } else if (strcmp(argv[i], "--user-words") == 0 && i + 1 < argc) {
@@ -469,7 +475,7 @@ static bool ParseArgs(int argc, char **argv, const char **lang, const char **ima
       *image = argv[i];
     } else {
       // Unexpected argument.
-      fprintf(stderr, "Error, unknown command line argument '%s'\n", argv[i]);
+      tprintf("ERROR: Unknown command line argument '%s'\n", argv[i]);
       return false;
     }
   }
@@ -481,7 +487,7 @@ static bool ParseArgs(int argc, char **argv, const char **lang, const char **ima
     if (*lang != nullptr && strcmp(*lang, "osd")) {
       // If the user explicitly specifies a language (other than osd)
       // or a script, only orientation can be detected.
-      fprintf(stderr, "Warning, detects only orientation with -l %s\n", *lang);
+      tprintf("WARNING: Detects only orientation with -l %s\n", *lang);
     } else {
       // That mode requires osd.traineddata to detect orientation and script.
       *lang = "osd";
@@ -514,7 +520,7 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {
-        tprintf("Error, could not create hOCR output file: %s\n", strerror(errno));
+        tprintf("ERROR: Could not create hOCR output file: %s\n", strerror(errno));
         error = true;
       }
     }
@@ -525,7 +531,7 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {
-        tprintf("Error, could not create ALTO output file: %s\n", strerror(errno));
+        tprintf("ERROR: Could not create ALTO output file: %s\n", strerror(errno));
         error = true;
       }
     }
@@ -538,16 +544,16 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {
-        tprintf("Error, could not create TSV output file: %s\n", strerror(errno));
+        tprintf("ERROR: Could not create TSV output file: %s\n", strerror(errno));
         error = true;
       }
     }
 
     api.GetBoolVariable("tessedit_create_pdf", &b);
     if (b) {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32) || defined(_WIN64)
       if (_setmode(_fileno(stdout), _O_BINARY) == -1)
-        tprintf("ERROR: cin to binary: %s", strerror(errno));
+        tprintf("ERROR: Cannot set STDIN to binary: %s", strerror(errno));
 #endif // WIN32
       bool textonly;
       api.GetBoolVariable("textonly_pdf", &textonly);
@@ -555,7 +561,7 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {
-        tprintf("Error, could not create PDF output file: %s\n", strerror(errno));
+        tprintf("ERROR: Could not create PDF output file: %s\n", strerror(errno));
         error = true;
       }
     }
@@ -567,7 +573,7 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {
-        tprintf("Error, could not create UNLV output file: %s\n", strerror(errno));
+        tprintf("ERROR: Could not create UNLV output file: %s\n", strerror(errno));
         error = true;
       }
     }
@@ -578,7 +584,7 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {
-        tprintf("Error, could not create LSTM BOX output file: %s\n", strerror(errno));
+        tprintf("ERROR: Could not create LSTM BOX output file: %s\n", strerror(errno));
         error = true;
       }
     }
@@ -589,7 +595,7 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {
-        tprintf("Error, could not create BOX output file: %s\n", strerror(errno));
+        tprintf("ERROR: Could not create BOX output file: %s\n", strerror(errno));
         error = true;
       }
     }
@@ -600,7 +606,7 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {
-        tprintf("Error, could not create WordStr BOX output file: %s\n", strerror(errno));
+        tprintf("ERROR: Could not create WordStr BOX output file: %s\n", strerror(errno));
         error = true;
       }
     }
@@ -614,7 +620,7 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {
-        tprintf("Error, could not create TXT output file: %s\n", strerror(errno));
+        tprintf("ERROR: Could not create TXT output file: %s\n", strerror(errno));
       }
     }
   }
@@ -716,7 +722,7 @@ int main(int argc, char **argv) {
   }
 
   if (init_failed) {
-    fprintf(stderr, "Could not initialize tesseract.\n");
+    tprintf("ERROR: Could not initialize tesseract.\n");
     return EXIT_FAILURE;
   }
 
@@ -750,7 +756,7 @@ int main(int argc, char **argv) {
   if (pagesegmode == tesseract::PSM_AUTO_ONLY) {
     Pix *pixs = pixRead(image);
     if (!pixs) {
-      fprintf(stderr, "Leptonica can't process input file: %s\n", image);
+      tprintf("ERROR: Leptonica can't process input file: %s\n", image);
       return 2;
     }
 
@@ -794,18 +800,18 @@ int main(int argc, char **argv) {
     const char *disabled_osd_msg =
         "\nERROR: The page segmentation mode 0 (OSD Only) is currently "
         "disabled.\n\n";
-    fprintf(stderr, "%s", disabled_osd_msg);
+    tprintf("%s", disabled_osd_msg);
     return EXIT_FAILURE;
   } else if (cur_psm == tesseract::PSM_AUTO_OSD) {
     api.SetPageSegMode(tesseract::PSM_AUTO);
     osd_warning +=
-        "\nWarning: The page segmentation mode 1 (Auto+OSD) is currently "
+        "\nWARNING: The page segmentation mode 1 (Auto+OSD) is currently "
         "disabled. "
         "Using PSM 3 (Auto) instead.\n\n";
   } else if (cur_psm == tesseract::PSM_SPARSE_TEXT_OSD) {
     api.SetPageSegMode(tesseract::PSM_SPARSE_TEXT);
     osd_warning +=
-        "\nWarning: The page segmentation mode 12 (Sparse text + OSD) is "
+        "\nWARNING: The page segmentation mode 12 (Sparse text + OSD) is "
         "currently disabled. "
         "Using PSM 11 (Sparse text) instead.\n\n";
   }
@@ -822,12 +828,12 @@ int main(int argc, char **argv) {
   if (!renderers.empty()) {
 #ifdef DISABLED_LEGACY_ENGINE
     if (!osd_warning.empty()) {
-      fprintf(stderr, "%s", osd_warning.c_str());
+      tprintf("%s", osd_warning.c_str());
     }
 #endif
     bool succeed = api.ProcessPages(image, nullptr, 0, renderers[0].get());
     if (!succeed) {
-      fprintf(stderr, "Error during processing.\n");
+      tprintf("ERROR: Error during page processing.\n");
       ret_val = EXIT_FAILURE;
     }
   }

--- a/src/textord/alignedblob.cpp
+++ b/src/textord/alignedblob.cpp
@@ -302,11 +302,11 @@ TabVector *AlignedBlob::FindVerticalAlignment(AlignedBlobParams align_params, BL
       }
       return result;
     } else if (debug) {
-      tprintf("Ragged tab used too many used points: %d out of %d\n", confirmed_points, pt_count);
+      tprintf("WARNING: Ragged tab used too many used points: %d out of %d\n", confirmed_points, pt_count);
     }
   } else if (debug) {
     tprintf(
-        "Tab vector failed basic tests: pt count %d vs min %d, "
+        "WARNING: Tab vector failed basic tests: pt count %d vs min %d, "
         "length %d vs min %d, min grad %g\n",
         pt_count, align_params.min_points, end_y - start_y, align_params.min_length,
         abs(end_x - start_x) * kMinTabGradient);

--- a/src/textord/baselinedetect.cpp
+++ b/src/textord/baselinedetect.cpp
@@ -399,7 +399,7 @@ float BaselineRow::PerpDistanceFromBaseline(const FCOORD &pt) const {
   float distance = baseline_vector * offset_vector;
   float sqlength = baseline_vector.sqlength();
   if (sqlength == 0.0f) {
-    tprintf("unexpected baseline vector (0,0)\n");
+    tprintf("Unexpected baseline vector (0,0)\n");
     return 0.0f;
   }
   return std::sqrt(distance * distance / sqlength);

--- a/src/textord/cjkpitch.cpp
+++ b/src/textord/cjkpitch.cpp
@@ -1117,7 +1117,7 @@ void compute_fixed_pitch_cjk(ICOORD page_tr, TO_BLOCK_LIST *port_blocks) {
   // Early exit if the page doesn't seem to contain fixed pitch rows.
   if (!analyzer.maybe_fixed_pitch()) {
     if (textord_debug_pitch_test) {
-      tprintf("Page doesn't seem to contain fixed pitch rows\n");
+      tprintf("INFO: Page doesn't seem to contain fixed pitch rows\n");
     }
     return;
   }

--- a/src/textord/colfind.cpp
+++ b/src/textord/colfind.cpp
@@ -363,7 +363,7 @@ int ColumnFinder::FindBlocks(PageSegMode pageseg_mode, Image scaled_color, int s
 
     // Make the column_sets_.
     if (!MakeColumns(false)) {
-      tprintf("Empty page!!\n");
+      tprintf("WARNING: Empty page!!\n");
       part_grid_.DeleteParts();
       return 0; // This is an empty page.
     }

--- a/src/textord/colpartition.cpp
+++ b/src/textord/colpartition.cpp
@@ -364,7 +364,7 @@ void ColPartition::ReflectInYAxis() {
 bool ColPartition::IsLegal() {
   if (bounding_box_.left() > bounding_box_.right()) {
     if (textord_debug_bugs) {
-      tprintf("Bounding box invalid\n");
+      tprintf("ERROR: Bounding box invalid\n");
       Print();
     }
     return false; // Bounding box invalid.
@@ -372,7 +372,7 @@ bool ColPartition::IsLegal() {
   if (left_margin_ > bounding_box_.left() ||
       right_margin_ < bounding_box_.right()) {
     if (textord_debug_bugs) {
-      tprintf("Margins invalid\n");
+      tprintf("ERROR: Margins invalid\n");
       Print();
     }
     return false; // Margins invalid.
@@ -977,12 +977,12 @@ void ColPartition::ComputeLimits() {
   }
 
   if (right_margin_ < bounding_box_.right() && textord_debug_bugs) {
-    tprintf("Made partition with bad right coords, %d < %d\n", right_margin_,
+    tprintf("WARNING: Made partition with bad right coords, %d < %d\n", right_margin_,
             bounding_box_.right());
     Print();
   }
   if (left_margin_ > bounding_box_.left() && textord_debug_bugs) {
-    tprintf("Made partition with bad left coords, %d > %d\n", left_margin_,
+    tprintf("WARNING: Made partition with bad left coords, %d > %d\n", left_margin_,
             bounding_box_.left());
     Print();
   }

--- a/src/textord/colpartitiongrid.cpp
+++ b/src/textord/colpartitiongrid.cpp
@@ -217,7 +217,7 @@ static bool OKMergeCandidate(const ColPartition *part,
         !part->OKDiacriticMerge(*candidate, debug) &&
         !candidate->OKDiacriticMerge(*part, debug)) {
       if (debug) {
-        tprintf("Candidate fails overlap and diacritic tests!\n");
+        tprintf("WARNING: Candidate fails overlap and diacritic tests!\n");
       }
       return false;
     }

--- a/src/textord/drawtord.cpp
+++ b/src/textord/drawtord.cpp
@@ -97,7 +97,7 @@ void plot_to_row(             // draw a row
   float left, right; // end of row
 
   if (it.empty()) {
-    tprintf("No blobs in row at %g\n", row->parallel_c());
+    tprintf("ERROR: No blobs in row at %g\n", row->parallel_c());
     return;
   }
   left = it.data()->bounding_box().left();

--- a/src/textord/fpchop.cpp
+++ b/src/textord/fpchop.cpp
@@ -111,8 +111,8 @@ ROW *fixed_pitch_words( // find lines
     xstarts[0] = rep_left;
   }
   if (cell_it.empty() || row->char_cells.singleton()) {
-    tprintf("Row without enough char cells!\n");
-    tprintf("Leftmost blob is at (%d,%d)\n", box_it.data()->bounding_box().left(),
+    tprintf("WARNING: Row without enough char cells!\n"
+            "Leftmost blob is at (%d,%d)\n", box_it.data()->bounding_box().left(),
             box_it.data()->bounding_box().bottom());
     return nullptr;
   }

--- a/src/textord/makerow.cpp
+++ b/src/textord/makerow.cpp
@@ -1691,7 +1691,7 @@ void correct_row_xheight(TO_ROW *row, float xheight, float ascrise, float descdr
   ROW_CATEGORY row_category = get_row_category(row);
   if (textord_debug_xheights) {
     tprintf(
-        "correcting row xheight: row->xheight %.4f"
+        "Correcting row xheight: row->xheight %.4f"
         ", row->acrise %.4f row->descdrop %.4f\n",
         row->xheight, row->ascrise, row->descdrop);
   }
@@ -1712,7 +1712,7 @@ void correct_row_xheight(TO_ROW *row, float xheight, float ascrise, float descdr
              (row_category == ROW_DESCENDERS_FOUND && (normal_xheight || cap_xheight)) ||
              (row_category == ROW_UNKNOWN && normal_xheight)) {
     if (textord_debug_xheights) {
-      tprintf("using average xheight\n");
+      tprintf("Using average xheight\n");
     }
     row->xheight = xheight;
     row->ascrise = ascrise;
@@ -1753,7 +1753,7 @@ void correct_row_xheight(TO_ROW *row, float xheight, float ascrise, float descdr
   }
   if (textord_debug_xheights) {
     tprintf(
-        "corrected row->xheight = %.4f, row->acrise = %.4f, row->descdrop"
+        "Corrected row->xheight = %.4f, row->acrise = %.4f, row->descdrop"
         " = %.4f\n",
         row->xheight, row->ascrise, row->descdrop);
   }

--- a/src/textord/oldbasel.cpp
+++ b/src/textord/oldbasel.cpp
@@ -1487,7 +1487,7 @@ void make_first_xheight( // find xheight
     tprintf("Output xheight=%g\n", row->xheight);
   }
   if (row->xheight < 0 && textord_oldbl_debug) {
-    tprintf("warning: Row Line height < 0; %4.2f\n", row->xheight);
+    tprintf("WARNING: Row Line height < 0; %4.2f\n", row->xheight);
   }
 
   if (sign_bit < 0) {

--- a/src/textord/pitsync1.cpp
+++ b/src/textord/pitsync1.cpp
@@ -395,7 +395,7 @@ void make_illegal_segment(   // find segmentation
     segpt = new FPSEGPT(x, false, offset, region_index, pitch, pitch_error, prev_list);
     if (segpt->previous() != nullptr) {
       ASSERT_HOST(offset >= 0);
-      fprintf(stderr, "made fake at %d\n", x);
+      tprintf("Made fake at %d\n", x);
       // make one up
       segpt_it.add_after_then_move(segpt);
       segpt->faked = true;

--- a/src/textord/strokewidth.cpp
+++ b/src/textord/strokewidth.cpp
@@ -125,7 +125,8 @@ StrokeWidth::~StrokeWidth() {
   if (widths_win_ != nullptr) {
     widths_win_->AwaitEvent(SVET_DESTROY);
     if (textord_tabfind_only_strokewidths) {
-      exit(0);
+      assert(!"unexpected textord_tabfind_only_strokewidths. code damaged?");
+      exit(1);
     }
     delete widths_win_;
   }

--- a/src/textord/topitch.cpp
+++ b/src/textord/topitch.cpp
@@ -241,7 +241,7 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
       if (block_votes == 0 && like_votes == 0 && other_votes > 0 &&
           (textord_debug_pitch_test || textord_debug_pitch_metric)) {
         tprintf(
-            "Warning:row %d of block %d set prop with no like rows against "
+            "WARNING: Row %d of block %d set prop with no like rows against "
             "trend\n",
             row_target, block_target);
       }
@@ -258,7 +258,7 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
       } else if (block_votes == 0 && like_votes > 0) {
         bad_row->fixed_pitch = like_stats.ile(0.5);
       } else {
-        tprintf("Warning:guessing pitch as xheight on row %d, block %d\n", row_target,
+        tprintf("WARNING: Guessing pitch as xheight on row %d, block %d\n", row_target,
                 block_target);
         bad_row->fixed_pitch = bad_row->xheight;
       }

--- a/src/textord/tordmain.cpp
+++ b/src/textord/tordmain.cpp
@@ -212,7 +212,7 @@ void Textord::find_components(Image pix, BLOCK_LIST *blocks, TO_BLOCK_LIST *to_b
   int width = pixGetWidth(pix);
   int height = pixGetHeight(pix);
   if (width > INT16_MAX || height > INT16_MAX) {
-    tprintf("Input image too large! (%d, %d)\n", width, height);
+    tprintf("ERROR: Input image too large! (%d, %d)\n", width, height);
     return; // Can't handle it.
   }
 

--- a/src/training/ambiguous_words.cpp
+++ b/src/training/ambiguous_words.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
   tesseract::Dict &dict = api.tesseract()->getDict();
   FILE *input_file = fopen(input_file_str, "rb");
   if (input_file == nullptr) {
-    tesseract::tprintf("Failed to open input wordlist file %s\n", input_file_str);
+    tesseract::tprintf("ERROR: Failed to open input wordlist file %s\n", input_file_str);
     return EXIT_FAILURE;
   }
   char str[CHARS_PER_LINE];

--- a/src/training/classifier_tester.cpp
+++ b/src/training/classifier_tester.cpp
@@ -47,7 +47,7 @@ static tesseract::ShapeClassifier *InitializeClassifier(const char *classifer_na
     }
   }
   if (classifier == CN_COUNT) {
-    fprintf(stderr, "Invalid classifier name:%s\n", FLAGS_classifier.c_str());
+    tprintf("ERROR: Invalid classifier name: %s\n", FLAGS_classifier.c_str());
     return nullptr;
   }
 
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
   tesseract::ShapeClassifier *shape_classifier =
       InitializeClassifier(FLAGS_classifier.c_str(), trainer->unicharset(), argc, argv, &api);
   if (shape_classifier == nullptr) {
-    fprintf(stderr, "Classifier init failed!:%s\n", FLAGS_classifier.c_str());
+    tprintf("ERROR: Classifier init failed!: %s\n", FLAGS_classifier.c_str());
     return EXIT_FAILURE;
   }
 

--- a/src/training/cntraining.cpp
+++ b/src/training/cntraining.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[]) {
   ParseArguments(&argc, &argv);
   int num_fonts = 0;
   for (const char *PageName = *++argv; PageName != nullptr; PageName = *++argv) {
-    printf("Reading %s ...\n", PageName);
+    tprintf("Reading %s ...\n", PageName);
     FILE *TrainingPage = fopen(PageName, "rb");
     ASSERT_HOST(TrainingPage);
     if (TrainingPage) {
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
       ++num_fonts;
     }
   }
-  printf("Clustering ...\n");
+  tprintf("Clustering ...\n");
   // To allow an individual font to form a separate cluster,
   // reduce the min samples:
   // Config.MinSamples = 0.5 / num_fonts;
@@ -154,7 +154,7 @@ int main(int argc, char *argv[]) {
         break;
       } else {
         Config.MinSamples *= 0.95;
-        printf(
+        tprintf(
             "0 significant protos for %s."
             " Retrying clustering with MinSamples = %f%%\n",
             CharSample->Label.c_str(), Config.MinSamples);
@@ -172,7 +172,7 @@ int main(int argc, char *argv[]) {
   for (auto &freeable_proto : freeable_protos) {
     FreeProtoList(&freeable_proto);
   }
-  printf("\n");
+  tprintf("\n");
   return EXIT_SUCCESS;
 } // main
 
@@ -201,7 +201,7 @@ static void WriteNormProtos(const char *Directory, LIST LabeledProtoList,
     Filename += "/";
   }
   Filename += "normproto";
-  printf("\nWriting %s ...", Filename.c_str());
+  tprintf("\nWriting %s ...", Filename.c_str());
   File = fopen(Filename.c_str(), "wb");
   ASSERT_HOST(File);
   fprintf(File, "%0d\n", feature_desc->NumParams);
@@ -210,8 +210,8 @@ static void WriteNormProtos(const char *Directory, LIST LabeledProtoList,
     LabeledProto = reinterpret_cast<LABELEDLIST>(LabeledProtoList->first_node());
     N = NumberOfProtos(LabeledProto->List, true, false);
     if (N < 1) {
-      printf(
-          "\nError! Not enough protos for %s: %d protos"
+      tprintf(
+          "\nERROR: Not enough protos for %s: %d protos"
           " (%d significant protos"
           ", %d insignificant protos)\n",
           LabeledProto->Label.c_str(), N, NumberOfProtos(LabeledProto->List, true, false),

--- a/src/training/combine_lang_model.cpp
+++ b/src/training/combine_lang_model.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
   // Load the input unicharset
   UNICHARSET unicharset;
   if (!unicharset.load_from_file(FLAGS_input_unicharset.c_str(), false)) {
-    tprintf("Failed to load unicharset from %s\n", FLAGS_input_unicharset.c_str());
+    tprintf("ERROR: Failed to load unicharset from %s\n", FLAGS_input_unicharset.c_str());
     return EXIT_FAILURE;
   }
   tprintf("Loaded unicharset of size %zu from file %s\n", unicharset.size(),

--- a/src/training/combine_tessdata.cpp
+++ b/src/training/combine_tessdata.cpp
@@ -29,7 +29,7 @@ using namespace tesseract;
 static int list_components(TessdataManager &tm, const char *filename) {
   // Initialize TessdataManager with the data in the given traineddata file.
   if (filename != nullptr && !tm.Init(filename)) {
-    tprintf("Failed to read %s\n", filename);
+    tprintf("ERROR: Failed to read %s\n", filename);
     return EXIT_FAILURE;
   }
   tm.Directory();
@@ -38,14 +38,14 @@ static int list_components(TessdataManager &tm, const char *filename) {
 
 static int list_network(TessdataManager &tm, const char *filename) {
   if (filename != nullptr && !tm.Init(filename)) {
-    tprintf("Failed to read %s\n", filename);
+    tprintf("ERROR: Failed to read %s\n", filename);
     return EXIT_FAILURE;
   }
   tesseract::TFile fp;
   if (tm.GetComponent(tesseract::TESSDATA_LSTM, &fp)) {
     tesseract::LSTMRecognizer recognizer;
     if (!recognizer.DeSerialize(&tm, &fp)) {
-      tprintf("Failed to deserialize LSTM in %s!\n", filename);
+      tprintf("ERROR: Failed to deserialize LSTM in %s!\n", filename);
       return EXIT_FAILURE;
     }
     std::cout << "LSTM: network=" << recognizer.GetNetwork()
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
     printf("%s\n", tesseract::TessBaseAPI::Version());
     return EXIT_SUCCESS;
   } else if (argc == 2) {
-    printf("Combining tessdata files\n");
+    tprintf("Combining tessdata files\n");
     std::string lang = argv[1];
     char *last = &argv[1][strlen(argv[1]) - 1];
     if (*last != '.') {
@@ -132,31 +132,31 @@ int main(int argc, char **argv) {
     std::string output_file = lang;
     output_file += kTrainedDataSuffix;
     if (!tm.CombineDataFiles(lang.c_str(), output_file.c_str())) {
-      printf("Error combining tessdata files into %s\n", output_file.c_str());
+      tprintf("ERROR: Error combining tessdata files into %s\n", output_file.c_str());
     } else {
-      printf("Output %s created successfully.\n", output_file.c_str());
+      tprintf("Output %s created successfully.\n", output_file.c_str());
     }
   } else if (argc >= 4 &&
              (strcmp(argv[1], "-e") == 0 || strcmp(argv[1], "-u") == 0)) {
     // Initialize TessdataManager with the data in the given traineddata file.
     if (!tm.Init(argv[2])) {
-      tprintf("Failed to read %s\n", argv[2]);
+      tprintf("ERROR: Failed to read %s\n", argv[2]);
       return EXIT_FAILURE;
     }
-    printf("Extracting tessdata components from %s\n", argv[2]);
+    tprintf("Extracting tessdata components from %s\n", argv[2]);
     if (strcmp(argv[1], "-e") == 0) {
       for (i = 3; i < argc; ++i) {
         errno = 0;
         if (tm.ExtractToFile(argv[i])) {
-          printf("Wrote %s\n", argv[i]);
+          tprintf("Wrote %s\n", argv[i]);
         } else if (errno == 0) {
-          printf(
-              "Not extracting %s, since this component"
+          tprintf(
+              "ERROR: Not extracting %s, since this component"
               " is not present\n",
               argv[i]);
           return EXIT_FAILURE;
         } else {
-          printf("Error, could not extract %s: %s\n", argv[i], strerror(errno));
+          tprintf("ERROR: Could not extract %s: %s\n", argv[i], strerror(errno));
           return EXIT_FAILURE;
         }
       }
@@ -170,9 +170,9 @@ int main(int argc, char **argv) {
         filename += tesseract::kTessdataFileSuffixes[i];
         errno = 0;
         if (tm.ExtractToFile(filename.c_str())) {
-          printf("Wrote %s\n", filename.c_str());
+          tprintf("Wrote %s\n", filename.c_str());
         } else if (errno != 0) {
-          printf("Error, could not extract %s: %s\n", filename.c_str(),
+          tprintf("ERROR: Could not extract %s: %s\n", filename.c_str(),
                  strerror(errno));
           return EXIT_FAILURE;
         }
@@ -184,7 +184,7 @@ int main(int argc, char **argv) {
     std::string traineddata_filename = new_traineddata_filename;
     traineddata_filename += ".__tmp__";
     if (rename(new_traineddata_filename, traineddata_filename.c_str()) != 0) {
-      tprintf("Failed to create a temporary file %s\n",
+      tprintf("ERROR: Failed to create a temporary file %s\n",
               traineddata_filename.c_str());
       return EXIT_FAILURE;
     }
@@ -196,17 +196,17 @@ int main(int argc, char **argv) {
     tm.OverwriteComponents(new_traineddata_filename, argv + 3, argc - 3);
   } else if (argc == 3 && strcmp(argv[1], "-c") == 0) {
     if (!tm.Init(argv[2])) {
-      tprintf("Failed to read %s\n", argv[2]);
+      tprintf("ERROR: Failed to read %s\n", argv[2]);
       return EXIT_FAILURE;
     }
     tesseract::TFile fp;
     if (!tm.GetComponent(tesseract::TESSDATA_LSTM, &fp)) {
-      tprintf("No LSTM Component found in %s!\n", argv[2]);
+      tprintf("ERROR: No LSTM Component found in %s!\n", argv[2]);
       return EXIT_FAILURE;
     }
     tesseract::LSTMRecognizer recognizer;
     if (!recognizer.DeSerialize(&tm, &fp)) {
-      tprintf("Failed to deserialize LSTM in %s!\n", argv[2]);
+      tprintf("ERROR: Failed to deserialize LSTM in %s!\n", argv[2]);
       return EXIT_FAILURE;
     }
     recognizer.ConvertToInt();
@@ -216,7 +216,7 @@ int main(int argc, char **argv) {
     tm.OverwriteEntry(tesseract::TESSDATA_LSTM, &lstm_data[0],
                       lstm_data.size());
     if (!tm.SaveFile(argv[2], nullptr)) {
-      tprintf("Failed to write modified traineddata:%s!\n", argv[2]);
+      tprintf("ERROR: Failed to write modified traineddata:%s!\n", argv[2]);
       return EXIT_FAILURE;
     }
   } else if (argc == 3 && strcmp(argv[1], "-d") == 0) {
@@ -236,36 +236,36 @@ int main(int argc, char **argv) {
     }
     return result;
   } else {
-    printf(
+    tprintf(
         "Usage for combining tessdata components:\n"
         "  %s language_data_path_prefix\n"
         "  (e.g. %s tessdata/eng.)\n\n",
         argv[0], argv[0]);
-    printf(
+    tprintf(
         "Usage for extracting tessdata components:\n"
         "  %s -e traineddata_file [output_component_file...]\n"
         "  (e.g. %s -e eng.traineddata eng.unicharset)\n\n",
         argv[0], argv[0]);
-    printf(
+    tprintf(
         "Usage for overwriting tessdata components:\n"
         "  %s -o traineddata_file [input_component_file...]\n"
         "  (e.g. %s -o eng.traineddata eng.unicharset)\n\n",
         argv[0], argv[0]);
-    printf(
+    tprintf(
         "Usage for unpacking all tessdata components:\n"
         "  %s -u traineddata_file output_path_prefix\n"
         "  (e.g. %s -u eng.traineddata tmp/eng.)\n\n",
         argv[0], argv[0]);
-    printf(
+    tprintf(
         "Usage for listing the network information\n"
         "  %s -l traineddata_file\n"
         "  (e.g. %s -l eng.traineddata)\n\n",
         argv[0], argv[0]);
-    printf(
+    tprintf(
         "Usage for listing directory of components:\n"
         "  %s -d traineddata_file\n\n",
         argv[0]);
-    printf(
+    tprintf(
         "Usage for compacting LSTM component to int:\n"
         "  %s -c traineddata_file\n",
         argv[0]);

--- a/src/training/common/commandlineflags.cpp
+++ b/src/training/common/commandlineflags.cpp
@@ -132,7 +132,7 @@ static void PrintCommandLineFlags() {
   const int kFlagNamePrefixLen = strlen(kFlagNamePrefix);
   for (auto &param : GlobalParams()->int_params) {
     if (!strncmp(param->name_str(), kFlagNamePrefix, kFlagNamePrefixLen)) {
-      printf("  --%s  %s  (type:int default:%d)\n",
+      tprintf("  --%s  %s  (type:int default:%d)\n",
              param->name_str() + kFlagNamePrefixLen,
              param->info_str(), int32_t(*param));
     }
@@ -140,7 +140,7 @@ static void PrintCommandLineFlags() {
   for (auto &param : GlobalParams()->double_params) {
     if (!strncmp(param->name_str(), kFlagNamePrefix,
                  kFlagNamePrefixLen)) {
-      printf("  --%s  %s  (type:double default:%g)\n",
+      tprintf("  --%s  %s  (type:double default:%g)\n",
              param->name_str() + kFlagNamePrefixLen,
              param->info_str(),
              static_cast<double>(*param));
@@ -148,7 +148,7 @@ static void PrintCommandLineFlags() {
   }
   for (auto &param : GlobalParams()->bool_params) {
     if (!strncmp(param->name_str(), kFlagNamePrefix, kFlagNamePrefixLen)) {
-      printf("  --%s  %s  (type:bool default:%s)\n",
+      tprintf("  --%s  %s  (type:bool default:%s)\n",
              param->name_str() + kFlagNamePrefixLen,
              param->info_str(),
              bool(*param) ? "true" : "false");
@@ -157,7 +157,7 @@ static void PrintCommandLineFlags() {
   for (auto &param : GlobalParams()->string_params) {
     if (!strncmp(param->name_str(), kFlagNamePrefix,
                  kFlagNamePrefixLen)) {
-      printf("  --%s  %s  (type:string default:%s)\n",
+      tprintf("  --%s  %s  (type:string default:%s)\n",
              param->name_str() + kFlagNamePrefixLen,
              param->info_str(),
              param->c_str());
@@ -167,13 +167,13 @@ static void PrintCommandLineFlags() {
 
 void ParseCommandLineFlags(const char *usage, int *argc, char ***argv, const bool remove_flags) {
   if (*argc == 1) {
-    printf("USAGE: %s\n", usage);
+    tprintf("USAGE: %s\n", usage);
     PrintCommandLineFlags();
     exit(0);
   }
 
   if (*argc > 1 && (!strcmp((*argv)[1], "-v") || !strcmp((*argv)[1], "--version"))) {
-    printf("%s\n", TessBaseAPI::Version());
+    tprintf("%s\n", TessBaseAPI::Version());
     exit(0);
   }
 
@@ -192,7 +192,7 @@ void ParseCommandLineFlags(const char *usage, int *argc, char ***argv, const boo
     }
     // If this is asking for usage, print the help message and abort.
     if (!strcmp(current_arg, "help")) {
-      printf("Usage:\n  %s [OPTION ...]\n\n", usage);
+      tprintf("Usage:\n  %s [OPTION ...]\n\n", usage);
       PrintCommandLineFlags();
       exit(0);
     }

--- a/src/training/common/commontraining.cpp
+++ b/src/training/common/commontraining.cpp
@@ -155,13 +155,13 @@ ShapeTable *LoadShapeTable(const std::string &file_prefix) {
     if (!shape_table->DeSerialize(&shape_fp)) {
       delete shape_table;
       shape_table = nullptr;
-      tprintf("Error: Failed to read shape table %s\n", shape_table_file.c_str());
+      tprintf("ERROR: Failed to read shape table %s\n", shape_table_file.c_str());
     } else {
       int num_shapes = shape_table->NumShapes();
       tprintf("Read shape table %s of %d shapes\n", shape_table_file.c_str(), num_shapes);
     }
   } else {
-    tprintf("Warning: No shape table file present: %s\n", shape_table_file.c_str());
+    tprintf("WARNING: No shape table file present: %s\n", shape_table_file.c_str());
   }
   return shape_table;
 }
@@ -173,11 +173,11 @@ void WriteShapeTable(const std::string &file_prefix, const ShapeTable &shape_tab
   FILE *fp = fopen(shape_table_file.c_str(), "wb");
   if (fp != nullptr) {
     if (!shape_table.Serialize(fp)) {
-      fprintf(stderr, "Error writing shape table: %s\n", shape_table_file.c_str());
+      tprintf("ERROR: Error writing shape table: %s\n", shape_table_file.c_str());
     }
     fclose(fp);
   } else {
-    fprintf(stderr, "Error creating shape table: %s\n", shape_table_file.c_str());
+    tprintf("ERROR: Error creating shape table: %s\n", shape_table_file.c_str());
   }
 }
 
@@ -272,7 +272,7 @@ std::unique_ptr<MasterTrainer> LoadTrainingData(const char *const *filelist, boo
   }
   trainer->PreTrainingSetup();
   if (!FLAGS_O.empty() && !trainer->unicharset().save_to_file(FLAGS_O.c_str())) {
-    fprintf(stderr, "Failed to save unicharset to file %s\n", FLAGS_O.c_str());
+    tprintf("ERROR: Failed to save unicharset to file %s\n", FLAGS_O.c_str());
     return {};
   }
 
@@ -353,7 +353,7 @@ void ReadTrainingSamples(const FEATURE_DEFS_STRUCT &feature_definitions, const c
       unicharset->unichar_insert(unichar);
       if (unicharset->size() > MAX_NUM_CLASSES) {
         tprintf(
-            "Error: Size of unicharset in training is "
+            "ERROR: Size of unicharset in training is "
             "greater than MAX_NUM_CLASSES\n");
         exit(1);
       }
@@ -641,7 +641,7 @@ CLASS_STRUCT *SetUpForFloat2Int(const UNICHARSET &unicharset, LIST LabeledClassL
   BIT_VECTOR NewConfig;
   BIT_VECTOR OldConfig;
 
-  //  printf("Float2Int ...\n");
+  //  tprintf("Float2Int ...\n");
 
   auto *float_classes = new CLASS_STRUCT[unicharset.size()];
   iterate(LabeledClassList) {

--- a/src/training/common/mastertrainer.cpp
+++ b/src/training/common/mastertrainer.cpp
@@ -111,7 +111,7 @@ bool MasterTrainer::Serialize(FILE *fp) const {
 void MasterTrainer::LoadUnicharset(const char *filename) {
   if (!unicharset_.load_from_file(filename)) {
     tprintf(
-        "Failed to load unicharset from file %s\n"
+        "ERROR: Failed to load unicharset from file %s\n"
         "Building unicharset for training from scratch...\n",
         filename);
     unicharset_.clear();
@@ -148,7 +148,7 @@ void MasterTrainer::ReadTrainingSamples(const char *page_name,
 
   FILE *fp = fopen(page_name, "rb");
   if (fp == nullptr) {
-    tprintf("Failed to open tr file: %s\n", page_name);
+    tprintf("ERROR: Failed to open tr file: %s\n", page_name);
     return;
   }
   tr_filenames_.emplace_back(page_name);
@@ -159,7 +159,7 @@ void MasterTrainer::ReadTrainingSamples(const char *page_name,
 
     char *space = strchr(buffer, ' ');
     if (space == nullptr) {
-      tprintf("Bad format in tr file, reading fontname, unichar\n");
+      tprintf("ERROR: Bad format in tr file, reading fontname, unichar\n");
       continue;
     }
     *space++ = '\0';
@@ -171,7 +171,7 @@ void MasterTrainer::ReadTrainingSamples(const char *page_name,
     std::string unichar;
     TBOX bounding_box;
     if (!ParseBoxFileStr(space, &page_number, unichar, &bounding_box)) {
-      tprintf("Bad format in tr file, reading box coords\n");
+      tprintf("ERROR: Bad format in tr file, reading box coords\n");
       continue;
     }
     auto char_desc = ReadCharDescription(feature_defs, fp);
@@ -379,7 +379,7 @@ void MasterTrainer::ReplicateAndRandomizeSamplesIfRequired() {
 bool MasterTrainer::LoadFontInfo(const char *filename) {
   FILE *fp = fopen(filename, "rb");
   if (fp == nullptr) {
-    fprintf(stderr, "Failed to load font_properties from %s\n", filename);
+    tprintf("ERROR: Failed to load font_properties from %s\n", filename);
     return false;
   }
   int italic, bold, fixed, serif, fraktur;
@@ -418,7 +418,7 @@ bool MasterTrainer::LoadXHeights(const char *filename) {
   }
   FILE *f = fopen(filename, "rb");
   if (f == nullptr) {
-    fprintf(stderr, "Failed to load font xheights from %s\n", filename);
+    tprintf("ERROR: Failed to load font xheights from %s\n", filename);
     return false;
   }
   tprintf("Reading x-heights from %s ...\n", filename);
@@ -445,7 +445,7 @@ bool MasterTrainer::LoadXHeights(const char *filename) {
     ++xheight_count;
   }
   if (xheight_count == 0) {
-    fprintf(stderr, "No valid xheights in %s!\n", filename);
+    tprintf("ERROR: No valid xheights in %s!\n", filename);
     fclose(f);
     return false;
   }
@@ -468,7 +468,7 @@ bool MasterTrainer::AddSpacingInfo(const char *filename) {
   // Find the fontinfo_id.
   int fontinfo_id = GetBestMatchingFontInfoId(filename);
   if (fontinfo_id < 0) {
-    tprintf("No font found matching fontinfo filename %s\n", filename);
+    tprintf("ERROR: No font found matching fontinfo filename %s\n", filename);
     fclose(fontinfo_file);
     return false;
   }
@@ -487,7 +487,7 @@ bool MasterTrainer::AddSpacingInfo(const char *filename) {
   for (int l = 0; l < num_unichars; ++l) {
     if (tfscanf(fontinfo_file, "%s %d %d %d", uch, &x_gap_before, &x_gap_after,
                 &num_kerned) != 4) {
-      tprintf("Bad format of font spacing file %s\n", filename);
+      tprintf("ERROR: Bad format of font spacing file %s\n", filename);
       fclose(fontinfo_file);
       return false;
     }
@@ -499,7 +499,7 @@ bool MasterTrainer::AddSpacingInfo(const char *filename) {
     }
     for (int k = 0; k < num_kerned; ++k) {
       if (tfscanf(fontinfo_file, "%s %d", kerned_uch, &x_gap) != 2) {
-        tprintf("Bad format of font spacing file %s\n", filename);
+        tprintf("ERROR: Bad format of font spacing file %s\n", filename);
         fclose(fontinfo_file);
         delete spacing;
         return false;
@@ -633,7 +633,7 @@ void MasterTrainer::WriteInttempAndPFFMTable(const UNICHARSET &unicharset,
       classify->CreateIntTemplates(float_classes, shape_set);
   FILE *fp = fopen(inttemp_file, "wb");
   if (fp == nullptr) {
-    tprintf("Error, failed to open file \"%s\"\n", inttemp_file);
+    tprintf("ERROR: Failed to open file \"%s\"\n", inttemp_file);
   } else {
     classify->WriteIntTemplates(fp, int_templates, shape_set);
     fclose(fp);
@@ -671,7 +671,7 @@ void MasterTrainer::WriteInttempAndPFFMTable(const UNICHARSET &unicharset,
   }
   fp = fopen(pffmtable_file, "wb");
   if (fp == nullptr) {
-    tprintf("Error, failed to open file \"%s\"\n", pffmtable_file);
+    tprintf("ERROR: Failed to open file \"%s\"\n", pffmtable_file);
   } else {
     tesseract::Serialize(fp, shapetable_cutoffs);
     for (size_t c = 0; c < unicharset.size(); ++c) {
@@ -697,7 +697,7 @@ void MasterTrainer::DebugCanonical(const char *unichar_str1,
     class_id2 = class_id1;
   }
   if (class_id1 == INVALID_UNICHAR_ID) {
-    tprintf("No unicharset entry found for %s\n", unichar_str1);
+    tprintf("ERROR: No unicharset entry found for %s\n", unichar_str1);
     return;
   } else {
     tprintf("Font ambiguities for unichar %d = %s and %d = %s\n", class_id1,

--- a/src/training/common/networkbuilder.cpp
+++ b/src/training/common/networkbuilder.cpp
@@ -55,7 +55,7 @@ bool NetworkBuilder::InitNetwork(int num_outputs, const char *network_spec, int 
     Series *top_series = nullptr;
     series->SplitAt(append_index, &bottom_series, &top_series);
     if (bottom_series == nullptr || top_series == nullptr) {
-      tprintf("Yikes! Splitting current network failed!!\n");
+      tprintf("ERROR: Yikes! Splitting current network failed!!\n");
       return false;
     }
     input_shape = bottom_series->OutputShape(input_shape);
@@ -113,7 +113,7 @@ Network *NetworkBuilder::BuildFromString(const StaticShape &input_shape, const c
     case 'O':
       return ParseOutput(input_shape, str);
     default:
-      tprintf("Invalid network spec:%s\n", *str);
+      tprintf("ERROR: Invalid network spec:%s\n", *str);
       return nullptr;
   }
   return nullptr;
@@ -130,7 +130,7 @@ Network *NetworkBuilder::ParseInput(const char **str) {
   shape.SetShape(batch, height, width, depth);
   // num_converted may or may not include the length.
   if (num_converted != 4 && num_converted != 5) {
-    tprintf("Must specify an input layer as the first layer, not %s!!\n", *str);
+    tprintf("ERROR: Must specify an input layer as the first layer, not %s!!\n", *str);
     return nullptr;
   }
   *str += length;
@@ -160,7 +160,7 @@ Network *NetworkBuilder::ParseSeries(const StaticShape &input_shape, Input *inpu
     series->AddToStack(network);
   }
   if (**str != ']') {
-    tprintf("Missing ] at end of [Series]!\n");
+    tprintf("ERROR: Missing ] at end of [Series]!\n");
     delete series;
     return nullptr;
   }
@@ -178,7 +178,7 @@ Network *NetworkBuilder::ParseParallel(const StaticShape &input_shape, const cha
     parallel->AddToStack(network);
   }
   if (**str != ')') {
-    tprintf("Missing ) at end of (Parallel)!\n");
+    tprintf("ERROR: Missing ) at end of (Parallel)!\n");
     delete parallel;
     return nullptr;
   }
@@ -205,7 +205,7 @@ Network *NetworkBuilder::ParseR(const StaticShape &input_shape, const char **str
   int replicas = strtol(*str + 1, &end, 10);
   *str = end;
   if (replicas <= 0) {
-    tprintf("Invalid R spec!:%s\n", end);
+    tprintf("ERROR: Invalid R spec!:%s\n", end);
     return nullptr;
   }
   auto *parallel = new Parallel("Replicated", NT_REPLICATED);
@@ -214,7 +214,7 @@ Network *NetworkBuilder::ParseR(const StaticShape &input_shape, const char **str
     str_copy = *str;
     Network *network = BuildFromString(input_shape, &str_copy);
     if (network == nullptr) {
-      tprintf("Invalid replicated network!\n");
+      tprintf("ERROR: Invalid replicated network!\n");
       delete parallel;
       return nullptr;
     }
@@ -233,16 +233,16 @@ Network *NetworkBuilder::ParseS(const StaticShape &input_shape, const char **str
     int x = strtol(*str + 1, &end, 10);
     *str = end;
     if (y <= 0 || x <= 0) {
-      tprintf("Invalid S spec!:%s\n", *str);
+      tprintf("ERROR: Invalid S spec!:%s\n", *str);
       return nullptr;
     }
     return new Reconfig("Reconfig", input_shape.depth(), x, y);
   } else if (**str == '(') {
     // TODO(rays) Add Generic reshape.
-    tprintf("Generic reshape not yet implemented!!\n");
+    tprintf("ERROR: Generic reshape not yet implemented!!\n");
     return nullptr;
   }
-  tprintf("Invalid S spec!:%s\n", *str);
+  tprintf("ERROR: Invalid S spec!:%s\n", *str);
   return nullptr;
 }
 
@@ -272,14 +272,14 @@ static NetworkType NonLinearity(char func) {
 Network *NetworkBuilder::ParseC(const StaticShape &input_shape, const char **str) {
   NetworkType type = NonLinearity((*str)[1]);
   if (type == NT_NONE) {
-    tprintf("Invalid nonlinearity on C-spec!: %s\n", *str);
+    tprintf("ERROR: Invalid nonlinearity on C-spec!: %s\n", *str);
     return nullptr;
   }
   int y = 0, x = 0, d = 0;
   char *end;
   if ((y = strtol(*str + 2, &end, 10)) <= 0 || *end != ',' ||
       (x = strtol(end + 1, &end, 10)) <= 0 || *end != ',' || (d = strtol(end + 1, &end, 10)) <= 0) {
-    tprintf("Invalid C spec!:%s\n", end);
+    tprintf("ERROR: Invalid C spec!:%s\n", end);
     return nullptr;
   }
   *str = end;
@@ -302,7 +302,7 @@ Network *NetworkBuilder::ParseM(const StaticShape &input_shape, const char **str
   char *end;
   if ((*str)[1] != 'p' || (y = strtol(*str + 2, &end, 10)) <= 0 || *end != ',' ||
       (x = strtol(end + 1, &end, 10)) <= 0) {
-    tprintf("Invalid Mp spec!:%s\n", *str);
+    tprintf("ERROR: Invalid Mp spec!:%s\n", *str);
     return nullptr;
   }
   *str = end;
@@ -334,7 +334,7 @@ Network *NetworkBuilder::ParseLSTM(const StaticShape &input_shape, const char **
     dir = key;
     dim = (*str)[2];
     if (dim != 'x' && dim != 'y') {
-      tprintf("Invalid dimension (x|y) in L Spec!:%s\n", *str);
+      tprintf("ERROR: Invalid dimension (x|y) in L Spec!:%s\n", *str);
       return nullptr;
     }
     chars_consumed = 3;
@@ -343,13 +343,13 @@ Network *NetworkBuilder::ParseLSTM(const StaticShape &input_shape, const char **
       type = NT_LSTM_SUMMARY;
     }
   } else {
-    tprintf("Invalid direction (f|r|b) in L Spec!:%s\n", *str);
+    tprintf("ERROR: Invalid direction (f|r|b) in L Spec!:%s\n", *str);
     return nullptr;
   }
   char *end;
   int num_states = strtol(*str + chars_consumed, &end, 10);
   if (num_states <= 0) {
-    tprintf("Invalid number of states in L Spec!:%s\n", *str);
+    tprintf("ERROR: Invalid number of states in L Spec!:%s\n", *str);
     return nullptr;
   }
   *str = end;
@@ -406,7 +406,7 @@ Network *NetworkBuilder::BuildLSTMXYQuad(int num_inputs, int num_states) {
 static Network *BuildFullyConnected(const StaticShape &input_shape, NetworkType type,
                                     const std::string &name, int depth) {
   if (input_shape.height() == 0 || input_shape.width() == 0) {
-    tprintf("Fully connected requires positive height and width, had %d,%d\n", input_shape.height(),
+    tprintf("ERROR: Fully connected requires positive height and width, had %d,%d\n", input_shape.height(),
             input_shape.width());
     return nullptr;
   }
@@ -428,13 +428,13 @@ Network *NetworkBuilder::ParseFullyConnected(const StaticShape &input_shape, con
   const char *spec_start = *str;
   NetworkType type = NonLinearity((*str)[1]);
   if (type == NT_NONE) {
-    tprintf("Invalid nonlinearity on F-spec!: %s\n", *str);
+    tprintf("ERROR: Invalid nonlinearity on F-spec!: %s\n", *str);
     return nullptr;
   }
   char *end;
   int depth = strtol(*str + 2, &end, 10);
   if (depth <= 0) {
-    tprintf("Invalid F spec!:%s\n", *str);
+    tprintf("ERROR: Invalid F spec!:%s\n", *str);
     return nullptr;
   }
   *str = end;
@@ -446,18 +446,18 @@ Network *NetworkBuilder::ParseFullyConnected(const StaticShape &input_shape, con
 Network *NetworkBuilder::ParseOutput(const StaticShape &input_shape, const char **str) {
   char dims_ch = (*str)[1];
   if (dims_ch != '0' && dims_ch != '1' && dims_ch != '2') {
-    tprintf("Invalid dims (2|1|0) in output spec!:%s\n", *str);
+    tprintf("ERROR: Invalid dims (2|1|0) in output spec!:%s\n", *str);
     return nullptr;
   }
   char type_ch = (*str)[2];
   if (type_ch != 'l' && type_ch != 's' && type_ch != 'c') {
-    tprintf("Invalid output type (l|s|c) in output spec!:%s\n", *str);
+    tprintf("ERROR: Invalid output type (l|s|c) in output spec!:%s\n", *str);
     return nullptr;
   }
   char *end;
   int depth = strtol(*str + 3, &end, 10);
   if (depth != num_softmax_outputs_) {
-    tprintf("Warning: given outputs %d not equal to unicharset of %d.\n", depth,
+    tprintf("WARNING: Given outputs %d not equal to unicharset of %d.\n", depth,
             num_softmax_outputs_);
     depth = num_softmax_outputs_;
   }
@@ -477,7 +477,7 @@ Network *NetworkBuilder::ParseOutput(const StaticShape &input_shape, const char 
   }
   // For 1-d y has to be fixed, and if not 1, moved to depth.
   if (input_shape.height() == 0) {
-    tprintf("Fully connected requires fixed height!\n");
+    tprintf("ERROR: Fully connected requires fixed height!\n");
     return nullptr;
   }
   int input_size = input_shape.height();

--- a/src/training/common/trainingsampleset.cpp
+++ b/src/training/common/trainingsampleset.cpp
@@ -153,7 +153,7 @@ bool TrainingSampleSet::DeSerialize(bool swap, FILE *fp) {
 void TrainingSampleSet::LoadUnicharset(const char *filename) {
   if (!unicharset_.load_from_file(filename)) {
     tprintf(
-        "Failed to load unicharset from file %s\n"
+        "ERROR: Failed to load unicharset from file %s\n"
         "Building unicharset from scratch...\n",
         filename);
     unicharset_.clear();
@@ -172,7 +172,7 @@ int TrainingSampleSet::AddSample(const char *unichar, TrainingSample *sample) {
     unicharset_.unichar_insert(unichar);
     if (unicharset_.size() > MAX_NUM_CLASSES) {
       tprintf(
-          "Error: Size of unicharset in TrainingSampleSet::AddSample is "
+          "ERROR: Size of unicharset in TrainingSampleSet::AddSample is "
           "greater than MAX_NUM_CLASSES\n");
       return -1;
     }
@@ -612,7 +612,7 @@ void TrainingSampleSet::ComputeCanonicalSamples(const IntFeatureMap &map, bool d
   ASSERT_HOST(font_class_array_ != nullptr);
   IntFeatureDist f_table;
   if (debug) {
-    tprintf("feature table size %d\n", map.sparse_size());
+    tprintf("Feature table size %d\n", map.sparse_size());
   }
   f_table.Init(&map);
   int worst_s1 = 0;

--- a/src/training/dawg2wordlist.cpp
+++ b/src/training/dawg2wordlist.cpp
@@ -29,14 +29,14 @@ static std::unique_ptr<tesseract::Dawg> LoadSquishedDawg(const UNICHARSET &unich
   const int kDictDebugLevel = 1;
   tesseract::TFile dawg_file;
   if (!dawg_file.Open(filename, nullptr)) {
-    tprintf("Could not open %s for reading.\n", filename);
+    tprintf("ERROR: Could not open %s for reading.\n", filename);
     return nullptr;
   }
   tprintf("Loading word list from %s\n", filename);
   auto retval = std::make_unique<tesseract::SquishedDawg>(tesseract::DAWG_TYPE_WORD, "eng",
                                                           SYSTEM_DAWG_PERM, kDictDebugLevel);
   if (!retval->Load(&dawg_file)) {
-    tprintf("Could not read %s\n", filename);
+    tprintf("ERROR: Could not read %s\n", filename);
     return nullptr;
   }
   tprintf("Word list loaded.\n");
@@ -59,7 +59,7 @@ static int WriteDawgAsWordlist(const UNICHARSET &unicharset, const tesseract::Da
                                const char *outfile_name) {
   FILE *out = fopen(outfile_name, "wb");
   if (out == nullptr) {
-    tprintf("Could not open %s for writing.\n", outfile_name);
+    tprintf("ERROR: Could not open %s for writing.\n", outfile_name);
     return EXIT_FAILURE;
   }
   WordOutputter outputter(out);
@@ -87,12 +87,12 @@ int main(int argc, char *argv[]) {
   const char *wordlist_file = argv[3];
   UNICHARSET unicharset;
   if (!unicharset.load_from_file(unicharset_file)) {
-    tprintf("Error loading unicharset from %s.\n", unicharset_file);
+    tprintf("ERROR: Error loading unicharset from %s.\n", unicharset_file);
     return EXIT_FAILURE;
   }
   auto dict = LoadSquishedDawg(unicharset, dawg_file);
   if (dict == nullptr) {
-    tprintf("Error loading dictionary from %s.\n", dawg_file);
+    tprintf("ERROR: Error loading dictionary from %s.\n", dawg_file);
     return EXIT_FAILURE;
   }
   int retval = WriteDawgAsWordlist(unicharset, dict.get(), wordlist_file);

--- a/src/training/degradeimage.cpp
+++ b/src/training/degradeimage.cpp
@@ -232,7 +232,7 @@ void GeneratePerspectiveDistortion(int width, int height, TRand *randomizer, Ima
     // Transform the image.
     Image transformed = pixProjective(*pix, im_coeffs, incolor);
     if (transformed == nullptr) {
-      tprintf("Projective transformation failed!!\n");
+      tprintf("ERROR: Projective transformation failed!!\n");
       return;
     }
     pix->destroy();

--- a/src/training/lstmeval.cpp
+++ b/src/training/lstmeval.cpp
@@ -33,34 +33,34 @@ int main(int argc, char **argv) {
   tesseract::CheckSharedLibraryVersion();
   ParseArguments(&argc, &argv);
   if (FLAGS_model.empty()) {
-    tprintf("Must provide a --model!\n");
+    tprintf("ERROR: Must provide a --model!\n");
     return EXIT_FAILURE;
   }
   if (FLAGS_eval_listfile.empty()) {
-    tprintf("Must provide a --eval_listfile!\n");
+    tprintf("ERROR: Must provide a --eval_listfile!\n");
     return EXIT_FAILURE;
   }
   tesseract::TessdataManager mgr;
   if (!mgr.Init(FLAGS_model.c_str())) {
     if (FLAGS_traineddata.empty()) {
-      tprintf("Must supply --traineddata to eval a training checkpoint!\n");
+      tprintf("ERROR: Must supply --traineddata to eval a training checkpoint!\n");
       return EXIT_FAILURE;
     }
-    tprintf("%s is not a recognition model, trying training checkpoint...\n", FLAGS_model.c_str());
+    tprintf("WARNING: %s is not a recognition model, trying training checkpoint...\n", FLAGS_model.c_str());
     if (!mgr.Init(FLAGS_traineddata.c_str())) {
-      tprintf("Failed to load language model from %s!\n", FLAGS_traineddata.c_str());
+      tprintf("ERROR: Failed to load language model from %s!\n", FLAGS_traineddata.c_str());
       return EXIT_FAILURE;
     }
     std::vector<char> model_data;
     if (!tesseract::LoadDataFromFile(FLAGS_model.c_str(), &model_data)) {
-      tprintf("Failed to load model from: %s\n", FLAGS_model.c_str());
+      tprintf("ERROR: Failed to load model from: %s\n", FLAGS_model.c_str());
       return EXIT_FAILURE;
     }
     mgr.OverwriteEntry(tesseract::TESSDATA_LSTM, &model_data[0], model_data.size());
   }
   tesseract::LSTMTester tester(static_cast<int64_t>(FLAGS_max_image_MB) * 1048576);
   if (!tester.LoadAllEvalData(FLAGS_eval_listfile.c_str())) {
-    tprintf("Failed to load eval data from: %s\n", FLAGS_eval_listfile.c_str());
+    tprintf("ERROR: Failed to load eval data from: %s\n", FLAGS_eval_listfile.c_str());
     return EXIT_FAILURE;
   }
   double errs = 0.0;

--- a/src/training/lstmtraining.cpp
+++ b/src/training/lstmtraining.cpp
@@ -82,11 +82,11 @@ int main(int argc, char **argv) {
   }
 #endif
   if (FLAGS_model_output.empty()) {
-    tprintf("Must provide a --model_output!\n");
+    tprintf("ERROR: Must provide a --model_output!\n");
     return EXIT_FAILURE;
   }
   if (FLAGS_traineddata.empty()) {
-    tprintf("Must provide a --traineddata see training documentation\n");
+    tprintf("ERROR: Must provide a --traineddata, see training documentation\n");
     return EXIT_FAILURE;
   }
 
@@ -97,11 +97,11 @@ int main(int argc, char **argv) {
   if (f != nullptr) {
     fclose(f);
     if (remove(test_file.c_str()) != 0) {
-      tprintf("Error, failed to remove %s: %s\n", test_file.c_str(), strerror(errno));
+      tprintf("ERROR: Failed to remove %s: %s\n", test_file.c_str(), strerror(errno));
       return EXIT_FAILURE;
     }
   } else {
-    tprintf("Error, model output cannot be written: %s\n", strerror(errno));
+    tprintf("ERROR: Model output cannot be written: %s\n", strerror(errno));
     return EXIT_FAILURE;
   }
 
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
                                  FLAGS_debug_interval,
                                  static_cast<int64_t>(FLAGS_max_image_MB) * 1048576);
   if (!trainer.InitCharSet(FLAGS_traineddata.c_str())) {
-    tprintf("Error, failed to read %s\n", FLAGS_traineddata.c_str());
+    tprintf("ERROR: Failed to read %s\n", FLAGS_traineddata.c_str());
     return EXIT_FAILURE;
   }
 
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
   // so do it now and exit.
   if (FLAGS_stop_training || FLAGS_debug_network) {
     if (!trainer.TryLoadingCheckpoint(FLAGS_continue_from.c_str(), nullptr)) {
-      tprintf("Failed to read continue from: %s\n", FLAGS_continue_from.c_str());
+      tprintf("ERROR: Failed to read continue from: %s\n", FLAGS_continue_from.c_str());
       return EXIT_FAILURE;
     }
     if (FLAGS_debug_network) {
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
         trainer.ConvertToInt();
       }
       if (!trainer.SaveTraineddata(FLAGS_model_output.c_str())) {
-        tprintf("Failed to write recognition model : %s\n", FLAGS_model_output.c_str());
+        tprintf("ERROR: Failed to write recognition model : %s\n", FLAGS_model_output.c_str());
       }
     }
     return EXIT_SUCCESS;
@@ -139,12 +139,12 @@ int main(int argc, char **argv) {
 
   // Get the list of files to process.
   if (FLAGS_train_listfile.empty()) {
-    tprintf("Must supply a list of training filenames! --train_listfile\n");
+    tprintf("ERROR: Must supply a list of training filenames! --train_listfile\n");
     return EXIT_FAILURE;
   }
   std::vector<std::string> filenames;
   if (!tesseract::LoadFileLinesToStrings(FLAGS_train_listfile.c_str(), &filenames)) {
-    tprintf("Failed to load list of training filenames from %s\n", FLAGS_train_listfile.c_str());
+    tprintf("ERROR: Failed to load list of training filenames from %s\n", FLAGS_train_listfile.c_str());
     return EXIT_FAILURE;
   }
 
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
       if (!trainer.TryLoadingCheckpoint(FLAGS_continue_from.c_str(),
                                         FLAGS_append_index >= 0 ? FLAGS_continue_from.c_str()
                                                                 : FLAGS_old_traineddata.c_str())) {
-        tprintf("Failed to continue from: %s\n", FLAGS_continue_from.c_str());
+        tprintf("ERROR: Failed to continue from: %s\n", FLAGS_continue_from.c_str());
         return EXIT_FAILURE;
       }
       tprintf("Continuing from %s\n", FLAGS_continue_from.c_str());
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
       if (FLAGS_append_index >= 0) {
         tprintf("Appending a new network to an old one!!");
         if (FLAGS_continue_from.empty()) {
-          tprintf("Must set --continue_from for appending!\n");
+          tprintf("ERROR: Must set --continue_from for appending!\n");
           return EXIT_FAILURE;
         }
       }
@@ -180,7 +180,7 @@ int main(int argc, char **argv) {
       if (!trainer.InitNetwork(FLAGS_net_spec.c_str(), FLAGS_append_index, FLAGS_net_mode,
                                FLAGS_weight_range, FLAGS_learning_rate, FLAGS_momentum,
                                FLAGS_adam_beta)) {
-        tprintf("Failed to create network from spec: %s\n", FLAGS_net_spec.c_str());
+        tprintf("ERROR: Failed to create network from spec: %s\n", FLAGS_net_spec.c_str());
         return EXIT_FAILURE;
       }
       trainer.set_perfect_delay(FLAGS_perfect_sample_delay);
@@ -190,7 +190,7 @@ int main(int argc, char **argv) {
           filenames,
           FLAGS_sequential_training ? tesseract::CS_SEQUENTIAL : tesseract::CS_ROUND_ROBIN,
           FLAGS_randomly_rotate)) {
-    tprintf("Load of images failed!!\n");
+    tprintf("ERROR: Load of images failed!!\n");
     return EXIT_FAILURE;
   }
 
@@ -199,7 +199,7 @@ int main(int argc, char **argv) {
   if (!FLAGS_eval_listfile.empty()) {
     using namespace std::placeholders; // for _1, _2, _3...
     if (!tester.LoadAllEvalData(FLAGS_eval_listfile.c_str())) {
-      tprintf("Failed to load eval data from: %s\n", FLAGS_eval_listfile.c_str());
+      tprintf("ERROR: Failed to load eval data from: %s\n", FLAGS_eval_listfile.c_str());
       return EXIT_FAILURE;
     }
     tester_callback = std::bind(&tesseract::LSTMTester::RunEvalAsync, &tester, _1, _2, _3, _4);

--- a/src/training/merge_unicharsets.cpp
+++ b/src/training/merge_unicharsets.cpp
@@ -19,6 +19,8 @@
 #include "commontraining.h" // CheckSharedLibraryVersion
 #include "unicharset.h"
 
+using namespace tesseract;
+
 int main(int argc, char **argv) {
   tesseract::CheckSharedLibraryVersion();
 
@@ -27,30 +29,30 @@ int main(int argc, char **argv) {
     return EXIT_SUCCESS;
   } else if (argc < 4) {
     // Print usage
-    printf(
+    tprintf(
         "Usage: %s -v | --version |\n"
         "       %s unicharset-in-1 ... unicharset-in-n unicharset-out\n",
         argv[0], argv[0]);
     return EXIT_FAILURE;
   }
 
-  tesseract::UNICHARSET input_unicharset, result_unicharset;
+  UNICHARSET input_unicharset, result_unicharset;
   for (int arg = 1; arg < argc - 1; ++arg) {
     // Load the input unicharset
     if (input_unicharset.load_from_file(argv[arg])) {
-      printf("Loaded unicharset of size %zu from file %s\n", input_unicharset.size(), argv[arg]);
+      tprintf("Loaded unicharset of size %zu from file %s\n", input_unicharset.size(), argv[arg]);
       result_unicharset.AppendOtherUnicharset(input_unicharset);
     } else {
-      printf("Failed to load unicharset from file %s!!\n", argv[arg]);
+      tprintf("ERROR: Failed to load unicharset from file %s!!\n", argv[arg]);
       return EXIT_FAILURE;
     }
   }
 
   // Save the combined unicharset.
   if (result_unicharset.save_to_file(argv[argc - 1])) {
-    printf("Wrote unicharset file %s.\n", argv[argc - 1]);
+    tprintf("Wrote unicharset file %s.\n", argv[argc - 1]);
   } else {
-    printf("Cannot save unicharset file %s.\n", argv[argc - 1]);
+    tprintf("ERROR: Cannot save unicharset file %s.\n", argv[argc - 1]);
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/src/training/mftraining.cpp
+++ b/src/training/mftraining.cpp
@@ -261,10 +261,10 @@ int main(int argc, char **argv) {
   delete[] float_classes;
   FreeLabeledClassList(mf_classes);
   delete shape_table;
-  printf("Done!\n");
+  tprintf("Done!\n");
   if (!FLAGS_test_ch.empty()) {
     // If we are displaying debug window(s), wait for the user to look at them.
-    printf("Hit return to exit...\n");
+    tprintf("Hit return to exit...\n");
     while (getchar() != '\n') {
       ;
     }

--- a/src/training/pango/boxchar.cpp
+++ b/src/training/pango/boxchar.cpp
@@ -53,7 +53,7 @@ void BoxChar::GetDirection(int *num_rtl, int *num_ltr) const {
   // Convert the unichar to UTF32 representation
   std::vector<char32> uni_vector = UNICHAR::UTF8ToUTF32(ch_.c_str());
   if (uni_vector.empty()) {
-    tprintf("Illegal utf8 in boxchar string:%s = ", ch_.c_str());
+    tprintf("ERROR: Illegal utf8 in boxchar string:%s = ", ch_.c_str());
     for (char c : ch_) {
       tprintf(" 0x%x", c);
     }
@@ -334,7 +334,7 @@ std::string BoxChar::GetTesseractBoxStr(int height, const std::vector<BoxChar *>
   for (auto boxe : boxes) {
     const Box *box = boxe->box_;
     if (box == nullptr) {
-      tprintf("Error: Call PrepareToWrite before WriteTesseractBoxFile!!\n");
+      tprintf("ERROR: Call PrepareToWrite before WriteTesseractBoxFile!!\n");
       return "";
     }
     int nbytes = snprintf(buffer, kMaxLineLength, "%s %d %d %d %d %d\n", boxe->ch_.c_str(), box->x,

--- a/src/training/pango/pango_font_info.cpp
+++ b/src/training/pango/pango_font_info.cpp
@@ -429,7 +429,7 @@ bool PangoFontInfo::CanRenderString(const char *utf8_word, int len,
         continue;
       }
       if (TLOG_IS_ON(2)) {
-        printf("start_byte=%d end_byte=%d start_glyph=%d end_glyph=%d ", start_byte_index,
+        tprintf("start_byte=%d end_byte=%d start_glyph=%d end_glyph=%d ", start_byte_index,
                end_byte_index, start_glyph_index, end_glyph_index);
       }
       for (int i = start_glyph_index, step = (end_glyph_index > start_glyph_index) ? 1 : -1;
@@ -440,11 +440,11 @@ bool PangoFontInfo::CanRenderString(const char *utf8_word, int len,
             (cluster_iter.glyph_item->glyphs->glyphs[i].glyph == dotted_circle_glyph);
         bad_glyph = unknown_glyph || illegal_glyph;
         if (TLOG_IS_ON(2)) {
-          printf("(%d=%d)", cluster_iter.glyph_item->glyphs->glyphs[i].glyph, bad_glyph ? 1 : 0);
+          tprintf("(%d=%d)", cluster_iter.glyph_item->glyphs->glyphs[i].glyph, bad_glyph ? 1 : 0);
         }
       }
       if (TLOG_IS_ON(2)) {
-        printf("  '%s'\n", cluster_text.c_str());
+        tprintf("  '%s'\n", cluster_text.c_str());
       }
       if (bad_glyph)
         tlog(1, "Found illegal glyph!\n");
@@ -711,21 +711,21 @@ void FontUtils::PangoFontTypeInfo() {
   PangoFontMap *font_map = pango_cairo_font_map_get_default();
   if (pango_cairo_font_map_get_font_type(reinterpret_cast<PangoCairoFontMap *>(font_map)) ==
       CAIRO_FONT_TYPE_TOY) {
-    printf("Using CAIRO_FONT_TYPE_TOY.\n");
+    tprintf("Using CAIRO_FONT_TYPE_TOY.\n");
   } else if (pango_cairo_font_map_get_font_type(reinterpret_cast<PangoCairoFontMap *>(font_map)) ==
              CAIRO_FONT_TYPE_FT) {
-    printf("Using CAIRO_FONT_TYPE_FT.\n");
+    tprintf("Using CAIRO_FONT_TYPE_FT.\n");
   } else if (pango_cairo_font_map_get_font_type(reinterpret_cast<PangoCairoFontMap *>(font_map)) ==
              CAIRO_FONT_TYPE_WIN32) {
-    printf("Using CAIRO_FONT_TYPE_WIN32.\n");
+    tprintf("Using CAIRO_FONT_TYPE_WIN32.\n");
   } else if (pango_cairo_font_map_get_font_type(reinterpret_cast<PangoCairoFontMap *>(font_map)) ==
              CAIRO_FONT_TYPE_QUARTZ) {
-    printf("Using CAIRO_FONT_TYPE_QUARTZ.\n");
+    tprintf("Using CAIRO_FONT_TYPE_QUARTZ.\n");
   } else if (pango_cairo_font_map_get_font_type(reinterpret_cast<PangoCairoFontMap *>(font_map)) ==
              CAIRO_FONT_TYPE_USER) {
-    printf("Using CAIRO_FONT_TYPE_USER.\n");
+    tprintf("Using CAIRO_FONT_TYPE_USER.\n");
   } else if (!font_map) {
-    printf("Cannot create pango cairo font map!\n");
+    tprintf("ERROR: Cannot create pango cairo font map!\n");
   }
 }
 

--- a/src/training/pango/stringrenderer.cpp
+++ b/src/training/pango/stringrenderer.cpp
@@ -76,7 +76,7 @@ static bool RandBool(const double prob, TRand *rand) {
 /* static */
 static Image CairoARGB32ToPixFormat(cairo_surface_t *surface) {
   if (cairo_image_surface_get_format(surface) != CAIRO_FORMAT_ARGB32) {
-    printf("Unexpected surface format %d\n", cairo_image_surface_get_format(surface));
+    tprintf("ERROR: Unexpected surface format %d\n", cairo_image_surface_get_format(surface));
     return nullptr;
   }
   const int width = cairo_image_surface_get_width(surface);

--- a/src/training/set_unicharset_properties.cpp
+++ b/src/training/set_unicharset_properties.cpp
@@ -28,11 +28,11 @@ int main(int argc, char **argv) {
 
   // Check validity of input flags.
   if (FLAGS_U.empty() || FLAGS_O.empty()) {
-    tprintf("Specify both input and output unicharsets!\n");
+    tprintf("ERROR: Specify both input and output unicharsets!\n");
     return EXIT_FAILURE;
   }
   if (FLAGS_script_dir.empty()) {
-    tprintf("Must specify a script_dir!\n");
+    tprintf("ERROR: Must specify a script_dir!\n");
     return EXIT_FAILURE;
   }
 

--- a/src/training/text2image.cpp
+++ b/src/training/text2image.cpp
@@ -457,15 +457,15 @@ static int Main() {
 
   // Check validity of input flags.
   if (FLAGS_text.empty()) {
-    tprintf("'--text' option is missing!\n");
+    tprintf("ERROR: '--text' option is missing!\n");
     return EXIT_FAILURE;
   }
   if (FLAGS_outputbase.empty()) {
-    tprintf("'--outputbase' option is missing!\n");
+    tprintf("ERROR: '--outputbase' option is missing!\n");
     return EXIT_FAILURE;
   }
   if (!FLAGS_unicharset_file.empty() && FLAGS_render_ngrams) {
-    tprintf("Use '--unicharset_file' only if '--render_ngrams' is set.\n");
+    tprintf("ERROR: Use '--unicharset_file' only if '--render_ngrams' is set.\n");
     return EXIT_FAILURE;
   }
 
@@ -474,11 +474,11 @@ static int Main() {
     font_name += ',';
     std::string pango_name;
     if (!FontUtils::IsAvailableFont(font_name.c_str(), &pango_name)) {
-      tprintf("Could not find font named '%s'.\n", FLAGS_font.c_str());
+      tprintf("ERROR: Could not find font named '%s'.\n", FLAGS_font.c_str());
       if (!pango_name.empty()) {
-        tprintf("Pango suggested font '%s'.\n", pango_name.c_str());
+        tprintf("  Pango suggested font '%s'.\n", pango_name.c_str());
       }
-      tprintf("Please correct --font arg.\n");
+      tprintf("  Please correct --font arg.\n");
       return EXIT_FAILURE;
     }
   }
@@ -524,14 +524,14 @@ static int Main() {
     render.set_gravity_hint_strong(true);
     render.set_render_fullwidth_latin(true);
   } else {
-    tprintf("Invalid writing mode: %s\n", FLAGS_writing_mode.c_str());
+    tprintf("ERROR: Invalid writing mode: %s\n", FLAGS_writing_mode.c_str());
     return EXIT_FAILURE;
   }
 
   std::string src_utf8;
   // This c_str is NOT redundant!
   if (!File::ReadFileToString(FLAGS_text.c_str(), &src_utf8)) {
-    tprintf("Failed to read file: %s\n", FLAGS_text.c_str());
+    tprintf("ERROR: Failed to read file: %s\n", FLAGS_text.c_str());
     return EXIT_FAILURE;
   }
 
@@ -539,7 +539,7 @@ static int Main() {
   if (strncmp(src_utf8.c_str(), "\xef\xbb\xbf", 3) == 0) {
     src_utf8.erase(0, 3);
   }
-  tlog(1, "Render string of size %zu\n", src_utf8.length());
+  tlog(1, "  Render string of size %zu\n", src_utf8.length());
 
   if (FLAGS_render_ngrams || FLAGS_only_extract_font_properties) {
     // Try to preserve behavior of old text2image by expanding inter-word
@@ -553,7 +553,7 @@ static int Main() {
     UNICHARSET unicharset;
     if (FLAGS_render_ngrams && !FLAGS_unicharset_file.empty() &&
         !unicharset.load_from_file(FLAGS_unicharset_file.c_str())) {
-      tprintf("Failed to load unicharset from file %s\n", FLAGS_unicharset_file.c_str());
+      tprintf("ERROR: Failed to load unicharset from file %s\n", FLAGS_unicharset_file.c_str());
       return EXIT_FAILURE;
     }
 
@@ -699,7 +699,7 @@ static int Main() {
     filename += ".fontlist.txt";
     FILE *fp = fopen(filename.c_str(), "wb");
     if (fp == nullptr) {
-      tprintf("Failed to create output font list %s\n", filename.c_str());
+      tprintf("ERROR: Failed to create output font list %s\n", filename.c_str());
     } else {
       for (auto &font_name : font_names) {
         fprintf(fp, "%s\n", font_name.c_str());
@@ -722,7 +722,7 @@ int main(int argc, char **argv) {
     static char envstring[] = "PANGOCAIRO_BACKEND=fc";
     putenv(envstring);
   } else {
-    printf(
+    tprintf(
         "Using '%s' as pango cairo backend based on environment "
         "variable.\n",
         backend);

--- a/src/training/unicharset/fileio.cpp
+++ b/src/training/unicharset/fileio.cpp
@@ -45,7 +45,7 @@ FILE *File::Open(const std::string &filename, const std::string &mode) {
 FILE *File::OpenOrDie(const std::string &filename, const std::string &mode) {
   FILE *stream = fopen(filename.c_str(), mode.c_str());
   if (stream == nullptr) {
-    tprintf("Unable to open '%s' in mode '%s': %s\n", filename.c_str(), mode.c_str(),
+    tprintf("ERROR: Unable to open '%s' in mode '%s': %s\n", filename.c_str(), mode.c_str(),
             strerror(errno));
   }
   return stream;
@@ -54,7 +54,7 @@ FILE *File::OpenOrDie(const std::string &filename, const std::string &mode) {
 void File::WriteStringToFileOrDie(const std::string &str, const std::string &filename) {
   FILE *stream = fopen(filename.c_str(), "wb");
   if (stream == nullptr) {
-    tprintf("Unable to open '%s' for writing: %s\n", filename.c_str(), strerror(errno));
+    tprintf("ERROR: Unable to open '%s' for writing: %s\n", filename.c_str(), strerror(errno));
     return;
   }
   fputs(str.c_str(), stream);

--- a/src/training/unicharset/lang_model_helpers.cpp
+++ b/src/training/unicharset/lang_model_helpers.cpp
@@ -74,7 +74,7 @@ std::string ReadFile(const std::string &filename, FileReader reader) {
   if (read_result) {
     return std::string(&data[0], data.size());
   }
-  tprintf("Failed to read data from: %s\n", filename.c_str());
+  tprintf("ERROR: Failed to read data from: %s\n", filename.c_str());
   return std::string();
 }
 
@@ -112,7 +112,7 @@ bool WriteRecoder(const UNICHARSET &unicharset, bool pass_through, const std::st
     int null_char = unicharset.has_special_codes() ? UNICHAR_BROKEN : unicharset.size();
     tprintf("Null char=%d\n", null_char);
     if (!recoder.ComputeEncoding(unicharset, null_char, radical_table_data)) {
-      tprintf("Creation of encoded unicharset failed!!\n");
+      tprintf("ERROR: Creation of encoded unicharset failed!!\n");
       return false;
     }
   }
@@ -162,7 +162,7 @@ static bool WriteDawgs(const std::vector<std::string> &words, const std::vector<
                        const std::vector<std::string> &numbers, bool lang_is_rtl,
                        const UNICHARSET &unicharset, TessdataManager *traineddata) {
   if (puncs.empty()) {
-    tprintf("Must have non-empty puncs list to use language models!!\n");
+    tprintf("ERROR: Must have non-empty puncs list to use language models!!\n");
     return false;
   }
   // For each of the dawg types, make the dawg, and write to traineddata.
@@ -204,7 +204,7 @@ int CombineLangModel(const UNICHARSET &unicharset, const std::string &script_dir
   }
   // Unicharset and recoder.
   if (!WriteUnicharset(unicharset, output_dir, lang, writer, &traineddata)) {
-    tprintf("Error writing unicharset!!\n");
+    tprintf("ERROR: Error writing unicharset!!\n");
     return EXIT_FAILURE;
   } else {
     tprintf("Config file is optional, continuing...\n");
@@ -218,16 +218,16 @@ int CombineLangModel(const UNICHARSET &unicharset, const std::string &script_dir
   std::string radical_filename = script_dir + "/radical-stroke.txt";
   std::string radical_data = ReadFile(radical_filename, reader);
   if (radical_data.empty()) {
-    tprintf("Error reading radical code table %s\n", radical_filename.c_str());
+    tprintf("ERROR: Error reading radical code table %s\n", radical_filename.c_str());
     return EXIT_FAILURE;
   }
   if (!WriteRecoder(unicharset, pass_through_recoder, output_dir, lang, writer, &radical_data,
                     &traineddata)) {
-    tprintf("Error writing recoder!!\n");
+    tprintf("ERROR: Error writing recoder!!\n");
   }
   if (!words.empty() || !puncs.empty() || !numbers.empty()) {
     if (!WriteDawgs(words, puncs, numbers, lang_is_rtl, unicharset, &traineddata)) {
-      tprintf("Error during conversion of wordlists to DAWGs!!\n");
+      tprintf("ERROR: Error during conversion of wordlists to DAWGs!!\n");
       return EXIT_FAILURE;
     }
   }
@@ -236,7 +236,7 @@ int CombineLangModel(const UNICHARSET &unicharset, const std::string &script_dir
   std::vector<char> traineddata_data;
   traineddata.Serialize(&traineddata_data);
   if (!WriteFile(output_dir, lang, ".traineddata", traineddata_data, writer)) {
-    tprintf("Error writing output traineddata file!!\n");
+    tprintf("ERROR: Error writing output traineddata file!!\n");
     return EXIT_FAILURE;
   }
   tprintf("Created %s/%s/%s.traineddata", output_dir.c_str(), lang.c_str(), lang.c_str());

--- a/src/training/unicharset/lstmtester.cpp
+++ b/src/training/unicharset/lstmtester.cpp
@@ -29,7 +29,7 @@ LSTMTester::LSTMTester(int64_t max_memory) : test_data_(max_memory) {}
 bool LSTMTester::LoadAllEvalData(const char *filenames_file) {
   std::vector<std::string> filenames;
   if (!LoadFileLinesToStrings(filenames_file, &filenames)) {
-    tprintf("Failed to load list of eval filenames from %s\n", filenames_file);
+    tprintf("ERROR: Failed to load list of eval filenames from %s\n", filenames_file);
     return false;
   }
   return LoadAllEvalData(filenames);

--- a/src/training/unicharset/lstmtrainer.cpp
+++ b/src/training/unicharset/lstmtrainer.cpp
@@ -111,7 +111,7 @@ bool LSTMTrainer::TryLoadingCheckpoint(const char *filename,
     return false;
   }
   if (IsIntMode()) {
-    tprintf("Error, %s is an integer (fast) model, cannot continue training\n",
+    tprintf("ERROR: %s is an integer (fast) model, cannot continue training\n",
             filename);
     return false;
   }
@@ -123,7 +123,7 @@ bool LSTMTrainer::TryLoadingCheckpoint(const char *filename,
   tprintf("Code range changed from %d to %d!\n", network_->NumOutputs(),
           recoder_.code_range());
   if (old_traineddata == nullptr || *old_traineddata == '\0') {
-    tprintf("Must supply the old traineddata for code conversion!\n");
+    tprintf("ERROR: Must supply the old traineddata for code conversion!\n");
     return false;
   }
   TessdataManager old_mgr;
@@ -516,7 +516,7 @@ bool LSTMTrainer::DeSerialize(const TessdataManager *mgr, TFile *fp) {
     // Special case. If we successfully decoded the recognizer, but fail here
     // then it means we were just given a recognizer, so issue a warning and
     // allow it.
-    tprintf("Warning: LSTMTrainer deserialized an LSTMRecognizer!\n");
+    tprintf("WARNING: LSTMTrainer deserialized an LSTMRecognizer!\n");
     learning_iteration_ = 0;
     network_->SetEnableTraining(TS_ENABLED);
     return true;
@@ -817,7 +817,7 @@ bool LSTMTrainer::EncodeString(const std::string &str,
                                const UnicharCompress *recoder, bool simple_text,
                                int null_char, std::vector<int> *labels) {
   if (str.c_str() == nullptr || str.length() <= 0) {
-    tprintf("Empty truth string!\n");
+    tprintf("ERROR: Empty truth string!\n");
     return false;
   }
   unsigned err_index;
@@ -858,7 +858,8 @@ bool LSTMTrainer::EncodeString(const std::string &str,
       return true;
     }
   }
-  tprintf("Encoding of string failed! Failure bytes:");
+  tprintf("ERROR: Encoding of string failed!\n");
+  tprintf("  Failure bytes:");
   while (err_index < cleaned.size()) {
     tprintf(" %x", cleaned[err_index++] & 0xff);
   }
@@ -905,7 +906,7 @@ Trainability LSTMTrainer::PrepareForBackward(const ImageData *trainingdata,
                                              NetworkIO *fwd_outputs,
                                              NetworkIO *targets) {
   if (trainingdata == nullptr) {
-    tprintf("Null trainingdata.\n");
+    tprintf("ERROR: Null trainingdata.\n");
     return UNENCODABLE;
   }
   // Ensure repeatability of random elements even across checkpoints.
@@ -913,7 +914,7 @@ Trainability LSTMTrainer::PrepareForBackward(const ImageData *trainingdata,
       debug_interval_ > 0 && training_iteration() % debug_interval_ == 0;
   std::vector<int> truth_labels;
   if (!EncodeString(trainingdata->transcription(), &truth_labels)) {
-    tprintf("Can't encode transcription: '%s' in language '%s'\n",
+    tprintf("ERROR: Can't encode transcription: '%s' in language '%s'\n",
             trainingdata->transcription().c_str(),
             trainingdata->language().c_str());
     return UNENCODABLE;
@@ -942,7 +943,7 @@ Trainability LSTMTrainer::PrepareForBackward(const ImageData *trainingdata,
     ++w;
   }
   if (w == truth_labels.size()) {
-    tprintf("Blank transcription: %s\n", trainingdata->transcription().c_str());
+    tprintf("ERROR: Blank transcription: %s\n", trainingdata->transcription().c_str());
     return UNENCODABLE;
   }
   float image_scale;
@@ -950,25 +951,25 @@ Trainability LSTMTrainer::PrepareForBackward(const ImageData *trainingdata,
   bool invert = trainingdata->boxes().empty();
   if (!RecognizeLine(*trainingdata, invert ? 0.5f : 0.0f, debug, invert, upside_down,
                      &image_scale, &inputs, fwd_outputs)) {
-    tprintf("Image %s not trainable\n", trainingdata->imagefilename().c_str());
+    tprintf("ERROR: Image %s not trainable\n", trainingdata->imagefilename().c_str());
     return UNENCODABLE;
   }
   targets->Resize(*fwd_outputs, network_->NumOutputs());
   LossType loss_type = OutputLossType();
   if (loss_type == LT_SOFTMAX) {
     if (!ComputeTextTargets(*fwd_outputs, truth_labels, targets)) {
-      tprintf("Compute simple targets failed for %s!\n",
+      tprintf("ERROR: Compute simple targets failed for %s!\n",
               trainingdata->imagefilename().c_str());
       return UNENCODABLE;
     }
   } else if (loss_type == LT_CTC) {
     if (!ComputeCTCTargets(truth_labels, fwd_outputs, targets)) {
-      tprintf("Compute CTC targets failed for %s!\n",
+      tprintf("ERROR: Compute CTC targets failed for %s!\n",
               trainingdata->imagefilename().c_str());
       return UNENCODABLE;
     }
   } else {
-    tprintf("Logistic outputs not implemented yet!\n");
+    tprintf("ERROR: Logistic outputs not implemented yet!\n");
     return UNENCODABLE;
   }
   std::vector<int> ocr_labels;
@@ -980,7 +981,7 @@ Trainability LSTMTrainer::PrepareForBackward(const ImageData *trainingdata,
   }
   if (!DebugLSTMTraining(inputs, *trainingdata, *fwd_outputs, truth_labels,
                          *targets)) {
-    tprintf("Input width was %d\n", inputs.Width());
+    tprintf("ERROR: Input width was %d\n", inputs.Width());
     return UNENCODABLE;
   }
   std::string ocr_text = DecodeLabels(ocr_labels);
@@ -1024,7 +1025,7 @@ bool LSTMTrainer::SaveTrainingDump(SerializeAmount serialize_amount,
 bool LSTMTrainer::ReadLocalTrainingDump(const TessdataManager *mgr,
                                         const char *data, int size) {
   if (size == 0) {
-    tprintf("Warning: data size is 0 in LSTMTrainer::ReadLocalTrainingDump\n");
+    tprintf("WARNING: Data size is 0 in LSTMTrainer::ReadLocalTrainingDump\n");
     return false;
   }
   TFile fp;
@@ -1159,7 +1160,7 @@ bool LSTMTrainer::DebugLSTMTraining(const NetworkIO &inputs,
                                     const NetworkIO &outputs) {
   const std::string &truth_text = DecodeLabels(truth_labels);
   if (truth_text.c_str() == nullptr || truth_text.length() <= 0) {
-    tprintf("Empty truth string at decode time!\n");
+    tprintf("ERROR: Empty truth string at decode time!\n");
     return false;
   }
   if (debug_interval_ != 0) {
@@ -1234,7 +1235,7 @@ bool LSTMTrainer::ComputeTextTargets(const NetworkIO &outputs,
                                      const std::vector<int> &truth_labels,
                                      NetworkIO *targets) {
   if (truth_labels.size() > targets->Width()) {
-    tprintf("Error: transcription %s too long to fit into target of width %d\n",
+    tprintf("ERROR: Transcription %s too long to fit into target of width %d\n",
             DecodeLabels(truth_labels).c_str(), targets->Width());
     return false;
   }

--- a/src/training/unicharset/unicharset_training_utils.cpp
+++ b/src/training/unicharset/unicharset_training_utils.cpp
@@ -103,7 +103,7 @@ void SetupBasicProperties(bool report_errors, bool decompose, UNICHARSET *unicha
       if (other_case_id != INVALID_UNICHAR_ID) {
         unicharset->set_other_case(unichar_id, other_case_id);
       } else if (unichar_id >= SPECIAL_UNICHAR_CODES_COUNT && report_errors) {
-        tprintf("Other case %s of %s is not in unicharset\n", other_case_uch.c_str(), unichar_str);
+        tprintf("ERROR: Other case %s of %s is not in unicharset\n", other_case_uch.c_str(), unichar_str);
       }
     }
 
@@ -121,7 +121,7 @@ void SetupBasicProperties(bool report_errors, bool decompose, UNICHARSET *unicha
     if (mirror_uch_id != INVALID_UNICHAR_ID) {
       unicharset->set_mirror(unichar_id, mirror_uch_id);
     } else if (report_errors) {
-      tprintf("Mirror %s of %s is not in unicharset\n", mirror_uch.c_str(), unichar_str);
+      tprintf("ERROR: Mirror %s of %s is not in unicharset\n", mirror_uch.c_str(), unichar_str);
     }
 
     // Record normalized version of this unichar.
@@ -151,12 +151,12 @@ void SetScriptProperties(const std::string &script_dir, UNICHARSET *unicharset) 
     if (script_set.load_from_file(filename.c_str())) {
       unicharset->SetPropertiesFromOther(script_set);
     } else if (s != unicharset->common_sid() && s != unicharset->null_sid()) {
-      tprintf("Failed to load script unicharset from:%s\n", filename.c_str());
+      tprintf("ERROR: Failed to load script unicharset from:%s\n", filename.c_str());
     }
   }
   for (int c = SPECIAL_UNICHAR_CODES_COUNT; c < unicharset->size(); ++c) {
     if (unicharset->PropertiesIncomplete(c)) {
-      tprintf("Warning: properties incomplete for index %d = %s\n", c,
+      tprintf("WARNING: Properties incomplete for index %d = %s\n", c,
               unicharset->id_to_unichar(c));
     }
   }

--- a/src/training/unicharset/validate_grapheme.cpp
+++ b/src/training/unicharset/validate_grapheme.cpp
@@ -20,13 +20,14 @@ bool ValidateGrapheme::ConsumeGraphemeIfValid() {
 #if 0
     // Reject easily detected badly formed sequences.
     if (prev_cc == CharClass::kWhitespace && is_combiner) {
-      if (report_errors_) tprintf("Word started with a combiner:0x%x\n", ch);
+      if (report_errors_)
+		  tprintf("ERROR: Word started with a combiner:0x%x\n", ch);
      return false;
     }
 #endif
     if (prev_cc == CharClass::kVirama && cc == CharClass::kVirama) {
       if (report_errors_) {
-        tprintf("Two grapheme links in a row:0x%x 0x%x\n", prev_ch, ch);
+        tprintf("ERROR: Two grapheme links in a row:0x%x 0x%x\n", prev_ch, ch);
       }
       return false;
     }
@@ -82,13 +83,13 @@ bool ValidateGrapheme::IsBadlyFormed(char32 prev_ch, char32 ch) {
   // Reject badly formed Indic vowels.
   if (IsBadlyFormedIndicVowel(prev_ch, ch)) {
     if (report_errors_) {
-      tprintf("Badly formed Indic vowel sequence:0x%x 0x%x\n", prev_ch, ch);
+      tprintf("ERROR: Badly formed Indic vowel sequence:0x%x 0x%x\n", prev_ch, ch);
     }
     return true;
   }
   if (IsBadlyFormedThai(prev_ch, ch)) {
     if (report_errors_) {
-      tprintf("Badly formed Thai:0x%x 0x%x\n", prev_ch, ch);
+      tprintf("ERROR: Badly formed Thai:0x%x 0x%x\n", prev_ch, ch);
     }
     return true;
   }

--- a/src/training/unicharset/validate_indic.cpp
+++ b/src/training/unicharset/validate_indic.cpp
@@ -26,7 +26,7 @@ bool ValidateIndic::ConsumeGraphemeIfValid() {
     case CharClass::kZeroWidthNonJoiner:
       // Apart from within an aksara, joiners are silently dropped.
       if (report_errors_) {
-        tprintf("Dropping isolated joiner: 0x%x\n", codes_[codes_used_].second);
+        tprintf("ERROR: Dropping isolated joiner: 0x%x\n", codes_[codes_used_].second);
       }
       ++codes_used_;
       return true;
@@ -35,7 +35,7 @@ bool ValidateIndic::ConsumeGraphemeIfValid() {
       return true;
     default:
       if (report_errors_) {
-        tprintf("Invalid start of grapheme sequence:%c=0x%x\n",
+        tprintf("ERROR: Invalid start of grapheme sequence:%c=0x%x\n",
                 static_cast<int>(codes_[codes_used_].first),
                 codes_[codes_used_].second);
       }
@@ -155,7 +155,7 @@ bool ValidateIndic::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
       // Post-matra viramas must be explicit, so no joiners allowed here.
       if (post_matra) {
         if (report_errors_) {
-          tprintf("ZWJ after a post-matra virama!!\n");
+          tprintf("ERROR: ZWJ after a post-matra virama!!\n");
         }
         return false;
       }
@@ -175,7 +175,7 @@ bool ValidateIndic::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
       if (codes_used_ < num_codes && codes_[codes_used_].second == kZeroWidthNonJoiner) {
         if (output_used_ == output_.size() || output_[output_used_] != kRayana) {
           if (report_errors_) {
-            tprintf("Virama ZWJ ZWNJ in non-Sinhala: base=0x%x!\n", static_cast<int>(script_));
+            tprintf("ERROR: Virama ZWJ ZWNJ in non-Sinhala: base=0x%x!\n", static_cast<int>(script_));
           }
           return false;
         }
@@ -200,14 +200,14 @@ bool ValidateIndic::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
     // Pre-virama joiner [{Z|z} H] requests specific conjunct.
     if (UseMultiCode(2)) {
       if (report_errors_) {
-        tprintf("Invalid pre-virama joiner with no 2nd consonant!!\n");
+        tprintf("ERROR: Invalid pre-virama joiner with no 2nd consonant!!\n");
       }
       return false;
     }
     if (codes_[codes_used_].second == kZeroWidthJoiner ||
         codes_[codes_used_].second == kZeroWidthNonJoiner) {
       if (report_errors_) {
-        tprintf("JHJ!!: 0x%x 0x%x 0x%x\n", joiner.second, output_.back(),
+        tprintf("ERROR: JHJ!!: 0x%x 0x%x 0x%x\n", joiner.second, output_.back(),
                 codes_[codes_used_].second);
       }
       return false;
@@ -250,7 +250,7 @@ bool ValidateIndic::ConsumeConsonantHeadIfValid() {
       joiner = codes_[codes_used_];
       if (++codes_used_ == num_codes) {
         if (report_errors_) {
-          tprintf("Skipping ending joiner: 0x%x 0x%x\n", output_.back(), joiner.second);
+          tprintf("ERROR: Skipping ending joiner: 0x%x 0x%x\n", output_.back(), joiner.second);
         }
         return true;
       }
@@ -258,7 +258,7 @@ bool ValidateIndic::ConsumeConsonantHeadIfValid() {
         output_.push_back(joiner.second);
       } else {
         if (report_errors_) {
-          tprintf("Skipping unnecessary joiner: 0x%x 0x%x 0x%x\n", output_.back(), joiner.second,
+          tprintf("WARNING: Skipping unnecessary joiner: 0x%x 0x%x 0x%x\n", output_.back(), joiner.second,
                   codes_[codes_used_].second);
         }
         joiner = std::make_pair(CharClass::kOther, 0);

--- a/src/training/unicharset/validate_javanese.cpp
+++ b/src/training/unicharset/validate_javanese.cpp
@@ -47,7 +47,7 @@ bool ValidateJavanese::ConsumeGraphemeIfValid() {
     case CharClass::kZeroWidthNonJoiner:
       // Apart from within an aksara, joiners are silently dropped.
       if (report_errors_) {
-        tprintf("Dropping isolated joiner: 0x%x\n", codes_[codes_used_].second);
+        tprintf("ERROR: Dropping isolated joiner: 0x%x\n", codes_[codes_used_].second);
       }
       ++codes_used_;
       return true;
@@ -56,7 +56,7 @@ bool ValidateJavanese::ConsumeGraphemeIfValid() {
       return true;
     default:
       if (report_errors_) {
-        tprintf("Invalid start of grapheme sequence:%c=0x%x\n",
+        tprintf("ERROR: Invalid start of grapheme sequence:%c=0x%x\n",
                 static_cast<int>(codes_[codes_used_].first),
                 codes_[codes_used_].second);
       }
@@ -79,7 +79,7 @@ bool ValidateJavanese::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
       // Post-matra viramas must be explicit, so no joiners allowed here.
       if (post_matra) {
         if (report_errors_) {
-          tprintf("ZWJ after a post-matra virama!!\n");
+          tprintf("ERROR: ZWJ after a post-matra virama!!\n");
         }
         return false;
       }
@@ -99,7 +99,7 @@ bool ValidateJavanese::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
       if (codes_used_ < num_codes && codes_[codes_used_].second == kZeroWidthNonJoiner) {
         if (output_used_ == output_.size() || output_[output_used_] != kCakra) {
           if (report_errors_) {
-            tprintf("Virama ZWJ ZWNJ in non-Sinhala: base=0x%x!\n", static_cast<int>(script_));
+            tprintf("ERROR: Virama ZWJ ZWNJ in non-Sinhala: base=0x%x!\n", static_cast<int>(script_));
           }
           return false;
         }
@@ -124,14 +124,14 @@ bool ValidateJavanese::ConsumeViramaIfValid(IndicPair joiner, bool post_matra) {
     // Pre-virama joiner [{Z|z} H] requests specific conjunct.
     if (UseMultiCode(2)) {
       if (report_errors_) {
-        tprintf("Invalid pre-virama joiner with no 2nd consonant!!\n");
+        tprintf("ERROR: Invalid pre-virama joiner with no 2nd consonant!!\n");
       }
       return false;
     }
     if (codes_[codes_used_].second == kZeroWidthJoiner ||
         codes_[codes_used_].second == kZeroWidthNonJoiner) {
       if (report_errors_) {
-        tprintf("JHJ!!: 0x%x 0x%x 0x%x\n", joiner.second, output_.back(),
+        tprintf("ERROR: JHJ!!: 0x%x 0x%x 0x%x\n", joiner.second, output_.back(),
                 codes_[codes_used_].second);
       }
       return false;
@@ -174,7 +174,7 @@ bool ValidateJavanese::ConsumeConsonantHeadIfValid() {
       joiner = codes_[codes_used_];
       if (++codes_used_ == num_codes) {
         if (report_errors_) {
-          tprintf("Skipping ending joiner: 0x%x 0x%x\n", output_.back(), joiner.second);
+          tprintf("ERROR: Skipping ending joiner: 0x%x 0x%x\n", output_.back(), joiner.second);
         }
         return true;
       }
@@ -182,7 +182,7 @@ bool ValidateJavanese::ConsumeConsonantHeadIfValid() {
         output_.push_back(joiner.second);
       } else {
         if (report_errors_) {
-          tprintf("Skipping unnecessary joiner: 0x%x 0x%x 0x%x\n", output_.back(), joiner.second,
+          tprintf("WARNING: Skipping unnecessary joiner: 0x%x 0x%x 0x%x\n", output_.back(), joiner.second,
                   codes_[codes_used_].second);
         }
         joiner = std::make_pair(CharClass::kOther, 0);

--- a/src/training/unicharset/validate_khmer.cpp
+++ b/src/training/unicharset/validate_khmer.cpp
@@ -28,7 +28,7 @@ bool ValidateKhmer::ConsumeGraphemeIfValid() {
   }
   if (codes_[codes_used_].first != CharClass::kConsonant) {
     if (report_errors_) {
-      tprintf("Invalid start of Khmer syllable:0x%x\n", codes_[codes_used_].second);
+      tprintf("ERROR: Invalid start of Khmer syllable:0x%x\n", codes_[codes_used_].second);
     }
     return false;
   }
@@ -58,7 +58,7 @@ bool ValidateKhmer::ConsumeGraphemeIfValid() {
       codes_[codes_used_].second == kZeroWidthNonJoiner) {
     if (CodeOnlyToOutput()) {
       if (report_errors_) {
-        tprintf("Unterminated joiner: 0x%x\n", output_.back());
+        tprintf("ERROR: Unterminated joiner: 0x%x\n", output_.back());
       }
       return false;
     }
@@ -74,7 +74,7 @@ bool ValidateKhmer::ConsumeGraphemeIfValid() {
     }
   } else if (num_matra_parts) {
     if (report_errors_) {
-      tprintf("Joiner with non-dependent vowel after it!:0x%x 0x%x\n", output_.back(),
+      tprintf("ERROR: Joiner with non-dependent vowel after it!:0x%x 0x%x\n", output_.back(),
               codes_[codes_used_].second);
     }
     return false;

--- a/src/training/unicharset/validate_myanmar.cpp
+++ b/src/training/unicharset/validate_myanmar.cpp
@@ -39,7 +39,7 @@ bool ValidateMyanmar::ConsumeGraphemeIfValid() {
     }
   } else {
     if (report_errors_) {
-      tprintf("Invalid start of Myanmar syllable:0x%x\n", codes_[codes_used_].second);
+      tprintf("ERROR: Invalid start of Myanmar syllable:0x%x\n", codes_[codes_used_].second);
     }
     return false; // One of these is required.
   }

--- a/src/training/unicharset_extractor.cpp
+++ b/src/training/unicharset_extractor.cpp
@@ -56,7 +56,7 @@ static void AddStringsToUnicharset(const std::vector<std::string> &strings, int 
         unicharset->unichar_insert(normed.c_str());
       }
     } else {
-      tprintf("Normalization failed for string '%s'\n", string.c_str());
+      tprintf("ERROR: Normalization failed for string '%s'\n", string.c_str());
     }
   }
 }
@@ -77,7 +77,7 @@ static int Main(int argc, char **argv) {
                    /*continue_on_failure*/ false, /*boxes*/ nullptr, &texts,
                    /*box_texts*/ nullptr, /*pages*/ nullptr);
       if (!res) {
-        tprintf("Cannot read box data from '%s'\n", argv[arg]);
+        tprintf("ERROR: Cannot read box data from '%s'\n", argv[arg]);
         return EXIT_FAILURE;
       }
     } else {
@@ -92,7 +92,7 @@ static int Main(int argc, char **argv) {
   if (unicharset.save_to_file(FLAGS_output_unicharset.c_str())) {
     tprintf("Wrote unicharset file %s\n", FLAGS_output_unicharset.c_str());
   } else {
-    tprintf("Cannot save unicharset file %s\n", FLAGS_output_unicharset.c_str());
+    tprintf("ERROR: Cannot save unicharset file %s\n", FLAGS_output_unicharset.c_str());
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/src/training/wordlist2dawg.cpp
+++ b/src/training/wordlist2dawg.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
       tprintf("Writing squished DAWG to '%s'\n", dawg_filename);
       dawg->write_squished_dawg(dawg_filename);
     } else {
-      tprintf("ERROR: Dawg is empty, skip producing the output file\n");
+      tprintf("WARNING: Dawg is empty, skip producing the output file\n");
     }
   } else if (argc == 5) {
     tprintf("Loading dawg DAWG from '%s'\n", dawg_filename);

--- a/src/training/wordlist2dawg.cpp
+++ b/src/training/wordlist2dawg.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
   const char *unicharset_file = argv[++argv_index];
   tprintf("Loading unicharset from '%s'\n", unicharset_file);
   if (!classify.getDict().getUnicharset().load_from_file(unicharset_file)) {
-    tprintf("Failed to load unicharset from '%s'\n", unicharset_file);
+    tprintf("ERROR: Failed to load unicharset from '%s'\n", unicharset_file);
     return EXIT_FAILURE;
   }
   const UNICHARSET &unicharset = classify.getDict().getUnicharset();
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
         classify.getDict().dawg_debug_level);
     tprintf("Reading word list from '%s'\n", wordlist_filename);
     if (!trie.read_and_add_word_list(wordlist_filename, unicharset, reverse_policy)) {
-      tprintf("Failed to add word list from '%s'\n", wordlist_filename);
+      tprintf("ERROR: Failed to add word list from '%s'\n", wordlist_filename);
       return EXIT_FAILURE;
     }
     tprintf("Reducing Trie to SquishedDawg\n");
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
       tprintf("Writing squished DAWG to '%s'\n", dawg_filename);
       dawg->write_squished_dawg(dawg_filename);
     } else {
-      tprintf("Dawg is empty, skip producing the output file\n");
+      tprintf("ERROR: Dawg is empty, skip producing the output file\n");
     }
   } else if (argc == 5) {
     tprintf("Loading dawg DAWG from '%s'\n", dawg_filename);
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
     tprintf("Checking word list from '%s'\n", wordlist_filename);
     words.check_for_words(wordlist_filename, unicharset, true);
   } else { // should never get here
-    tprintf("Invalid command-line options\n");
+    tprintf("ERROR: Invalid command-line options\n");
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;


### PR DESCRIPTION
follow-up to dev mailing list discuss + issue #3998: RFC:  Info messages to stdout from training utils (Issue #3998)

Here's the extract/backport from my master branch:

- use tprintf() for all error/warning/info/debug-diagnostics output --> fprintf(stderr, msg) --> tprintf(msg). This also anticipates migrating tesseract to using the fmt library (C++20) as done by @stweil in a dev branch.
- all error messages are prefixed with 'ERROR: '. This enables users, f.e., to grep/filter the stderr/log using a regex like 
   `/^ERROR: /` 
   to filter out the error messages. 
   
   Application code which overrides the tprintf() API is another example: there error messages can be easily picked up and sent to different monitor channels / GUI windows / etc. in environments where there's no stdout/stderr (MSWindows GUI) or where end users are not accustomed to watching stdout/stderr.
- ditto for 'WARNING: ' level messages.

CAVEAT: this is a manual transfer from my master branch + code review while I was at it. I hope I got them all... :-)