### PR TITLE
Support building and running unit tests with CMake toolchain

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -64,6 +64,12 @@ jobs:
         with:
              submodules: recursive
 
+      - name: Download fonts, tessdata and langdata required for tests
+        run: |
+          git clone https://github.com/egorpugin/tessdata tessdata_unittest
+          cp tessdata_unittest/fonts/* test/testing/
+          mv tessdata_unittest/* ../
+
       - name: Configure Tesseract (Linux)
         run: |
              mkdir build
@@ -74,6 +80,7 @@ jobs:
                -G Ninja \
                -DCMAKE_BUILD_TYPE=Release \
                -DOPENMP_BUILD=OFF \
+               -DBUILD_TESTING=ON \
                -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} \
                -DCMAKE_INSTALL_PREFIX:PATH=inst
         if: runner.os == 'Linux'
@@ -101,6 +108,11 @@ jobs:
         run: |
              cmake --build build --config Release --target install
 
+      - name: Make and run Unit Tests (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          cmake --build build --config Release --target check
+
       - name: Display Tesseract Version
         run: |
              build/inst/bin/tesseract -v
@@ -109,12 +121,6 @@ jobs:
         run: |
              build/inst/bin/lstmtraining -v
              build/inst/bin/text2image -v
-
-      - name: Download fonts, tessdata and langdata required for tests
-        run: |
-             git clone https://github.com/egorpugin/tessdata tessdata_unittest
-             cp tessdata_unittest/fonts/* test/testing/
-             mv tessdata_unittest/* ../
 
       - name: List languages in different tessdata-dir
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ option(ENABLE_NATIVE
 # see
 # https://stackoverflow.com/questions/52653025/why-is-march-native-used-so-rarely
 option(BUILD_TRAINING_TOOLS "Build training tools" ON)
-option(BUILD_TESTS "Build tests" OFF)
+option(BUILD_TESTING "Build tests" OFF)
 option(USE_SYSTEM_ICU "Use system ICU" OFF)
 option(DISABLE_TIFF "Disable build with libtiff (if available)" OFF)
 option(DISABLE_ARCHIVE "Disable build with libarchive (if available)" OFF)
@@ -564,7 +564,7 @@ message(STATUS "Disable the legacy OCR engine [DISABLED_LEGACY_ENGINE]: "
                "${DISABLED_LEGACY_ENGINE}")
 message(STATUS "Build training tools [BUILD_TRAINING_TOOLS]: "
                "${BUILD_TRAINING_TOOLS}")
-message(STATUS "Build tests [BUILD_TESTS]: ${BUILD_TESTS}")
+message(STATUS "Build tests [BUILD_TESTING]: ${BUILD_TESTING}")
 if(ENABLE_OPENCL)
   message(
     STATUS
@@ -910,16 +910,13 @@ if(OPENMP_BUILD AND UNIX)
 endif()
 
 # ##############################################################################
-
-if(BUILD_TESTS
-   AND EXISTS
-       ${CMAKE_CURRENT_SOURCE_DIR}/unittest/third_party/googletest/CMakeLists.txt
-)
-  add_subdirectory(unittest/third_party/googletest)
-endif()
-
 if(BUILD_TRAINING_TOOLS)
   add_subdirectory(src/training)
+endif()
+
+if(BUILD_TESTING)
+  include(CTest)
+  add_subdirectory(unittest)
 endif()
 
 get_target_property(tesseract_NAME libtesseract NAME)

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,0 +1,185 @@
+#
+# tesseract unittest
+#
+
+# Prefetch googletest if it is not already initialized with `git submodule update --init`
+include(FetchContent)
+FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG main # as .gitmodules does not enforce releases tag we track the main branch
+        SOURCE_DIR ${CMAKE_SOURCE_DIR}/unittest/third_party/googletest
+)
+FetchContent_Populate(googletest)
+add_subdirectory(${googletest_SOURCE_DIR}
+        ${googletest_BINARY_DIR}
+        EXCLUDE_FROM_ALL
+)
+
+include(GoogleTest)
+
+# FIXME As in the Makefile.am (see fileio_test_LDADD), some tests will fail to compile if BUILD_TRAINING_TOOLS=OFF
+if (NOT BUILD_TRAINING_TOOLS)
+    message(WARNING "Tesseract-dev: running unit tests without building training tools is currently not supported")
+endif ()
+
+# core tests
+set(TESSERACT_UNITTESTS
+        apiexample
+        cleanapi
+        colpartition
+        denorm
+        fileio
+        heap
+        imagedata
+        intsimdmatrix
+        lang_model
+        layout
+        ligature_table
+        linlsq
+        list
+        loadlang
+        matrix
+        networkio
+        nthitem
+        pagesegmode
+        paragraphs
+        progress
+        qrsequence
+        recodebeam
+        rect
+        resultiterator
+        scanutils
+        stats
+        stridemap
+        stringrenderer
+        tablefind
+        tablerecog
+        tabvector
+        tatweel
+        tfile
+)
+
+set(tatweel_test_src
+        third_party/utf/rune.c
+        util/utf8/unicodetext.cc
+        util/utf8/unilib.cc)
+
+# Legacy engine tests
+if (NOT DISABLED_LEGACY_ENGINE)
+    set(TESSERACT_UNITTESTS
+            ${TESSERACT_UNITTESTS}
+            equationdetect
+            indexmapbidi
+            intfeaturemap
+            osd
+            params_model
+            shapetable
+            textlineprojection
+    )
+endif ()
+
+# training tests
+if (BUILD_TRAINING_TOOLS)
+    set(TESSERACT_UNITTESTS
+            ${TESSERACT_UNITTESTS}
+            baseapi
+            baseapi_thread
+            commandlineflags
+            dawg
+            lstm_recode
+            lstm_squashed
+            lstm
+            lstmtrainer
+            normstrngs
+            pango_font_info
+            unichar
+            unicharcompress
+            unicharset
+            validate_grapheme
+            validate_indic
+            validate_khmer
+            validate_myanmar
+            validator
+    )
+    if (NOT DISABLED_LEGACY_ENGINE)
+        set(TESSERACT_UNITTESTS
+                ${TESSERACT_UNITTESTS}
+                applybox
+                bitvector
+        )
+    endif ()
+endif ()
+
+# Look for top source directory parent for traineddata files
+execute_process(
+        COMMAND pwd
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/..
+        OUTPUT_VARIABLE CMAKE_SOURCE_PARENT_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Absolute path of directory 'tessdata' with traineddata files
+set(TESSDATA_DIR ${CMAKE_SOURCE_PARENT_DIR}/tessdata)
+IF(NOT EXISTS ${TESSDATA_DIR})
+    message(FATAL_ERROR "TESSDATA_DIR=${TESSDATA_DIR} directory does not exist, please see unittest requirements in README.md")
+endif ()
+
+set(LANGDATA_DIR ${CMAKE_SOURCE_PARENT_DIR}/langdata_lstm)
+IF(NOT EXISTS ${LANGDATA_DIR})
+    message(FATAL_ERROR "LANGDATA_DIR=${LANGDATA_DIR} directory does not exist, please see unittest requirements in README.md")
+endif ()
+
+set(TESSBIN_DIR ${CMAKE_BINARY_DIR}/bin)
+
+# Absolute path of directory 'testing' with test images and ground truth texts
+set(TESTING_DIR ${CMAKE_SOURCE_DIR}/test/testing)
+set(TESTDATA_DIR ${CMAKE_SOURCE_DIR}/test/testdata)
+
+set(TESSERACT_UNITTEST_CXXFLAG
+        -DTESSBIN_DIR="${TESSBIN_DIR}"
+        -DTESSDATA_DIR="${TESSDATA_DIR}"
+        -DLANGDATA_DIR="${LANGDATA_DIR}"
+        -DTESTING_DIR="${TESTING_DIR}"
+        -DTESTDATA_DIR="${TESTDATA_DIR}"
+)
+
+add_custom_target(build_tests)
+
+foreach (unittest ${TESSERACT_UNITTESTS})
+    set(${unittest}_test_src
+            ${${unittest}_test_src}
+            ${unittest}_test.cc)
+    add_executable(
+            ${unittest}_test
+            EXCLUDE_FROM_ALL
+            ${${unittest}_test_src}
+    )
+    add_dependencies(${unittest}_test tesseract)
+    target_compile_options(${unittest}_test PRIVATE ${TESSERACT_UNITTEST_CXXFLAG})
+    target_include_directories(${unittest}_test PRIVATE ${CMAKE_SOURCE_DIR}/unittest)
+
+    target_link_libraries(
+            ${unittest}_test
+            gtest
+            gmock
+            gtest_main
+            libtesseract
+    )
+
+    if (BUILD_TRAINING_TOOLS)
+        target_link_libraries(
+                ${unittest}_test
+                common_training
+                unicharset_training
+                pango_training
+        )
+    endif ()
+
+    gtest_discover_tests(${unittest}_test)
+    add_test(NAME ${unittest}_test COMMAND ${unittest}_test)
+    add_dependencies(build_tests ${unittest}_test)
+endforeach ()
+
+add_custom_target(check COMMAND ctest --output-on-failure)
+add_dependencies(check build_tests)

--- a/unittest/README.md
+++ b/unittest/README.md
@@ -86,3 +86,16 @@ git submodule update --init
 export TESSDATA_PREFIX=/prefix/to/path/to/tessdata
 make check
 ```
+
+## Run tests using CMake toolchain
+```
+cmake -DBUILD_TESTING=ON -B build 
+export TESSDATA_PREFIX=/prefix/to/path/to/tessdata
+cmake --build build --target check
+```
+
+### Run a single test target
+```
+cmake --build build --target fileio_test
+./build/bin/fileio_test
+```


### PR DESCRIPTION
**Context:**

- CMake `all` target was actually not building tests with `-DBUILD_TESTS=ON`. Tests were implemented only in make toolchain. Some IDE and developers could not easily work with current cmake/ctest toolchain.

**Changes**: 

1. new `build_tests` and `check` cmake targets which build and run all unit tests (61 as of now). Support of both options `BUILD_TRAINING_TOOLS` and `DISABLED_LEGACY_ENGINE`
2. `BUILD_TESTS` option has been replaced by the standard [CTest](https://cmake.org/cmake/help/latest/module/CTest.html) `BUILD_TESTING`
3. CMake Github workflow has been updated to reflect these changes, and a new check unittest step is added on linux os only
4. unittest/README.md has been updated to document cmake toolchain check target

**Limitations**: 

- [ ] Github workflow cmake-win64.yml is not updated because it is required to install (at least?) icu before test and training compilation.
- [ ] Github workflow cmake.yml does not execute unittest for MacOs because some fonts are missing: `FontUtilsTest.*` are failing. One can probably easy fix it later on.
- [ ] `TENSORFLOW` option yet to be supported in cmake toolchain.
- [X] It is required to enable options `-DBUILD_TRAINING_TOOLS=ON` and `-DBUILD_TESTING=ON` altogether as in the make toolchain, tests cannot compile without it.

**Checks**:
- [X] GitHub workflows [cmake.yml](https://github.com/phymbert/tesseract/actions/runs/7241204284) and [cmake-64.yml](https://github.com/phymbert/tesseract/actions/runs/7241172680/job/19724976343) have been run without  regression.