### PR TITLE
Remove excessive floating-point divides

### DIFF
--- a/src/lstm/functions.h
+++ b/src/lstm/functions.h
@@ -200,8 +200,9 @@ inline void SoftmaxInPlace(int n, T *inout) {
     inout[i] = prob;
   }
   if (prob_total > 0) {
+    T inv_prob_total = 1.0/prob_total;
     for (int i = 0; i < n; i++) {
-      inout[i] /= prob_total;
+      inout[i] *= inv_prob_total;
     }
   }
 }

--- a/src/lstm/functions.h
+++ b/src/lstm/functions.h
@@ -200,7 +200,7 @@ inline void SoftmaxInPlace(int n, T *inout) {
     inout[i] = prob;
   }
   if (prob_total > 0) {
-    T inv_prob_total = 1.0/prob_total;
+    T inv_prob_total = 1 / prob_total;
     for (int i = 0; i < n; i++) {
       inout[i] *= inv_prob_total;
     }

--- a/src/lstm/networkio.cpp
+++ b/src/lstm/networkio.cpp
@@ -224,7 +224,7 @@ void NetworkIO::Copy2DImage(int batch, Image pix, float black, float contrast, T
   int target_width = stride_map_.Size(FD_WIDTH);
   int num_features = NumFeatures();
   bool color = num_features == 3;
-  float inv_contrast = 1.0/contrast;
+  float inv_contrast = 1 / contrast;
   if (width > target_width) {
     width = target_width;
   }
@@ -265,7 +265,7 @@ void NetworkIO::Copy1DGreyImage(int batch, Image pix, float black, float contras
   index.AddOffset(batch, FD_BATCH);
   int t = index.t();
   int target_width = stride_map_.Size(FD_WIDTH);
-  float inv_contrast = 1.0/contrast;
+  float inv_contrast = 1 / contrast;
   if (width > target_width) {
     width = target_width;
   }

--- a/src/lstm/networkio.h
+++ b/src/lstm/networkio.h
@@ -92,7 +92,8 @@ public:
   // pixel: the value of the pixel from the image (in one channel)
   // black: the pixel value to map to the lowest of the range of *this
   // contrast: the range of pixel values to stretch to half the range of *this.
-  void SetPixel(int t, int f, int pixel, float black, float contrast);
+  // inv_contrast: one over the contrast, to save a divide
+  void SetPixel(int t, int f, int pixel, float black, float inv_contrast);
   // Converts the array to a Pix. Must be pixDestroyed after use.
   Image ToPix() const;
   // Prints the first and last num timesteps of the array for each feature.

--- a/src/textord/pithsync.cpp
+++ b/src/textord/pithsync.cpp
@@ -120,6 +120,7 @@ void FPCUTPT::assign(       // constructor
                          // half of pitch
   int16_t half_pitch = pitch / 2 - 1;
   uint32_t lead_flag; // new flag
+  float inv_projection_scale = 1.0/projection_scale;
 
   if (half_pitch > 31) {
     half_pitch = 31;
@@ -166,7 +167,7 @@ void FPCUTPT::assign(       // constructor
             }
           }
           balance_count =
-              static_cast<int16_t>(balance_count * textord_balance_factor / projection_scale);
+              static_cast<int16_t>(balance_count * textord_balance_factor * inv_projection_scale);
         }
         r_index = segpt->region_index + 1;
         total = segpt->mean_sum + dist;
@@ -221,6 +222,7 @@ void FPCUTPT::assign_cheap( // constructor
                          // half of pitch
   int16_t half_pitch = pitch / 2 - 1;
   uint32_t lead_flag; // new flag
+  float inv_projection_scale = 1.0/projection_scale;
 
   if (half_pitch > 31) {
     half_pitch = 31;
@@ -260,7 +262,7 @@ void FPCUTPT::assign_cheap( // constructor
           lead_flag &= lead_flag - 1;
         }
         balance_count =
-            static_cast<int16_t>(balance_count * textord_balance_factor / projection_scale);
+            static_cast<int16_t>(balance_count * textord_balance_factor * projection_scale);
       }
       r_index = segpt->region_index + 1;
       total = segpt->mean_sum + dist;
@@ -511,6 +513,7 @@ double check_pitch_sync3(    // find segmentation
   int16_t best_fake;            // best fake level
   int16_t best_count;           // no of cuts
   FPSEGPT_IT seg_it = seg_list; // output iterator
+  float inv_projection_scale = 1.0/projection_scale;
 
   end = (end - start) % pitch;
   if (pitch < 3) {
@@ -597,7 +600,7 @@ double check_pitch_sync3(    // find segmentation
         offset = projection->pile_count(x);
         faking = true;
       } else {
-        projection_offset = static_cast<int16_t>(projection->pile_count(x) / projection_scale);
+        projection_offset = static_cast<int16_t>(projection->pile_count(x) * inv_projection_scale);
         if (projection_offset > offset) {
           offset = projection_offset;
         }

--- a/src/textord/pithsync.cpp
+++ b/src/textord/pithsync.cpp
@@ -120,7 +120,7 @@ void FPCUTPT::assign(       // constructor
                          // half of pitch
   int16_t half_pitch = pitch / 2 - 1;
   uint32_t lead_flag; // new flag
-  float inv_projection_scale = 1.0/projection_scale;
+  float inv_projection_scale = 1 / projection_scale;
 
   if (half_pitch > 31) {
     half_pitch = 31;
@@ -222,7 +222,7 @@ void FPCUTPT::assign_cheap( // constructor
                          // half of pitch
   int16_t half_pitch = pitch / 2 - 1;
   uint32_t lead_flag; // new flag
-  float inv_projection_scale = 1.0/projection_scale;
+  float inv_projection_scale = 1 / projection_scale;
 
   if (half_pitch > 31) {
     half_pitch = 31;
@@ -262,7 +262,7 @@ void FPCUTPT::assign_cheap( // constructor
           lead_flag &= lead_flag - 1;
         }
         balance_count =
-            static_cast<int16_t>(balance_count * textord_balance_factor * projection_scale);
+            static_cast<int16_t>(balance_count * textord_balance_factor * inv_projection_scale);
       }
       r_index = segpt->region_index + 1;
       total = segpt->mean_sum + dist;
@@ -513,7 +513,7 @@ double check_pitch_sync3(    // find segmentation
   int16_t best_fake;            // best fake level
   int16_t best_count;           // no of cuts
   FPSEGPT_IT seg_it = seg_list; // output iterator
-  float inv_projection_scale = 1.0/projection_scale;
+  float inv_projection_scale = 1 / projection_scale;
 
   end = (end - start) % pitch;
   if (pitch < 3) {


### PR DESCRIPTION
Loft the loop-invariant divide outside the hot loops, and/or invert the variable to turn FDIV into FMUL.

Most CPUs are slower at FP division compared to FP multiplication. This should provide some uplift in performance. I was testing with the integer models.