### PR TITLE
Fix code for generating config files

### DIFF
--- a/include/tesseract/baseapi.h
+++ b/include/tesseract/baseapi.h
@@ -156,10 +156,18 @@ public:
 
 #endif
 
-  /**
-   * Print Tesseract parameters to the given file.
+  /** 
+   * Print Tesseract parameters to the given file with descriptions of each option. 
+   * Cannot be used as Tesseract configuration file due to descriptions 
+   * (use DumpVariables instead to create config files).
    */
   void PrintVariables(FILE *fp) const;
+
+  /** 
+   * Print Tesseract parameters to the given file without descriptions. 
+   * Can be used as Tesseract configuration file.
+  */
+  void DumpVariables(FILE *fp) const;
 
   /**
    * Get value of named variable as a string, if it exists.

--- a/include/tesseract/capi.h
+++ b/include/tesseract/capi.h
@@ -217,6 +217,10 @@ TESS_API void TessBaseAPIPrintVariables(const TessBaseAPI *handle, FILE *fp);
 TESS_API BOOL TessBaseAPIPrintVariablesToFile(const TessBaseAPI *handle,
                                               const char *filename);
 
+TESS_API void TessBaseAPIDumpVariables(const TessBaseAPI *handle, FILE *fp);
+TESS_API BOOL TessBaseAPIDumpVariablesToFile(const TessBaseAPI *handle,
+                                              const char *filename);
+
 TESS_API int TessBaseAPIInit1(TessBaseAPI *handle, const char *datapath,
                               const char *language, TessOcrEngineMode oem,
                               char **configs, int configs_size);

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -352,9 +352,21 @@ void TessBaseAPI::PrintFontsTable(FILE *fp) const {
 
 #endif
 
-/** Print Tesseract parameters to the given file. */
+/** 
+ * Print Tesseract parameters to the given file with descriptions of each option. 
+ * Cannot be used as Tesseract configuration file due to descriptions 
+ * (use DumpVariables instead to create config files).
+ */
 void TessBaseAPI::PrintVariables(FILE *fp) const {
-  ParamUtils::PrintParams(fp, tesseract_->params());
+  ParamUtils::PrintParams(fp, tesseract_->params(), true);
+}
+
+/** 
+ * Print Tesseract parameters to the given file without descriptions. 
+ * Can be used as Tesseract configuration file.
+*/
+void TessBaseAPI::DumpVariables(FILE *fp) const {
+  ParamUtils::PrintParams(fp, tesseract_->params(), false);
 }
 
 /**
@@ -1295,7 +1307,7 @@ bool TessBaseAPI::ProcessPage(Pix *pix, int page_index, const char *filename,
     if (fp == nullptr) {
       tprintf("Error, failed to open file \"%s\"\n", kOldVarsFile);
     } else {
-      PrintVariables(fp);
+      DumpVariables(fp);
       fclose(fp);
     }
     // Switch to alternate mode for retry.

--- a/src/api/capi.cpp
+++ b/src/api/capi.cpp
@@ -212,6 +212,20 @@ BOOL TessBaseAPIPrintVariablesToFile(const TessBaseAPI *handle, const char *file
   return FALSE;
 }
 
+void TessBaseAPIDumpVariables(const TessBaseAPI *handle, FILE *fp) {
+  handle->DumpVariables(fp);
+}
+
+BOOL TessBaseAPIDumpVariablesToFile(const TessBaseAPI *handle, const char *filename) {
+  FILE *fp = fopen(filename, "w");
+  if (fp != nullptr) {
+    handle->DumpVariables(fp);
+    fclose(fp);
+    return TRUE;
+  }
+  return FALSE;
+}
+
 int TessBaseAPIInit4(TessBaseAPI *handle, const char *datapath, const char *language,
                      TessOcrEngineMode mode, char **configs, int configs_size, char **vars_vec,
                      char **vars_values, size_t vars_vec_size, BOOL set_only_non_debug_params) {

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -125,7 +125,7 @@ bool Tesseract::ProcessTargetWord(const TBOX &word_box, const TBOX &target_word_
         if (config_fp == nullptr) {
           tprintf("Error, failed to open file \"%s\"\n", backup_config_file_);
         } else {
-          ParamUtils::PrintParams(config_fp, params());
+          ParamUtils::PrintParams(config_fp, params(), false);
           fclose(config_fp);
         }
         ParamUtils::ReadParamsFile(word_config, SET_PARAM_CONSTRAINT_DEBUG_ONLY, params());

--- a/src/ccutil/params.cpp
+++ b/src/ccutil/params.cpp
@@ -161,27 +161,43 @@ bool ParamUtils::GetParamAsString(const char *name, const ParamsVectors *member_
   return false;
 }
 
-void ParamUtils::PrintParams(FILE *fp, const ParamsVectors *member_params) {
+void ParamUtils::PrintParams(FILE *fp, const ParamsVectors *member_params, bool print_info) {
   int num_iterations = (member_params == nullptr) ? 1 : 2;
   std::ostringstream stream;
   stream.imbue(std::locale::classic());
   for (int v = 0; v < num_iterations; ++v) {
     const ParamsVectors *vec = (v == 0) ? GlobalParams() : member_params;
     for (auto int_param : vec->int_params) {
-      stream << int_param->name_str() << '\t' << (int32_t)(*int_param) << '\t'
-             << int_param->info_str() << '\n';
+      if (print_info) {
+        stream << int_param->name_str() << '\t' << (int32_t)(*int_param) << '\t'
+              << int_param->info_str() << '\n';
+      } else {
+        stream << int_param->name_str() << '\t' << (int32_t)(*int_param) << '\n';
+      }
     }
     for (auto bool_param : vec->bool_params) {
-      stream << bool_param->name_str() << '\t' << bool(*bool_param) << '\t'
-             << bool_param->info_str() << '\n';
+      if (print_info) {
+        stream << bool_param->name_str() << '\t' << bool(*bool_param) << '\t'
+              << bool_param->info_str() << '\n';
+      } else {
+        stream << bool_param->name_str() << '\t' << bool(*bool_param) << '\n';
+      }
     }
     for (auto string_param : vec->string_params) {
-      stream << string_param->name_str() << '\t' << string_param->c_str() << '\t'
-             << string_param->info_str() << '\n';
+      if (print_info) {
+        stream << string_param->name_str() << '\t' << string_param->c_str() << '\t'
+              << string_param->info_str() << '\n';
+      } else {
+        stream << string_param->name_str() << '\t' << string_param->c_str() << '\n';
+      }
     }
     for (auto double_param : vec->double_params) {
-      stream << double_param->name_str() << '\t' << (double)(*double_param) << '\t'
-             << double_param->info_str() << '\n';
+      if (print_info) {
+        stream << double_param->name_str() << '\t' << (double)(*double_param) << '\t'
+              << double_param->info_str() << '\n';
+      } else {
+        stream << double_param->name_str() << '\t' << (double)(*double_param) << '\n';
+      }
     }
   }
   fprintf(fp, "%s", stream.str().c_str());

--- a/src/ccutil/params.h
+++ b/src/ccutil/params.h
@@ -103,7 +103,7 @@ public:
                                std::string *value);
 
   // Print parameters to the given file.
-  static void PrintParams(FILE *fp, const ParamsVectors *member_params);
+  static void PrintParams(FILE *fp, const ParamsVectors *member_params, bool print_info = true);
 
   // Resets all parameters back to default values;
   static void ResetToDefaults(ParamsVectors *member_params);


### PR DESCRIPTION
Resolves #3943, see that issue for a full explanation and previous discussion on this issue. 

In short, the function `ParamUtils::PrintParams` previously created a machine-readable config file with parameter names and values.  It was then edited to add human-readable descriptions to each of the parameters.  While this change undoubtedly made the results easier for users to interpret, the resulting files no longer functioned properly as config files.  This (1) broke the parts of the code that assumed `ParamUtils::PrintParams` created machine-readable config files and (2) meant there was no longer an API function for creating machine-readable config files using the current settings. 

This PR fixes both issues:
1. A boolean parameter has been added to `ParamUtils::PrintParams` to specify whether descriptions of parameters should be printed
   1. This parameter is true by default, so printing to the console (for example) still includes the descriptions
   2. When `ParamUtils::PrintParams` is inarguably being used with the intent of creating a machine-readable config file, the parameter is set to `true`
1. An API function named `DumpVariables` has been added, which creates config files (the old behavior of `PrintVariables`)