### PR TITLE
Make `TessdataManager` able to save archive using LibArchive

### DIFF
--- a/src/ccutil/tessdatamanager.h
+++ b/src/ccutil/tessdatamanager.h
@@ -223,6 +223,7 @@ public:
 private:
   // Use libarchive.
   bool LoadArchiveFile(const char *filename);
+  bool SaveArchiveFile(const char *filename) const;
 
   /**
    * Fills type with TessdataType of the tessdata component represented by the

--- a/src/training/combine_tessdata.cpp
+++ b/src/training/combine_tessdata.cpp
@@ -219,6 +219,19 @@ int main(int argc, char **argv) {
       tprintf("Failed to write modified traineddata:%s!\n", argv[2]);
       return EXIT_FAILURE;
     }
+  } else if (argc == 3 && strcmp(argv[1], "-t") == 0) {
+#if defined(HAVE_LIBARCHIVE)
+      if (!tm.Init(argv[2])) {
+        tprintf("Failed to read %s\n", argv[2]);
+        return EXIT_FAILURE;
+      }
+      if (!tm.SaveFile(argv[2], nullptr)) {
+        tprintf("Failed to tranform traineddata:%s!\n", argv[2]);
+        return EXIT_FAILURE;
+      }
+#else
+      tprintf("Failed to load libarchive. Is tesseract compiled with libarchive support?\n");
+#endif
   } else if (argc == 3 && strcmp(argv[1], "-d") == 0) {
     return list_components(tm, argv[2]);
   } else if (argc == 3 && strcmp(argv[1], "-l") == 0) {
@@ -271,6 +284,10 @@ int main(int argc, char **argv) {
     printf(
         "Usage for compacting LSTM component to int:\n"
         "  %s -c traineddata_file\n",
+        argv[0]);
+    printf(
+        "Usage for transforming the proprietary .traineddata file to a zip archive:\n"
+        "  %s -t traineddata_file\n",
         argv[0]);
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
 - Made `TessDataManager` able to save archive using LibArchive
 - Added `-t` option to `combine_tessdata` to transform proprietary `.traineddata` to archive file.