### PR TITLE
Fix typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,7 @@ if(OPENMP_BUILD)
   if(NOT OpenMP_FOUND
      AND CLANG
      AND WIN32)
-    # workaroung because find_package(OpenMP) does not work for clang-cl
+    # workaround because find_package(OpenMP) does not work for clang-cl
     # https://gitlab.kitware.com/cmake/cmake/issues/19404
     check_include_file_cxx(omp.h HAVE_OMP_H_INCLUDE)
     find_library(OpenMP_LIBRARY NAMES omp libomp.lib)

--- a/src/textord/edgblob.cpp
+++ b/src/textord/edgblob.cpp
@@ -174,7 +174,7 @@ int32_t OL_BUCKETS::outline_complexity(C_OUTLINE *outline, // parent outline
         if (child_count + grandchild_count > max_count) { // too complex
           if (edges_debug) {
             tprintf(
-                "Disgard outline on child_count=%d + grandchild_count=%d "
+                "Discard outline on child_count=%d + grandchild_count=%d "
                 "> max_count=%d\n",
                 child_count, grandchild_count, max_count);
           }


### PR DESCRIPTION
Found via `codespell -q 3 -L bu,eiter,fo,fpr,inout,numer,pixes,thisy`