### PR TITLE
Update hocrrenderer.cpp for solving the issue #4045

### DIFF
--- a/src/ccstruct/stepblob.h
+++ b/src/ccstruct/stepblob.h
@@ -78,7 +78,7 @@ public:
   int32_t count_transitions( // count maxima
       int32_t threshold);    // size threshold
 
-  void move(const ICOORD vec);         // repostion blob by vector
+  void move(const ICOORD vec);         // reposition blob by vector
   void rotate(const FCOORD &rotation); // Rotate by given vector.
 
   // Adds sub-pixel resolution EdgeOffsets for the outlines using greyscale


### PR DESCRIPTION
To resolve the issue of Tesseract's hOCR output not displaying as XHTML in Chrome, modifications were made in the hocrrenderer.cpp file. These changes ensure proper generation of hOCR markup, including text direction and baseline information, allowing Chrome to correctly render the output as expected in an XHTML format.