### PR TITLE
Allow for text angle/gradient to be retrieved

### DIFF
--- a/include/tesseract/baseapi.h
+++ b/include/tesseract/baseapi.h
@@ -347,6 +347,11 @@ public:
   Pix *GetThresholdedImage();
 
   /**
+   * Return average gradient of lines on page.
+   */
+  float GetGradient();
+
+  /**
    * Get the result of page layout analysis as a leptonica-style
    * Boxa, Pixa pair, in reading order.
    * Can be called before or after Recognize.
@@ -719,6 +724,12 @@ public:
   void set_min_orientation_margin(double margin);
   /* @} */
 
+  /**
+   * Find lines from the image making the BLOCK_LIST.
+   * @return 0 on success.
+   */
+  int FindLines();
+
 protected:
   /** Common code for setting the image. Returns true if Init has been called.
    */
@@ -729,12 +740,6 @@ protected:
    * the source is thresholded to pix instead of the internal IMAGE.
    */
   virtual bool Threshold(Pix **pix);
-
-  /**
-   * Find lines from the image making the BLOCK_LIST.
-   * @return 0 on success.
-   */
-  int FindLines();
 
   /** Delete the pageres and block list ready for a new page. */
   void ClearResults();

--- a/include/tesseract/baseapi.h
+++ b/include/tesseract/baseapi.h
@@ -724,12 +724,6 @@ public:
   void set_min_orientation_margin(double margin);
   /* @} */
 
-  /**
-   * Find lines from the image making the BLOCK_LIST.
-   * @return 0 on success.
-   */
-  int FindLines();
-
 protected:
   /** Common code for setting the image. Returns true if Init has been called.
    */
@@ -740,6 +734,12 @@ protected:
    * the source is thresholded to pix instead of the internal IMAGE.
    */
   virtual bool Threshold(Pix **pix);
+
+  /**
+   * Find lines from the image making the BLOCK_LIST.
+   * @return 0 on success.
+   */
+  int FindLines();
 
   /** Delete the pageres and block list ready for a new page. */
   void ClearResults();

--- a/include/tesseract/capi.h
+++ b/include/tesseract/capi.h
@@ -274,6 +274,7 @@ TESS_API void TessBaseAPISetRectangle(TessBaseAPI *handle, int left, int top,
                                       int width, int height);
 
 TESS_API struct Pix *TessBaseAPIGetThresholdedImage(TessBaseAPI *handle);
