### PR TITLE
Fix building elf_aux_info() support on OpenBSD/arm

### DIFF
--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -61,7 +61,6 @@
 #    include <sys/auxv.h>
 #  elif defined(HAVE_ELF_AUX_INFO)
 #    include <sys/auxv.h>
-#    include <sys/elf.h>
 #  endif
 #endif
 


### PR DESCRIPTION
Remove the unnecessary use of the sys/elf.h header which breaks
the build.