### PR TITLE
Clean code

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -412,7 +412,7 @@ int TessBaseAPI::Init(const char *data, int data_size, const char *language, Ocr
     if (data_size != 0) {
       mgr.LoadMemBuffer(language, data, data_size);
     }
-    if (tesseract_->init_tesseract(datapath.c_str(), output_file_.c_str(), language, oem, configs,
+    if (tesseract_->init_tesseract(datapath, output_file_, language, oem, configs,
                                    configs_size, vars_vec, vars_values, set_only_non_debug_params,
                                    &mgr) != 0) {
       return -1;
@@ -2176,7 +2176,7 @@ int TessBaseAPI::FindLines() {
             " but data path is undefined\n");
         delete osd_tesseract_;
         osd_tesseract_ = nullptr;
-      } else if (osd_tesseract_->init_tesseract(datapath_.c_str(), "", "osd", OEM_TESSERACT_ONLY,
+      } else if (osd_tesseract_->init_tesseract(datapath_, "", "osd", OEM_TESSERACT_ONLY,
                                                 nullptr, 0, nullptr, nullptr, false, &mgr) == 0) {
         osd_tess = osd_tesseract_;
         osd_tesseract_->set_source_resolution(thresholder_->GetSourceYResolution());

--- a/src/ccstruct/dppoint.cpp
+++ b/src/ccstruct/dppoint.cpp
@@ -76,7 +76,7 @@ int64_t DPPoint::CostWithVariance(const DPPoint *prev) {
   int delta = this - prev;
   int32_t n = prev->n_ + 1;
   int32_t sig_x = prev->sig_x_ + delta;
-  int64_t sig_xsq = prev->sig_xsq_ + delta * delta;
+  int64_t sig_xsq = prev->sig_xsq_ + static_cast<int64_t>(delta) * delta;
   int64_t cost = (sig_xsq - sig_x * sig_x / n) / n;
   cost += prev->total_cost_;
   UpdateIfBetter(cost, prev->total_steps_ + 1, prev, n, sig_x, sig_xsq);

--- a/src/training/pango/boxchar.cpp
+++ b/src/training/pango/boxchar.cpp
@@ -278,8 +278,8 @@ bool BoxChar::MostlyVertical(const std::vector<BoxChar *> &boxes) {
       int dx = boxes[i]->box_->x - boxes[i - 1]->box_->x;
       int dy = boxes[i]->box_->y - boxes[i - 1]->box_->y;
       if (abs(dx) > abs(dy) * kMinNewlineRatio || abs(dy) > abs(dx) * kMinNewlineRatio) {
-        total_dx += dx * dx;
-        total_dy += dy * dy;
+        total_dx += static_cast<int64_t>(dx) * dx;
+        total_dy += static_cast<int64_t>(dy) * dy;
       }
     }
   }


### PR DESCRIPTION
- Avoid 32 bit overflow in multiplication
- Avoid unnecessary string conversions