### PR TITLE
use constexpr for kDawgMagicNumber

### DIFF
--- a/src/dict/dawg.h
+++ b/src/dict/dawg.h
@@ -110,7 +110,7 @@ static const char kWildcard[] = "*";
 class TESS_API Dawg {
 public:
   /// Magic number to determine endianness when reading the Dawg from file.
-  static const int16_t kDawgMagicNumber = 42;
+  static constexpr int16_t kDawgMagicNumber = 42;
   /// A special unichar id that indicates that any appropriate pattern
   /// (e.g.dictionary word, 0-9 digit, etc) can be inserted instead
   /// Used for expressing patterns in punctuation and number Dawgs.


### PR DESCRIPTION
This should fix UnitTest build on main branch.
# Notes

1.  I do not understand why problem occurred 2 week ago - there was irrelevant modification only in tprintf.{cpp,h}
2.  I do not understand why next `static const UNICHAR_ID kPatternUnicharID` definition is OK for unittest.
3. I do not understand why there is problem only in UnitTest and another Github Actions work fine...