### PR TITLE
Workaround for assertion-related SIGABRT

### DIFF
--- a/src/ccstruct/pageres.cpp
+++ b/src/ccstruct/pageres.cpp
@@ -1499,8 +1499,18 @@ void PAGE_RES_IT::DeleteCurrentWord() {
         break;
       }
     }
-    ASSERT_HOST(!w_it.cycled_list());
-    delete w_it.extract();
+    // previous code asserted that the check in the previous loop would always
+    // be entered, and thus this loop would always be broken. It makes sense to
+    // only delete the iterator point if the loop didn't finish naturally, so
+    // we'll make this a conditional check instead of an assertion. it's not
+    // clear if this will force negative downstream effects, but unlike the
+    // previous fix which simply commented the assertion, we will not blindly
+    // call delete in this scenario. this should be a safer approach, although
+    // it may have impact to the data or outputs in connection with this "part
+    // of combination" logic.
+    if (!w_it.cycled_list()) {
+      delete w_it.extract();
+    }
   }
   // Remove the WERD_RES for the new_word.
   // Remove the WORD_RES from the ROW_RES.


### PR DESCRIPTION
Change firm assertion and deletion pattern to conditional based on outcome of previous loop. This may fix the assertion issues seen in #4148 but is unclear if it will have downstream negative effects for the output.