### PR TITLE
Disable -mfpu=neon for aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,11 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm.*")
   set(HAVE_AVX512F FALSE)
   set(HAVE_FMA FALSE)
   set(HAVE_SSE4_1 FALSE)
+
   check_cxx_compiler_flag("-mfpu=neon" HAVE_NEON)
+  if(HAVE_NEON)
+    set(NEON_COMPILE_FLAGS "-mfpu=neon")
+  endif(HAVE_NEON)
 
 else()
 
@@ -272,7 +276,6 @@ else()
 endif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|x86_64|AMD64|amd64|i386|i686")
 
 if(HAVE_NEON)
-  set(NEON_COMPILE_FLAGS "-mfpu=neon")
   message(STATUS "LTO build is not supported on arm/RBPi.")
   set(ENABLE_LTO FALSE)  # enable LTO cause fatal error on arm/RBPi
 endif()


### PR DESCRIPTION
This PR removes the -mfpu command line argument on aarch64, because it is not available in gcc on this architecture.
See: https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html