### PR TITLE
Fix a tiny typo in `publictypes.h`

### DIFF
--- a/include/tesseract/publictypes.h
+++ b/include/tesseract/publictypes.h
@@ -67,7 +67,7 @@ enum PolyBlockType {
   PT_COUNT
 };
 
-/** Returns true if PolyBlockType is of horizontal line type */
+/** Returns true if PolyBlockType is of line type */
 inline bool PTIsLineType(PolyBlockType type) {
   return type == PT_HORZ_LINE || type == PT_VERT_LINE;
 }


### PR DESCRIPTION
To fix a tiny typo in a comment in `publictypes.h`.