### PR TITLE
Add language information to the TSV output (fixes #1861)

### DIFF
--- a/include/tesseract/baseapi.h
+++ b/include/tesseract/baseapi.h
@@ -564,7 +564,8 @@ public:
    * page_number is 0-based but will appear in the output as 1-based.
    * Returned string must be freed with the delete [] operator.
    */
-  char *GetTSVText(int page_number);
+  char *GetTSVText(int page_number, bool font_info=false,
+                   bool lang_info=false);
 
   /**
    * Make a box file for LSTM training from the internal data structures.

--- a/include/tesseract/baseapi.h
+++ b/include/tesseract/baseapi.h
@@ -564,7 +564,15 @@ public:
    * page_number is 0-based but will appear in the output as 1-based.
    * Returned string must be freed with the delete [] operator.
    */
-  char *GetTSVText(int page_number, bool lang_info=false);
+  char *GetTSVText(int page_number);
+
+  /**
+   * Make a TSV-formatted string from the internal data structures.
+   * Allows additional column with detected language.
+   * page_number is 0-based but will appear in the output as 1-based.
+   * Returned string must be freed with the delete [] operator.
+   */
+  char *GetTSVText(int page_number, bool lang_info);
 
   /**
    * Make a box file for LSTM training from the internal data structures.

--- a/include/tesseract/baseapi.h
+++ b/include/tesseract/baseapi.h
@@ -564,8 +564,7 @@ public:
    * page_number is 0-based but will appear in the output as 1-based.
    * Returned string must be freed with the delete [] operator.
    */
-  char *GetTSVText(int page_number, bool font_info=false,
-                   bool lang_info=false);
+  char *GetTSVText(int page_number, bool lang_info=false);
 
   /**
    * Make a box file for LSTM training from the internal data structures.

--- a/include/tesseract/renderer.h
+++ b/include/tesseract/renderer.h
@@ -197,8 +197,7 @@ private:
  */
 class TESS_API TessTsvRenderer : public TessResultRenderer {
 public:
-  TessTsvRenderer(const char *outputbase, bool font_info, bool lang_info);
-  explicit TessTsvRenderer(const char *outputbase, bool font_info);
+  explicit TessTsvRenderer(const char *outputbase, bool lang_info);
   explicit TessTsvRenderer(const char *outputbase);
 
 protected:
@@ -207,7 +206,6 @@ protected:
   bool EndDocumentHandler() override;
 
 private:
-  bool font_info_; // whether to print font information
   bool lang_info_; // whether to print language information
 };
 

--- a/include/tesseract/renderer.h
+++ b/include/tesseract/renderer.h
@@ -197,6 +197,7 @@ private:
  */
 class TESS_API TessTsvRenderer : public TessResultRenderer {
 public:
+  TessTsvRenderer(const char *outputbase, bool font_info, bool lang_info);
   explicit TessTsvRenderer(const char *outputbase, bool font_info);
   explicit TessTsvRenderer(const char *outputbase);
 
@@ -207,6 +208,7 @@ protected:
 
 private:
   bool font_info_; // whether to print font information
+  bool lang_info_; // whether to print language information
 };
 
 /**

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -1421,6 +1421,16 @@ static void AddBoxToTSV(const PageIterator *it, PageIteratorLevel level, std::st
  * page_number is 0-based but will appear in the output as 1-based.
  * Returned string must be freed with the delete [] operator.
  */
+char *TessBaseAPI::GetTSVText(int page_number) {
+  return GetTSVText(page_number, false);
+}
+
+/**
+ * Make a TSV-formatted string from the internal data structures.
+ * Allows additional column with detected language.
+ * page_number is 0-based but will appear in the output as 1-based.
+ * Returned string must be freed with the delete [] operator.
+ */
 char *TessBaseAPI::GetTSVText(int page_number, bool lang_info) {
   if (tesseract_ == nullptr || (page_res_ == nullptr && Recognize(nullptr) < 0)) {
     return nullptr;

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -1421,7 +1421,7 @@ static void AddBoxToTSV(const PageIterator *it, PageIteratorLevel level, std::st
  * page_number is 0-based but will appear in the output as 1-based.
  * Returned string must be freed with the delete [] operator.
  */
-char *TessBaseAPI::GetTSVText(int page_number, bool font_info, bool lang_info) {
+char *TessBaseAPI::GetTSVText(int page_number, bool lang_info) {
   if (tesseract_ == nullptr || (page_res_ == nullptr && Recognize(nullptr) < 0)) {
     return nullptr;
   }
@@ -1434,8 +1434,6 @@ char *TessBaseAPI::GetTSVText(int page_number, bool font_info, bool lang_info) {
   int par_num = 0;
   int line_num = 0;
   int word_num = 0;
-  std::string x_font;
-  int x_fsize = 0;
   std::string lang;
 
   std::string tsv_str;
@@ -1449,10 +1447,6 @@ char *TessBaseAPI::GetTSVText(int page_number, bool font_info, bool lang_info) {
   tsv_str += "\t" + std::to_string(rect_width_);
   tsv_str += "\t" + std::to_string(rect_height_);
   tsv_str += "\t-1";
-  if (font_info) {
-    tsv_str += "\t" + x_font;
-    tsv_str += "\t" + x_fsize;
-  }
   if (lang_info) {
     tsv_str += "\t" + lang;
   }
@@ -1478,9 +1472,6 @@ char *TessBaseAPI::GetTSVText(int page_number, bool font_info, bool lang_info) {
       tsv_str += "\t" + std::to_string(word_num);
       AddBoxToTSV(res_it.get(), RIL_BLOCK, tsv_str);
       tsv_str += "\t-1";
-      if (font_info) {
-        tsv_str += "\t\t";
-      }
       if (lang_info) {
         tsv_str += "\t";
       }
@@ -1500,9 +1491,6 @@ char *TessBaseAPI::GetTSVText(int page_number, bool font_info, bool lang_info) {
       tsv_str += "\t" + std::to_string(word_num);
       AddBoxToTSV(res_it.get(), RIL_PARA, tsv_str);
       tsv_str += "\t-1";
-      if (font_info) {
-        tsv_str += "\t\t";
-      }
       if (lang_info) {
         tsv_str += "\t" + lang;
       }
@@ -1518,9 +1506,6 @@ char *TessBaseAPI::GetTSVText(int page_number, bool font_info, bool lang_info) {
       tsv_str += "\t" + std::to_string(word_num);
       AddBoxToTSV(res_it.get(), RIL_TEXTLINE, tsv_str);
       tsv_str += "\t-1";
-      if (font_info) {
-        tsv_str += "\t\t";
-      }
       if (lang_info) {
         tsv_str += "\t";
       }
@@ -1542,18 +1527,6 @@ char *TessBaseAPI::GetTSVText(int page_number, bool font_info, bool lang_info) {
     tsv_str += "\t" + std::to_string(bottom - top);
     tsv_str += "\t" + std::to_string(res_it->Confidence(RIL_WORD));
 
-    if (font_info) {
-      bool bold, italic, underlined, monospace, serif, smallcaps;
-      int pointsize, font_id;
-      const char *font_name =
-        res_it->WordFontAttributes(&bold, &italic, &underlined, &monospace,
-                                   &serif, &smallcaps, &pointsize, &font_id);
-      tsv_str += "\t";
-      if (font_name) {
-        tsv_str += HOcrEscape(font_name);
-      }
-      tsv_str += "\t" + std::to_string(pointsize);
-    }
     if (lang_info) {
       const char *word_lang = res_it->WordRecognitionLanguage();
       tsv_str += "\t";

--- a/src/api/renderer.cpp
+++ b/src/api/renderer.cpp
@@ -157,18 +157,33 @@ bool TessTextRenderer::AddImageHandler(TessBaseAPI *api) {
  **********************************************************************/
 TessTsvRenderer::TessTsvRenderer(const char *outputbase) : TessResultRenderer(outputbase, "tsv") {
   font_info_ = false;
+  lang_info_ = false;
 }
 
 TessTsvRenderer::TessTsvRenderer(const char *outputbase, bool font_info)
     : TessResultRenderer(outputbase, "tsv") {
   font_info_ = font_info;
+  lang_info_ = false;
+}
+
+TessTsvRenderer::TessTsvRenderer(const char *outputbase, bool font_info, bool lang_info)
+    : TessResultRenderer(outputbase, "tsv") {
+  font_info_ = font_info;
+  lang_info_ = lang_info;
 }
 
 bool TessTsvRenderer::BeginDocumentHandler() {
   // Output TSV column headings
   AppendString(
       "level\tpage_num\tblock_num\tpar_num\tline_num\tword_"
-      "num\tleft\ttop\twidth\theight\tconf\ttext\n");
+      "num\tleft\ttop\twidth\theight\tconf\t");
+  if (font_info_) {
+    AppendString("x_font\tx_fsize\t");
+  }
+  if (lang_info_) {
+    AppendString("lang\t");
+  }
+  AppendString("text\n");
   return true;
 }
 
@@ -177,7 +192,7 @@ bool TessTsvRenderer::EndDocumentHandler() {
 }
 
 bool TessTsvRenderer::AddImageHandler(TessBaseAPI *api) {
-  const std::unique_ptr<const char[]> tsv(api->GetTSVText(imagenum()));
+  const std::unique_ptr<const char[]> tsv(api->GetTSVText(imagenum(), font_info_, lang_info_));
   if (tsv == nullptr) {
     return false;
   }

--- a/src/api/renderer.cpp
+++ b/src/api/renderer.cpp
@@ -156,19 +156,11 @@ bool TessTextRenderer::AddImageHandler(TessBaseAPI *api) {
  * TSV Text Renderer interface implementation
  **********************************************************************/
 TessTsvRenderer::TessTsvRenderer(const char *outputbase) : TessResultRenderer(outputbase, "tsv") {
-  font_info_ = false;
   lang_info_ = false;
 }
 
-TessTsvRenderer::TessTsvRenderer(const char *outputbase, bool font_info)
+TessTsvRenderer::TessTsvRenderer(const char *outputbase, bool lang_info)
     : TessResultRenderer(outputbase, "tsv") {
-  font_info_ = font_info;
-  lang_info_ = false;
-}
-
-TessTsvRenderer::TessTsvRenderer(const char *outputbase, bool font_info, bool lang_info)
-    : TessResultRenderer(outputbase, "tsv") {
-  font_info_ = font_info;
   lang_info_ = lang_info;
 }
 
@@ -177,9 +169,6 @@ bool TessTsvRenderer::BeginDocumentHandler() {
   AppendString(
       "level\tpage_num\tblock_num\tpar_num\tline_num\tword_"
       "num\tleft\ttop\twidth\theight\tconf\t");
-  if (font_info_) {
-    AppendString("x_font\tx_fsize\t");
-  }
   if (lang_info_) {
     AppendString("lang\t");
   }
@@ -192,7 +181,7 @@ bool TessTsvRenderer::EndDocumentHandler() {
 }
 
 bool TessTsvRenderer::AddImageHandler(TessBaseAPI *api) {
-  const std::unique_ptr<const char[]> tsv(api->GetTSVText(imagenum(), font_info_, lang_info_));
+  const std::unique_ptr<const char[]> tsv(api->GetTSVText(imagenum(), lang_info_));
   if (tsv == nullptr) {
     return false;
   }

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -399,6 +399,7 @@ Tesseract::Tesseract()
                     this->params())
     , BOOL_MEMBER(textord_tabfind_show_vlines, false, "Debug line finding", this->params())
     , BOOL_MEMBER(textord_use_cjk_fp_model, false, "Use CJK fixed pitch model", this->params())
+    , BOOL_MEMBER(tsv_lang_info, false, "Include language info in the  .tsv output file", this->params())
     , BOOL_MEMBER(poly_allow_detailed_fx, false,
                   "Allow feature extractors to see the original outline", this->params())
     , BOOL_INIT_MEMBER(tessedit_init_config_only, false,

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -920,6 +920,7 @@ public:
   BOOL_VAR_H(tessedit_flip_0O);
   double_VAR_H(tessedit_lower_flip_hyphen);
   double_VAR_H(tessedit_upper_flip_hyphen);
+  BOOL_VAR_H(tsv_lang_info);
   BOOL_VAR_H(rej_trust_doc_dawg);
   BOOL_VAR_H(rej_1Il_use_dict_word);
   BOOL_VAR_H(rej_1Il_trust_permuter_type);

--- a/src/tesseract.cpp
+++ b/src/tesseract.cpp
@@ -533,11 +533,9 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
 
     api.GetBoolVariable("tessedit_create_tsv", &b);
     if (b) {
-      bool font_info;
       bool lang_info;
-      api.GetBoolVariable("hocr_font_info", &font_info);
       api.GetBoolVariable("tsv_lang_info", &lang_info);
-      auto renderer = std::make_unique<tesseract::TessTsvRenderer>(outputbase, font_info, lang_info);
+      auto renderer = std::make_unique<tesseract::TessTsvRenderer>(outputbase, lang_info);
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {

--- a/src/tesseract.cpp
+++ b/src/tesseract.cpp
@@ -534,8 +534,10 @@ static void PreloadRenderers(tesseract::TessBaseAPI &api,
     api.GetBoolVariable("tessedit_create_tsv", &b);
     if (b) {
       bool font_info;
+      bool lang_info;
       api.GetBoolVariable("hocr_font_info", &font_info);
-      auto renderer = std::make_unique<tesseract::TessTsvRenderer>(outputbase, font_info);
+      api.GetBoolVariable("tsv_lang_info", &lang_info);
+      auto renderer = std::make_unique<tesseract::TessTsvRenderer>(outputbase, font_info, lang_info);
       if (renderer->happy()) {
         renderers.push_back(std::move(renderer));
       } else {

--- a/tessdata/configs/tsv
+++ b/tessdata/configs/tsv
@@ -1,1 +1,2 @@
 tessedit_create_tsv 1
+tsv_lang_info 0


### PR DESCRIPTION
Also make the font_info flag work on TSV output.

The existing code was reading `hocr_font_info` but not using it when producing output. This PR fixes that, too but it feels a rather undocumented feature without reading the source code. I wonder where to document that. Maybe as a comment on the `tsv` example config?