### PR TITLE
Remove outdated docker-compose.yml (Fixes #4492)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,2 +1,0 @@
-tesseract:
-  build: .


### PR DESCRIPTION
This PR removes the outdated `docker-compose.yml`(https://github.com/Mohataseem89/tesseract/blob/main/docker-compose.yml) file.

The file used legacy docker-compose v1 syntax:

    tesseract:
        build: .

It appears to be unused in the current project workflow and was originally added during Travis CI Docker experiments.
As discussed in #4492 and confirmed by maintainers, removing this file reduces confusion and repository clutter.
no functional changes were made
