### PR TITLE
Optimize dot product using restrict keyword (Fixes #4393)

### DIFF
--- a/src/arch/dotproduct.cpp
+++ b/src/arch/dotproduct.cpp
@@ -19,7 +19,8 @@
 namespace tesseract {
 
 // Computes and returns the dot product of the two n-vectors u and v.
-TFloat DotProductNative(const TFloat *u, const TFloat *v, int n) {
+// Note: Added TESS_RESTRICT to u and v
+TFloat DotProductNative(const TFloat* TESS_RESTRICT u, const TFloat* TESS_RESTRICT v, int n) {
   TFloat total = 0;
 #if defined(OPENMP_SIMD) || defined(_OPENMP)
 #pragma omp simd reduction(+:total)

--- a/src/arch/dotproduct.h
+++ b/src/arch/dotproduct.h
@@ -19,25 +19,34 @@
 
 #include "tesstypes.h"
 
+// Added for Issue #4393
+#if defined(_MSC_VER)
+#  define TESS_RESTRICT __restrict
+#elif defined(__GNUC__) || defined(__clang__)
+#  define TESS_RESTRICT __restrict__
+#else
+#  define TESS_RESTRICT
+#endif
+
 namespace tesseract {
 
 // Computes and returns the dot product of the n-vectors u and v.
-TFloat DotProductNative(const TFloat *u, const TFloat *v, int n);
+TFloat DotProductNative(const TFloat* TESS_RESTRICT u, const TFloat* TESS_RESTRICT v, int n);
 
 // Uses Intel AVX intrinsics to access the SIMD instruction set.
-TFloat DotProductAVX(const TFloat *u, const TFloat *v, int n);
+TFloat DotProductAVX(const TFloat* TESS_RESTRICT u, const TFloat* TESS_RESTRICT v, int n);
 
 // Uses Intel AVX512F intrinsics to access the SIMD instruction set.
-TFloat DotProductAVX512F(const TFloat *u, const TFloat *v, int n);
+TFloat DotProductAVX512F(const TFloat* TESS_RESTRICT u, const TFloat* TESS_RESTRICT v, int n);
 
 // Use Intel FMA.
-TFloat DotProductFMA(const TFloat *u, const TFloat *v, int n);
+TFloat DotProductFMA(const TFloat* TESS_RESTRICT u, const TFloat* TESS_RESTRICT v, int n);
 
 // Uses Intel SSE intrinsics to access the SIMD instruction set.
-TFloat DotProductSSE(const TFloat *u, const TFloat *v, int n);
+TFloat DotProductSSE(const TFloat* TESS_RESTRICT u, const TFloat* TESS_RESTRICT v, int n);
 
 // Use NEON intrinsics.
-TFloat DotProductNEON(const TFloat *u, const TFloat *v, int n);
+TFloat DotProductNEON(const TFloat* TESS_RESTRICT u, const TFloat* TESS_RESTRICT v, int n);
 
 } // namespace tesseract.
 

--- a/src/arch/dotproductavx.cpp
+++ b/src/arch/dotproductavx.cpp
@@ -30,7 +30,7 @@ namespace tesseract {
 // Computes and returns the dot product of the n-vectors u and v.
 // Uses Intel AVX intrinsics to access the SIMD instruction set.
 #if defined(FAST_FLOAT)
-float DotProductAVX(const float *u, const float *v, int n) {
+float DotProductAVX(const float* TESS_RESTRICT u, const float* TESS_RESTRICT v, int n) {
   const unsigned quot = n / 8;
   const unsigned rem = n % 8;
   __m256 t0 = _mm256_setzero_ps();
@@ -51,7 +51,7 @@ float DotProductAVX(const float *u, const float *v, int n) {
   return result;
 }
 #else
-double DotProductAVX(const double *u, const double *v, int n) {
+double DotProductAVX(const double* TESS_RESTRICT u, const double* TESS_RESTRICT v, int n) {
   const unsigned quot = n / 8;
   const unsigned rem = n % 8;
   __m256d t0 = _mm256_setzero_pd();

--- a/src/arch/dotproductavx512.cpp
+++ b/src/arch/dotproductavx512.cpp
@@ -30,7 +30,7 @@ namespace tesseract {
 // Computes and returns the dot product of the n-vectors u and v.
 // Uses Intel AVX intrinsics to access the SIMD instruction set.
 #  if defined(FAST_FLOAT)
-float DotProductAVX512F(const float *u, const float *v, int n) {
+float DotProductAVX512F(const float* TESS_RESTRICT u, const float* TESS_RESTRICT v, int n) {
   const unsigned quot = n / 16;
   const unsigned rem = n % 16;
   __m512 t0 = _mm512_setzero_ps();
@@ -48,7 +48,7 @@ float DotProductAVX512F(const float *u, const float *v, int n) {
   return result;
 }
 #  else
-double DotProductAVX512F(const double *u, const double *v, int n) {
+double DotProductAVX512F(const double* TESS_RESTRICT u, const double* TESS_RESTRICT v, int n) {
   const unsigned quot = n / 8;
   const unsigned rem = n % 8;
   __m512d t0 = _mm512_setzero_pd();

--- a/src/arch/dotproductfma.cpp
+++ b/src/arch/dotproductfma.cpp
@@ -30,7 +30,7 @@ namespace tesseract {
 // Computes and returns the dot product of the n-vectors u and v.
 // Uses Intel FMA intrinsics to access the SIMD instruction set.
 #if defined(FAST_FLOAT)
-float DotProductFMA(const float *u, const float *v, int n) {
+float DotProductFMA(const float* TESS_RESTRICT u, const float* TESS_RESTRICT v, int n) {
   const unsigned quot = n / 16;
   const unsigned rem = n % 16;
   __m256 t0 = _mm256_setzero_ps();
@@ -57,7 +57,7 @@ float DotProductFMA(const float *u, const float *v, int n) {
   return result;
 }
 #else
-double DotProductFMA(const double *u, const double *v, int n) {
+double DotProductFMA(const double* TESS_RESTRICT u, const double* TESS_RESTRICT v, int n) {
   const unsigned quot = n / 8;
   const unsigned rem = n % 8;
   __m256d t0 = _mm256_setzero_pd();

--- a/src/arch/dotproductneon.cpp
+++ b/src/arch/dotproductneon.cpp
@@ -26,7 +26,7 @@ namespace tesseract {
 
 #if defined(FAST_FLOAT) && defined(__ARM_ARCH_ISA_A64)
 
-float DotProductNEON(const float *u, const float *v, int n) {
+float DotProductNEON(const float* TESS_RESTRICT u, const float* TESS_RESTRICT v, int n) {
   float32x4_t result0123 = vdupq_n_f32(0.0f);
   float32x4_t result4567 = vdupq_n_f32(0.0f);
   while (n > 7) {
@@ -53,7 +53,7 @@ float DotProductNEON(const float *u, const float *v, int n) {
 #else
 
 // Computes and returns the dot product of the two n-vectors u and v.
-TFloat DotProductNEON(const TFloat *u, const TFloat *v, int n) {
+TFloat DotProductNEON(const TFloat* TESS_RESTRICT u, const TFloat* TESS_RESTRICT v, int n) {
   TFloat total = 0;
 #if defined(OPENMP_SIMD) || defined(_OPENMP)
 #pragma omp simd reduction(+:total)

--- a/src/arch/dotproductsse.cpp
+++ b/src/arch/dotproductsse.cpp
@@ -31,7 +31,7 @@ namespace tesseract {
 // Computes and returns the dot product of the n-vectors u and v.
 // Uses Intel SSE intrinsics to access the SIMD instruction set.
 #if defined(FAST_FLOAT)
-float DotProductSSE(const float *u, const float *v, int n) {
+float DotProductSSE(const float* TESS_RESTRICT u, const float* TESS_RESTRICT v, int n) {
   int max_offset = n - 4;
   int offset = 0;
   // Accumulate a set of 4 sums in sum, by loading pairs of 4 values from u and
@@ -90,7 +90,7 @@ float DotProductSSE(const float *u, const float *v, int n) {
   return result;
 }
 #else
-double DotProductSSE(const double *u, const double *v, int n) {
+double DotProductSSE(const double* TESS_RESTRICT u, const double* TESS_RESTRICT v, int n) {
   int max_offset = n - 2;
   int offset = 0;
   // Accumulate a set of 2 sums in sum, by loading pairs of 2 values from u and


### PR DESCRIPTION
### Description
addresses issue #4393 by adding the `restrict` keyword to the dot product functions. This informs the compiler that the input arrays do not overlap, enabling better SIMD vectorization and potential performance improvements.

### Changes
- Defined a `TESS_RESTRICT` macro in `src/arch/dotproduct.h` to handle compiler differences:
  - Uses `__restrict` for MSVC.
  - Uses `__restrict__` for GCC/Clang.
- Updated function signatures to use `TESS_RESTRICT` on pointer arguments (`u` and `v`) in:
  - `DotProductNative`
  - `DotProductAVX` / `AVX512F`
  - `DotProductSSE`
  - `DotProductFMA`
  - `DotProductNEON`

### Verification
- [x] Code compiles successfully.
- [ ] Passed existing tests (CI checks pending).