### PR TITLE
Fix invalid empty interval in punct_stripped() for all-punctuation words

### DIFF
--- a/src/ccstruct/ratngs.cpp
+++ b/src/ccstruct/ratngs.cpp
@@ -370,7 +370,7 @@ void WERD_CHOICE::punct_stripped(unsigned *start, unsigned *end) const {
   while (*start < length() && unicharset()->get_ispunctuation(unichar_id(*start))) {
     (*start)++;
   }
-  while (*end > 0 && unicharset()->get_ispunctuation(unichar_id(*end - 1))) {
+  while (*end > *start && unicharset()->get_ispunctuation(unichar_id(*end - 1))) {
     (*end)--;
   }
 }


### PR DESCRIPTION
punct_stripped() may currently produce invalid empty intervals (where end < start) for all-punctuation words. As a result, EqualIgnoringCaseAndTerminalPunct() crashes in this loop due to an unsigned integer underflow in w1end - w1start:

  for (unsigned i = 0; i < w1end - w1start; i++) {
    if (uchset->to_lower(word1.unichar_id(w1start + i)) !=
        uchset->to_lower(word2.unichar_id(w2start + i))) {
      return false;
    }
  }
  
Bug was introduced with the following commit:

-----------------------------------------------------------
  
Revision: 97048fe3e4813d6c2350a370b915563688123f2c
Author: Stefan Weil <sw@weilnetz.de>
Date: 09/10/2021 20:50:39
Message:
ccstruct: Fix some signed/unsigned compiler warnings

Remove also a local buffer in function REJMAP::print.

-----------------------------------------------------------

There was no unsigned integer underflow before, because the interval was signed.