### PR TITLE
Calculate row bounding box in single-word mode per #4304

### DIFF
--- a/src/textord/wordseg.cpp
+++ b/src/textord/wordseg.cpp
@@ -87,6 +87,7 @@ void make_single_word(bool one_blob, TO_ROW_LIST *rows, ROW_LIST *real_rows) {
     word->set_flag(W_EOL, true);
     word->set_flag(W_DONT_CHOP, one_blob);
     word_it.add_after_then_move(word);
+    real_row->recalc_bounding_box();
     row_it.add_after_then_move(real_row);
   }
 }


### PR DESCRIPTION
See #4304 for full context.  

In short, `ROW` objects are expected to have valid/accurate bounding boxes, which are accessed using `row->bounding_box()`.  However, bounding box values are not calculated automatically--the method `row_obj->recalc_bounding_box()` must be run after the row is created and populated to calculate the bounding box.  This happens correctly in 5 of the 6 instances where `new ROW` is called, however does not occur in 1 case (within the `make_single_word` function that runs when `psm` is `SINGLE_WORD` or `SINGLE_CHAR`).  

This PR fixes this by adding the required call to `recalc_bounding_box` within `make_single_word`.  This brings that function in line with all the other functions that create `ROW` objects.  

This change fixes the bug described in #4304, where baselines are not correctly calculated when using certain `psm` settings.  After implementing this fix, the motivating example in that issue is resolved, and the baseline is calculated correctly. 