### PR TITLE
Ignore illegal TESSDATA_PREFIX (not existing filesystem entry, issue #4277)

### DIFF
--- a/src/ccutil/ccutil.cpp
+++ b/src/ccutil/ccutil.cpp
@@ -17,7 +17,8 @@
 #include "ccutil.h"
 
 #include <cstdlib>
-#include <cstring> // for std::strrchr
+#include <cstring>    // for std::strrchrA
+#include <filesystem> // for std::filesystem
 
 namespace tesseract {
 
@@ -47,6 +48,12 @@ void CCUtil::main_setup(const std::string &argv0, const std::string &basename) {
   imagebasename = basename; /**< name of image */
 
   const char *tessdata_prefix = getenv("TESSDATA_PREFIX");
+
+  // Ignore TESSDATA_PREFIX if there is no matching filesystem entry.
+  if (tessdata_prefix != nullptr && !std::filesystem::exists(tessdata_prefix)) {
+    tprintf("Warning: TESSDATA_PREFIX %s does not exist, ignore it\n", tessdata_prefix);
+    tessdata_prefix = nullptr;
+  }
 
   if (!argv0.empty()) {
     /* Use tessdata prefix from the command line. */


### PR DESCRIPTION
Don't check for a directory, because a symbolic link is also allowed.