### PR TITLE
Improve CCUtil::main_setup (fixes issue #4230)

### DIFF
--- a/src/ccutil/ccutil.cpp
+++ b/src/ccutil/ccutil.cpp
@@ -46,7 +46,7 @@ CCUtil::~CCUtil() = default;
 void CCUtil::main_setup(const std::string &argv0, const std::string &basename) {
   imagebasename = basename; /**< name of image */
 
-  char *tessdata_prefix = getenv("TESSDATA_PREFIX");
+  const char *tessdata_prefix = getenv("TESSDATA_PREFIX");
 
   if (!argv0.empty()) {
     /* Use tessdata prefix from the command line. */
@@ -77,17 +77,20 @@ void CCUtil::main_setup(const std::string &argv0, const std::string &basename) {
   if (datadir.empty()) {
 #if defined(TESSDATA_PREFIX)
     // Use tessdata prefix which was compiled in.
-    datadir = TESSDATA_PREFIX "/tessdata";
+    // Note that some software (for example conda) patch TESSDATA_PREFIX
+    // in the binary, so it should not be used directly with a std::string.
+    tessdata_prefix = TESSDATA_PREFIX;
+    datadir = tessdata_prefix;
+    datadir += "/tessdata/";
 #else
     datadir = "./";
 #endif /* TESSDATA_PREFIX */
   }
 
   // check for missing directory separator
-  const char *lastchar = datadir.c_str();
-  lastchar += datadir.length() - 1;
-  if ((strcmp(lastchar, "/") != 0) && (strcmp(lastchar, "\\") != 0)) {
-    datadir += "/";
+  const char lastchar = datadir.back();
+  if (lastchar != '/' && lastchar != '\\') {
+    datadir += '/';
   }
 }
 

--- a/src/ccutil/ccutil.cpp
+++ b/src/ccutil/ccutil.cpp
@@ -77,7 +77,7 @@ void CCUtil::main_setup(const std::string &argv0, const std::string &basename) {
   if (datadir.empty()) {
 #if defined(TESSDATA_PREFIX)
     // Use tessdata prefix which was compiled in.
-    // Note that some software (for example conda) patch TESSDATA_PREFIX
+    // Note that some software (for example conda) patches TESSDATA_PREFIX
     // in the binary, so it should not be used directly with a std::string.
     tessdata_prefix = TESSDATA_PREFIX;
     datadir = tessdata_prefix;


### PR DESCRIPTION
Conda installations patch TESSDATA_PREFIX in the binary. That does not work for std::string because the length won't be patched, so use a normal C string which can be patched.

Simplify also the code which checks the last character of datadir.