### PR TITLE
Remove set but not used variable

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -1414,7 +1414,6 @@ char *TessBaseAPI::GetTSVText(int page_number) {
     return nullptr;
   }
 
-  int lcnt = 1, bcnt = 1, pcnt = 1, wcnt = 1;
   int page_id = page_number + 1; // we use 1-based page numbers.
 
   int page_num = page_id;
@@ -1496,23 +1495,11 @@ char *TessBaseAPI::GetTSVText(int page_number) {
     tsv_str += "\t" + std::to_string(res_it->Confidence(RIL_WORD));
     tsv_str += "\t";
 
-    // Increment counts if at end of block/paragraph/textline.
-    if (res_it->IsAtFinalElement(RIL_TEXTLINE, RIL_WORD)) {
-      lcnt++;
-    }
-    if (res_it->IsAtFinalElement(RIL_PARA, RIL_WORD)) {
-      pcnt++;
-    }
-    if (res_it->IsAtFinalElement(RIL_BLOCK, RIL_WORD)) {
-      bcnt++;
-    }
-
     do {
       tsv_str += std::unique_ptr<const char[]>(res_it->GetUTF8Text(RIL_SYMBOL)).get();
       res_it->Next(RIL_SYMBOL);
     } while (!res_it->Empty(RIL_BLOCK) && !res_it->IsAtBeginningOf(RIL_WORD));
     tsv_str += "\n"; // end of row
-    wcnt++;
   }
 
   char *ret = new char[tsv_str.length() + 1];

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -1685,7 +1685,6 @@ void Tesseract::fix_rep_char(PAGE_RES_IT *page_res_it) {
   word_res->done = true;
 
   // Measure the mean space.
-  int gap_count = 0;
   WERD *werd = word_res->word;
   C_BLOB_IT blob_it(werd->cblob_list());
   C_BLOB *prev_blob = blob_it.data();
@@ -1693,7 +1692,6 @@ void Tesseract::fix_rep_char(PAGE_RES_IT *page_res_it) {
     C_BLOB *blob = blob_it.data();
     int gap = blob->bounding_box().left();
     gap -= prev_blob->bounding_box().right();
-    ++gap_count;
     prev_blob = blob;
   }
   // Just correct existing classification.

--- a/src/ccmain/osdetect.cpp
+++ b/src/ccmain/osdetect.cpp
@@ -223,7 +223,6 @@ int orientation_and_script_detection(const char *filename, OSResults *osr,
 // Returns a non-zero number of blobs if the page was successfully processed, or
 // zero if the page had too few characters to be reliable
 int os_detect(TO_BLOCK_LIST *port_blocks, OSResults *osr, tesseract::Tesseract *tess) {
-  int blobs_total = 0;
   TO_BLOCK_IT block_it;
   block_it.set_to_list(port_blocks);
 
@@ -241,7 +240,6 @@ int os_detect(TO_BLOCK_LIST *port_blocks, OSResults *osr, tesseract::Tesseract *
       BLOBNBOX *bbox = bbox_it.data();
       C_BLOB *blob = bbox->cblob();
       TBOX box = blob->bounding_box();
-      ++blobs_total;
 
       // Catch illegal value of box width and avoid division by zero.
       if (box.width() == 0) {
@@ -286,7 +284,6 @@ int os_detect_blobs(const std::vector<int> *allowed_scripts, BLOBNBOX_CLIST *blo
 
   BLOBNBOX_C_IT filtered_it(blob_list);
   int real_max = std::min(filtered_it.length(), maxCharactersToTry);
-  // tprintf("Total blobs found = %d\n", blobs_total);
   // tprintf("Number of blobs post-filtering = %d\n", filtered_it.length());
   // tprintf("Number of blobs to try = %d\n", real_max);
 

--- a/src/classify/normmatch.cpp
+++ b/src/classify/normmatch.cpp
@@ -112,7 +112,6 @@ float Classify::ComputeNormMatch(CLASS_ID ClassId, const FEATURE_STRUCT &feature
     tprintf("\nChar norm for class %s\n", unicharset.id_to_unichar(ClassId));
   }
 
-  int ProtoId = 0;
   iterate(Protos) {
     auto Proto = reinterpret_cast<PROTOTYPE *>(Protos->first_node());
     float Delta = feature.Params[CharNormY] - Proto->Mean[CharNormY];
@@ -146,7 +145,6 @@ float Classify::ComputeNormMatch(CLASS_ID ClassId, const FEATURE_STRUCT &feature
       BestMatch = Match;
     }
 
-    ProtoId++;
   }
   return 1.0 - NormEvidenceOf(BestMatch);
 } /* ComputeNormMatch */

--- a/src/textord/topitch.cpp
+++ b/src/textord/topitch.cpp
@@ -151,7 +151,6 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
   int like_votes;                // votes over page
   int other_votes;               // votes of unlike blocks
   int block_index;               // number of block
-  int row_index;                 // number of row
   int maxwidth;                  // max pitch
   TO_BLOCK_IT block_it = blocks; // block iterator
   TO_BLOCK *block;               // current block
@@ -172,7 +171,6 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
       if (pb != nullptr && !pb->IsText()) {
         continue; // Non text doesn't exist!
       }
-      row_index = 1;
       TO_ROW_IT row_it(block->get_rows());
       for (row_it.mark_cycle_pt(); !row_it.cycled_list(); row_it.forward()) {
         row = row_it.data();
@@ -226,7 +224,6 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
             other_votes--;
           }
         }
-        row_index++;
       }
       block_index++;
     }
@@ -518,7 +515,6 @@ bool try_rows_fixed(     // find line stats
     bool testing_on      // correct orientation
 ) {
   TO_ROW *row;           // current row
-  int32_t row_index;     // row number.
   int32_t def_fixed = 0; // counters
   int32_t def_prop = 0;
   int32_t maybe_fixed = 0;
@@ -529,7 +525,6 @@ bool try_rows_fixed(     // find line stats
   float lower, upper; // cluster thresholds
   TO_ROW_IT row_it = block->get_rows();
 
-  row_index = 1;
   for (row_it.mark_cycle_pt(); !row_it.cycled_list(); row_it.forward()) {
     row = row_it.data();
     ASSERT_HOST(row->xheight > 0);
@@ -541,7 +536,6 @@ bool try_rows_fixed(     // find line stats
         row->kern_size = lower;
       }
     }
-    row_index++;
   }
   count_block_votes(block, def_fixed, def_prop, maybe_fixed, maybe_prop, corr_fixed, corr_prop,
                     dunno);

--- a/src/training/cntraining.cpp
+++ b/src/training/cntraining.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[]) {
   InitFeatureDefs(&FeatureDefs);
 
   ParseArguments(&argc, &argv);
-  int num_fonts = 0;
+  // int num_fonts = 0;
   for (const char *PageName = *++argv; PageName != nullptr; PageName = *++argv) {
     printf("Reading %s ...\n", PageName);
     FILE *TrainingPage = fopen(PageName, "rb");
@@ -124,7 +124,7 @@ int main(int argc, char *argv[]) {
     if (TrainingPage) {
       ReadTrainingSamples(FeatureDefs, PROGRAM_FEATURE_TYPE, 100, nullptr, TrainingPage, &CharList);
       fclose(TrainingPage);
-      ++num_fonts;
+      // ++num_fonts;
     }
   }
   printf("Clustering ...\n");

--- a/src/training/common/errorcounter.cpp
+++ b/src/training/common/errorcounter.cpp
@@ -114,7 +114,6 @@ void ErrorCounter::DebugNewErrors(ShapeClassifier *new_classifier, ShapeClassifi
   ErrorCounter new_counter(new_classifier->GetUnicharset(), fontsize);
   std::vector<UnicharRating> results;
 
-  int total_samples = 0;
   int error_samples = 25;
   int total_new_errors = 0;
   // Iterate over all the samples, accumulating errors.
@@ -145,7 +144,6 @@ void ErrorCounter::DebugNewErrors(ShapeClassifier *new_classifier, ShapeClassifi
         }
       }
     }
-    ++total_samples;
   }
   tprintf("Total new errors = %d\n", total_new_errors);
 }

--- a/src/training/common/sampleiterator.cpp
+++ b/src/training/common/sampleiterator.cpp
@@ -240,11 +240,9 @@ int SampleIterator::UniformSamples() {
 // to 1. Returns the minimum assigned sample weight.
 double SampleIterator::NormalizeSamples() {
   double total_weight = 0.0;
-  int sample_count = 0;
   for (Begin(); !AtEnd(); Next()) {
     const TrainingSample &sample = GetSample();
     total_weight += sample.weight();
-    ++sample_count;
   }
   // Normalize samples.
   double min_assigned_sample_weight = 1.0;


### PR DESCRIPTION
reported by clang.

And If I understand the code correctly: this old code (3.01) calculates  gap, but never use it...
https://github.com/tesseract-ocr/tesseract/blob/1569e5080810f4652b720bcd344026a9b236ec50/src/ccmain/control.cpp#L1687-L1698
