### PR TITLE
Fixed the GetUTF8Text method to return nullptr instead of asserting

### DIFF
--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -47,7 +47,9 @@ char *LTRResultIterator::GetUTF8Text(PageIteratorLevel level) const {
   std::string text;
   PAGE_RES_IT res_it(*it_);
   WERD_CHOICE *best_choice = res_it.word()->best_choice;
-  ASSERT_HOST(best_choice != nullptr);
+  if (best_choice == nullptr) {
+    return nullptr; // No recognition results available
+  }
   if (level == RIL_SYMBOL) {
     text = res_it.word()->BestUTF8(blob_index_, false);
   } else if (level == RIL_WORD) {
@@ -59,7 +61,9 @@ char *LTRResultIterator::GetUTF8Text(PageIteratorLevel level) const {
       do {            // for each text line in a paragraph
         do {          // for each word in a text line
           best_choice = res_it.word()->best_choice;
-          ASSERT_HOST(best_choice != nullptr);
+          if (best_choice == nullptr) {
+            break; // Skip words without recognition results
+          }
           text += best_choice->unichar_string();
           text += " ";
           res_it.forward();
@@ -102,16 +106,20 @@ float LTRResultIterator::Confidence(PageIteratorLevel level) const {
     case RIL_BLOCK:
       do {
         best_choice = res_it.word()->best_choice;
-        mean_certainty += best_choice->certainty();
-        ++certainty_count;
+        if (best_choice != nullptr) {
+          mean_certainty += best_choice->certainty();
+          ++certainty_count;
+        }
         res_it.forward();
       } while (res_it.block() == res_it.prev_block());
       break;
     case RIL_PARA:
       do {
         best_choice = res_it.word()->best_choice;
-        mean_certainty += best_choice->certainty();
-        ++certainty_count;
+        if (best_choice != nullptr) {
+          mean_certainty += best_choice->certainty();
+          ++certainty_count;
+        }
         res_it.forward();
       } while (res_it.block() == res_it.prev_block() &&
                res_it.row()->row->para() == res_it.prev_row()->row->para());
@@ -119,20 +127,26 @@ float LTRResultIterator::Confidence(PageIteratorLevel level) const {
     case RIL_TEXTLINE:
       do {
         best_choice = res_it.word()->best_choice;
-        mean_certainty += best_choice->certainty();
-        ++certainty_count;
+        if (best_choice != nullptr) {
+          mean_certainty += best_choice->certainty();
+          ++certainty_count;
+        }
         res_it.forward();
       } while (res_it.row() == res_it.prev_row());
       break;
     case RIL_WORD:
       best_choice = res_it.word()->best_choice;
-      mean_certainty = best_choice->certainty();
-      certainty_count = 1;
+      if (best_choice != nullptr) {
+        mean_certainty = best_choice->certainty();
+        certainty_count = 1;
+      }
       break;
     case RIL_SYMBOL:
       best_choice = res_it.word()->best_choice;
-      mean_certainty = best_choice->certainty(blob_index_);
-      certainty_count = 1;
+      if (best_choice != nullptr) {
+        mean_certainty = best_choice->certainty(blob_index_);
+        certainty_count = 1;
+      }
   }
   if (certainty_count > 0) {
     mean_certainty /= certainty_count;
@@ -224,8 +238,8 @@ StrongScriptDirection LTRResultIterator::WordDirection() const {
 
 // Returns true if the current word was found in a dictionary.
 bool LTRResultIterator::WordIsFromDictionary() const {
-  if (it_->word() == nullptr) {
-    return false; // Already at the end!
+  if (it_->word() == nullptr || it_->word()->best_choice == nullptr) {
+    return false; // Already at the end or no recognition results!
   }
   int permuter = it_->word()->best_choice->permuter();
   return permuter == SYSTEM_DAWG_PERM || permuter == FREQ_DAWG_PERM || permuter == USER_DAWG_PERM;
@@ -241,8 +255,8 @@ int LTRResultIterator::BlanksBeforeWord() const {
 
 // Returns true if the current word is numeric.
 bool LTRResultIterator::WordIsNumeric() const {
-  if (it_->word() == nullptr) {
-    return false; // Already at the end!
+  if (it_->word() == nullptr || it_->word()->best_choice == nullptr) {
+    return false; // Already at the end or no recognition results!
   }
   int permuter = it_->word()->best_choice->permuter();
   return permuter == NUMBER_PERM;
@@ -313,8 +327,11 @@ char *LTRResultIterator::WordNormedUTF8Text() const {
   if (it_->word() == nullptr) {
     return nullptr; // Already at the end!
   }
-  std::string ocr_text;
   WERD_CHOICE *best_choice = it_->word()->best_choice;
+  if (best_choice == nullptr) {
+    return nullptr; // No recognition results available
+  }
+  std::string ocr_text;
   const UNICHARSET *unicharset = it_->word()->uch_set;
   for (unsigned i = 0; i < best_choice->length(); ++i) {
     ocr_text += unicharset->get_normed_unichar(best_choice->unichar_id(i));
@@ -339,7 +356,7 @@ const char *LTRResultIterator::WordLattice(int *lattice_size) const {
 // If iterating at a higher level object than symbols, eg words, then
 // this will return the attributes of the first symbol in that word.
 bool LTRResultIterator::SymbolIsSuperscript() const {
-  if (cblob_it_ == nullptr && it_->word() != nullptr) {
+  if (cblob_it_ == nullptr && it_->word() != nullptr && it_->word()->best_choice != nullptr) {
     return it_->word()->best_choice->BlobPosition(blob_index_) == SP_SUPERSCRIPT;
   }
   return false;
@@ -349,7 +366,7 @@ bool LTRResultIterator::SymbolIsSuperscript() const {
 // If iterating at a higher level object than symbols, eg words, then
 // this will return the attributes of the first symbol in that word.
 bool LTRResultIterator::SymbolIsSubscript() const {
-  if (cblob_it_ == nullptr && it_->word() != nullptr) {
+  if (cblob_it_ == nullptr && it_->word() != nullptr && it_->word()->best_choice != nullptr) {
     return it_->word()->best_choice->BlobPosition(blob_index_) == SP_SUBSCRIPT;
   }
   return false;
@@ -359,7 +376,7 @@ bool LTRResultIterator::SymbolIsSubscript() const {
 // If iterating at a higher level object than symbols, eg words, then
 // this will return the attributes of the first symbol in that word.
 bool LTRResultIterator::SymbolIsDropcap() const {
-  if (cblob_it_ == nullptr && it_->word() != nullptr) {
+  if (cblob_it_ == nullptr && it_->word() != nullptr && it_->word()->best_choice != nullptr) {
     return it_->word()->best_choice->BlobPosition(blob_index_) == SP_DROPCAP;
   }
   return false;

--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -51,7 +51,11 @@ char *LTRResultIterator::GetUTF8Text(PageIteratorLevel level) const {
     return nullptr; // No recognition results available
   }
   if (level == RIL_SYMBOL) {
-    text = res_it.word()->BestUTF8(blob_index_, false);
+    const char *utf8 = res_it.word()->BestUTF8(blob_index_, false);
+    if (utf8 == nullptr) {
+      return nullptr;
+    }
+    text = utf8;
   } else if (level == RIL_WORD) {
     text = best_choice->unichar_string();
   } else {
@@ -62,7 +66,9 @@ char *LTRResultIterator::GetUTF8Text(PageIteratorLevel level) const {
         do {          // for each word in a text line
           best_choice = res_it.word()->best_choice;
           if (best_choice == nullptr) {
-            break; // Skip words without recognition results
+            res_it.forward();
+            eol = res_it.row() != res_it.prev_row();
+            continue; // Skip words without recognition results.
           }
           text += best_choice->unichar_string();
           text += " ";

--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -47,7 +47,7 @@ char *LTRResultIterator::GetUTF8Text(PageIteratorLevel level) const {
   std::string text;
   PAGE_RES_IT res_it(*it_);
   WERD_CHOICE *best_choice = res_it.word()->best_choice;
-  if (best_choice == nullptr) {
+  if ((level == RIL_WORD || level == RIL_SYMBOL) && best_choice == nullptr) {
     return nullptr; // No recognition results available
   }
   if (level == RIL_SYMBOL) {
@@ -75,7 +75,9 @@ char *LTRResultIterator::GetUTF8Text(PageIteratorLevel level) const {
           res_it.forward();
           eol = res_it.row() != res_it.prev_row();
         } while (!eol);
-        text.resize(text.length() - 1);
+        if (!text.empty()) {
+          text.resize(text.length() - 1);
+        }
         text += line_separator_;
         eop = res_it.block() != res_it.prev_block() ||
               res_it.row()->row->para() != res_it.prev_row()->row->para();

--- a/src/ccmain/resultiterator.cpp
+++ b/src/ccmain/resultiterator.cpp
@@ -706,7 +706,9 @@ void ResultIterator::AppendUTF8WordText(std::string *text) const {
   if (!it_->word()) {
     return;
   }
-  ASSERT_HOST(it_->word()->best_choice != nullptr);
+  if (it_->word()->best_choice == nullptr) {
+    return; // No recognition results available
+  }
   bool reading_direction_is_ltr = current_paragraph_is_ltr_ ^ in_minor_direction_;
   if (at_beginning_of_minor_run_) {
     *text += reading_direction_is_ltr ? kLRM : kRLM;

--- a/src/ccmain/resultiterator.cpp
+++ b/src/ccmain/resultiterator.cpp
@@ -690,7 +690,7 @@ char *ResultIterator::GetUTF8Text(PageIteratorLevel level) const {
       if (utf8 == nullptr) {
         return nullptr;
       }
-      text = utf8;
+      text += utf8;
       if (IsAtFinalSymbolOfWord()) {
         AppendSuffixMarks(&text);
       }

--- a/src/ccmain/resultiterator.cpp
+++ b/src/ccmain/resultiterator.cpp
@@ -710,7 +710,9 @@ void ResultIterator::AppendUTF8WordText(std::string *text) const {
   if (!it_->word()) {
     return;
   }
-  ASSERT_HOST(it_->word()->best_choice != nullptr);
+  if (it_->word()->best_choice == nullptr) {
+    return; // No recognition results available
+  }
   bool reading_direction_is_ltr = current_paragraph_is_ltr_ ^ in_minor_direction_;
   if (at_beginning_of_minor_run_) {
     *text += reading_direction_is_ltr ? kLRM : kRLM;

--- a/src/ccmain/resultiterator.cpp
+++ b/src/ccmain/resultiterator.cpp
@@ -673,14 +673,24 @@ char *ResultIterator::GetUTF8Text(PageIteratorLevel level) const {
       it.IterateAndAppendUTF8TextlineText(&text);
     } break;
     case RIL_WORD:
+      if (it_->word()->best_choice == nullptr) {
+        return nullptr;
+      }
       AppendUTF8WordText(&text);
       break;
     case RIL_SYMBOL: {
+      if (it_->word()->best_choice == nullptr) {
+        return nullptr;
+      }
       bool reading_direction_is_ltr = current_paragraph_is_ltr_ ^ in_minor_direction_;
       if (at_beginning_of_minor_run_) {
         text += reading_direction_is_ltr ? kLRM : kRLM;
       }
-      text = it_->word()->BestUTF8(blob_index_, false);
+      const char *utf8 = it_->word()->BestUTF8(blob_index_, false);
+      if (utf8 == nullptr) {
+        return nullptr;
+      }
+      text = utf8;
       if (IsAtFinalSymbolOfWord()) {
         AppendSuffixMarks(&text);
       }

--- a/unittest/resultiterator_test.cc
+++ b/unittest/resultiterator_test.cc
@@ -654,6 +654,7 @@ TEST_F(ResultIteratorTest, TextlineOrderSanityCheck) {
 
 TEST_F(ResultIteratorTest, NullBestChoiceRegressionTest) {
   SetImage("phototest.tif");
+  ASSERT_EQ(api_.Recognize(nullptr), 0);
   std::unique_ptr<ResultIterator> r_it(api_.GetIterator());
   ASSERT_NE(r_it, nullptr);
 

--- a/unittest/resultiterator_test.cc
+++ b/unittest/resultiterator_test.cc
@@ -1,14 +1,31 @@
 
 #include <tesseract/baseapi.h>
 #include <tesseract/resultiterator.h>
+#include <memory>
 #include <string>
 #include "image.h"      // for Image
+#include "pageres.h"
 #include "scrollview.h"
 
 #include "include_gunit.h"
 #include "log.h" // for LOG
 
 namespace tesseract {
+
+class TestLTRResultIterator : public LTRResultIterator {
+ public:
+  using LTRResultIterator::LTRResultIterator;
+
+  explicit TestLTRResultIterator(const LTRResultIterator &src) : LTRResultIterator(src) {}
+
+  WERD_RES *CurrentWord() const { return it_->word(); }
+
+  void SetCurrentWordBestChoiceNull() {
+    if (it_ != nullptr && it_->word() != nullptr) {
+      it_->word()->best_choice = nullptr;
+    }
+  }
+};
 
 // DEFINE_string(tess_config, "", "config file for tesseract");
 // DEFINE_bool(visual_test, false, "Runs a visual test using scrollview");
@@ -633,6 +650,45 @@ TEST_F(ResultIteratorTest, TextlineOrderSanityCheck) {
     VerifySaneTextlineOrder(true, word_dirs, kNumWords);
     VerifySaneTextlineOrder(false, word_dirs, kNumWords);
   }
+}
+
+TEST_F(ResultIteratorTest, NullBestChoiceRegressionTest) {
+  SetImage("phototest.tif");
+  std::unique_ptr<ResultIterator> r_it(api_.GetIterator());
+  ASSERT_NE(r_it, nullptr);
+
+  std::vector<std::pair<std::string, TestLTRResultIterator>> words;
+  for (TestLTRResultIterator it(*r_it); !it.Empty(RIL_WORD); it.Next(RIL_WORD)) {
+    if (it.CurrentWord() == nullptr || it.CurrentWord()->best_choice == nullptr) {
+      continue;
+    }
+    char *word = it.GetUTF8Text(RIL_WORD);
+    if (word == nullptr) {
+      continue;
+    }
+    words.emplace_back(word, TestLTRResultIterator(it));
+    delete[] word;
+  }
+  ASSERT_GE(words.size(), 3);
+
+  auto target = words[1];
+  target.second.SetCurrentWordBestChoiceNull();
+  EXPECT_EQ(nullptr, target.second.GetUTF8Text(RIL_WORD));
+  EXPECT_EQ(nullptr, target.second.GetUTF8Text(RIL_SYMBOL));
+
+  char *text = target.second.GetUTF8Text(RIL_TEXTLINE);
+  ASSERT_NE(text, nullptr);
+  std::string text_line(text);
+  delete[] text;
+  EXPECT_NE(text_line.find(words[2].first), std::string::npos)
+      << "A null best_choice should not stop textline traversal";
+
+  char *para_text = target.second.GetUTF8Text(RIL_PARA);
+  ASSERT_NE(para_text, nullptr);
+  std::string para(para_text);
+  delete[] para_text;
+  EXPECT_NE(para.find(words[2].first), std::string::npos)
+      << "A null best_choice should not stop paragraph traversal";
 }
 
 // TODO: Missing image


### PR DESCRIPTION
### Description

This PR fixes a crash in the `GetUTF8Text` method by returning `nullptr` instead of asserting when `best_choice` is `nullptr`.

### Background

The issue was originally reported in [sirfz/tesserocr#324](https://github.com/sirfz/tesserocr/issues/324), where a crash/assertion failure occurred when passing an empty image to tesserocr/Tesseract. The error message was:

```
best_choice != nullptr:Error:Assert failed: in file F:\Projects\Community\tesseract\src\ccmain\ltrresultiterator.cpp, line 52
```

While reproducing the issue with a test C++ program, I encountered a similar crash in another location:

```
it_->word()->best_choice != nullptr:Error:Assert failed: in file F:\Projects\Community\tesseract\src\ccmain\resultiterator.cpp, line 709
```

### Changes

* Modified `GetUTF8Text` to safely return `nullptr` if `best_choice` is `nullptr`, instead of triggering an assertion failure.

### Additional Notes

* I tested this with Warp2, which suggested updating multiple instances of `ASSERT_HOST(best_choice != nullptr);`. This PR addresses the crash in the context of `GetUTF8Text`.
* There are still 3 other occurrences of this assertion in the following files:

  * `src/ccmain/recogtraining.cpp`
  * `src/ccstruct/pageres.cpp`

  It's unclear if those should also be replaced, as they may be used in different contexts (e.g., training or layout analysis). Further review is recommended before changing them.

### Reproduction

Here is a minimal test program that reproduces the crash (when using an empty image):

```cpp
//  test_ResultIterator.cpp
#include <leptonica/allheaders.h>
#include <tesseract/baseapi.h>

#include <iostream>

int main(int argc, char *argv[]) {
  tesseract::TessBaseAPI *api = new tesseract::TessBaseAPI();

  if (api->Init(NULL, "chi_sim")) {
    fprintf(stderr, "Could not initialize tesseract.\n");
    exit(1);
  }

  // Create a small empty/blank image (1x1 pixel)
  Pix* pix = pixCreate(100, 100, 8);
  if (pix == nullptr) {
    std::cerr << "Could not create empty image." << std::endl;
    return 1;
  }
  api->SetImage(pix);

  api->SetPageSegMode(tesseract::PSM_SINGLE_CHAR);
  api->Recognize(0);
  int out_offset;
  float out_slope;
  if (api->GetTextDirection(&out_offset, &out_slope)) {
    std::cout << "out_offset: " << out_offset << std::endl;
    std::cout << "out_slope: " << out_slope << std::endl;
  } else {
    std::cout << "GetTextDirection failed." << std::endl;
  }
  // Get the iterator and try to imitate relevant part of MapWordConfidences function
  tesseract::ResultIterator* ri = api->GetIterator();
  tesseract::PageIteratorLevel level = tesseract::RIL_WORD;
  if (ri != nullptr) {
    do {
      const char* word = ri->GetUTF8Text(level);
      auto word_confidence = ri->Confidence(level);
      std::cout << "Word confidence(" << word << "): " << word_confidence << std::endl;
    } while (ri->Next(level));
  }

  delete ri;
  api->End();
  delete api;
  pixDestroy(&pix);
  std::cout << "Test completed successfully - no crash!" << std::endl;
  return 0;
}

```