### PR TITLE
Avoid redundant conversion from std::string to char * to std::string

### DIFF
--- a/src/training/unicharset/fileio.cpp
+++ b/src/training/unicharset/fileio.cpp
@@ -71,7 +71,7 @@ bool File::Readable(const std::string &filename) {
 }
 
 bool File::ReadFileToString(const std::string &filename, std::string *out) {
-  FILE *stream = File::Open(filename.c_str(), "rb");
+  FILE *stream = File::Open(filename, "rb");
   if (stream == nullptr) {
     return false;
   }

--- a/src/training/unicharset/lang_model_helpers.cpp
+++ b/src/training/unicharset/lang_model_helpers.cpp
@@ -129,7 +129,7 @@ bool WriteRecoder(const UNICHARSET &unicharset, bool pass_through, const std::st
   std::string suffix;
   suffix += ".charset_size=" + std::to_string(recoder.code_range());
   suffix += ".txt";
-  return WriteFile(output_dir, lang, suffix.c_str(), recoder_data, writer);
+  return WriteFile(output_dir, lang, suffix, recoder_data, writer);
 }
 
 // Helper builds a dawg from the given words, using the unicharset as coding,


### PR DESCRIPTION
This fixes two issues reported by Codacy.