+TESS_API float TessBaseAPIGetGradient(TessBaseAPI *handle);
 TESS_API struct Boxa *TessBaseAPIGetRegions(TessBaseAPI *handle,
                                             struct Pixa **pixa);
 TESS_API struct Boxa *TessBaseAPIGetTextlines(TessBaseAPI *handle,

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -2201,6 +2201,13 @@ int TessBaseAPI::FindLines() {
   return 0;
 }
 
+/**
+ * Return average gradient of lines on page.
+ */
+float TessBaseAPI::GetGradient() {
+  return tesseract_->gradient();
+}
+
 /** Delete the pageres and clear the block list ready for a new page. */
 void TessBaseAPI::ClearResults() {
   if (tesseract_ != nullptr) {

--- a/src/api/capi.cpp
+++ b/src/api/capi.cpp
@@ -327,6 +327,10 @@ struct Pix *TessBaseAPIGetThresholdedImage(TessBaseAPI *handle) {
   return handle->GetThresholdedImage();
 }
 
+float TessBaseAPIGetGradient(TessBaseAPI *handle) {
+  return handle->GetGradient();
+}
+
 void TessBaseAPIClearPersistentCache(TessBaseAPI * /*handle*/) {
   TessBaseAPI::ClearPersistentCache();
 }

--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -168,7 +168,7 @@ int Tesseract::SegmentPage(const char *input_file, BLOCK_LIST *blocks, Tesseract
   bool cjk_mode = textord_use_cjk_fp_model;
 
   textord_.TextordPage(pageseg_mode, reskew_, width, height, pix_binary_, pix_thresholds_,
-                       pix_grey_, splitting || cjk_mode, &diacritic_blobs, blocks, &to_blocks);
+                       pix_grey_, splitting || cjk_mode, &diacritic_blobs, blocks, &to_blocks, &gradient_);
   return auto_page_seg_ret_val;
 }
 

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -495,6 +495,7 @@ void Tesseract::Clear() {
   scaled_color_.destroy();
   deskew_ = FCOORD(1.0f, 0.0f);
   reskew_ = FCOORD(1.0f, 0.0f);
+  gradient_ = 0.0f;
   splitter_.Clear();
   scaled_factor_ = -1;
   for (auto &sub_lang : sub_langs_) {

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -458,6 +458,7 @@ Tesseract::Tesseract()
     , scaled_factor_(-1)
     , deskew_(1.0f, 0.0f)
     , reskew_(1.0f, 0.0f)
+    , gradient_(0.0f)
     , most_recently_used_(this)
     , font_table_size_(0)
 #ifndef DISABLED_LEGACY_ENGINE

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -200,6 +200,9 @@ public:
   const FCOORD &reskew() const {
     return reskew_;
   }
+  float gradient() const {
+    return gradient_;
+  }
   // Destroy any existing pix and return a pointer to the pointer.
   Image *mutable_pix_binary() {
     pix_binary_.destroy();
@@ -1001,6 +1004,7 @@ private:
   int scaled_factor_;
   FCOORD deskew_;
   FCOORD reskew_;
+  float gradient_;
   TesseractStats stats_;
   // Sub-languages to be tried in addition to this.
   std::vector<Tesseract *> sub_langs_;

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -1004,7 +1004,7 @@ private:
   int scaled_factor_;
   FCOORD deskew_;
   FCOORD reskew_;
-  float gradient_ = 0.0f;
+  float gradient_;
   TesseractStats stats_;
   // Sub-languages to be tried in addition to this.
   std::vector<Tesseract *> sub_langs_;

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -1004,7 +1004,7 @@ private:
   int scaled_factor_;
   FCOORD deskew_;
   FCOORD reskew_;
-  float gradient_;
+  float gradient_ = 0.0f;
   TesseractStats stats_;
   // Sub-languages to be tried in addition to this.
   std::vector<Tesseract *> sub_langs_;

--- a/src/textord/textord.cpp
+++ b/src/textord/textord.cpp
@@ -177,7 +177,7 @@ Textord::Textord(CCStruct *ccstruct)
 void Textord::TextordPage(PageSegMode pageseg_mode, const FCOORD &reskew, int width, int height,
                           Image binary_pix, Image thresholds_pix, Image grey_pix, bool use_box_bottoms,
                           BLOBNBOX_LIST *diacritic_blobs, BLOCK_LIST *blocks,
-                          TO_BLOCK_LIST *to_blocks) {
+                          TO_BLOCK_LIST *to_blocks, float *gradient) {
   page_tr_.set_x(width);
   page_tr_.set_y(height);
   if (to_blocks->empty()) {
@@ -219,15 +219,14 @@ void Textord::TextordPage(PageSegMode pageseg_mode, const FCOORD &reskew, int wi
   TO_BLOCK_IT to_block_it(to_blocks);
   TO_BLOCK *to_block = to_block_it.data();
   // Make the rows in the block.
-  float gradient;
   // Do it the old fashioned way.
   if (PSM_LINE_FIND_ENABLED(pageseg_mode)) {
-    gradient = make_rows(page_tr_, to_blocks);
+    *gradient = make_rows(page_tr_, to_blocks);
   } else if (!PSM_SPARSE(pageseg_mode)) {
     // RAW_LINE, SINGLE_LINE, SINGLE_WORD and SINGLE_CHAR all need a single row.
-    gradient = make_single_row(page_tr_, pageseg_mode != PSM_RAW_LINE, to_block, to_blocks);
+    *gradient = make_single_row(page_tr_, pageseg_mode != PSM_RAW_LINE, to_block, to_blocks);
   } else {
-    gradient = 0.0f;
+    *gradient = 0.0f;
   }
   BaselineDetect baseline_detector(textord_baseline_debug, reskew, to_blocks);
   baseline_detector.ComputeStraightBaselines(use_box_bottoms);
@@ -236,7 +235,7 @@ void Textord::TextordPage(PageSegMode pageseg_mode, const FCOORD &reskew, int wi
   // Now make the words in the lines.
   if (PSM_WORD_FIND_ENABLED(pageseg_mode)) {
     // SINGLE_LINE uses the old word maker on the single line.
-    make_words(this, page_tr_, gradient, blocks, to_blocks);
+    make_words(this, page_tr_, *gradient, blocks, to_blocks);
   } else {
     // SINGLE_WORD and SINGLE_CHAR cram all the blobs into a
     // single word, and in SINGLE_CHAR mode, all the outlines

--- a/src/textord/textord.h
+++ b/src/textord/textord.h
@@ -89,7 +89,8 @@ public:
   // to the appropriate word(s) in case they are really diacritics.
   void TextordPage(PageSegMode pageseg_mode, const FCOORD &reskew, int width, int height,
                    Image binary_pix, Image thresholds_pix, Image grey_pix, bool use_box_bottoms,
-                   BLOBNBOX_LIST *diacritic_blobs, BLOCK_LIST *blocks, TO_BLOCK_LIST *to_blocks);
+                   BLOBNBOX_LIST *diacritic_blobs, BLOCK_LIST *blocks, TO_BLOCK_LIST *to_blocks,
+                   float *gradient);
 
   // If we were supposed to return only a single textline, and there is more
   // than one, clean up and leave only the best.


### PR DESCRIPTION
Tesseract already calculates the average gradient (angle) of text lines within `Textord::TextordPage` at present.  The gradient of the text is useful information (as Tesseract performs poorly when the gradient is not [almost] zero), however the average gradient only exists within the [`Textord::TextordPage` function](https://github.com/tesseract-ocr/tesseract/blob/c9895dbad439e5ff42f45ef1d03fe5e8572f2e89/src/textord/textord.cpp#LL222C18-L222C18) at present, with no way for users to access it.  Using the API, getting the gradient currently requires running `Recognize` or `AnalyseLayout` and using the results to manually re-calculate the gradient. 

This PR allows for users to directly retrieve the existing average gradient value calculated in `Textord::TextordPage` using a function named `GetGradient`.  This function can be called any time after `FindLines` has been run.  ~~I also made `FindLines` public so it can be run directly without running `Recognize` or `AnalyseLayout` first (running `AnalyseLayout` would result in paragraph recognition being run twice).~~

I've already used this branch to implement an auto-rotate feature in the latest version of [Tesseract.js](https://github.com/naptha/tesseract.js/) that (unlike adding an auto-rotate pre-processing step) does not negatively impact performance for images without problematic rotation.  A basic script using `GetGradient` is below for demonstrative purposes, along with a test image (named `rotate_image.png` in the code).  Resolves #3836. 

```
#include <tesseract/baseapi.h>
#include <leptonica/allheaders.h>

int main()
{
    tesseract::TessBaseAPI *api = new tesseract::TessBaseAPI();
    // Initialize tesseract-ocr with English, without specifying tessdata path
    if (api->Init(NULL, "eng")) {
        fprintf(stderr, "Could not initialize tesseract.\n");
        exit(1);
    }

    // Open input image with leptonica library
    Pix *image = pixRead("rotate_image.png");
    api->SetImage(image);

    // Find lines, get average gradient
    api->AnalyseLayout();
    float gradient = api->GetGradient();

    printf("Average Gradient: %f\n", gradient);

    // Destroy used object and release memory
    api->End();
    delete api;
    pixDestroy(&image);

    return 0;
}

```

```
Average Gradient: 0.085301
```

<img src="https://user-images.githubusercontent.com/100809261/236986469-eb2a10a9-002c-462d-8662-55ec0d315bf7.png" width="250px"/>
