### PR TITLE
`oss-fuzz-build.sh`: explicitly pass `--disable-openmp`

### DIFF
--- a/unittest/fuzzers/oss-fuzz-build.sh
+++ b/unittest/fuzzers/oss-fuzz-build.sh
@@ -17,13 +17,13 @@
 
 cd $SRC/leptonica
 ./autogen.sh
-./configure --disable-shared
+./configure --disable-shared --disable-openmp
 make SUBDIRS=src install -j$(nproc)
 ldconfig
 
 cd $SRC/tesseract
 ./autogen.sh
-CXXFLAGS="$CXXFLAGS -D_GLIBCXX_DEBUG" ./configure --disable-graphics --disable-shared
+CXXFLAGS="$CXXFLAGS -D_GLIBCXX_DEBUG" ./configure --disable-graphics --disable-shared --disable-openmp
 make -j$(nproc)
 
 # Get the models which are needed for the fuzzers.


### PR DESCRIPTION
https://github.com/google/oss-fuzz/pull/11548 will add openmp runtime to oss-fuzz, and that breaks the build of this project. Explicitly opt-out to keep the build green.