### PR TITLE
initDSProfile: correct std::vector usage

### DIFF
--- a/src/opencl/openclwrapper.cpp
+++ b/src/opencl/openclwrapper.cpp
@@ -191,7 +191,6 @@ static ds_status initDSProfile(ds_profile **p, const char *version) {
 
   profile->numDevices = numDevices + 1; // +1 to numDevices to include the native CPU
   profile->devices.resize(profile->numDevices);
-  memset(profile->devices.data(), 0, profile->numDevices * sizeof(ds_device));
 
   next = 0;
   for (i = 0; i < numPlatforms; i++) {

--- a/src/opencl/openclwrapper.cpp
+++ b/src/opencl/openclwrapper.cpp
@@ -174,8 +174,8 @@ static ds_status initDSProfile(ds_profile **p, const char *version) {
   clGetPlatformIDs(0, nullptr, &numPlatforms);
 
   if (numPlatforms > 0) {
-    platforms.reserve(numPlatforms);
-    clGetPlatformIDs(numPlatforms, &platforms[0], nullptr);
+    platforms.resize(numPlatforms);
+    clGetPlatformIDs(numPlatforms, platforms.data(), nullptr);
   }
 
   numDevices = 0;
@@ -186,12 +186,12 @@ static ds_status initDSProfile(ds_profile **p, const char *version) {
   }
 
   if (numDevices > 0) {
-    devices.reserve(numDevices);
+    devices.resize(numDevices);
   }
 
   profile->numDevices = numDevices + 1; // +1 to numDevices to include the native CPU
-  profile->devices.reserve(profile->numDevices);
-  memset(&profile->devices[0], 0, profile->numDevices * sizeof(ds_device));
+  profile->devices.resize(profile->numDevices);
+  memset(profile->devices.data(), 0, profile->numDevices * sizeof(ds_device));
 
   next = 0;
   for (i = 0; i < numPlatforms; i++) {


### PR DESCRIPTION
Inside initDSProfile use std::vector::resize instead of std::vector::reserve, due to later usage it by index that triggers debug cheks (reserver does not change size) under MSVC.