### PR TITLE
cmake: Correctly set the soversion based on SemVer properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -827,7 +827,7 @@ set_target_properties(
                           ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 set_target_properties(
   libtesseract PROPERTIES SOVERSION
-                          ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
+                          ${VERSION_MAJOR}.${VERSION_MINOR})
 
 set_target_properties(
   libtesseract


### PR DESCRIPTION
As this project follows Semantic Versioning, the shared object version should match these semantics.

The two options that make sense here are to have the soversion set to the version major (so only breaking changes are tracked) or to set to version major and minor (so breaking and API additions are tracked).

Since the Windows version of the library already uses version major and version minor, let's just do this universally.

Fixes: 832926f5afebd9a5a81343425e733708332f730f ("Update library version handling for cmake")