### PR TITLE
Send output of combine_tessdata -d to stdout instead of stderr. Fixes #4149

### DIFF
--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -211,11 +211,11 @@ void TessdataManager::Clear() {
 
 // Prints a directory of contents.
 void TessdataManager::Directory() const {
-  tprintf("Version:%s\n", VersionString().c_str());
+  printf("Version:%s\n", VersionString().c_str());
   auto offset = TESSDATA_NUM_ENTRIES * sizeof(int64_t);
   for (unsigned i = 0; i < TESSDATA_NUM_ENTRIES; ++i) {
     if (!entries_[i].empty()) {
-      tprintf("%u:%s:size=%zu, offset=%zu\n", i, kTessdataFileSuffixes[i], entries_[i].size(),
+      printf("%u:%s:size=%zu, offset=%zu\n", i, kTessdataFileSuffixes[i], entries_[i].size(),
               offset);
       offset += entries_[i].size();
     }

--- a/src/training/combine_tessdata.cpp
+++ b/src/training/combine_tessdata.cpp
@@ -266,6 +266,9 @@ int main(int argc, char **argv) {
         "  %s -d traineddata_file\n\n",
         argv[0]);
     printf(
+        "NOTE: Above two flags may combined as -dl or -ld to get both outputs"
+        );
+    printf(
         "Usage for compacting LSTM component to int:\n"
         "  %s -c traineddata_file\n",
         argv[0]);


### PR DESCRIPTION
Fixes #4149.

Rather than sending the listing to `stderr` send it to `stdout` like is done for the network listing.

Also document the hidden `-ld` and `-dl` switch combos in the help message.