### PR TITLE
Fix regression in layout detection since 5.0.0 (fixes issue #4014)

### DIFF
--- a/src/textord/colpartitiongrid.cpp
+++ b/src/textord/colpartitiongrid.cpp
@@ -1609,10 +1609,10 @@ BlobRegionType ColPartitionGrid::SmoothInOneDirection(
     }
     // See if we have a decision yet.
     auto image_count = counts[NPT_IMAGE];
-    auto htext_score = counts[NPT_HTEXT] + counts[NPT_WEAK_HTEXT] -
-                       (image_count + counts[NPT_WEAK_VTEXT]);
-    auto vtext_score = counts[NPT_VTEXT] + counts[NPT_WEAK_VTEXT] -
-                       (image_count + counts[NPT_WEAK_HTEXT]);
+    int htext_score = counts[NPT_HTEXT] + counts[NPT_WEAK_HTEXT] -
+                      (image_count + counts[NPT_WEAK_VTEXT]);
+    int vtext_score = counts[NPT_VTEXT] + counts[NPT_WEAK_VTEXT] -
+                      (image_count + counts[NPT_WEAK_HTEXT]);
     if (image_count > 0 && image_bias - htext_score >= kSmoothDecisionMargin &&
         image_bias - vtext_score >= kSmoothDecisionMargin) {
       *best_distance = dists[NPT_IMAGE][0];


### PR DESCRIPTION
"auto" resulted in unsigned numbers, but htext_score and vtest_score can be negative.

Fixes: 842cca1d49617dd8 ("Fix more signed/unsigned compiler warnings")