### PR TITLE
Fix loading of sublangs (regression)

### DIFF
--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -306,9 +306,10 @@ int Tesseract::init_tesseract(const std::string &arg0, const std::string &textba
   // Add any languages that this language requires
   bool loaded_primary = false;
   // Load the rest into sub_langs_.
-  // A range based for loop does not work here because langs_to_load
+  // WARNING: A range based for loop does not work here because langs_to_load
   // might be changed in the loop when a new submodel is found.
-  for (auto &lang_to_load : langs_to_load) {
+  for (size_t lang_index = 0; lang_index < langs_to_load.size(); ++lang_index) {
+    auto &lang_to_load = langs_to_load[lang_index];
     if (!IsStrInList(lang_to_load, langs_not_to_load)) {
       const char *lang_str = lang_to_load.c_str();
       Tesseract *tess_to_init;


### PR DESCRIPTION
Model files which where defined with tessedit_load_sublangs in another model file where no longer loaded since Tesseract release 5.0.0-rc2.

Fixes: 9091055783ac8f03 ("Fix loading of additional model files")