### PR TITLE
Fix build without git clone in cloned directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 # ----------------------------------------
 AC_PREREQ([2.69])
 AC_INIT([tesseract],
-        [m4_esyscmd_s([git describe --abbrev=4 2>/dev/null || cat VERSION])],
+        [m4_esyscmd_s([test -d .git && git describe --abbrev=4 2>/dev/null || cat VERSION])],
         [https://github.com/tesseract-ocr/tesseract/issues],,
         [https://github.com/tesseract-ocr/tesseract/])
 


### PR DESCRIPTION
FreeBSD uses git to manage Ports Tree. Tesseract, when building from the Ports Tree, is built from a tarball that doesn't have .git and then git describe is ran on top of the Ports Tree.