### PR TITLE
RFC: ParamUtils::ReportParamsUsageStatistics(): report the tesseract variables actually used during the current run.

### DIFF
--- a/include/tesseract/baseapi.h
+++ b/include/tesseract/baseapi.h
@@ -161,6 +161,17 @@ public:
    */
   void PrintVariables(FILE *fp) const;
 
+  /*
+  * Report parameters' usage statistics, i.e. report which params have been
+  * set, modified and read/checked until now during this run-time's lifetime.
+  *
+  * Use this method for run-time 'discovery' about which tesseract parameters
+  * are actually *used* during your particular usage of the library, ergo
+  * answering the question:
+  * "Which of all those parameters are actually *relevant* to my use case today?"
+  */
+  void ReportParamsUsageStatistics() const;
+
   /**
    * Get value of named variable as a string, if it exists.
    */

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -292,8 +292,8 @@ bool TessBaseAPI::SetDebugVariable(const char *name, const char *value) {
 }
 
 bool TessBaseAPI::GetIntVariable(const char *name, int *value) const {
-  auto *p = ParamUtils::FindParam<IntParam>(name, GlobalParams()->int_params,
-                                            tesseract_->params()->int_params);
+  auto *p = ParamUtils::FindParam<IntParam>(name, GlobalParams()->int_params(),
+                                            tesseract_->params()->int_params());
   if (p == nullptr) {
     return false;
   }
@@ -302,8 +302,8 @@ bool TessBaseAPI::GetIntVariable(const char *name, int *value) const {
 }
 
 bool TessBaseAPI::GetBoolVariable(const char *name, bool *value) const {
-  auto *p = ParamUtils::FindParam<BoolParam>(name, GlobalParams()->bool_params,
-                                             tesseract_->params()->bool_params);
+  auto *p = ParamUtils::FindParam<BoolParam>(name, GlobalParams()->bool_params(),
+                                             tesseract_->params()->bool_params());
   if (p == nullptr) {
     return false;
   }
@@ -312,14 +312,14 @@ bool TessBaseAPI::GetBoolVariable(const char *name, bool *value) const {
 }
 
 const char *TessBaseAPI::GetStringVariable(const char *name) const {
-  auto *p = ParamUtils::FindParam<StringParam>(name, GlobalParams()->string_params,
-                                               tesseract_->params()->string_params);
+  auto *p = ParamUtils::FindParam<StringParam>(name, GlobalParams()->string_params(),
+                                               tesseract_->params()->string_params());
   return (p != nullptr) ? p->c_str() : nullptr;
 }
 
 bool TessBaseAPI::GetDoubleVariable(const char *name, double *value) const {
-  auto *p = ParamUtils::FindParam<DoubleParam>(name, GlobalParams()->double_params,
-                                               tesseract_->params()->double_params);
+  auto *p = ParamUtils::FindParam<DoubleParam>(name, GlobalParams()->double_params(),
+                                               tesseract_->params()->double_params());
   if (p == nullptr) {
     return false;
   }
@@ -355,6 +355,19 @@ void TessBaseAPI::PrintFontsTable(FILE *fp) const {
 /** Print Tesseract parameters to the given file. */
 void TessBaseAPI::PrintVariables(FILE *fp) const {
   ParamUtils::PrintParams(fp, tesseract_->params());
+}
+
+// Report parameters' usage statistics, i.e. report which params have been
+// set, modified and read/checked until now during this run-time's lifetime.
+//
+// Use this method for run-time 'discovery' about which tesseract parameters
+// are actually *used* during your particular usage of the library, ergo
+// answering the question:
+// "Which of all those parameters are actually *relevant* to my use case today?"
+void TessBaseAPI::ReportParamsUsageStatistics() const {
+	tesseract::ParamsVectors *vec = tesseract_->params();
+
+	ParamUtils::ReportParamsUsageStatistics(vec);
 }
 
 /**

--- a/src/ccmain/paramsd.cpp
+++ b/src/ccmain/paramsd.cpp
@@ -212,16 +212,16 @@ SVMenuNode *ParamsEditor::BuildListOfAllLeaves(tesseract::Tesseract *tess) {
   int num_iterations = (tess->params() == nullptr) ? 1 : 2;
   for (int v = 0; v < num_iterations; ++v) {
     tesseract::ParamsVectors *vec = (v == 0) ? GlobalParams() : tess->params();
-    for (auto &param : vec->int_params) {
+    for (auto &param : vec->int_params()) {
       vc_it.add_after_then_move(new ParamContent(param));
     }
-    for (auto &param : vec->bool_params) {
+    for (auto &param : vec->bool_params()) {
       vc_it.add_after_then_move(new ParamContent(param));
     }
-    for (auto &param : vec->string_params) {
+    for (auto &param : vec->string_params()) {
       vc_it.add_after_then_move(new ParamContent(param));
     }
-    for (auto &param : vec->double_params) {
+    for (auto &param : vec->double_params()) {
       vc_it.add_after_then_move(new ParamContent(param));
     }
   }

--- a/src/ccutil/params.cpp
+++ b/src/ccutil/params.cpp
@@ -18,10 +18,13 @@
 
 #include "params.h"
 
-#include "helpers.h"  // for chomp_string
+#include "helpers.h"  // for chomp_string, mupdf imports, etc.: see also the header collision comment in there (MSVC-specific).
 #include "host.h"     // tesseract/export.h, windows.h for MAX_PATH
 #include "serialis.h" // for TFile
 #include "tprintf.h"
+
+#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <climits> // for INT_MIN, INT_MAX
 #include <cmath>   // for NAN, std::isnan
@@ -31,10 +34,12 @@
 #include <locale>  // for std::locale::classic
 #include <sstream> // for std::stringstream
 
+
 namespace tesseract {
 
+TESS_API
 tesseract::ParamsVectors *GlobalParams() {
-  static tesseract::ParamsVectors global_params = tesseract::ParamsVectors();
+  static tesseract::ParamsVectors global_params; // static auto-inits at startup
   return &global_params;
 }
 
@@ -42,7 +47,7 @@ bool ParamUtils::ReadParamsFile(const char *file, SetParamConstraint constraint,
                                 ParamsVectors *member_params) {
   TFile fp;
   if (!fp.Open(file, nullptr)) {
-    tprintf("read_params_file: Can't open %s\n", file);
+    tprintf("ERROR: read_params_file: Can't open file {}\n", file);
     return true;
   }
   return ReadParamsFromFp(constraint, &fp, member_params);
@@ -71,18 +76,157 @@ bool ParamUtils::ReadParamsFromFp(SetParamConstraint constraint, TFile *fp,
 
       if (!foundit) {
         anyerr = true; // had an error
-        tprintf("Warning: Parameter not found: %s\n", line);
+        tprintf("WARNING: Parameter not found: {}\n", line);
       }
     }
   }
   return anyerr;
 }
 
+void ParamUtils::ReportParamsUsageStatistics(const ParamsVectors *member_params)
+{
+  std::string report_path = vars_report_file;
+  FILE* f = nullptr;
+
+  if (report_path == "stdout" || report_path == "-" || report_path == "1")
+    f = stdout;
+  else if (report_path == "stdeerr" || report_path == "+" || report_path == "2")
+    f = stderr;
+  else if (!report_path.empty())
+  {
+#if defined(HAVE_MUPDF)
+    fz_context* ctx = fz_get_global_context();
+    fz_mkdir_for_file(ctx, report_path.c_str());
+    f = fz_fopen_utf8(ctx, report_path.c_str(), "w");
+#else
+    f = fopen(report_path.c_str(), "w");
+#endif
+    if (!f)
+    {
+      tprintf("ERROR: Cannot produce paramater usage report file: {}\n", report_path);
+    }
+  }
+
+  if (!f)
+    return;
+
+  fprintf(f, "\n\nTesseract Parameter Usage Statistics: which params have been relevant?\n"
+            "----------------------------------------------------------------------\n\n");
+
+  // first collect all parameter names:
+
+  typedef enum {
+    INT_PARAM = 0,
+    BOOL_PARAM,
+    DOUBLE_PARAM,
+    STRING_PARAM,
+  } param_type_t;
+
+  typedef struct param_info {
+    const char* name;
+    bool global;
+    param_type_t type;
+    const Param* ref;
+  } param_info_t;
+
+  std::vector<param_info_t> param_names;
+
+  if (member_params != nullptr) {
+    for (auto p : member_params->int_params_c()) {
+      param_names.push_back({ p->name_str(), false, INT_PARAM, p });
+    }
+    for (auto p : member_params->bool_params_c()) {
+      param_names.push_back({ p->name_str(), false, BOOL_PARAM, p });
+    }
+    for (auto p : member_params->string_params_c()) {
+      param_names.push_back({ p->name_str(), false, STRING_PARAM, p });
+    }
+    for (auto p : member_params->double_params_c()) {
+      param_names.push_back({ p->name_str(), false, DOUBLE_PARAM, p });
+    }
+  }
+
+  const ParamsVectors* globals = GlobalParams();
+
+  for (auto p : globals->int_params_c()) {
+    param_names.push_back({ p->name_str(), true, INT_PARAM, p });
+  }
+  for (auto p : globals->bool_params_c()) {
+    param_names.push_back({ p->name_str(), true, BOOL_PARAM, p });
+  }
+  for (auto p : globals->string_params_c()) {
+    param_names.push_back({ p->name_str(), true, STRING_PARAM, p });
+  }
+  for (auto p : globals->double_params_c()) {
+    param_names.push_back({ p->name_str(), true, DOUBLE_PARAM, p });
+  }
+
+  sort(param_names.begin(), param_names.end(), [](param_info_t& a, param_info_t& b)
+  {
+  int rv = strcmp(b.name, a.name);
+  if (rv == 0)
+  {
+    rv = (int) b.global - (int) a.global;
+  }
+#if !defined(NDEBUG)
+  if (rv == 0) 
+  {
+  	fprintf(stderr, "Apparently you have double-defined Tesseract Variable: '%s'! Fix that in the source code!\n", a.name);
+	ASSEERT0(!"Apparently you have double-defined a Tesseract Variable.");
+  }
+#endif
+  return rv >= 0;
+  });
+
+  static const char* type_map[] = { "[Integer]", "[Boolean]", "[Float]", "[String]" };
+  static const char* categories[] = { "(Global)", "(Local)" };
+  static const char* write_access[] = { ".", "w", "W" };
+  static const char* read_access[] = { ".", "r", "R" };
+
+  auto acc = [](int access) {
+    if (access > 2)
+      access = 2;
+    return access;
+  };
+
+  for (auto item : param_names) {
+    const Param* p = item.ref;
+    auto stats = p->access_counts();
+    if (stats.reading > 0)
+    {
+      fmt::print(f, "* {:.<60} {:8} {}{} {:9} = {}\n", p->name_str(), categories[item.global], write_access[acc(stats.writing)], read_access[acc(stats.reading)], type_map[item.type], p->formatted_value_str());
+    }
+  }
+
+  if (report_all_variables)
+  {
+    fprintf(f, "\n\nUnused parameters:\n\n");
+
+    for (auto item : param_names) {
+      const Param* p = item.ref;
+      auto stats = p->access_counts();
+      if (stats.reading <= 0)
+      {
+        fmt::print(f, "* {:.<60} {:8} {}{} {:9} = {}\n", p->name_str(), categories[item.global], write_access[acc(stats.writing)], read_access[acc(stats.reading)], type_map[item.type], p->formatted_value_str());
+      }
+    }
+  }
+
+  if (f != stdout)
+  {
+    fclose(f);
+  }
+  else
+  {
+    fflush(stdout);
+  }
+}
+
 bool ParamUtils::SetParam(const char *name, const char *value, SetParamConstraint constraint,
                           ParamsVectors *member_params) {
   // Look for the parameter among string parameters.
   auto *sp =
-      FindParam<StringParam>(name, GlobalParams()->string_params, member_params->string_params);
+      FindParam<StringParam>(name, GlobalParams()->string_params(), member_params->string_params());
   if (sp != nullptr && sp->constraint_ok(constraint)) {
     sp->set_value(value);
   }
@@ -91,7 +235,7 @@ bool ParamUtils::SetParam(const char *name, const char *value, SetParamConstrain
   }
 
   // Look for the parameter among int parameters.
-  auto *ip = FindParam<IntParam>(name, GlobalParams()->int_params, member_params->int_params);
+  auto *ip = FindParam<IntParam>(name, GlobalParams()->int_params(), member_params->int_params());
   if (ip && ip->constraint_ok(constraint)) {
     int intval = INT_MIN;
     std::stringstream stream(value);
@@ -103,7 +247,7 @@ bool ParamUtils::SetParam(const char *name, const char *value, SetParamConstrain
   }
 
   // Look for the parameter among bool parameters.
-  auto *bp = FindParam<BoolParam>(name, GlobalParams()->bool_params, member_params->bool_params);
+  auto *bp = FindParam<BoolParam>(name, GlobalParams()->bool_params(), member_params->bool_params());
   if (bp != nullptr && bp->constraint_ok(constraint)) {
     if (*value == 'T' || *value == 't' || *value == 'Y' || *value == 'y' || *value == '1') {
       bp->set_value(true);
@@ -114,7 +258,7 @@ bool ParamUtils::SetParam(const char *name, const char *value, SetParamConstrain
 
   // Look for the parameter among double parameters.
   auto *dp =
-      FindParam<DoubleParam>(name, GlobalParams()->double_params, member_params->double_params);
+      FindParam<DoubleParam>(name, GlobalParams()->double_params(), member_params->double_params());
   if (dp != nullptr && dp->constraint_ok(constraint)) {
     double doubleval = NAN;
     std::stringstream stream(value);
@@ -131,26 +275,26 @@ bool ParamUtils::GetParamAsString(const char *name, const ParamsVectors *member_
                                   std::string *value) {
   // Look for the parameter among string parameters.
   auto *sp =
-      FindParam<StringParam>(name, GlobalParams()->string_params, member_params->string_params);
+      FindParam<StringParam>(name, GlobalParams()->string_params_c(), member_params->string_params_c());
   if (sp) {
     *value = sp->c_str();
     return true;
   }
   // Look for the parameter among int parameters.
-  auto *ip = FindParam<IntParam>(name, GlobalParams()->int_params, member_params->int_params);
+  auto *ip = FindParam<IntParam>(name, GlobalParams()->int_params_c(), member_params->int_params_c());
   if (ip) {
     *value = std::to_string(int32_t(*ip));
     return true;
   }
   // Look for the parameter among bool parameters.
-  auto *bp = FindParam<BoolParam>(name, GlobalParams()->bool_params, member_params->bool_params);
+  auto *bp = FindParam<BoolParam>(name, GlobalParams()->bool_params_c(), member_params->bool_params_c());
   if (bp != nullptr) {
     *value = bool(*bp) ? "1" : "0";
     return true;
   }
   // Look for the parameter among double parameters.
   auto *dp =
-      FindParam<DoubleParam>(name, GlobalParams()->double_params, member_params->double_params);
+      FindParam<DoubleParam>(name, GlobalParams()->double_params_c(), member_params->double_params_c());
   if (dp != nullptr) {
     std::ostringstream stream;
     stream.imbue(std::locale::classic());
@@ -163,27 +307,55 @@ bool ParamUtils::GetParamAsString(const char *name, const ParamsVectors *member_
 
 void ParamUtils::PrintParams(FILE *fp, const ParamsVectors *member_params) {
   int num_iterations = (member_params == nullptr) ? 1 : 2;
+  // When printing to stdout info text is included.
+  // Info text is omitted when printing to a file (would result in an invalid config file).
+  if (!fp)
+	  fp = stdout;
+  bool print_info = (fp == stdout || fp == stderr);
   std::ostringstream stream;
   stream.imbue(std::locale::classic());
   for (int v = 0; v < num_iterations; ++v) {
     const ParamsVectors *vec = (v == 0) ? GlobalParams() : member_params;
-    for (auto int_param : vec->int_params) {
-      stream << int_param->name_str() << '\t' << (int32_t)(*int_param) << '\t'
-             << int_param->info_str() << '\n';
+    for (auto int_param : vec->int_params_c()) {
+      if (print_info) {
+        stream << int_param->name_str() << '\t' << (int32_t)(*int_param) << '\t'
+              << int_param->info_str() << '\n';
+      } else {
+        stream << int_param->name_str() << '\t' << (int32_t)(*int_param) << '\n';
+      }
     }
-    for (auto bool_param : vec->bool_params) {
-      stream << bool_param->name_str() << '\t' << bool(*bool_param) << '\t'
-             << bool_param->info_str() << '\n';
+    for (auto bool_param : vec->bool_params_c()) {
+      if (print_info) {
+        stream << bool_param->name_str() << '\t' << bool(*bool_param) << '\t'
+              << bool_param->info_str() << '\n';
+      } else {
+        stream << bool_param->name_str() << '\t' << bool(*bool_param) << '\n';
+      }
     }
-    for (auto string_param : vec->string_params) {
-      stream << string_param->name_str() << '\t' << string_param->c_str() << '\t'
-             << string_param->info_str() << '\n';
+    for (auto string_param : vec->string_params_c()) {
+      if (print_info) {
+        stream << string_param->name_str() << '\t' << string_param->c_str() << '\t'
+              << string_param->info_str() << '\n';
+      } else {
+        stream << string_param->name_str() << '\t' << string_param->c_str() << '\n';
+      }
     }
-    for (auto double_param : vec->double_params) {
-      stream << double_param->name_str() << '\t' << (double)(*double_param) << '\t'
-             << double_param->info_str() << '\n';
+    for (auto double_param : vec->double_params_c()) {
+      if (print_info) {
+        stream << double_param->name_str() << '\t' << (double)(*double_param) << '\t'
+              << double_param->info_str() << '\n';
+      } else {
+        stream << double_param->name_str() << '\t' << (double)(*double_param) << '\n';
+      }
     }
   }
+#ifdef HAVE_MUPDF
+  if (print_info)
+  {
+	  tprintf("{}", stream.str().c_str());
+	  return;
+  }
+#endif
   fprintf(fp, "%s", stream.str().c_str());
 }
 
@@ -192,16 +364,16 @@ void ParamUtils::ResetToDefaults(ParamsVectors *member_params) {
   int num_iterations = (member_params == nullptr) ? 1 : 2;
   for (int v = 0; v < num_iterations; ++v) {
     ParamsVectors *vec = (v == 0) ? GlobalParams() : member_params;
-    for (auto &param : vec->int_params) {
+    for (auto &param : vec->int_params()) {
       param->ResetToDefault();
     }
-    for (auto &param : vec->bool_params) {
+    for (auto &param : vec->bool_params()) {
       param->ResetToDefault();
     }
-    for (auto &param : vec->string_params) {
+    for (auto &param : vec->string_params()) {
       param->ResetToDefault();
     }
-    for (auto &param : vec->double_params) {
+    for (auto &param : vec->double_params()) {
       param->ResetToDefault();
     }
   }

--- a/src/ccutil/params.h
+++ b/src/ccutil/params.h
@@ -2,6 +2,8 @@
  * File:        params.h
  * Description: Class definitions of the *_VAR classes for tunable constants.
  * Author:      Ray Smith
+ * 
+ * UTF8 detect helper statement: «bloody MSVC»
  *
  * (C) Copyright 1991, Hewlett-Packard Ltd.
  ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,11 +45,43 @@ enum SetParamConstraint {
   SET_PARAM_CONSTRAINT_NON_INIT_ONLY,
 };
 
-struct ParamsVectors {
-  std::vector<IntParam *> int_params;
-  std::vector<BoolParam *> bool_params;
-  std::vector<StringParam *> string_params;
-  std::vector<DoubleParam *> double_params;
+class ParamsVectors {
+  std::vector<IntParam *> _int_params;
+  std::vector<BoolParam *> _bool_params;
+  std::vector<StringParam *> _string_params;
+  std::vector<DoubleParam *> _double_params;
+
+public:
+	ParamsVectors() {
+	}
+	~ParamsVectors() {
+	}
+
+	std::vector<IntParam *> &int_params() {
+		return _int_params;
+	}
+	std::vector<BoolParam *> &bool_params() {
+		return _bool_params;
+	}
+	std::vector<StringParam *> &string_params() {
+		return _string_params;
+	}
+	std::vector<DoubleParam *> &double_params() {
+		return _double_params;
+	}
+
+	const std::vector<IntParam *> &int_params_c() const {
+		return _int_params;
+	}
+	const std::vector<BoolParam *> &bool_params_c() const {
+		return _bool_params;
+	}
+	const std::vector<StringParam *> &string_params_c() const {
+		return _string_params;
+	}
+	const std::vector<DoubleParam *> &double_params_c() const {
+		return _double_params;
+	}
 };
 
 // Utility functions for working with Tesseract parameters.
@@ -69,6 +103,25 @@ public:
   static bool SetParam(const char *name, const char *value, SetParamConstraint constraint,
                        ParamsVectors *member_params);
 
+  // accept both - and _ in key names, e.g. user-specified 'debug-all' would match 'debug_all'
+  // in the database.
+  static inline bool CompareKeys(const char *db_key, const char *user_key)
+  {
+	  // if (0 == strcmp(db_key, user_key))
+	  //   return true;
+
+	  for (; *db_key && *user_key; db_key++, user_key++)
+	  {
+		  if (*db_key != *user_key)
+		  {
+			  if (*db_key == '_' && *user_key == '-')
+				  continue;
+			  return false;
+		  }
+	  }
+	  return true;
+  }
+
   // Returns the pointer to the parameter with the given name (of the
   // appropriate type) if it was found in the vector obtained from
   // GlobalParams() or in the given member_params.
@@ -76,16 +129,16 @@ public:
   static T *FindParam(const char *name, const std::vector<T *> &global_vec,
                       const std::vector<T *> &member_vec) {
     for (auto *param : global_vec) {
-      if (strcmp(param->name_str(), name) == 0) {
+      if (CompareKeys(param->name_str(), name)) {
         return param;
       }
     }
     for (auto *param : member_vec) {
-      if (strcmp(param->name_str(), name) == 0) {
+      if (CompareKeys(param->name_str(), name)) {
         return param;
       }
     }
-    return nullptr;
+	return nullptr;
   }
   // Removes the given pointer to the param from the given vector.
   template <class T>
@@ -104,6 +157,15 @@ public:
 
   // Print parameters to the given file.
   static void PrintParams(FILE *fp, const ParamsVectors *member_params);
+
+  // Report parameters' usage statistics, i.e. report which params have been
+  // set, modified and read/checked until now during this run-time's lifetime.
+  //
+  // Use this method for run-time 'discovery' about which tesseract parameters
+  // are actually *used* during your particular usage of the library, ergo
+  // answering the question:
+  // "Which of all those parameters are actually *relevant* to my use case today?"
+  static void ReportParamsUsageStatistics(const ParamsVectors *member_params);
 
   // Resets all parameters back to default values;
   static void ResetToDefaults(ParamsVectors *member_params);
@@ -133,16 +195,29 @@ public:
             (constraint == SET_PARAM_CONSTRAINT_NON_INIT_ONLY && !this->is_init()));
   }
 
+  typedef struct access_counts {
+	  int reading;
+	  int writing;
+  } access_counts_t;
+
+  access_counts_t access_counts() const {
+	  return access_counts_;
+  }
+
+  virtual std::string formatted_value_str() const = 0;
+
 protected:
   Param(const char *name, const char *comment, bool init)
       : name_(name), info_(comment), init_(init) {
     debug_ = (strstr(name, "debug") != nullptr) || (strstr(name, "display"));
+	access_counts_ = {0,0};
   }
 
   const char *name_; // name of this parameter
   const char *info_; // for menus
   bool init_;        // needs to be set before init
   bool debug_;
+  mutable access_counts_t access_counts_;
 };
 
 class IntParam : public Param {
@@ -151,40 +226,51 @@ public:
       : Param(name, comment, init) {
     value_ = value;
     default_ = value;
-    params_vec_ = &(vec->int_params);
-    vec->int_params.push_back(this);
+	access_counts_.writing++;
+    params_vec_ = vec;
+    vec->int_params().push_back(this);
   }
   ~IntParam() {
-    ParamUtils::RemoveParam<IntParam>(this, params_vec_);
+    ParamUtils::RemoveParam<IntParam>(this, &params_vec_->int_params());
   }
   operator int32_t() const {
-    return value_;
+	  access_counts_.reading++;
+	  return value_;
   }
   void operator=(int32_t value) {
-    value_ = value;
+	  access_counts_.writing++;
+	  value_ = value;
   }
   void set_value(int32_t value) {
-    value_ = value;
+	  access_counts_.writing++;
+	  value_ = value;
   }
   void ResetToDefault() {
-    value_ = default_;
+      access_counts_.writing++;
+      value_ = default_;
   }
   void ResetFrom(const ParamsVectors *vec) {
-    for (auto *param : vec->int_params) {
+    for (auto *param : vec->int_params_c()) {
       if (strcmp(param->name_str(), name_) == 0) {
-        // printf("overriding param %s=%d by =%d\n", name_, value_,
-        // param);
-        value_ = *param;
+        // tprintf("overriding param {}={} by ={}\n", name_, value_,
+        // *param);
+          access_counts_.writing++;
+          value_ = *param;
         break;
       }
     }
   }
 
+  virtual std::string formatted_value_str() const override {
+      return std::to_string(value_);
+  }
+
 private:
   int32_t value_;
   int32_t default_;
-  // Pointer to the vector that contains this param (not owned by this class).
-  std::vector<IntParam *> *params_vec_;
+
+  // Pointer to the vector that contains this param (not owned by this class). Used by the destructor.
+  ParamsVectors *params_vec_;
 };
 
 class BoolParam : public Param {
@@ -193,40 +279,51 @@ public:
       : Param(name, comment, init) {
     value_ = value;
     default_ = value;
-    params_vec_ = &(vec->bool_params);
-    vec->bool_params.push_back(this);
+	access_counts_.writing++;
+	params_vec_ = vec;
+    vec->bool_params().push_back(this);
   }
   ~BoolParam() {
-    ParamUtils::RemoveParam<BoolParam>(this, params_vec_);
+    ParamUtils::RemoveParam<BoolParam>(this, &params_vec_->bool_params());
   }
   operator bool() const {
-    return value_;
+	  access_counts_.reading++;
+	  return value_;
   }
   void operator=(bool value) {
-    value_ = value;
+	  access_counts_.writing++;
+	  value_ = value;
   }
   void set_value(bool value) {
-    value_ = value;
+	  access_counts_.writing++;
+	  value_ = value;
   }
   void ResetToDefault() {
-    value_ = default_;
+      access_counts_.writing++;
+      value_ = default_;
   }
   void ResetFrom(const ParamsVectors *vec) {
-    for (auto *param : vec->bool_params) {
+    for (auto *param : vec->bool_params_c()) {
       if (strcmp(param->name_str(), name_) == 0) {
-        // printf("overriding param %s=%s by =%s\n", name_, value_ ? "true" :
+        // tprintf("overriding param {}={} by ={}\n", name_, value_ ? "true" :
         // "false", *param ? "true" : "false");
-        value_ = *param;
+          access_counts_.writing++;
+          value_ = *param;
         break;
       }
     }
   }
 
+  virtual std::string formatted_value_str() const override {
+      return std::to_string(value_);
+  }
+
 private:
   bool value_;
   bool default_;
+
   // Pointer to the vector that contains this param (not owned by this class).
-  std::vector<BoolParam *> *params_vec_;
+  ParamsVectors *params_vec_;
 };
 
 class StringParam : public Param {
@@ -236,52 +333,74 @@ public:
       : Param(name, comment, init) {
     value_ = value;
     default_ = value;
-    params_vec_ = &(vec->string_params);
-    vec->string_params.push_back(this);
+	access_counts_.writing++;
+	params_vec_ = vec;
+    vec->string_params().push_back(this);
   }
   ~StringParam() {
-    ParamUtils::RemoveParam<StringParam>(this, params_vec_);
+    ParamUtils::RemoveParam<StringParam>(this, &params_vec_->string_params());
   }
   operator std::string &() {
-    return value_;
+	  access_counts_.reading++;
+	  return value_;
   }
   const char *c_str() const {
-    return value_.c_str();
+	  access_counts_.reading++;
+	  return value_.c_str();
   }
   bool contains(char c) const {
-    return value_.find(c) != std::string::npos;
+	  access_counts_.reading++;
+	  return value_.find(c) != std::string::npos;
   }
   bool empty() const {
-    return value_.empty();
+	  access_counts_.reading++;
+	  return value_.empty();
   }
   bool operator==(const std::string &other) const {
-    return value_ == other;
+	  access_counts_.reading++;
+	  return value_ == other;
   }
   void operator=(const std::string &value) {
-    value_ = value;
+	  access_counts_.writing++;
+	  value_ = value;
   }
   void set_value(const std::string &value) {
-    value_ = value;
+	  access_counts_.writing++;
+	  value_ = value;
+  }
+  const std::string &value() {
+	  access_counts_.reading++;
+	  return value_;
   }
   void ResetToDefault() {
-    value_ = default_;
+      access_counts_.writing++;
+      value_ = default_;
   }
   void ResetFrom(const ParamsVectors *vec) {
-    for (auto *param : vec->string_params) {
+    for (auto *param : vec->string_params_c()) {
       if (strcmp(param->name_str(), name_) == 0) {
-        // printf("overriding param %s=%s by =%s\n", name_, value_,
+        // tprintf("overriding param {}={} by ={}\n", name_, value_,
         // param->c_str());
-        value_ = *param;
+          access_counts_.writing++;
+          value_ = *param;
         break;
       }
     }
   }
 
+  virtual std::string formatted_value_str() const override {
+      std::string rv = (const char *)u8"«";
+      rv += value_;
+      rv += (const char *)u8"»";
+      return rv;
+  }
+
 private:
   std::string value_;
   std::string default_;
+
   // Pointer to the vector that contains this param (not owned by this class).
-  std::vector<StringParam *> *params_vec_;
+  ParamsVectors *params_vec_;
 };
 
 class DoubleParam : public Param {
@@ -290,40 +409,57 @@ public:
       : Param(name, comment, init) {
     value_ = value;
     default_ = value;
-    params_vec_ = &(vec->double_params);
-    vec->double_params.push_back(this);
+	access_counts_.writing++;
+	params_vec_ = vec;
+    vec->double_params().push_back(this);
   }
   ~DoubleParam() {
-    ParamUtils::RemoveParam<DoubleParam>(this, params_vec_);
+    ParamUtils::RemoveParam<DoubleParam>(this, &params_vec_->double_params());
   }
   operator double() const {
-    return value_;
+	  access_counts_.reading++;
+	  return value_;
   }
   void operator=(double value) {
-    value_ = value;
+	  access_counts_.writing++;
+	  value_ = value;
   }
   void set_value(double value) {
-    value_ = value;
+	  access_counts_.writing++;
+	  value_ = value;
   }
   void ResetToDefault() {
-    value_ = default_;
+      access_counts_.writing++;
+      value_ = default_;
   }
   void ResetFrom(const ParamsVectors *vec) {
-    for (auto *param : vec->double_params) {
+    for (auto *param : vec->double_params_c()) {
       if (strcmp(param->name_str(), name_) == 0) {
-        // printf("overriding param %s=%f by =%f\n", name_, value_,
+        // tprintf("overriding param {}={} by ={}\n", name_, value_,
         // *param);
-        value_ = *param;
+          access_counts_.writing++;
+          value_ = *param;
         break;
       }
     }
   }
 
+  virtual std::string formatted_value_str() const override {
+#if 0
+      return std::to_string(value_);   // always outputs %.6f format style values
+#else
+      char sbuf[40];
+      snprintf(sbuf, sizeof(sbuf), "%1.f", value_);
+      return sbuf;
+#endif
+  }
+
 private:
   double value_;
   double default_;
+
   // Pointer to the vector that contains this param (not owned by this class).
-  std::vector<DoubleParam *> *params_vec_;
+  ParamsVectors *params_vec_;
 };
 
 // Global parameter lists.
@@ -337,6 +473,7 @@ private:
 // parameters are converted to members.
 TESS_API
 ParamsVectors *GlobalParams();
+
 
 /*************************************************************************
  * Note on defining parameters.
@@ -381,6 +518,12 @@ ParamsVectors *GlobalParams();
 #define STRING_INIT_MEMBER(name, val, comment, vec) name(val, #name, comment, true, vec)
 
 #define double_INIT_MEMBER(name, val, comment, vec) name(val, #name, comment, true, vec)
+
+// ------------------------------------
+
+extern BOOL_VAR_H(debug_all);
+extern STRING_VAR_H(vars_report_file);
+extern BOOL_VAR_H(report_all_variables);
 
 } // namespace tesseract
 


### PR DESCRIPTION
> RFC: ParamUtils::ReportParamsUsageStatistics() work extracted from master; rough first draft, as in: not compile-tested, not backported to using `[sf]printf()` instead of `fmt::format` et al.

The idea is this:

I assume I am not alone in this.

When running tesseract, I wonder which **variables** (`tesseract -c var=value`) are actually used and *might* have an impact on what I'm trying to do. This includes the `debug_*` variable set -- though I tend to tweak that set through debugger runs. 🤧 

This code, ripped straight from my master branch, hence non-working in tesseract mainline due to various other patches I pulled in or did myself over time, is to give an idea of how this should look, code-wise.

The tesseract variable class tracks access (read & write invocations), the whole access thing is parked behind a couple of getter/setters so we can guarantee access tracking accuracy, so we get reports like these at the end of a tesseract run:

> ... where the rw column is lower-case for single-access, upper-case for multiple-access. A single 'w' for everyone is obvious as tesseract initializes all variables to default values. The 'unused variables' section is an extra, which I use to notice: "_Aha! I *think* that one is relevant, but why didn't it get accessed? What do I have to do to change the run-time path so it gets involved?_"


```

Tesseract Parameter Usage Statistics: which params have been relevant?
----------------------------------------------------------------------

* bidi_debug.................................................. (Global) WR [Integer] = 0
* chop_ok_split............................................... (Global) wr [Float]   = 100
* classify_bln_numeric_mode................................... (Global) wR [Boolean] = 0
* classify_debug_level........................................ (Global) WR [Integer] = 1
* classify_max_certainty_margin............................... (Global) wR [Float]   = 6
* classify_max_rating_ratio................................... (Global) wR [Float]   = 2
* classify_use_pre_adapted_templates.......................... (Global) wr [Boolean] = 0
* debug_all................................................... (Local)  WR [Boolean] = 1
* debug_output_path........................................... (Global) WR [String]  = «unnamed-medium-133-bicubic-after-thres-png-PAR-N-debug»
* debug_write_unlv............................................ (Global) wr [Boolean] = 0
* document_title.............................................. (Local)  wr [String]  = «»
* dotproduct.................................................. (Local)  WR [String]  = «avx2»
* edges_boxarea............................................... (Local)  wR [Float]   = 1
* edges_childarea............................................. (Local)  wR [Float]   = 1
* edges_children_count_limit.................................. (Local)  wR [Integer] = 45
* edges_children_fix.......................................... (Local)  wR [Boolean] = 0
* edges_children_per_grandchild............................... (Local)  wR [Integer] = 10
* edges_debug................................................. (Local)  WR [Boolean] = 1
* edges_use_new_outline_complexity............................ (Local)  wR [Boolean] = 0
* enable_noise_removal........................................ (Global) wr [Boolean] = 1
* gapmap_big_gaps............................................. (Local)  wR [Float]   = 2
* gapmap_debug................................................ (Local)  WR [Boolean] = 1
* gapmap_no_isolated_quanta................................... (Local)  wR [Boolean] = 0
* gapmap_use_ends............................................. (Local)  wR [Boolean] = 0
* hocr_char_boxes............................................. (Global) Wr [Boolean] = 1
* hocr_font_info.............................................. (Global) WR [Boolean] = 1
* hocr_images................................................. (Global) Wr [Boolean] = 1
* interactive_display_mode.................................... (Global) wr [Boolean] = 0
* invert_threshold............................................ (Global) wR [Float]   = 1
* jpg_quality................................................. (Global) wr [Integer] = 85
* lstm_choice_iterations...................................... (Global) wR [Integer] = 5
* lstm_choice_mode............................................ (Global) wR [Integer] = 0
* lstm_rating_coefficient..................................... (Global) wR [Float]   = 5
* lstm_use_matrix............................................. (Global) wr [Boolean] = 1
* max_page_gradient_recognize................................. (Global) wr [Float]   = 100
* ocr_devanagari_split_strategy............................... (Global) wr [Integer] = 0
* oldbl_dot_error_size........................................ (Local)  wR [Float]   = 1
* oldbl_holed_losscount....................................... (Local)  wR [Integer] = 10
* page_separator.............................................. (Global) wr [String]  = «»
* pageseg_apply_music_mask.................................... (Global) wr [Boolean] = 0
* pageseg_devanagari_split_strategy........................... (Global) wR [Integer] = 0
* paragraph_debug_level....................................... (Global) Wr [Integer] = 3
* paragraph_text_based........................................ (Global) Wr [Boolean] = 0
* pitsync_joined_edge......................................... (Local)  wR [Float]   = 1
* pitsync_linear_version...................................... (Local)  wR [Integer] = 6
* poly_allow_detailed_fx...................................... (Global) wR [Boolean] = 0
* poly_debug.................................................. (Local)  WR [Boolean] = 0
* poly_wide_objects_better.................................... (Local)  wR [Boolean] = 1
* preprocess_graynorm_mode.................................... (Global) Wr [Integer] = 0
* preserve_interword_spaces................................... (Global) wR [Boolean] = 0
* scribe_save_binary_rotated_image............................ (Global) WR [Boolean] = 1
* scribe_save_grey_rotated_image.............................. (Global) WR [Boolean] = 1
* scribe_save_original_rotated_image.......................... (Global) Wr [Boolean] = 1
* stream_filelist............................................. (Local)  wr [Boolean] = 0
* suspect_level............................................... (Global) wR [Integer] = 99
* tess_debug_lstm............................................. (Global) WR [Boolean] = 0
* tessedit_ambigs_training.................................... (Global) wR [Boolean] = 0
* tessedit_char_blacklist..................................... (Global) wR [String]  = «»
* tessedit_char_unblacklist................................... (Global) wR [String]  = «»
* tessedit_char_whitelist..................................... (Global) wR [String]  = «»
* tessedit_create_alto........................................ (Global) Wr [Boolean] = 1
* tessedit_create_boxfile..................................... (Global) Wr [Boolean] = 1
* tessedit_create_hocr........................................ (Global) Wr [Boolean] = 1
* tessedit_create_lstmbox..................................... (Global) Wr [Boolean] = 1
* tessedit_create_page........................................ (Global) WR [Boolean] = 1
* tessedit_create_pdf......................................... (Global) Wr [Boolean] = 1
* tessedit_create_tsv......................................... (Global) Wr [Boolean] = 1
* tessedit_create_txt......................................... (Global) Wr [Boolean] = 1
* tessedit_create_wordstrbox.................................. (Global) Wr [Boolean] = 1
* tessedit_do_invert.......................................... (Global) wR [Boolean] = 1
* tessedit_dump_choices....................................... (Global) WR [Boolean] = 1
* tessedit_dump_pageseg_images................................ (Global) WR [Boolean] = 1
* tessedit_init_config_only................................... (Global) wR [Boolean] = 0
* tessedit_load_sublangs...................................... (Global) wr [String]  = «»
* tessedit_make_boxes_from_boxes.............................. (Global) wR [Boolean] = 0
* tessedit_minimal_rej_pass1.................................. (Global) wr [Boolean] = 0
* tessedit_minimal_rejection.................................. (Global) wR [Boolean] = 0
* tessedit_ocr_engine_mode.................................... (Global) WR [Integer] = 1
* tessedit_pageseg_mode....................................... (Global) WR [Integer] = 3
* tessedit_parallelize........................................ (Global) wr [Integer] = 0
* tessedit_rejection_debug.................................... (Global) WR [Boolean] = 1
* tessedit_resegment_from_boxes............................... (Global) wR [Boolean] = 0
* tessedit_resegment_from_line_boxes.......................... (Global) wr [Boolean] = 0
* tessedit_tess_adaption_mode................................. (Global) wr [Integer] = 39
* tessedit_test_adaption...................................... (Global) wr [Boolean] = 0
* tessedit_timing_debug....................................... (Global) WR [Boolean] = 1
* tessedit_train_from_boxes................................... (Global) wR [Boolean] = 0
* tessedit_train_line_recognizer.............................. (Global) wR [Boolean] = 0
* tessedit_write_block_separators............................. (Global) wR [Boolean] = 0
* tessedit_write_images....................................... (Global) Wr [Boolean] = 1
* tessedit_write_params_to_file............................... (Global) wr [String]  = «»
* tessedit_write_unlv......................................... (Global) WR [Boolean] = 1
* tessedit_zero_rejection..................................... (Global) wR [Boolean] = 0
* test_pt..................................................... (Global) wR [Boolean] = 0
* textonly_pdf................................................ (Global) Wr [Boolean] = 0
* textord_all_prop............................................ (Local)  wR [Boolean] = 0
* textord_ascheight_mode_fraction............................. (Local)  wR [Float]   = 0
* textord_ascx_ratio_max...................................... (Local)  wR [Float]   = 2
* textord_ascx_ratio_min...................................... (Local)  wR [Float]   = 1
* textord_balance_factor...................................... (Local)  wR [Float]   = 1
* textord_baseline_debug...................................... (Global) Wr [Integer] = 0
* textord_biased_skewcalc..................................... (Local)  wR [Boolean] = 1
* textord_blockndoc_fixed..................................... (Local)  wr [Boolean] = 0
* textord_blocksall_fixed..................................... (Local)  wR [Boolean] = 0
* textord_blocksall_prop...................................... (Local)  wR [Boolean] = 0
* textord_blshift_maxshift.................................... (Global) wR [Float]   = 0
* textord_blshift_xfraction................................... (Global) wR [Float]   = 10
* textord_chop_width.......................................... (Local)  wR [Float]   = 2
* textord_chopper_test........................................ (Local)  wR [Boolean] = 0
* textord_debug_baselines..................................... (Local)  WR [Boolean] = 1
* textord_debug_block......................................... (Local)  WR [Integer] = 9
* textord_debug_bugs.......................................... (Local)  WR [Integer] = 9
* textord_debug_pitch_metric.................................. (Local)  WR [Boolean] = 1
* textord_debug_pitch_test.................................... (Local)  WR [Boolean] = 1
* textord_debug_tabfind....................................... (Local)  WR [Integer] = 0
* textord_debug_xheights...................................... (Local)  WR [Boolean] = 1
* textord_descheight_mode_fraction............................ (Local)  wR [Float]   = 0
* textord_descx_ratio_max..................................... (Local)  wR [Float]   = 1
* textord_descx_ratio_min..................................... (Local)  wR [Float]   = 0
* textord_disable_pitch_test.................................. (Local)  wR [Boolean] = 0
* textord_dotmatrix_gap....................................... (Local)  wR [Integer] = 3
* textord_equation_detect..................................... (Global) wr [Boolean] = 0
* textord_excess_blobsize..................................... (Local)  wR [Float]   = 1
* textord_expansion_factor.................................... (Local)  wR [Float]   = 1
* textord_fast_pitch_test..................................... (Local)  wR [Boolean] = 0
* textord_fix_makerow_bug..................................... (Local)  wR [Boolean] = 1
* textord_fix_xheight_bug..................................... (Local)  wR [Boolean] = 1
* textord_force_make_prop_words............................... (Local)  wR [Boolean] = 0
* textord_fpiqr_ratio......................................... (Local)  wR [Float]   = 2
* textord_heavy_nr............................................ (Local)  wr [Boolean] = 0
* textord_initialasc_ile...................................... (Global) wR [Float]   = 1
* textord_initialx_ile........................................ (Global) wR [Float]   = 1
* textord_interpolating_skew.................................. (Local)  wR [Boolean] = 1
* textord_linespace_iqrlimit.................................. (Local)  wR [Float]   = 0
* textord_max_blob_overlaps................................... (Local)  wR [Integer] = 4
* textord_max_noise_size...................................... (Global) wR [Integer] = 7
* textord_max_pitch_iqr....................................... (Local)  wR [Float]   = 0
* textord_min_blob_height_fraction............................ (Local)  wR [Float]   = 1
* textord_min_linesize........................................ (Local)  wR [Float]   = 1
* textord_min_xheight......................................... (Local)  wR [Integer] = 10
* textord_minxh............................................... (Local)  wR [Float]   = 0
* textord_new_initial_xheight................................. (Local)  wR [Boolean] = 1
* textord_no_rejects.......................................... (Global) wR [Boolean] = 0
* textord_noise_area_ratio.................................... (Global) wR [Float]   = 1
* textord_noise_debug......................................... (Global) WR [Boolean] = 1
* textord_noise_hfract........................................ (Global) wR [Float]   = 0
* textord_noise_normratio..................................... (Global) wR [Float]   = 2
* textord_noise_rejrows....................................... (Global) wR [Boolean] = 1
* textord_noise_rejwords...................................... (Global) wR [Boolean] = 1
* textord_noise_rowratio...................................... (Global) wR [Float]   = 6
* textord_noise_sizefraction.................................. (Global) wR [Integer] = 10
* textord_noise_sizelimit..................................... (Global) wR [Float]   = 1
* textord_noise_sncount....................................... (Global) wR [Integer] = 1
* textord_noise_sxfract....................................... (Global) wR [Float]   = 0
* textord_noise_syfract....................................... (Global) wR [Float]   = 0
* textord_noise_translimit.................................... (Global) wR [Integer] = 16
* textord_occupancy_threshold................................. (Local)  wR [Float]   = 0
* textord_old_baselines....................................... (Local)  wR [Boolean] = 1
* textord_old_xheight......................................... (Local)  wR [Boolean] = 0
* textord_oldbl_debug......................................... (Local)  WR [Boolean] = 0
* textord_oldbl_jumplimit..................................... (Local)  wR [Float]   = 0
* textord_oldbl_merge_parts................................... (Local)  wR [Boolean] = 1
* textord_oldbl_paradef....................................... (Local)  wR [Boolean] = 1
* textord_oldbl_split_splines................................. (Local)  wR [Boolean] = 1
* textord_overlap_x........................................... (Local)  wR [Float]   = 0
* textord_parallel_baselines.................................. (Local)  wR [Boolean] = 1
* textord_pitch_range......................................... (Local)  wR [Integer] = 2
* textord_pitch_rowsimilarity................................. (Local)  wR [Float]   = 0
* textord_pitch_scalebigwords................................. (Local)  wR [Boolean] = 0
* textord_projection_scale.................................... (Local)  wR [Float]   = 0
* textord_really_old_xheight.................................. (Local)  wR [Boolean] = 0
* textord_restore_underlines.................................. (Local)  wR [Boolean] = 1
* textord_show_expanded_rows.................................. (Local)  wR [Boolean] = 0
* textord_show_final_rows..................................... (Local)  wR [Boolean] = 0
* textord_show_initial_rows................................... (Local)  wR [Boolean] = 0
* textord_show_initial_words.................................. (Local)  wR [Boolean] = 0
* textord_show_parallel_rows.................................. (Local)  wR [Boolean] = 0
* textord_single_height_mode.................................. (Global) wR [Boolean] = 0
* textord_skew_ile............................................ (Local)  wR [Float]   = 1
* textord_skew_lag............................................ (Local)  wR [Float]   = 0
* textord_skewsmooth_offset................................... (Local)  wR [Integer] = 4
* textord_skewsmooth_offset2.................................. (Local)  wR [Integer] = 1
* textord_spacesize_ratioprop................................. (Local)  wR [Float]   = 2
* textord_spline_medianwin.................................... (Local)  wR [Integer] = 6
* textord_spline_minblobs..................................... (Local)  wR [Integer] = 8
* textord_spline_shift_fraction............................... (Local)  wR [Float]   = 0
* textord_straight_baselines.................................. (Local)  wR [Boolean] = 0
* textord_tabfind_aligned_gap_fraction........................ (Global) wr [Float]   = 1
* textord_tabfind_find_tables................................. (Local)  wr [Boolean] = 1
* textord_tabfind_force_vertical_text......................... (Global) wr [Boolean] = 0
* textord_tabfind_show_images................................. (Local)  WR [Integer] = 0
* textord_tabfind_show_strokewidths........................... (Local)  wr [Integer] = 0
* textord_tabfind_show_vlines................................. (Global) Wr [Boolean] = 1
* textord_tabfind_vertical_text............................... (Global) wr [Boolean] = 1
* textord_tabfind_vertical_text_ratio......................... (Global) wr [Float]   = 1
* textord_tablefind_recognize_tables.......................... (Local)  wr [Boolean] = 0
* textord_test_landscape...................................... (Local)  wR [Boolean] = 0
* textord_test_x.............................................. (Local)  wR [Integer] = -2147483647
* textord_test_y.............................................. (Local)  wR [Integer] = -2147483647
* textord_underline_width..................................... (Local)  wR [Float]   = 2
* textord_use_cjk_fp_model.................................... (Global) wR [Boolean] = 0
* textord_width_limit......................................... (Local)  wR [Float]   = 8
* textord_words_def_fixed..................................... (Local)  wR [Float]   = 0
* textord_words_def_prop...................................... (Local)  wR [Float]   = 0
* textord_words_default_maxspace.............................. (Local)  wR [Float]   = 4
* textord_words_default_minspace.............................. (Local)  wR [Float]   = 1
* textord_words_default_nonspace.............................. (Local)  wR [Float]   = 0
* textord_words_maxspace...................................... (Local)  wR [Float]   = 4
* textord_words_min_minspace.................................. (Local)  wR [Float]   = 0
* textord_words_pitchsd_threshold............................. (Local)  wR [Float]   = 0
* textord_words_veto_power.................................... (Local)  wR [Integer] = 5
* textord_wordstats_smooth_factor............................. (Local)  wR [Float]   = 0
* textord_xheight_error_margin................................ (Local)  wR [Float]   = 0
* textord_xheight_mode_fraction............................... (Local)  wR [Float]   = 0
* thresholding_debug.......................................... (Global) WR [Boolean] = 1
* thresholding_kfactor........................................ (Global) wr [Float]   = 0
* thresholding_method......................................... (Global) wr [Integer] = 0
* thresholding_score_fraction................................. (Global) wr [Float]   = 0
* thresholding_smooth_kernel_size............................. (Global) wr [Float]   = 0
* thresholding_tile_size...................................... (Global) wr [Float]   = 0
* thresholding_window_size.................................... (Global) wr [Float]   = 0
* tosp_all_flips_fuzzy........................................ (Global) wR [Boolean] = 0
* tosp_block_use_cert_spaces.................................. (Global) wR [Boolean] = 1
* tosp_debug_level............................................ (Global) WR [Integer] = 3
* tosp_dont_fool_with_small_kerns............................. (Global) wR [Float]   = -1
* tosp_enough_small_gaps...................................... (Global) wr [Float]   = 1
* tosp_enough_space_samples_for_median........................ (Global) wR [Integer] = 3
* tosp_few_samples............................................ (Global) wR [Integer] = 40
* tosp_flip_caution........................................... (Global) wR [Float]   = 0
* tosp_flip_fuzz_kn_to_sp..................................... (Global) wR [Boolean] = 1
* tosp_flip_fuzz_sp_to_kn..................................... (Global) wR [Boolean] = 1
* tosp_force_wordbreak_on_punct............................... (Global) wR [Boolean] = 0
* tosp_fuzzy_kn_fraction...................................... (Global) wR [Float]   = 1
* tosp_fuzzy_limit_all........................................ (Global) wR [Boolean] = 1
* tosp_fuzzy_sp_fraction...................................... (Global) wR [Float]   = 1
* tosp_fuzzy_space_factor..................................... (Global) wR [Float]   = 1
* tosp_fuzzy_space_factor1.................................... (Global) wR [Float]   = 1
* tosp_fuzzy_space_factor2.................................... (Global) wR [Float]   = 1
* tosp_gap_factor............................................. (Global) wR [Float]   = 1
* tosp_ignore_big_gaps........................................ (Global) wR [Float]   = -1
* tosp_ignore_very_big_gaps................................... (Global) wR [Float]   = 4
* tosp_improve_thresh......................................... (Global) wR [Boolean] = 0
* tosp_init_guess_kn_mult..................................... (Global) wR [Float]   = 2
* tosp_init_guess_xht_mult.................................... (Global) wR [Float]   = 0
* tosp_kern_gap_factor1....................................... (Global) wR [Float]   = 2
* tosp_kern_gap_factor2....................................... (Global) wR [Float]   = 1
* tosp_kern_gap_factor3....................................... (Global) wR [Float]   = 3
* tosp_large_kerning.......................................... (Global) wR [Float]   = 0
* tosp_max_sane_kn_thresh..................................... (Global) wR [Float]   = 5
* tosp_min_sane_kn_sp......................................... (Global) wR [Float]   = 2
* tosp_narrow_aspect_ratio.................................... (Global) wR [Float]   = 0
* tosp_narrow_blobs_not_cert.................................. (Global) wR [Boolean] = 1
* tosp_narrow_fraction........................................ (Global) wR [Float]   = 0
* tosp_near_lh_edge........................................... (Global) wR [Float]   = 0
* tosp_old_sp_kn_th_factor.................................... (Global) wr [Float]   = 2
* tosp_old_to_constrain_sp_kn................................. (Global) wR [Boolean] = 0
* tosp_old_to_method.......................................... (Global) wR [Boolean] = 0
* tosp_only_small_gaps_for_kern............................... (Global) wR [Boolean] = 0
* tosp_only_use_prop_rows..................................... (Global) wR [Boolean] = 1
* tosp_only_use_xht_gaps...................................... (Global) wR [Boolean] = 0
* tosp_pass_wide_fuzz_sp_to_context........................... (Global) wR [Float]   = 1
* tosp_recovery_isolated_row_stats............................ (Global) wR [Boolean] = 1
* tosp_redo_kern_limit........................................ (Global) wR [Integer] = 10
* tosp_rep_space.............................................. (Global) wR [Float]   = 2
* tosp_row_use_cert_spaces.................................... (Global) wR [Boolean] = 1
* tosp_row_use_cert_spaces1................................... (Global) wR [Boolean] = 1
* tosp_rule_9_test_punct...................................... (Global) wr [Boolean] = 0
* tosp_sanity_method.......................................... (Global) wR [Integer] = 1
* tosp_short_row.............................................. (Global) wR [Integer] = 20
* tosp_silly_kn_sp_gap........................................ (Global) wR [Float]   = 0
* tosp_stats_use_xht_gaps..................................... (Global) wR [Boolean] = 1
* tosp_table_fuzzy_kn_sp_ratio................................ (Global) wR [Float]   = 3
* tosp_table_kn_sp_ratio...................................... (Global) wR [Float]   = 2
* tosp_table_xht_sp_ratio..................................... (Global) wR [Float]   = 0
* tosp_threshold_bias1........................................ (Global) wR [Float]   = 0
* tosp_threshold_bias2........................................ (Global) wR [Float]   = 0
* tosp_use_pre_chopping....................................... (Global) wR [Boolean] = 0
* tosp_use_xht_gaps........................................... (Global) wR [Boolean] = 1
* tosp_wide_aspect_ratio...................................... (Global) wR [Float]   = 0
* tosp_wide_fraction.......................................... (Global) wR [Float]   = 1
* unlv_tilde_crunching........................................ (Global) WR [Boolean] = 1
* use_ambigs_for_adaption..................................... (Global) wr [Boolean] = 0
* user_defined_dpi............................................ (Global) wr [Integer] = 0
* user_patterns_file.......................................... (Global) wr [String]  = «»
* user_patterns_suffix........................................ (Global) wr [String]  = «»
* user_words_file............................................. (Global) wr [String]  = «»
* user_words_suffix........................................... (Global) wr [String]  = «»
* vars_report_file............................................ (Local)  wr [String]  = «+»
* words_default_fixed_limit................................... (Local)  wR [Float]   = 1
* words_default_fixed_space................................... (Local)  wR [Float]   = 1
* words_default_prop_nonspace................................. (Local)  wR [Float]   = 0
* words_initial_lower......................................... (Local)  wR [Float]   = 1
* words_initial_upper......................................... (Local)  wR [Float]   = 0


Unused parameters:

* FLAGS_D..................................................... (Local)  w. [String]  = «»
* FLAGS_F..................................................... (Local)  w. [String]  = «font_properties»
* FLAGS_O..................................................... (Local)  w. [String]  = «»
* FLAGS_U..................................................... (Local)  w. [String]  = «unicharset»
* FLAGS_X..................................................... (Local)  w. [String]  = «»
* FLAGS_adam_beta............................................. (Local)  w. [Float]   = 1
* FLAGS_append_index.......................................... (Local)  w. [Integer] = -1
* FLAGS_canonical_class1...................................... (Local)  w. [String]  = «»
* FLAGS_canonical_class2...................................... (Local)  w. [String]  = «»
* FLAGS_classifier............................................ (Local)  w. [String]  = «»
* FLAGS_clusterconfig_confidence.............................. (Local)  w. [Float]   = 0
* FLAGS_clusterconfig_independence............................ (Local)  w. [Float]   = 1
* FLAGS_clusterconfig_max_illegal............................. (Local)  w. [Float]   = 0
* FLAGS_clusterconfig_min_samples_fraction.................... (Local)  w. [Float]   = 1
* FLAGS_configfile............................................ (Local)  w. [String]  = «»
* FLAGS_continue_from......................................... (Local)  w. [String]  = «»
* FLAGS_convert_to_int........................................ (Local)  w. [Boolean] = 0
* FLAGS_debug_interval........................................ (Local)  w. [Integer] = 0
* FLAGS_debug_level........................................... (Local)  w. [Integer] = 0
* FLAGS_debug_network......................................... (Local)  w. [Boolean] = 0
* FLAGS_display_canonical_font................................ (Local)  w. [Integer] = -1
* FLAGS_display_cloud_font.................................... (Local)  w. [Integer] = -1
* FLAGS_eval_listfile......................................... (Local)  w. [String]  = «»
* FLAGS_fontconfig_tmpdir..................................... (Local)  w. [String]  = «»
* FLAGS_fonts_dir............................................. (Local)  w. [String]  = «»
* FLAGS_lang.................................................. (Local)  w. [String]  = «eng»
* FLAGS_learning_rate......................................... (Local)  w. [Float]   = 0
* FLAGS_load_images........................................... (Local)  w. [Integer] = 0
* FLAGS_max_image_MB.......................................... (Local)  w. [Integer] = 2000
* FLAGS_max_iterations........................................ (Local)  w. [Integer] = 0
* FLAGS_model................................................. (Local)  w. [String]  = «»
* FLAGS_model_output.......................................... (Local)  w. [String]  = «lstmtrain»
* FLAGS_momentum.............................................. (Local)  w. [Float]   = 1
* FLAGS_net_mode.............................................. (Local)  w. [Integer] = 192
* FLAGS_net_spec.............................................. (Local)  w. [String]  = «»
* FLAGS_old_traineddata....................................... (Local)  w. [String]  = «»
* FLAGS_output_trainer........................................ (Local)  w. [String]  = «»
* FLAGS_perfect_sample_delay.................................. (Local)  w. [Integer] = 0
* FLAGS_randomly_rotate....................................... (Local)  w. [Boolean] = 0
* FLAGS_reset_learning_rate................................... (Local)  w. [Boolean] = 0
* FLAGS_sequential_training................................... (Local)  w. [Boolean] = 0
* FLAGS_stop_training......................................... (Local)  w. [Boolean] = 0
* FLAGS_target_error_rate..................................... (Local)  w. [Float]   = 0
* FLAGS_tessdata_dir.......................................... (Local)  w. [String]  = «»
* FLAGS_test_ch............................................... (Local)  w. [String]  = «»
* FLAGS_tlog_level............................................ (Local)  W. [Integer] = 10000
* FLAGS_train_listfile........................................ (Local)  w. [String]  = «»
* FLAGS_traineddata........................................... (Local)  w. [String]  = «»
* FLAGS_verbosity............................................. (Local)  w. [Integer] = 1
* FLAGS_weight_range.......................................... (Local)  w. [Float]   = 0
* allow_blob_division......................................... (Global) w. [Boolean] = 1
* ambigs_debug_level.......................................... (Global) w. [Integer] = 0
* applybox_debug.............................................. (Global) W. [Integer] = 0
* applybox_exposure_pattern................................... (Global) w. [String]  = «.exp»
* applybox_learn_chars_and_char_frags_mode.................... (Global) w. [Boolean] = 0
* applybox_learn_ngrams_mode.................................. (Global) w. [Boolean] = 0
* applybox_page............................................... (Global) w. [Integer] = 0
* assume_fixed_pitch_char_segment............................. (Global) w. [Boolean] = 0
* bland_unrej................................................. (Global) w. [Boolean] = 0
* certainty_scale............................................. (Global) w. [Float]   = 20
* chop_center_knob............................................ (Global) w. [Float]   = 0
* chop_centered_maxwidth...................................... (Global) w. [Integer] = 90
* chop_debug.................................................. (Global) W. [Integer] = 0
* chop_enable................................................. (Global) w. [Boolean] = 1
* chop_good_split............................................. (Global) w. [Float]   = 50
* chop_inside_angle........................................... (Global) w. [Integer] = -50
* chop_min_outline_area....................................... (Global) w. [Integer] = 2000
* chop_min_outline_points..................................... (Global) w. [Integer] = 6
* chop_new_seam_pile.......................................... (Global) w. [Boolean] = 1
* chop_overlap_knob........................................... (Global) w. [Float]   = 1
* chop_same_distance.......................................... (Global) w. [Integer] = 2
* chop_seam_pile_size......................................... (Global) w. [Integer] = 150
* chop_sharpness_knob......................................... (Global) w. [Float]   = 0
* chop_split_dist_knob........................................ (Global) w. [Float]   = 1
* chop_split_length........................................... (Global) w. [Integer] = 10000
* chop_vertical_creep......................................... (Global) w. [Boolean] = 0
* chop_width_change_knob...................................... (Global) w. [Float]   = 5
* chop_x_y_weight............................................. (Global) w. [Integer] = 3
* chs_leading_punct........................................... (Global) w. [String]  = «('`"»
* chs_trailing_punct1......................................... (Global) w. [String]  = «).,;:?!»
* chs_trailing_punct2......................................... (Global) w. [String]  = «)'`"»
* classify_adapt_feature_threshold............................ (Global) w. [Integer] = 230
* classify_adapt_proto_threshold.............................. (Global) w. [Integer] = 230
* classify_adapted_pruning_factor............................. (Global) w. [Float]   = 3
* classify_adapted_pruning_threshold.......................... (Global) w. [Float]   = -1
* classify_char_norm_range.................................... (Global) w. [Float]   = 0
* classify_character_fragments_garbage_certainty_threshold.... (Global) w. [Float]   = -3
* classify_class_pruner_multiplier............................ (Global) w. [Integer] = 15
* classify_class_pruner_threshold............................. (Global) w. [Integer] = 229
* classify_cp_angle_pad_loose................................. (Local)  w. [Float]   = 45
* classify_cp_angle_pad_medium................................ (Local)  w. [Float]   = 20
* classify_cp_angle_pad_tight................................. (Local)  w. [Float]   = 10
* classify_cp_cutoff_strength................................. (Global) w. [Integer] = 7
* classify_cp_end_pad_loose................................... (Local)  w. [Float]   = 1
* classify_cp_end_pad_medium.................................. (Local)  w. [Float]   = 1
* classify_cp_end_pad_tight................................... (Local)  w. [Float]   = 1
* classify_cp_side_pad_loose.................................. (Local)  w. [Float]   = 3
* classify_cp_side_pad_medium................................. (Local)  w. [Float]   = 1
* classify_cp_side_pad_tight.................................. (Local)  w. [Float]   = 1
* classify_debug_character_fragments.......................... (Global) W. [Boolean] = 1
* classify_enable_adaptive_debugger........................... (Global) W. [Boolean] = 1
* classify_enable_adaptive_matcher............................ (Global) w. [Boolean] = 1
* classify_enable_learning.................................... (Global) w. [Boolean] = 1
* classify_font_name.......................................... (Local)  w. [String]  = «UnknownFont»
* classify_integer_matcher_multiplier......................... (Global) w. [Integer] = 10
* classify_learn_debug_str.................................... (Global) w. [String]  = «»
* classify_learning_debug_level............................... (Global) W. [Integer] = 9
* classify_max_slope.......................................... (Local)  w. [Float]   = 2
* classify_min_slope.......................................... (Local)  w. [Float]   = 0
* classify_misfit_junk_penalty................................ (Global) w. [Float]   = 0
* classify_nonlinear_norm..................................... (Global) w. [Boolean] = 0
* classify_norm_adj_curl...................................... (Local)  w. [Float]   = 2
* classify_norm_adj_midpoint.................................. (Local)  w. [Float]   = 32
* classify_norm_method........................................ (Global) w. [Integer] = 1
* classify_num_cp_levels...................................... (Local)  w. [Integer] = 3
* classify_pico_feature_length................................ (Local)  w. [Float]   = 0
* classify_pp_angle_pad....................................... (Local)  w. [Float]   = 45
* classify_pp_end_pad......................................... (Local)  w. [Float]   = 1
* classify_pp_side_pad........................................ (Local)  w. [Float]   = 3
* classify_save_adapted_templates............................. (Global) w. [Boolean] = 0
* conflict_set_I_l_1.......................................... (Global) w. [String]  = «Il1[]»
* crunch_accept_ok............................................ (Global) w. [Boolean] = 1
* crunch_debug................................................ (Global) W. [Integer] = 0
* crunch_del_cert............................................. (Global) w. [Float]   = -10
* crunch_del_high_word........................................ (Global) w. [Float]   = 2
* crunch_del_low_word......................................... (Global) w. [Float]   = 1
* crunch_del_max_ht........................................... (Global) w. [Float]   = 3
* crunch_del_min_ht........................................... (Global) w. [Float]   = 1
* crunch_del_min_width........................................ (Global) w. [Float]   = 3
* crunch_del_rating........................................... (Global) w. [Float]   = 60
* crunch_early_convert_bad_unlv_chs........................... (Global) w. [Boolean] = 0
* crunch_early_merge_tess_fails............................... (Global) w. [Boolean] = 1
* crunch_include_numerals..................................... (Global) w. [Boolean] = 0
* crunch_leave_accept_strings................................. (Global) w. [Boolean] = 0
* crunch_leave_lc_strings..................................... (Global) w. [Integer] = 4
* crunch_leave_ok_strings..................................... (Global) w. [Boolean] = 1
* crunch_leave_uc_strings..................................... (Global) w. [Integer] = 4
* crunch_long_repetitions..................................... (Global) w. [Integer] = 3
* crunch_poor_garbage_cert.................................... (Global) w. [Float]   = -9
* crunch_poor_garbage_rate.................................... (Global) w. [Float]   = 60
* crunch_pot_indicators....................................... (Global) w. [Integer] = 1
* crunch_pot_poor_cert........................................ (Global) w. [Float]   = -8
* crunch_pot_poor_rate........................................ (Global) w. [Float]   = 40
* crunch_rating_max........................................... (Global) w. [Integer] = 10
* crunch_small_outlines_size.................................. (Global) w. [Float]   = 1
* crunch_terrible_garbage..................................... (Global) w. [Boolean] = 1
* crunch_terrible_rating...................................... (Global) w. [Float]   = 80
* curl_timeout................................................ (Local)  w. [Integer] = 0
* dawg_debug_level............................................ (Global) W. [Integer] = 3
* debug_baseline_fit.......................................... (Global) W. [Integer] = 1
* debug_baseline_y_coord...................................... (Global) W. [Integer] = -2000
* debug_fix_space_level....................................... (Global) W. [Integer] = 9
* debug_noise_removal......................................... (Global) W. [Integer] = 0
* debug_x_ht_level............................................ (Global) W. [Integer] = 3
* devanagari_split_debugimage................................. (Local)  W. [Boolean] = 1
* devanagari_split_debuglevel................................. (Local)  W. [Integer] = 3
* disable_character_fragments................................. (Global) w. [Boolean] = 1
* doc_dict_certainty_threshold................................ (Global) w. [Float]   = -2
* doc_dict_pending_threshold.................................. (Global) w. [Float]   = 0
* edges_max_children_layers................................... (Local)  w. [Integer] = 5
* edges_max_children_per_outline.............................. (Local)  w. [Integer] = 10
* edges_min_nonhole........................................... (Local)  w. [Integer] = 12
* edges_patharea_ratio........................................ (Local)  w. [Integer] = 40
* equationdetect_save_bi_image................................ (Local)  w. [Boolean] = 0
* equationdetect_save_merged_image............................ (Local)  w. [Boolean] = 0
* equationdetect_save_seed_image.............................. (Local)  w. [Boolean] = 0
* equationdetect_save_spt_image............................... (Local)  w. [Boolean] = 0
* file_type................................................... (Global) w. [String]  = «.tif»
* fixsp_done_mode............................................. (Global) w. [Integer] = 1
* fixsp_non_noise_limit....................................... (Global) w. [Integer] = 1
* fixsp_small_outlines_size................................... (Global) w. [Float]   = 0
* force_word_assoc............................................ (Global) w. [Boolean] = 0
* hyphen_debug_level.......................................... (Global) W. [Integer] = 3
* language_model_debug_level.................................. (Global) W. [Integer] = 3
* language_model_min_compound_length.......................... (Global) w. [Integer] = 3
* language_model_ngram_nonmatch_score......................... (Global) w. [Float]   = -40
* language_model_ngram_on..................................... (Global) w. [Boolean] = 0
* language_model_ngram_order.................................. (Global) w. [Integer] = 8
* language_model_ngram_rating_factor.......................... (Global) w. [Float]   = 16
* language_model_ngram_scale_factor........................... (Global) w. [Float]   = 0
* language_model_ngram_small_prob............................. (Global) w. [Float]   = 0
* language_model_ngram_space_delimited_language............... (Global) w. [Boolean] = 1
* language_model_ngram_use_only_first_uft8_step............... (Global) w. [Boolean] = 0
* language_model_penalty_case................................. (Global) w. [Float]   = 0
* language_model_penalty_chartype............................. (Global) w. [Float]   = 0
* language_model_penalty_font................................. (Global) w. [Float]   = 0
* language_model_penalty_increment............................ (Global) w. [Float]   = 0
* language_model_penalty_non_dict_word........................ (Global) w. [Float]   = 0
* language_model_penalty_non_freq_dict_word................... (Global) w. [Float]   = 0
* language_model_penalty_punc................................. (Global) w. [Float]   = 0
* language_model_penalty_script............................... (Global) w. [Float]   = 1
* language_model_penalty_spacing.............................. (Global) w. [Float]   = 0
* language_model_use_sigmoidal_certainty...................... (Global) w. [Boolean] = 0
* language_model_viterbi_list_max_num_prunable................ (Global) w. [Integer] = 10
* language_model_viterbi_list_max_size........................ (Global) w. [Integer] = 500
* load_bigram_dawg............................................ (Global) w. [Boolean] = 1
* load_freq_dawg.............................................. (Global) w. [Boolean] = 1
* load_number_dawg............................................ (Global) w. [Boolean] = 1
* load_punc_dawg.............................................. (Global) w. [Boolean] = 1
* load_system_dawg............................................ (Global) w. [Boolean] = 1
* load_unambig_dawg........................................... (Global) w. [Boolean] = 1
* matcher_avg_noise_size...................................... (Global) w. [Float]   = 12
* matcher_bad_match_pad....................................... (Global) w. [Float]   = 0
* matcher_clustering_max_angle_delta.......................... (Global) w. [Float]   = 0
* matcher_debug_flags......................................... (Global) W. [Integer] = 0
* matcher_debug_level......................................... (Global) W. [Integer] = 3
* matcher_debug_separate_windows.............................. (Global) W. [Boolean] = 1
* matcher_good_threshold...................................... (Global) w. [Float]   = 0
* matcher_min_examples_for_prototyping........................ (Global) w. [Integer] = 3
* matcher_perfect_threshold................................... (Global) w. [Float]   = 0
* matcher_permanent_classes_min............................... (Global) w. [Integer] = 1
* matcher_rating_margin....................................... (Global) w. [Float]   = 0
* matcher_reliable_adaptive_result............................ (Global) w. [Float]   = 0
* matcher_sufficient_examples_for_prototyping................. (Global) w. [Integer] = 5
* max_permuter_attempts....................................... (Global) w. [Integer] = 10000
* merge_fragments_in_matrix................................... (Global) w. [Boolean] = 1
* min_characters_to_try....................................... (Global) w. [Integer] = 50
* min_orientation_margin...................................... (Global) w. [Float]   = 7
* min_sane_x_ht_pixels........................................ (Global) w. [Integer] = 8
* multilang_debug_level....................................... (Global) W. [Integer] = 3
* noise_cert_basechar......................................... (Global) w. [Float]   = -8
* noise_cert_disjoint......................................... (Global) w. [Float]   = -1
* noise_cert_factor........................................... (Global) w. [Float]   = 0
* noise_cert_punc............................................. (Global) w. [Float]   = -3
* noise_maxperblob............................................ (Global) w. [Integer] = 8
* noise_maxperword............................................ (Global) w. [Integer] = 16
* numeric_punctuation......................................... (Global) w. [String]  = «.,»
* ok_repeated_ch_non_alphanum_wds............................. (Global) w. [String]  = «-?*=»
* oldbl_corrfix............................................... (Local)  w. [Boolean] = 1
* oldbl_xhfix................................................. (Local)  w. [Boolean] = 0
* oldbl_xhfract............................................... (Local)  w. [Float]   = 0
* outlines_2.................................................. (Global) w. [String]  = «ij!?%":;»
* outlines_odd................................................ (Global) w. [String]  = «%| »
* output_ambig_words_file..................................... (Global) w. [String]  = «»
* pitsync_offset_freecut_fraction............................. (Local)  w. [Float]   = 0
* prioritize_division......................................... (Global) w. [Boolean] = 0
* quality_blob_pc............................................. (Global) w. [Float]   = 0
* quality_char_pc............................................. (Global) w. [Float]   = 1
* quality_min_initial_alphas_reqd............................. (Global) w. [Integer] = 2
* quality_outline_pc.......................................... (Global) w. [Float]   = 1
* quality_rej_pc.............................................. (Global) w. [Float]   = 0
* quality_rowrej_pc........................................... (Global) w. [Float]   = 1
* rating_scale................................................ (Global) w. [Float]   = 2
* rej_1Il_trust_permuter_type................................. (Global) w. [Boolean] = 1
* rej_1Il_use_dict_word....................................... (Global) w. [Boolean] = 0
* rej_alphas_in_number_perm................................... (Global) w. [Boolean] = 0
* rej_trust_doc_dawg.......................................... (Global) w. [Boolean] = 0
* rej_use_good_perm........................................... (Global) w. [Boolean] = 1
* rej_use_sensible_wd......................................... (Global) w. [Boolean] = 0
* rej_use_tess_accepted....................................... (Global) w. [Boolean] = 1
* rej_use_tess_blanks......................................... (Global) w. [Boolean] = 1
* rej_whole_of_mostly_reject_word_fract....................... (Global) w. [Float]   = 1
* repair_unchopped_blobs...................................... (Global) w. [Integer] = 1
* save_alt_choices............................................ (Global) w. [Boolean] = 1
* save_doc_words.............................................. (Global) w. [Boolean] = 0
* segment_nonalphabetic_script................................ (Global) w. [Boolean] = 0
* segment_penalty_dict_case_bad............................... (Global) w. [Float]   = 1
* segment_penalty_dict_case_ok................................ (Global) w. [Float]   = 1
* segment_penalty_dict_frequent_word.......................... (Global) w. [Float]   = 1
* segment_penalty_dict_nonword................................ (Global) w. [Float]   = 1
* segment_penalty_garbage..................................... (Global) w. [Float]   = 2
* segsearch_debug_level....................................... (Global) W. [Integer] = 3
* segsearch_max_char_wh_ratio................................. (Global) w. [Float]   = 2
* segsearch_max_futile_classifications........................ (Global) w. [Integer] = 20
* segsearch_max_pain_points................................... (Global) w. [Integer] = 2000
* speckle_large_max_size...................................... (Global) w. [Float]   = 0
* speckle_rating_penalty...................................... (Global) w. [Float]   = 10
* stopper_allowable_character_badness......................... (Global) w. [Float]   = 3
* stopper_certainty_per_char.................................. (Global) w. [Float]   = -1
* stopper_debug_level......................................... (Global) W. [Integer] = 3
* stopper_no_acceptable_choices............................... (Global) w. [Boolean] = 0
* stopper_nondict_certainty_base.............................. (Global) w. [Float]   = -3
* stopper_phase2_certainty_rejection_offset................... (Global) w. [Float]   = 1
* stopper_smallword_size...................................... (Global) w. [Integer] = 2
* subscript_max_y_top......................................... (Global) w. [Float]   = 1
* superscript_bettered_certainty.............................. (Global) w. [Float]   = 1
* superscript_debug........................................... (Global) W. [Integer] = 0
* superscript_min_y_bottom.................................... (Global) w. [Float]   = 0
* superscript_scaledown_ratio................................. (Global) w. [Float]   = 0
* superscript_worse_certainty................................. (Global) w. [Float]   = 2
* suspect_accept_rating....................................... (Global) w. [Float]   = -1000
* suspect_constrain_1Il....................................... (Global) w. [Boolean] = 0
* suspect_rating_per_ch....................................... (Global) w. [Float]   = 1000
* suspect_short_words......................................... (Global) w. [Integer] = 2
* tess_bn_matching............................................ (Global) w. [Boolean] = 0
* tess_cn_matching............................................ (Global) w. [Boolean] = 0
* tessedit_adaption_debug..................................... (Global) W. [Boolean] = 1
* tessedit_bigram_debug....................................... (Global) W. [Integer] = 0
* tessedit_certainty_threshold................................ (Global) w. [Float]   = -2
* tessedit_class_miss_scale................................... (Global) w. [Float]   = 0
* tessedit_create_page_polygon................................ (Global) w. [Boolean] = 1
* tessedit_create_page_wordlevel.............................. (Global) w. [Boolean] = 0
* tessedit_debug_block_rejection.............................. (Global) W. [Boolean] = 1
* tessedit_debug_doc_rejection................................ (Global) W. [Boolean] = 1
* tessedit_debug_fonts........................................ (Global) W. [Boolean] = 1
* tessedit_debug_quality_metrics.............................. (Global) W. [Boolean] = 1
* tessedit_display_outwords................................... (Global) w. [Boolean] = 0
* tessedit_dont_blkrej_good_wds............................... (Global) w. [Boolean] = 0
* tessedit_dont_rowrej_good_wds............................... (Global) w. [Boolean] = 0
* tessedit_enable_bigram_correction........................... (Global) w. [Boolean] = 1
* tessedit_enable_dict_correction............................. (Global) w. [Boolean] = 0
* tessedit_enable_doc_dict.................................... (Global) w. [Boolean] = 1
* tessedit_fix_fuzzy_spaces................................... (Global) w. [Boolean] = 1
* tessedit_fix_hyphens........................................ (Global) w. [Boolean] = 1
* tessedit_flip_0O............................................ (Global) w. [Boolean] = 1
* tessedit_font_id............................................ (Global) w. [Integer] = 0
* tessedit_good_doc_still_rowrej_wd........................... (Global) w. [Float]   = 1
* tessedit_good_quality_unrej................................. (Global) w. [Boolean] = 1
* tessedit_image_border....................................... (Global) w. [Integer] = 2
* tessedit_lower_flip_hyphen.................................. (Global) w. [Float]   = 2
* tessedit_override_permuter.................................. (Global) w. [Boolean] = 1
* tessedit_page_number........................................ (Global) w. [Integer] = -1
* tessedit_prefer_joined_punct................................ (Global) w. [Boolean] = 0
* tessedit_preserve_blk_rej_perfect_wds....................... (Global) w. [Boolean] = 1
* tessedit_preserve_min_wd_len................................ (Global) w. [Integer] = 2
* tessedit_preserve_row_rej_perfect_wds....................... (Global) w. [Boolean] = 1
* tessedit_reject_bad_qual_wds................................ (Global) w. [Boolean] = 1
* tessedit_reject_block_percent............................... (Global) w. [Float]   = 45
* tessedit_reject_doc_percent................................. (Global) w. [Float]   = 65
* tessedit_reject_mode........................................ (Global) w. [Integer] = 0
* tessedit_reject_row_percent................................. (Global) w. [Float]   = 40
* tessedit_row_rej_good_docs.................................. (Global) w. [Boolean] = 1
* tessedit_truncate_wordchoice_log............................ (Global) w. [Integer] = 10
* tessedit_unrej_any_wd....................................... (Global) w. [Boolean] = 0
* tessedit_upper_flip_hyphen.................................. (Global) w. [Float]   = 2
* tessedit_use_primary_params_model........................... (Global) w. [Boolean] = 0
* tessedit_use_reject_spaces.................................. (Global) w. [Boolean] = 1
* tessedit_whole_wd_rej_row_percent........................... (Global) w. [Float]   = 70
* tessedit_word_for_word...................................... (Global) w. [Boolean] = 0
* tessedit_write_rep_codes.................................... (Global) w. [Boolean] = 0
* tessedit_zero_kelvin_rejection.............................. (Global) w. [Boolean] = 0
* test_pt_x................................................... (Global) w. [Float]   = 100000
* test_pt_y................................................... (Global) w. [Float]   = 100000
* textord_debug_blob.......................................... (Local)  W. [Boolean] = 1
* textord_debug_printable..................................... (Local)  W. [Boolean] = 1
* textord_fp_chop_error....................................... (Local)  w. [Integer] = 2
* textord_lms_line_trials..................................... (Local)  w. [Integer] = 12
* textord_min_blobs_in_row.................................... (Local)  w. [Integer] = 4
* textord_ocropus_mode........................................ (Local)  w. [Boolean] = 0
* textord_show_blobs.......................................... (Global) w. [Boolean] = 0
* textord_show_boxes.......................................... (Global) w. [Boolean] = 0
* textord_show_final_blobs.................................... (Local)  w. [Boolean] = 0
* textord_show_page_cuts...................................... (Local)  w. [Boolean] = 0
* textord_show_row_cuts....................................... (Local)  w. [Boolean] = 0
* textord_space_size_is_variable.............................. (Local)  w. [Boolean] = 0
* textord_tabfind_only_strokewidths........................... (Local)  w. [Boolean] = 0
* textord_tabfind_show_finaltabs.............................. (Local)  w. [Boolean] = 0
* textord_tabfind_show_initialtabs............................ (Local)  w. [Boolean] = 0
* textord_tabvector_vertical_box_ratio........................ (Local)  w. [Float]   = 1
* textord_tabvector_vertical_gap_fraction..................... (Local)  w. [Float]   = 1
* textord_testregion_bottom................................... (Local)  w. [Integer] = -1
* textord_testregion_left..................................... (Local)  w. [Integer] = -1
* textord_testregion_right.................................... (Local)  w. [Integer] = 2147483647
* textord_testregion_top...................................... (Local)  w. [Integer] = 2147483647
* textord_underline_offset.................................... (Local)  w. [Float]   = 0
* textord_underline_threshold................................. (Local)  w. [Float]   = 1
* textord_words_definite_spread............................... (Local)  w. [Float]   = 0
* textord_words_initial_lower................................. (Local)  w. [Float]   = 0
* textord_words_initial_upper................................. (Local)  w. [Float]   = 0
* textord_words_minlarge...................................... (Local)  w. [Float]   = 1
* tosp_old_to_bug_fix......................................... (Global) w. [Boolean] = 0
* training_angle_match_scale.................................. (Local)  w. [Float]   = 1
* training_angle_pad.......................................... (Local)  w. [Float]   = 45
* training_orthogonal_bbox_pad................................ (Local)  w. [Float]   = 3
* training_similarity_curl.................................... (Local)  w. [Float]   = 2
* training_similarity_midpoint................................ (Local)  w. [Float]   = 0
* training_tangent_bbox_pad................................... (Local)  w. [Float]   = 1
* unrecognised_char........................................... (Global) w. [String]  = «|»
* use_only_first_uft8_step.................................... (Global) w. [Boolean] = 0
* word_to_debug............................................... (Global) W. [String]  = «Y»
* wordrec_debug_blamer........................................ (Global) W. [Boolean] = 1
* wordrec_debug_level......................................... (Global) W. [Integer] = 3
* wordrec_display_segmentations............................... (Global) w. [Integer] = 0
* wordrec_display_splits...................................... (Local)  w. [Boolean] = 0
* wordrec_enable_assoc........................................ (Global) w. [Boolean] = 1
* wordrec_max_join_chunks..................................... (Global) w. [Integer] = 4
* wordrec_run_blamer.......................................... (Global) w. [Boolean] = 0
* wordrec_skip_no_truth_words................................. (Global) w. [Boolean] = 0
* x_ht_acceptance_tolerance................................... (Global) w. [Integer] = 8
* x_ht_min_change............................................. (Global) w. [Integer] = 8
* xheight_penalty_inconsistent................................ (Global) w. [Float]   = 0
* xheight_penalty_subscripts.................................. (Global) w. [Float]   = 0
```

BTW: I find the leader dots do improve readability (though I'ld loved it when `fmt` could do some spaces *first*, but that's just being fancy 😉 ) which is another argument to perhaps migrate to `fmt` inside tprintf() as was done by @stweil. Of course, the same can be accomplished with the sprintf() series, but I was lazy and found `fmt` does this 'by default': `{:.<30}` and presto: leader dots (or rather more precisely technical: *trailer* dots 😄 🥳 )

