### PR TITLE
Modernize code for renderers and remove filename conversion for Windows

### DIFF
--- a/src/api/hocrrenderer.cpp
+++ b/src/api/hocrrenderer.cpp
@@ -21,9 +21,6 @@
 #include <locale>              // for std::locale::classic
 #include <memory>              // for std::unique_ptr
 #include <sstream>             // for std::stringstream
-#ifdef _WIN32
-#  include "host.h" // windows.h for MultiByteToWideChar, ...
-#endif
 #include <tesseract/renderer.h>
 #include "helpers.h"        // for copy_string
 #include "tesseractclass.h" // for Tesseract
@@ -150,23 +147,6 @@ char *TessBaseAPI::GetHOCRText(ETEXT_DESC *monitor, int page_number) {
   if (input_file_.empty()) {
     SetInputName(nullptr);
   }
-
-#ifdef _WIN32
-  // convert input name from ANSI encoding to utf-8
-  int str16_len =
-      MultiByteToWideChar(CP_ACP, 0, input_file_.c_str(), -1, nullptr, 0);
-  wchar_t *uni16_str = new WCHAR[str16_len];
-  str16_len = MultiByteToWideChar(CP_ACP, 0, input_file_.c_str(), -1, uni16_str,
-                                  str16_len);
-  int utf8_len = WideCharToMultiByte(CP_UTF8, 0, uni16_str, str16_len, nullptr,
-                                     0, nullptr, nullptr);
-  char *utf8_str = new char[utf8_len];
-  WideCharToMultiByte(CP_UTF8, 0, uni16_str, str16_len, utf8_str, utf8_len,
-                      nullptr, nullptr);
-  input_file_ = utf8_str;
-  delete[] uni16_str;
-  delete[] utf8_str;
-#endif
 
   std::stringstream hocr_str;
   // Use "C" locale (needed for double values x_size and x_descenders).


### PR DESCRIPTION
Commit db52047420c54bd added the filename conversion for the hOCR renderer, but it was removed later for TSV in commit 6700edd8bcdd2a4.

Tesseract does not use a filename conversion anywhere else, so remove it for the other renderers, too.