### PR TITLE
Correct mutex call to prevent multiple instances

### DIFF
--- a/nsis/tesseract.nsi
+++ b/nsis/tesseract.nsi
@@ -1437,8 +1437,9 @@ Function PreventMultipleInstances
   System::Call 'kernel32::CreateMutex(p 0, i 0, t "${PRODUCT_NAME}") p .r1 ?e'
   Pop $R0
   ; 183 is the Windows error code for ERROR_ALREADY_EXISTS
-  StrCmp $R0 183 0 +3
+  StrCmp $R0 183 0 +4
     MessageBox MB_OK|MB_ICONEXCLAMATION "The installer is already running." /SD IDOK
+    Pop $R0
     Abort
   Pop $R0
 FunctionEnd


### PR DESCRIPTION
By dropping the "A" from ``CreateMutex``, the ``System`` plugin natively maps the call to ``CreateMutexW`` because the installer is running in Unicode mode. It will properly register the string "Tesseract-OCR" in Windows. When the second instance launches, it will hit that exact same string, receive error ``183``, and gracefully abort before corrupting the installation.

<img width="332" height="353" alt="image" src="https://github.com/user-attachments/assets/21840297-ae27-48a2-8aad-f3f42159191f" />
