### PR TITLE
Use AM_CPPFLAGS also for compilation of all sources

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -654,9 +654,7 @@ libtesseract_la_SOURCES += src/viewer/svmnode.cpp
 libtesseract_la_SOURCES += src/viewer/svutil.cpp
 
 EXTRA_PROGRAMS += svpaint
-svpaint_CPPFLAGS =
-svpaint_CPPFLAGS += -I$(top_builddir)/include
-svpaint_CPPFLAGS += -I$(top_srcdir)/include
+svpaint_CPPFLAGS = $(AM_CPPFLAGS)
 svpaint_CPPFLAGS += -I$(top_srcdir)/src/ccstruct
 svpaint_CPPFLAGS += -I$(top_srcdir)/src/viewer
 svpaint_SOURCES = src/svpaint.cpp
@@ -709,7 +707,7 @@ endif
 
 bin_PROGRAMS = tesseract
 tesseract_SOURCES = src/tesseract.cpp
-tesseract_CPPFLAGS =
+tesseract_CPPFLAGS = $(AM_CPPFLAGS)
 tesseract_CPPFLAGS += -I$(top_srcdir)/src/arch
 tesseract_CPPFLAGS += -I$(top_srcdir)/src/ccmain
 tesseract_CPPFLAGS += -I$(top_srcdir)/src/ccstruct
@@ -720,10 +718,6 @@ tesseract_CPPFLAGS += -I$(top_srcdir)/src/dict
 tesseract_CPPFLAGS += -I$(top_srcdir)/src/textord
 tesseract_CPPFLAGS += -I$(top_srcdir)/src/viewer
 tesseract_CPPFLAGS += -I$(top_srcdir)/src/wordrec
-tesseract_CPPFLAGS += $(AM_CPPFLAGS)
-if VISIBILITY
-tesseract_CPPFLAGS += -DTESS_IMPORTS
-endif
 
 tesseract_LDFLAGS = $(OPENMP_CXXFLAGS)
 
@@ -769,12 +763,11 @@ endif
 
 CLEANFILES += $(EXTRA_PROGRAMS)
 
-training_CPPFLAGS := -DPANGO_ENABLE_ENGINE
+training_CPPFLAGS = $(AM_CPPFLAGS)
+training_CPPFLAGS += -DPANGO_ENABLE_ENGINE
 training_CPPFLAGS += -DTESS_COMMON_TRAINING_API=
 training_CPPFLAGS += -DTESS_PANGO_TRAINING_API=
 training_CPPFLAGS += -DTESS_UNICHARSET_TRAINING_API=
-training_CPPFLAGS += -I$(top_builddir)/include
-training_CPPFLAGS += -I$(top_srcdir)/include
 training_CPPFLAGS += -I$(top_srcdir)/src/training
 training_CPPFLAGS += -I$(top_srcdir)/src/training/common
 training_CPPFLAGS += -I$(top_srcdir)/src/training/pango
@@ -1105,7 +1098,7 @@ TESTDATA_DIR=$(shell cd $(top_srcdir) && pwd)/test/testdata
 # Suppress some memory leaks reported by LeakSanitizer.
 export LSAN_OPTIONS=suppressions=$(top_srcdir)/unittest/tesseract_leaksanitizer.supp
 
-unittest_CPPFLAGS =
+unittest_CPPFLAGS = $(AM_CPPFLAGS)
 unittest_CPPFLAGS += -DTESSBIN_DIR="\"$(abs_top_builddir)\""
 unittest_CPPFLAGS += -DLANGDATA_DIR="\"$(LANGDATA_DIR)\""
 unittest_CPPFLAGS += -DTESSDATA_DIR="\"$(TESSDATA_DIR)\""
@@ -1118,8 +1111,6 @@ endif # DISABLED_LEGACY_ENGINE
 unittest_CPPFLAGS += -DTESS_COMMON_TRAINING_API=
 unittest_CPPFLAGS += -DTESS_PANGO_TRAINING_API=
 unittest_CPPFLAGS += -DTESS_UNICHARSET_TRAINING_API=
-unittest_CPPFLAGS += -I$(top_builddir)/include
-unittest_CPPFLAGS += -I$(top_srcdir)/include
 unittest_CPPFLAGS += -I$(top_srcdir)/src/arch
 unittest_CPPFLAGS += -I$(top_srcdir)/src/ccmain
 unittest_CPPFLAGS += -I$(top_srcdir)/src/ccstruct


### PR DESCRIPTION
It was not used for all sources before. Therefore some parts of the code (especially the code for training) used different compiler options. For example NDEBUG was not defined, and so the training code was built with debug assertions (resulting in potentially slower execution).