### PR TITLE
Simplify code for osdetect

### DIFF
--- a/include/tesseract/osdetect.h
+++ b/include/tesseract/osdetect.h
@@ -101,9 +101,6 @@ public:
 
 private:
   OSResults *osr_;
-  static const char *korean_script_;
-  static const char *japanese_script_;
-  static const char *fraktur_script_;
   int korean_id_;
   int japanese_id_;
   int katakana_id_;

--- a/src/ccmain/osdetect.cpp
+++ b/src/ccmain/osdetect.cpp
@@ -48,18 +48,6 @@ const float kHanRatioInJapanese = 0.3;
 
 const float kNonAmbiguousMargin = 1.0;
 
-// General scripts
-static const char *han_script = "Han";
-static const char *latin_script = "Latin";
-static const char *katakana_script = "Katakana";
-static const char *hiragana_script = "Hiragana";
-static const char *hangul_script = "Hangul";
-
-// Pseudo-scripts Name
-const char *ScriptDetector::korean_script_ = "Korean";
-const char *ScriptDetector::japanese_script_ = "Japanese";
-const char *ScriptDetector::fraktur_script_ = "Fraktur";
-
 void OSResults::update_best_orientation() {
   float first = orientations[0];
   float second = orientations[1];
@@ -450,14 +438,16 @@ ScriptDetector::ScriptDetector(const std::vector<int> *allowed_scripts, OSResult
   osr_ = osr;
   tess_ = tess;
   allowed_scripts_ = allowed_scripts;
-  katakana_id_ = tess_->unicharset.add_script(katakana_script);
-  hiragana_id_ = tess_->unicharset.add_script(hiragana_script);
-  han_id_ = tess_->unicharset.add_script(han_script);
-  hangul_id_ = tess_->unicharset.add_script(hangul_script);
-  japanese_id_ = tess_->unicharset.add_script(japanese_script_);
-  korean_id_ = tess_->unicharset.add_script(korean_script_);
-  latin_id_ = tess_->unicharset.add_script(latin_script);
-  fraktur_id_ = tess_->unicharset.add_script(fraktur_script_);
+  // General scripts
+  katakana_id_ = tess_->unicharset.add_script("Katakana");
+  hiragana_id_ = tess_->unicharset.add_script("Hiragana");
+  han_id_ = tess_->unicharset.add_script("Han");
+  hangul_id_ = tess_->unicharset.add_script("Hangul");
+  latin_id_ = tess_->unicharset.add_script("Latin");
+  // Pseudo-scripts
+  fraktur_id_ = tess_->unicharset.add_script("Fraktur");
+  japanese_id_ = tess_->unicharset.add_script("Japanese");
+  korean_id_ = tess_->unicharset.add_script("Korean");
 }
 
 // Score the given blob and return true if it is now sure of the script after


### PR DESCRIPTION
Remove the private static char pointers from osdetect.h.

This does not break the API because the removed pointers are no member variables, and they could not be accessed because they were private.

As all script names were used only once, there is also no need to have additional pointer constants, and using the names directly simplifies the code.