### PR TITLE
Replace deprecated runner macos-12 by macos-latest in GitHub actions

### DIFF
--- a/.github/workflows/autotools-macos.yml
+++ b/.github/workflows/autotools-macos.yml
@@ -14,8 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: macos-12-clang-14-autotools, os: macos-12, cxx: clang++ }
-          #- { name: macos-12-gcc-11-autotools, os: macos-12, cxx: g++-11 }
+          - { name: macos-latest-clang-autotools, os: macos-latest, cxx: clang++ }
 
     steps:
     - uses: actions/checkout@v4
@@ -114,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: macos-12-clang-14-autotools, os: macos-12, cxx: clang++ }
+          - { name: macos-latest-clang-autotools, os: macos-latest, cxx: clang++ }
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: macos-14-clang-15-cmake, os: macos-14, cxx: clang++ } # default        
+          - { name: macos-14-clang-15-cmake, os: macos-14, cxx: clang++ } # default
           - { name: macos-14-gcc-14-cmake, os: macos-14, cxx: g++-14 } #installed
           - { name: macos-15-clang-cmake, os: macos-15, cxx: clang++ } # default
 

--- a/.github/workflows/unittest-macos.yml
+++ b/.github/workflows/unittest-macos.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         config:
           - { name: macos-arm-14-clang-unittest, os: macos-14, cxx: clang++ } # Apple silicon
-          - { name: macos-12-clang-unittest, os: macos-12, cxx: clang++ }
-          - { name: macos-12-gcc-unittest, os: macos-12, cxx: g++ }
+          - { name: macos-latest-clang-unittest, os: macos-latest, cxx: clang++ }
+          - { name: macos-latest-gcc-unittest, os: macos-latest, cxx: g++ }
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The macOS 12 runner image will be removed by December 3rd, 2024.