### PR TITLE
Add silent installation support

### DIFF
--- a/nsis/tesseract.nsi
+++ b/nsis/tesseract.nsi
@@ -1198,7 +1198,16 @@ Function .onInit
   SetRegView 64
 !endif
   Call PreventMultipleInstances
-  !insertmacro MUI_LANGDLL_DISPLAY
+
+  ${If} ${Silent}
+    ; Silent mode: Set defaults to skip dialogs
+    StrCpy $LANGUAGE ${LANG_ENGLISH}
+    StrCpy $MultiUser.InstallMode "AllUsers"
+  ${Else}
+    ; Interactive mode: Show language dialog
+    !insertmacro MUI_LANGDLL_DISPLAY
+  ${EndIf}
+  
   ;RequestExecutionLevel admin
   !insertmacro MULTIUSER_INIT
 
@@ -1229,7 +1238,7 @@ Function .onInit
       StrCmp $0 0 0 +3
         !insertmacro REMOVE_REGKEY ${OLD_KEY}
         Goto SkipUnInstall
-      messagebox mb_ok "Uninstaller failed:\n$0\n\nYou need to remove program manually."
+      messagebox mb_ok "Uninstaller failed:\n$0\n\nYou need to remove program manually." /SD IDOK
   SkipUnInstall:
     ;InitPluginsDir
     ;File /oname=$PLUGINSDIR\splash.bmp "${NSISDIR}\Contrib\Graphics\Header\nsis.bmp"
@@ -1422,7 +1431,7 @@ Function un.onInit
 FunctionEnd
 
 Function .onInstFailed
-  MessageBox MB_OK "Installation failed."
+  MessageBox MB_OK "Installation failed." /SD IDOK
 FunctionEnd
 
 !ifdef SHOW_README


### PR DESCRIPTION
Summary

  This PR adds proper silent installation support for the installer. Currently, the /S parameter is ignored
  because UI dialogs still appear.

  Changes

  - Skip language selection dialog in silent mode (default to English)
  - Default to AllUsers installation mode when running silently
  - Add /SD parameter to MessageBoxes for automatic dismissal in silent mode

  Problem

  When running tesseract-ocr-w64-setup-*.exe /S, the installer still shows:
  1. Language selection dialog (MUI_LANGDLL_DISPLAY)
  2. MessageBoxes without silent defaults

  This prevents automated deployment via tools like Microsoft Intune, SCCM, or other software deployment systems.