### PR TITLE
Support for Sgaw and W Pwo Karen languages in the Myanmar validator.

### DIFF
--- a/src/training/unicharset/validate_myanmar.cpp
+++ b/src/training/unicharset/validate_myanmar.cpp
@@ -140,9 +140,17 @@ bool ValidateMyanmar::ConsumeOptionalSignsIfPresent() {
   }
   // Tone mark extensions.
   ch = codes_[codes_used_].second;
-  if (ch == 0x1038 || ch == kMyanmarAsat || ch == 0x1063 || ch == 0x1064 ||
+  if (ch == 0x102c || ch == 0x1038 || ch == kMyanmarAsat || (0x1062 <= ch && ch <= 0x1064) ||
       (0x1069 <= ch && ch <= 0x106d) || (0x1087 <= ch && ch <= 0x108d) || ch == 0x108f ||
       ch == 0x109a || ch == 0x109b || (0xaa7b <= ch && ch <= 0xaa7d)) {
+    if (UseMultiCode(1)) {
+      return true;
+    }
+  }
+  // Sgaw tones 0x1062, 0x1063 must be followed by asat.
+  // W Pwo tones 0x1069, 0x106a, and 0x106b may be followed by dot below or visarga (nasal).
+  ch = codes_[codes_used_].second; 
+  if (ch == 0x103a || ch == 0x1037 || ch == 0x1038) {
     if (UseMultiCode(1)) {
       return true;
     }


### PR DESCRIPTION
Fixes the issue reported in #4061 

1. Added 0x102c and 0x1062 in the tone mark section, in Karen these can be tones too.

2. Added the optional 0x103a, 0x1037, and 0x1038 after the tones. Asat is part of the Sgaw tone mark and dot below and visarga are used as nasal marks following the Pwo tones.

And here are some text files for testing:
 
[test_strings.txt](https://github.com/tesseract-ocr/tesseract/files/11398793/test_strings.txt) - A few Sgaw and Pwo test strings highlighting the errors this PR fixes.
[syllables_sgaw.txt](https://github.com/tesseract-ocr/tesseract/files/11398835/syllables_sgaw.txt) - All possible Sgaw syllables.
[syllables_pwo.txt](https://github.com/tesseract-ocr/tesseract/files/11398791/syllables_pwo.txt) - All possible Pwo syllables.
