### PR TITLE
Fix grey result of indexed PNG in pdfrenderer.

### DIFF
--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -664,8 +664,6 @@ bool TessPDFRenderer::BeginDocumentHandler() {
 bool TessPDFRenderer::imageToPDFObj(Pix *pix, const char *filename, long int objnum,
                                     char **pdf_object, long int *pdf_object_size,
                                     const int jpg_quality) {
-  int sad;
-
   if (!pdf_object_size || !pdf_object) {
     return false;
   }
@@ -676,7 +674,7 @@ bool TessPDFRenderer::imageToPDFObj(Pix *pix, const char *filename, long int obj
   }
 
   L_Compressed_Data *cid = nullptr;
-  sad = l_generateCIDataForPdf(filename, pix, jpg_quality, &cid);
+  auto sad = l_generateCIDataForPdf(filename, pix, jpg_quality, &cid);
 
   if (sad || !cid) {
     l_CIDataDestroy(&cid);

--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -664,6 +664,8 @@ bool TessPDFRenderer::BeginDocumentHandler() {
 bool TessPDFRenderer::imageToPDFObj(Pix *pix, const char *filename, long int objnum,
                                     char **pdf_object, long int *pdf_object_size,
                                     const int jpg_quality) {
+  int sad;
+
   if (!pdf_object_size || !pdf_object) {
     return false;
   }
@@ -674,14 +676,7 @@ bool TessPDFRenderer::imageToPDFObj(Pix *pix, const char *filename, long int obj
   }
 
   L_Compressed_Data *cid = nullptr;
-
-  int sad = 0;
-  if (pixGetInputFormat(pix) == IFF_PNG) {
-    sad = pixGenerateCIData(pix, L_FLATE_ENCODE, 0, 0, &cid);
-  }
-  if (!cid) {
-    sad = l_generateCIDataForPdf(filename, pix, jpg_quality, &cid);
-  }
+  sad = l_generateCIDataForPdf(filename, pix, jpg_quality, &cid);
 
   if (sad || !cid) {
     l_CIDataDestroy(&cid);


### PR DESCRIPTION
When giving tesseract PNG images with an indexed color map with the "pdf" output, these images come out grayscale. Removing a special case for PNG images in pdfrenderer fixes that.

I tested the patch with PNG images containing indexed color maps and containing rgb content.