### PR TITLE
fix: Fix snap package building

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,13 +13,13 @@ description: |
 
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict
+base: core22
 
 apps:
   tesseract:
-    command: >
-      env
-      TESSDATA_PREFIX=$SNAP_USER_COMMON
-      tesseract
+    command: usr/local/bin/tesseract
+    environment:
+      TESSDATA_PREFIX: $SNAP_USER_COMMON
     plugs:
       - home
       - removable-media
@@ -30,9 +30,9 @@ parts:
     plugin: autotools
     build-packages:
       - pkg-config
-      - libpng12-dev
-      - libjpeg8-dev
-      - libtiff5-dev
+      - libpng-dev
+      - libjpeg-dev
+      - libtiff-dev
       - zlib1g-dev
       - libicu-dev
       - libpango1.0-dev


### PR DESCRIPTION
This patch fixes the outdated snap package recipe to make the snap buildable with the current Snapcraft release(7.3.1).