### PR TITLE
Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-BasedOnStyle: Google
+# Google-based Style
 
 # Modifications for Tesseract.
 
@@ -10,10 +10,15 @@ IndentPPDirectives: AfterHash
 
 # Default style for some settings.
 
+# Offset for access modifiers.
 AccessModifierOffset: -2
+# Do not allow short loops on a single line.
 AllowShortLoopsOnASingleLine: false
 # Enforce always the same pointer alignment.
 DerivePointerAlignment: false
+# Preserve include blocks.
 IncludeBlocks: Preserve
+# Right-align pointer.
 PointerAlignment: Right
+# Spaces before trailing comments.
 SpacesBeforeTrailingComments: 1


### PR DESCRIPTION
Explanation:

AllowShortFunctionsOnASingleLine: Empty: Allows only empty functions to be merged into a single line.
AllowShortIfStatementsOnASingleLine: false: Disallows short "if" statements to be placed on a single line.
IndentPPDirectives: AfterHash: Indents preprocessor directives after the hash character (#).
AccessModifierOffset: -2: Sets the offset (indentation) for access modifiers as -2 spaces.
AllowShortLoopsOnASingleLine: false: Disallows short loops to be placed on a single line.
DerivePointerAlignment: false: Ensures that pointer alignment is always the same and not derived.
IncludeBlocks: Preserve: Preserves the formatting of include blocks.
PointerAlignment: Right: Right-aligns pointers.
SpacesBeforeTrailingComments: 1: Sets 1 space before trailing comments.