### PR TITLE
Fix crash when tessdata directory doesn't exist

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -146,11 +146,6 @@ static void ExtractFontName(const char* filename, std::string* fontname) {
  */
 static void addAvailableLanguages(const std::string &datadir,
                                   std::vector<std::string> *langs) {
-  // Check if directory exists before attempting to iterate
-  if (!std::filesystem::exists(datadir) || !std::filesystem::is_directory(datadir)) {
-    return;
-  }
-  
   try {
     for (const auto& entry :
          std::filesystem::recursive_directory_iterator(datadir,
@@ -162,7 +157,7 @@ static void addAvailableLanguages(const std::string &datadir,
       }
     }
   } catch (const std::filesystem::filesystem_error&) {
-    // Silently handle filesystem errors (e.g., permission denied, corrupted filesystem)
+    // Silently handle filesystem errors (e.g., missing directory, corrupted filesystem)
     // The function will return with whatever languages were found so far
   }
 }

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -146,14 +146,24 @@ static void ExtractFontName(const char* filename, std::string* fontname) {
  */
 static void addAvailableLanguages(const std::string &datadir,
                                   std::vector<std::string> *langs) {
-  for (const auto& entry :
-       std::filesystem::recursive_directory_iterator(datadir,
-         std::filesystem::directory_options::follow_directory_symlink |
-         std::filesystem::directory_options::skip_permission_denied)) {
-    auto path = entry.path().lexically_relative(datadir);
-    if (path.extension() == ".traineddata") {
-      langs->push_back(path.replace_extension("").string());
+  // Check if directory exists before attempting to iterate
+  if (!std::filesystem::exists(datadir) || !std::filesystem::is_directory(datadir)) {
+    return;
+  }
+  
+  try {
+    for (const auto& entry :
+         std::filesystem::recursive_directory_iterator(datadir,
+           std::filesystem::directory_options::follow_directory_symlink |
+           std::filesystem::directory_options::skip_permission_denied)) {
+      auto path = entry.path().lexically_relative(datadir);
+      if (path.extension() == ".traineddata") {
+        langs->push_back(path.replace_extension("").string());
+      }
     }
+  } catch (const std::filesystem::filesystem_error&) {
+    // Silently handle filesystem errors (e.g., permission denied, corrupted filesystem)
+    // The function will return with whatever languages were found so far
   }
 }
 


### PR DESCRIPTION
 
 Solution
Added two-layer protection in `addAvailableLanguages()`:

1. Preventive check: Verify directory exists before attempting iteration
2. Exception handling: Catch filesystem errors during traversal

Changes
- Add `std::filesystem::exists()` and `std::filesystem::is_directory()` checks
- Wrap `recursive_directory_iterator` in try-catch block
- Function now returns gracefully with empty language list instead of crashing

 Testing
- Verified fix handles missing directories without crashing
- Tested edge cases (empty paths, permission denied scenarios)

Impact
- After: Graceful degradation - returns empty language list and continues running

This fix improves robustness for users with incomplete Tesseract installations.


Contributing to Hacktoberfest 2025