### PR TITLE
Handle no dictionary words during pass 1 word recognition (issue #4448)

### DIFF
--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -353,7 +353,7 @@ bool Tesseract::recog_all_words(PAGE_RES *page_res, ETEXT_DESC *monitor,
       }
 
       // Count dict words.
-      if (page_res_it.word()->best_choice->permuter() == USER_DAWG_PERM) {
+      if (page_res_it.word()->best_choice && page_res_it.word()->best_choice->permuter() == USER_DAWG_PERM) {
         ++(stats_.dict_words);
       }
 


### PR DESCRIPTION
Previously if page_res_it.word()->best_choice == nullptr, dereferencing it in page_res_it.word()->best_choice->permuter() caused a segmentation fault.

By checking best_choice != nullptr, i.e. there is a dictionary word, before dereferencing it, the crash is avoided.