### PR TITLE
Force TCP v4 for socket to ScrollView server. Fixes #3000

### DIFF
--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -244,15 +244,10 @@ static const char *ScrollViewProg() {
 
 // The arguments to the program to invoke to start ScrollView
 static std::string ScrollViewCommand(const std::string &scrollview_path) {
-  // The following ugly ifdef is to enable the output of the java runtime
-  // to be sent down a black hole on non-windows to ignore all the
-  // exceptions in piccolo. Ideally piccolo would be debugged to make
-  // this unnecessary.
-  // Also the path has to be separated by ; on windows and : otherwise.
+  // Quote our paths on Windows to deal with spaces
 #  ifdef _WIN32
   const char cmd_template[] =
       "-Djava.library.path=\"%s\" -jar \"%s/ScrollView.jar\"";
-
 #  else
   const char cmd_template[] =
       "-c \"trap 'kill %%1' 0 1 2 ; java "
@@ -279,6 +274,7 @@ SVNetwork::SVNetwork(const char *hostname, int port) {
   buffer_ptr_ = nullptr;
 
   struct addrinfo *addr_info = nullptr;
+  struct addrinfo hints = {0, PF_INET, SOCK_STREAM};
   auto port_string = std::to_string(port);
 #  ifdef _WIN32
   // Initialize Winsock
@@ -289,7 +285,7 @@ SVNetwork::SVNetwork(const char *hostname, int port) {
   }
 #  endif // _WIN32
 
-  if (getaddrinfo(hostname, port_string.c_str(), nullptr, &addr_info) != 0) {
+  if (getaddrinfo(hostname, port_string.c_str(), &hints, &addr_info) != 0) {
     std::cerr << "Error resolving name for ScrollView host "
               << std::string(hostname) << ":" << port << std::endl;
 #  ifdef _WIN32


### PR DESCRIPTION
Fixes #3000.

Without any hints, we can end up with a UDP socket which won't work with the TCP socket that the Java ScrollView display server is listening on. Use hints for TCP v4 so that we get the right kind of socket returned.

Also, delete some obsolete comments nearby.