### PR TITLE
ERRCODE::error: throw std::runtime_error instead of abort()

### DIFF
--- a/src/ccutil/errcode.cpp
+++ b/src/ccutil/errcode.cpp
@@ -70,17 +70,11 @@ void ERRCODE::error(         // handle error
       return; // report only
     case TESSEXIT:
     case ABORT:
-#if !defined(NDEBUG)
-      // Create a deliberate abnormal exit as the stack trace is more useful
-      // that way. This is done only in debug builds, because the
-      // error message "segmentation fault" confuses most normal users.
-#  if defined(__GNUC__)
-      __builtin_trap();
-#  else
-      *reinterpret_cast<int *>(0) = 0;
-#  endif
-#endif
-      abort();
+      // This used to trigger a segfault or abort();
+      // However, at least for library use, only exceptions should be acceptable.
+      // Even in the standalone application case, exceptions are better,
+      // because the default handler will print the message along with the stack trace.
+      throw std::runtime_error(msg.str());
     default:
       BADERRACTION.error("error", ABORT);
   }


### PR DESCRIPTION
Related to https://github.com/tesseract-ocr/tesseract/issues/2990 (although it does not replace the `exit()` calls – yet).

@kba will provide an easily reproducable example of such failing assertions. (My current case is more special / harder to reconstruct.)

But regardless of the concrete issues that _cause_ these failed assertions, which of course need to be addressed themselves, this makes Tesseract usable productively as a library. (You can catch these exceptions.)

(No idea what's the matter with CI here, btw.)