### PR TITLE
Fix Broken URLs in citations.bib

### DIFF
--- a/CITATIONS.bib
+++ b/CITATIONS.bib
@@ -20,7 +20,7 @@
   publisher = {ACM},
   series = {ACM International Conference Proceeding Series},
   title = {Adapting the Tesseract Open Source OCR Engine for Multilingual OCR.},
-  url = {http://www.google.de/research/pubs/archive/35248.pdf},
+  url = {https://storage.googleapis.com/pub-tools-public-publication-data/pdf/35248.pdf},
   year = 2009,
   isbn = {978-1-60558-698-4},
   date = {2009-07-25}
@@ -33,7 +33,7 @@
   title = {Combined Orientation and Script Detection using the Tesseract OCR Engine},
   booktitle = {MOCR '09: Proceedings of the International Workshop on Multilingual OCR},
   editor = {Venu Govindaraju and Premkumar Natarajan and Santanu Chaudhury and Daniel P. Lopresti},
-  url = {http://www.google.de/research/pubs/archive/35506.pdf}
+  url = {https://storage.googleapis.com/pub-tools-public-publication-data/pdf/35506.pdf}
   year = {2009},
   isbn = {978-1-60558-698-4},
   pages = {1--7},
@@ -47,7 +47,7 @@
   author = {Ray Smith},
   title = {Hybrid Page Layout Analysis via Tab-Stop Detection},
   booktitle = {ICDAR '09: Proceedings of the 2009 10th International Conference on Document Analysis and Recognition},
-  url = {http://www.google.de/research/pubs/archive/35094.pdf}
+  url = {https://storage.googleapis.com/pub-tools-public-publication-data/pdf/35094.pdf}
   year = {2009},
   isbn = {978-0-7695-3725-2},
   pages = {241--245},
@@ -60,7 +60,7 @@
   author = {Ray Smith},
   title = {An Overview of the Tesseract OCR Engine},
   booktitle = {ICDAR '07: Proceedings of the Ninth International Conference on Document Analysis and Recognition},
-  url = {http://www.google.de/research/pubs/archive/33418.pdf}
+  url = {https://storage.googleapis.com/pub-tools-public-publication-data/pdf/33418.pdf}
   year = {2007},
   isbn = {0-7695-2822-8},
   pages = {629--633},


### PR DESCRIPTION
Context: I noticed that many URLs in the citations.bib file linked to Google papers were returning a 404 error.
Changes Made: Updated these URLs to point to the correct locations.