### PR TITLE
Improve markup in unicharset_extractor.1.asc

### DIFF
--- a/doc/unicharset_extractor.1.asc
+++ b/doc/unicharset_extractor.1.asc
@@ -1,3 +1,7 @@
+:doctype: manpage
+:man manual: User Commands
+:man source: tesseract
+
 UNICHARSET_EXTRACTOR(1)
 =======================
 
@@ -7,34 +11,34 @@ unicharset_extractor - Reads box or plain text files to extract the unicharset.
 
 SYNOPSIS
 --------
-*unicharset_extractor*  [--output_unicharset filename] [--norm_mode mode] box_or_text_file [...]
+*unicharset_extractor*  [*--output_unicharset* _filename_] [*--norm_mode* _mode_] _box_or_text_file_ [...]
 
-Where mode means:
+Where _mode_ means:
  1=combine graphemes (use for Latin and other simple scripts)
  2=split graphemes (use for Indic/Khmer/Myanmar)
  3=pure unicode (use for Arabic/Hebrew/Thai/Tibetan)
 
 DESCRIPTION
 -----------
-Tesseract needs to know the set of possible characters it can output.
-To generate the unicharset data file, use the unicharset_extractor
+*tesseract* needs to know the set of possible characters it can output.
+To generate the _unicharset_ data file, use the *unicharset_extractor*
 program on training pages bounding box files or a plain text file:
 
     unicharset_extractor fontfile_1.box fontfile_2.box ...
 
-The unicharset will be put into the file './unicharset' if no output filename is provided.
+The unicharset will be put into the file _./unicharset_ if no output filename is provided.
 
-*NOTE* Use the appropriate norm_mode based on the language.
+*NOTE*: Use the appropriate *norm_mode* based on the language.
 
 SEE ALSO
 --------
-tesseract(1), unicharset(5)
+*tesseract*(1), *unicharset*(5)
 
-<https://tesseract-ocr.github.io/tessdoc/Training-Tesseract.html>
+https://tesseract-ocr.github.io/tessdoc/Training-Tesseract.html[]
 
 HISTORY
 -------
-unicharset_extractor first appeared in Tesseract 2.00.
+*unicharset_extractor* first appeared in Tesseract 2.00.
 
 COPYING
 -------


### PR DESCRIPTION
Hello,

I've tried to improve the markup in unicharset_extractor.1.asc. Some explanations:

The man page man-pages.7 ("Fomatting conventions") describes how we should treat command names, literal options and file names. I've applied that to write command names and options in bold, file names italic.

The current links in the SEE ALSO sections are unformatted, but should be bold. Especially online man page collections (like [1]) need this formatting to generate clickable links to that man pages (by the way, this applies also to external commands found in "description" paragraphs etc.).

Currently I've written the following file header:
`:man source: tesseract`
This is still incomplete. For an example what it should be, see [2]. With the macro {release-version} we would be able to write an unique version number into the header of the rendered man page. Don't know how to expand the macro; maybe refer to the util-linux code…?

If you agree with the changes, I will continue on review the formatting of the other man pages.

[1] https://man.archlinux.org/man/unicharset_extractor.1#SEE_ALSO
[2] https://github.com/util-linux/util-linux/blob/master/text-utils/col.1.adoc?plain=1#L44