### PR TITLE
Check if NEON extension are actually available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,10 +178,20 @@ case "${host_cpu}" in
     ;;
 
   arm*)
-
-    AX_CHECK_COMPILE_FLAG([-mfpu=neon], [neon=true], [neon=false], [$WERROR])
-    AM_CONDITIONAL([HAVE_NEON], $neon)
-    if $neon; then
+    SAVE_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="-mfpu=neon $CXXFLAGS"
+    AC_MSG_CHECKING([for NEON support])
+    AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([], [[
+    #ifndef __ARM_NEON
+           #error
+    #endif
+    ]])],
+    [neon=yes], [neon=no])
+    AC_MSG_RESULT([$neon])
+    CXXFLAGS="$SAVE_CXXFLAGS"
+    AM_CONDITIONAL([HAVE_NEON], test "xyes" = "x$neon")
+    if test "xyes" = "$neon"; then
       AC_DEFINE([HAVE_NEON], [1], [Enable NEON instructions])
       NEON_CXXFLAGS="-mfpu=neon"
       AC_SUBST([NEON_CXXFLAGS])


### PR DESCRIPTION
User may pass own compiler flags to configure which override those provided by project through automake. Therefore it is possible for user on ARM platform to pass CXXFLAGS=-mfpu=vfp which will effectively disable NEON even though used compiler supports -mfpu=neon (since user supplied flags take precedence compiler invocation will use flags: -mfpu=neon -mfpu=vfp). Instead of checking whether compiler supports -mfpu=neon flag, check if NEON extensions are available by checking if __ARM_NEON is defined when compiling with -mfpu=neon and user supplied flags combined.