### PR TITLE
Fix Apple CMAKE_SYSTEM_PROCESSOR not set when crosscompiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,18 @@ if(WIN32)
 else()
   option(SW_BUILD "Build with sw" OFF)
 endif()
+
+# Apple's toolchains dont populate CMAKE_SYSTEM_PROCESSOR when crosscompiling
+# instead it uses CMAKE_OSX_ARCHITECTURES which can contain multiple architectures
+if(APPLE AND NOT CMAKE_SYSTEM_PROCESSOR AND CMAKE_OSX_ARCHITECTURES)
+  list(LENGTH CMAKE_OSX_ARCHITECTURES NO_OF_ARCH)
+  if(NO_OF_ARCH GREATER 1)
+    message(FATAL_ERROR "Apple's universal build for ${NO_OF_ARCH} architectures not supported. CMAKE_OSX_ARCHITECTURES: ${CMAKE_OSX_ARCHITECTURES}")
+  endif()
+  set(CMAKE_SYSTEM_PROCESSOR "${CMAKE_OSX_ARCHITECTURES}" CACHE STRING "Target processor" FORCE)
+  message(STATUS "CMAKE_SYSTEM_PROCESSOR set to '${CMAKE_SYSTEM_PROCESSOR}' from CMAKE_OSX_ARCHITECTURES")
+endif()
+
 option(OPENMP_BUILD "Build with openmp support" OFF) # see issue #1662
 option(GRAPHICS_DISABLED "Disable disable graphics (ScrollView)" OFF)
 option(DISABLED_LEGACY_ENGINE "Disable the legacy OCR engine" OFF)


### PR DESCRIPTION
When CMAKE_SYSTEM_PROCESSOR isn't set, crosscompilation for iOS fails because required .cpp files are not found.
CMAKE_SYSTEM_PROCESSOR isn't used by Apple as their toolchains use only CMAKE_OSX_ARCHITECTURES which is a **list** of architectures. 

It doesn't look like this CMake supports Apple's _universal builds_, so I've made logic that if we are building only for one architecture we set CMAKE_SYSTEM_PROCESSOR to CMAKE_OSX_ARCHITECTURES, and if its trying to build _universal build_ we fail with a message.
