### PR TITLE
Add environment path management for installation

### DIFF
--- a/nsis/Makefile.am
+++ b/nsis/Makefile.am
@@ -12,11 +12,15 @@ Plugins/x86-unicode/INetC.dll:
 	curl -OsS https://nsis.sourceforge.io/mediawiki/images/c/c9/Inetc.zip
 	unzip Inetc.zip $@
 
+Plugins/x86-unicode/EnVar.dll:
+	curl -OsS https://nsis.sourceforge.io/mediawiki/images/7/7f/EnVar_plugin.zip
+	unzip EnVar_plugin.zip $@
+
 winpath.exe: winpath.cpp
 	x86_64-w64-mingw32-g++ -Os -o $@ $<
 	x86_64-w64-mingw32-strip --strip-unneeded $@
 
-winsetup: Plugins/x86-unicode/INetC.dll winpath.exe
+winsetup: Plugins/x86-unicode/INetC.dll Plugins/x86-unicode/EnVar.dll winpath.exe
 	makensis -DCROSSBUILD -DSHARED -DSIGNCODE=$(SIGNCODE) -DSRCDIR=$(top_srcdir) -DVERSION=${gitrev} $(shell test "$(host_cpu)" = x86_64 && echo "-DW64") -NOCD $(top_srcdir)/nsis/tesseract.nsi
 
 endif

--- a/nsis/tesseract.nsi
+++ b/nsis/tesseract.nsi
@@ -1103,7 +1103,7 @@ SectionGroup "Additional language data (download)" SecGrp_ALD
 
 SectionGroupEnd
 
-Section -SecAddEnvPath
+Section /o "Add to PATH environment variable" SecAddEnvPath
   ; Check if the installer is running in "Current User" mode
   StrCmp $MultiUser.InstallMode "CurrentUser" SetUserPath 0
 
@@ -1135,6 +1135,7 @@ SectionEnd
   LangString DESC_SEC0001 ${LANG_ENGLISH} "Installation files."
   ;LangString DESC_SecHelp ${LANG_ENGLISH} "Help information."
   LangString DESC_SecCS    ${LANG_ENGLISH} "Add shortcuts to Start menu."
+  LangString DESC_SecAddEnvPath ${LANG_ENGLISH} "Allows running Tesseract from any command prompt."
 
   LangString DESC_SEC0001 ${LANG_FRENCH} "Fichier d'installation."
   ;LangString DESC_SecHelp ${LANG_FRENCH} "Aide."
@@ -1164,6 +1165,7 @@ SectionEnd
   !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
     !insertmacro MUI_DESCRIPTION_TEXT ${SEC0001} $(DESC_SEC0001)
     !insertmacro MUI_DESCRIPTION_TEXT ${SecCS} $(DESC_SecCS)
+    !insertmacro MUI_DESCRIPTION_TEXT ${SecAddEnvPath} $(DESC_SecAddEnvPath)
   !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 ;--------------------------------
@@ -1451,6 +1453,17 @@ Function .onInit
     Vietnamese: !insertmacro SelectSection ${SecLang_vie}
 
     lang_end:
+
+    ; --- Command Line Parsing ---
+    ${GetParameters} $R0
+
+    ; Check for "Add to PATH environment variable" flag (case-insensitive)
+    ClearErrors
+    ${GetOptions} $R0 "/ADDENVPATH" $R1
+    ${IfNot} ${Errors}
+      !insertmacro SelectSection ${SecAddEnvPath}
+    ${EndIf}
+    ; ----------------------------
 FunctionEnd
 
 Function un.onInit

--- a/nsis/tesseract.nsi
+++ b/nsis/tesseract.nsi
@@ -1122,7 +1122,10 @@ Section /o "Add to PATH environment variable" SecAddEnvPath
 
   UpdatePath:
     EnVar::AddValue "Path" "$INSTDIR"
-    Pop $0 ; Clean up the stack (returns 0 on success)
+    Pop $0 ; Returns 0 on success, non-zero on error
+    StrCmp $0 "0" +3 0
+    DetailPrint "Warning: Failed to add installation directory to PATH (EnVar::AddValue returned $0)."
+    MessageBox MB_ICONEXCLAMATION "Warning: The installer could not add Tesseract to the PATH environment variable.$\r$\nYou may need to add '$INSTDIR' to PATH manually."
 SectionEnd
 
 ;--------------------------------
@@ -1236,6 +1239,8 @@ Section -un.Main UNSEC0000
   RemovePath:
     EnVar::DeleteValue "Path" "$INSTDIR"
     Pop $0
+    StrCmp $0 "0" +2 0
+    DetailPrint "Warning: failed to remove $INSTDIR from PATH (EnVar::DeleteValue result: $0)"
 SectionEnd
 
 Function PageReinstall


### PR DESCRIPTION
## Description
This PR enhances the Windows installer by automatically adding the Tesseract installation directory to the system or user `PATH` environment variable. This allows users and automated scripts to run `tesseract.exe` from any command prompt immediately after installation without manual configuration.

### Motivation
Standardizing the `PATH` configuration during installation improves the out-of-the-box experience and simplifies automated, unattended infrastructure deployments. Previously, users had to manually edit their environment variables after installing.

### Key Changes
- **Dynamic Privilege Handling:** The script now checks both `$MultiUser.InstallMode` and the actual account privileges (`UserInfo::GetAccountType`). It safely writes to `HKLM` if running as an Administrator (All Users) or falls back to `HKCU` for standard users (Current User).
- **Safe Environment Variable Manipulation:** Integrated the `EnVar` plugin to modify the `PATH`. This is highly recommended over native NSIS registry commands to avoid truncating existing `PATH` strings that exceed 1024 characters.
- **Clean Uninstallation:** Added logic to the uninstaller to dynamically check the installation mode and safely remove the Tesseract directory from the `PATH`.

## Notes for Reviewers
⚠️ **Build Dependency Update:** Compiling `tesseract.nsi` now requires the [EnVar plugin](https://nsis.sourceforge.io/EnVar_plug-in) to be present in the NSIS plugins directory.