### PR TITLE
fix failure to OCR: general quality issue due to LSTM being fed noisy/crappy *original* image pixels instead of cleaned-up binarized pixels.

### DIFF
--- a/src/ccmain/equationdetect.cpp
+++ b/src/ccmain/equationdetect.cpp
@@ -1437,7 +1437,7 @@ void EquationDetect::PaintColParts(const std::string &outfile) const {
 void EquationDetect::PrintSpecialBlobsDensity(const ColPartition *part) const {
   ASSERT_HOST(part);
   TBOX box(part->bounding_box());
-  int h = pixGetHeight(lang_tesseract_->BestPix());
+  int h = lang_tesseract_->ImageHeight();
   tprintf("Printing special blobs density values for ColParition (t=%d,b=%d) ", h - box.top(),
           h - box.bottom());
   box.print();

--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -183,8 +183,7 @@ ImageData *Tesseract::GetRectImage(const TBOX &box, const BLOCK &block, int padd
     revised_box->rotate(block.re_rotation());
   }
   // Now revised_box always refers to the image.
-  // BestPix is never colormapped, but may be of any depth.
-  Image pix = BestPix();
+  Image pix = pix_binary();
   int width = pixGetWidth(pix);
   int height = pixGetHeight(pix);
   TBOX image_box(0, 0, width, height);


### PR DESCRIPTION
- fix Bushnell OCR bug (failure to properly OCR the number "11"; see message chain in mailing list: https://groups.google.com/g/tesseract-ocr/c/5jrGvsrdqig/m/jvTG6L9zBgAJ; this includes sample images, text output and context as originally reported by Astro/Nor): 

  ## root cause: 

  it turns out tesseract erroneously grabs the ORIGINAL image (instead of the THRESHOLDED/BINARIZED one!) to extract the word box (`Tesseract::GetRectImage()`) which will be fed into the LSTM OCR neural net in order to OCR the detected text area.

  Ergo: this fix SHOULD improve OCR results generally, as this is a **generic bug** which impacts ALL text bboxes found in a given input page image, which are then being pumped into the LSTM engine to obtain OCR'ed text.

  This fix was verified to work in an otherwise patched/augmented tesseract rig: [GerHobbelt/tesseract](https://github.com/GerHobbelt/tesseract): commit series bb37cf3c2e3f177cf41d2e8a01a648bcc53f3911, ffc1997483f6380583fb6921910896826a62d304, 15d2952fc4d8f5407e5491112794f9cb2c0b0f77, 69416e594ac84078898800222168e4bfdad68ef1, f49826b7354436c6dfe6c1672e5b55235dab756b, d53c1a219ae78a1091bdc3a168d3881d7043d8f6, 44f2f8486c1b0064402b45b194100d0007a07698, where I worked on removing the curious `BestPix()` API, which SEEMINGLY was originally meant for ScrollView-et-al debug display purposes, but is (IMO) an ill-named API for that purpose.

- remove accompanying, now obsolete, comment

- also remove the need for `BestPix()` API usage in `EquationDetect::PrintSpecialBlobsDensity()` by invoking the API that delivers what's actually used there: the image height. Here `BestPix()` usage is also wrong (theoretically) as the sought-after image height is about the actual height of the **binarized image data**, which represent the cleaned-up-and-ready-for-use OCR sourcing image data.

---

## Corollary of this bug

Anyone feeding tesseract monochrome (pre-thresholded/binarized) images from an **external cleanup+binarization process** SHOULD already get best OCR results and SHOULD NOT be impacted by this bug, nor this fix. (As then there would be no difference between 'original pix' and 'binary pix' from tesseract's perspective.)

