### PR TITLE
Improve the DebugDump output by slightly adjusting the format.

### DIFF
--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -518,7 +518,7 @@ void RowScratchRegisters::AppendDebugInfo(const ParagraphTheory &theory,
   // The largest (positive and negative) numbers are reported for lindent & rindent.
   // While the column header has widths 5,4,4,5, it is therefore opportune to slightly
   // offset the widths in the format string here to allow ample space for lindent & rindent
-  // while keeeping the final table output nicely readable: 4,5,5,4.
+  // while keeping the final table output nicely readable: 4,5,5,4.
   snprintf(s, sizeof(s), "[%4d,%5d;%5d,%4d]", lmargin_, lindent_, rindent_, rmargin_);
   dbg.emplace_back(s);
   std::string model_string;

--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -514,8 +514,12 @@ void RowScratchRegisters::AppendDebugHeaderFields(std::vector<std::string> &head
 
 void RowScratchRegisters::AppendDebugInfo(const ParagraphTheory &theory,
                                           std::vector<std::string> &dbg) const {
-  char s[30];
-  snprintf(s, sizeof(s), "[%3d,%3d;%3d,%3d]", lmargin_, lindent_, rindent_, rmargin_);
+  char s[60];
+  // The largest (positive and negative) numbers are reported for lindent & rindent.
+  // While the column header has widths 5,4,4,5, it is therefore opportune to slightly
+  // offset the widths in the format string here to allow ample space for lindent & rindent
+  // while keeeping the final table output nicely readable: 4,5,5,4.
+  snprintf(s, sizeof(s), "[%4d,%5d;%5d,%4d]", lmargin_, lindent_, rindent_, rmargin_);
   dbg.emplace_back(s);
   std::string model_string;
   model_string += static_cast<char>(GetLineType());


### PR DESCRIPTION
Improve the DebugDump output by slightly adjusting the format for the numeric columns, which was 3,3,3,3 and overflowing in our test runs, damaging the table layout. See rationale in the code comment:

------

  // The largest (positive and negative) numbers are reported for lindent & rindent.
  // While the column header has widths 5,4,4,5, it is therefore opportune to slightly
  // offset the widths in the format string here to allow ample space for lindent & rindent
  // while keeeping the final table output nicely readable: 4,5,5,4.

# Conflicts:
#	src/ccmain/paragraphs.cpp

-----------

Sample output: (BTW: note the '1270' in there, which previously pushed the table layout out of whack)

```
Active Paragraph Models:
# End of Pass 4
#row space .. lword[widthSEL]                      rword[widthSEL]                 [lmarg,lind;rind,rmarg] model text                                                                        
0    17       xxxxxxxxxxxxxxxxxxxxxxx[410sel]      xxxxxxx[75sel]                  [   0,    0;  211,  30] U:0   xxxxxxxxxxxxxxxxxxxxxxx xxxxxxx                                             
1    17       xx[56sel]                            xxxxxxxx[98sel]                 [   0,  659;    9,  30] U:0                                         xx xxxxxxxx xxxxxxxx                  
2    15       x[8sel]                              xxxxxxxx[96sel]                 [   0,  659;    9,  30] U:0                                              x xxxxxxxx xxxxxxxx              
3    17       x[3sel]                              xxxxxxxx[98sel]                 [   0,  592;    9,  30] U:0                                     x x xxxxxxxx xxxxxxxx                     
4    16       xxxxxxxxxxxxxxxxxxxxxx[377sel]       x[5sel]                         [   0,  391;   76,  30] U:0                           xxxxxxxxxxxxxxxxxxxxxx x x                          
5    17       xxxxxxxxxxxx[175sel]                 xxxxxxxxx[145sel]               [   0,  658;    9,  30] U:0                                         xxxxxxxxxxxx x xxxxxxxxx              
6    14       x[7sel]                              xxxxxxxxxxx[128sel]             [   0,   13;  -22,  30] U:0   x xx xxxxxxxxxx x xxxxxxxxxxx                                               
7    16       xxxxxxxxxxxxxxxxxxxxxxxxx[430sel]    xxx[43sel]                      [   0,  401;  244,  30] U:0                            xxxxxxxxxxxxxxxxxxxxxxxxx xxx                      
8    14       xx[29sel]                            x[10sel]                        [   0,   12;   98,  30] U:0   xx xxxxxxxxxxxxxxxxxxxx x                                                   
9    15       x[25sel]                             x[25sel]                        [   0,    0; 1270,  30] U:0   x                                                                           
10   15       xxx[97sel]                           xxxxxxxxx[106sel]               [   0,    0;    1,  30] U:0   xxx xxxxxxxxxxxxxxxxxxx xxxxxxxxx                                           
11   15       x[31sel]                             xxxxx[63sel]                    [   0,   15;   42,  30] U:0    x x xxxxxxxxxxxx x xxxxx                                                   
12   15       xxxxxxxxxxxxxxxxxxx[375sel]          x[18sel]                        [   0,  382;  193,  30] U:0                            xxxxxxxxxxxxxxxxxxx xx x                           
13   16       x[6sel]                              x[9sel]                         [   0,  241;   98,  30] U:0                  x xxxxxxxxxxxxxxxxx x                                        
14   13       x[177sel]                            xxxxxxxxxxx[169sel]             [   0,    0;    1,  30] U:0   x xxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxx                                         
15   16       x[17sel]                             xxxxx[62sel]                    [   0,   46;   43,  30] U:0     x xx xxxxxxxxxxxxxx xxxxx                                                 
16   12       xx[36sel]                            xxxxxxxxxxxxxxxxxx[282sel]      [   0,    0;  354,  30] U:0   xx xxxx xxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxx                                   
17   20       x[4sel]                              xxxxxx[65sel]                   [   0,   77;  222,  30] U:0      x x x x xxxxxxxxxxx xxxxx x xxxxxx                                       
18   19       xx[64sel]                            xxxxxxx[96sel]                  [   0,  658;   10,  30] U:0                                     xx xxx xxxxxxx                            
19   16       xx[51sel]                            xx[27sel]                       [   0,  172;   35,  30] U:0             xx xxxxxx xxxxxxxx xx                                             
20   14       xxxxxxxxxxxxxxxxxxx[325sel]          xxxxxxxxx[105sel]               [   0,  658;    1,  30] U:0                                                  xxxxxxxxxxxxxxxxxxx xxxxxxxxx
21   15       x[3sel]                              xxxxxxxxxxx[128sel]             [   0,  324;  -23,  30] U:0                        x xxxxxxxxxxx xxxxxxxxxxx                              
22   15       x[26sel]                             xxxxxx[63sel]                   [   0,   13;  221,  30] U:0   x x xxxxxxxxxxxxxxxxx xxxxxx                                                
23   15       x[9sel]                              x[4sel]                         [   0,  659;  101,  30] U:0                                              x x xxxxxx x                     
24   17       xxxxxxxxxxxxxxxxx[323sel]            xxxx[41sel]                     [   0,  401;  243,  30] U:0                          xxxxxxxxxxxxxxxxx xxxx                               
25   14       x[9sel]                              x[4sel]                         [   0,  659;  101,  30] U:0                                                  x xxxxxxxxxxxxxx x           
26   18       x[6sel]                              x[4sel]                         [   0,  534;  101,  30] U:0                                x x xxxxxxxx x                                 
27   17       x[4sel]                              xxxxxxxxx[135sel]               [   0,  499;  -30,  30] U:0                                x xxxxxxxxxx x xxxxxxxxx                       
28   14       xx[20sel]                            xxxxxx[64sel]                   [   0,  401;  570,  30] U:0                               xx xxxxxxxxx xxxxxx                             
29   16       xxxxxxxxxxxxxxxxxx[325sel]           xxxxxxxx[96sel]                 [   0,  659;    9,  30] U:0                                            xxxxxxxxxxxxxxxxxx xxxxxxxx        
30   15       xxxxxxxxxxxxxxxxxxxxx[385sel]        xxxxxxxxx[105sel]               [   0,  599;    0,  30] U:0                                          xxxxxxxxxxxxxxxxxxxxx xxxxxxxxx      
31   15       x[5sel]                              xxxxxxxxxxx[127sel]             [   0,  550;  -22,  30] U:0                                       x xxxxxxxxx xx xxxxxxxxxxx              
32   16       xxxxxxxxxxxxxxxxxxxxxxxxxxxx[455sel] x[9sel]                         [   0,  392;   98,  30] U:0                           xxxxxxxxxxxxxxxxxxxxxxxxxxxx xxxx x                 
33   14       xxxxxxxxxxxxxxxxxxxxx[367sel]        xxxxxxxxxxxxxxxxxxxxx[367sel]   [   0,  402;  525,  30] U:0                               xxxxxxxxxxxxxxxxxxxxx                           
34   16       xxxxxxxxx[175sel]                    x[4sel]                         [   0,  659;  101,  30] U:0                                            xxxxxxxxx x x                      
35   16       xxxxxxxxxxxx[220sel]                 xxxxxxxxxxxx[141sel]            [   0,  367;  491,  30] U:0                         xxxxxxxxxxxx xxxxxxxxxxxx                             
36   17       xxxxxxxxxxxxxxxx[334sel]             x[4sel]                         [   0,  659;  101,  30] U:0                                         xxxxxxxxxxxxxxxx x                    
37   13       xxxxxxxxxxx[186sel]                  xxxxxxxxxxxxxxxxx[223sel]       [   0,  402;  412,  30] U:0                                 xxxxxxxxxxx xxxxxxxxxxxxxxxxx                 
38   14       xxxxxxxxxxxxxxxxxxxxxxx[432sel]      xxxxxxxxxxxxxxxxxxxxxxx[432sel] [   0,  402;  460,  30] U:0                               xxxxxxxxxxxxxxxxxxxxxxx                         
39   15       xxxxxxxxx[174sel]                    x[4sel]                         [   0,  659;  101,  30] U:0                                              xxxxxxxxx x                      
40   13       xxxxxxxxxxx[186sel]                  xxxxxxxxxxxxxxxxx[226sel]       [   0,  402;  412,  30] U:0                                 xxxxxxxxxxx xxxxxxxxxxxxxxxxx                 
Active Paragraph Models:
# Final Paragraph Segmentation
```