### PR TITLE
Fix spurious interword spaces in CJK/non-space-delimited text output

### DIFF
--- a/src/ccmain/resultiterator.cpp
+++ b/src/ccmain/resultiterator.cpp
@@ -720,6 +720,43 @@ void ResultIterator::AppendUTF8WordText(std::string *text) const {
   AppendSuffixMarks(text);
 }
 
+// Returns false if the word's first character belongs to a non-space-delimited
+// script (Han, Thai, Hangul, Hiragana, Katakana) or to a Unicode block that
+// contains characters with Script=Common which are used exclusively in CJK
+// contexts (e.g. U+30FC KATAKANA-HIRAGANA PROLONGED SOUND MARK, U+3002
+// IDEOGRAPHIC FULL STOP).  Used to suppress spurious spaces between
+// characters in languages that do not use spaces as word delimiters.
+static bool IsWordSpaceDelimited(const WERD_RES *word) {
+  if (!word || !word->best_choice || word->best_choice->length() == 0 ||
+      !word->uch_set) {
+    return true; // safe default: treat as space-delimited
+  }
+  const UNICHAR_ID uid = word->best_choice->unichar_id(0);
+  // Script-level check: covers Han, Thai, Hangul, Hiragana, Katakana.
+  if (!word->uch_set->IsSpaceDelimited(uid)) {
+    return false;
+  }
+  // Block-level fallback for characters that share Script=Common with Latin
+  // but belong to CJK-specific blocks.  id_to_unichar_ext resolves any
+  // private Tesseract encodings to their canonical Unicode UTF-8 form before
+  // the codepoint check.
+  const char *utf8 = word->uch_set->id_to_unichar_ext(uid);
+  if (utf8 == nullptr || utf8[0] == '\0') {
+    return true;
+  }
+  // All target ranges start at U+3000; single-byte UTF-8 (ASCII, U+0000-U+007F)
+  // can never match, so skip the UNICHAR decode entirely for Latin text.
+  if ((unsigned char)utf8[0] < 0x80) {
+    return true;
+  }
+  const int cp = UNICHAR(utf8, -1).first_uni();
+  return !((cp >= 0x3000 && cp <= 0x303F) || // CJK Symbols and Punctuation
+           (cp >= 0x3040 && cp <= 0x309F) || // Hiragana block (Script=Common marks)
+           (cp >= 0x30A0 && cp <= 0x30FF) || // Katakana block (Script=Common marks)
+           (cp >= 0xFE30 && cp <= 0xFE4F) || // CJK Compatibility Forms
+           (cp >= 0xFF00 && cp <= 0xFF9F));   // Halfwidth and Fullwidth Forms
+}
+
 void ResultIterator::IterateAndAppendUTF8TextlineText(std::string *text) {
   if (Empty(RIL_WORD)) {
     Next(RIL_WORD);
@@ -743,15 +780,26 @@ void ResultIterator::IterateAndAppendUTF8TextlineText(std::string *text) {
   }
 
   int words_appended = 0;
+  bool prev_is_space_delimited = true;
   do {
-    int numSpaces = preserve_interword_spaces_ ? it_->word()->word->space() : (words_appended > 0);
-    for (int i = 0; i < numSpaces; ++i) {
-      *text += " ";
+    const bool curr_is_space_delimited = IsWordSpaceDelimited(it_->word());
+    int num_spaces;
+    if (preserve_interword_spaces_) {
+      num_spaces = it_->word()->word->space();
+    } else if (words_appended > 0 &&
+               !prev_is_space_delimited && !curr_is_space_delimited) {
+      num_spaces = 0;
+    } else {
+      num_spaces = (words_appended > 0) ? 1 : 0;
+    }
+    prev_is_space_delimited = curr_is_space_delimited;
+    for (int i = 0; i < num_spaces; ++i) {
+      *text += ' ';
     }
     AppendUTF8WordText(text);
-    words_appended++;
+    ++words_appended;
     if (BidiDebug(2)) {
-      tprintf("Num spaces=%d, text=%s\n", numSpaces, text->c_str());
+      tprintf("Num spaces=%d, text=%s\n", num_spaces, text->c_str());
     }
   } while (Next(RIL_WORD) && !IsAtBeginningOf(RIL_TEXTLINE));
   if (BidiDebug(1)) {


### PR DESCRIPTION
## Problem

When using `GetUTF8Text()` on CJK (Chinese, Japanese, Korean) or Thai content, Tesseract inserts a space between every recognized word. Since the LSTM engine segments non-space-delimited text into individual characters or short runs as separate `WERD_RES` objects, the output contains a spurious space after each character:

```
Input image: 床前明月光          (Li Bai, 静夜思)
Old output:  床 前 明 月 光
New output:  床前明月光
```

Root cause: `IterateAndAppendUTF8TextlineText()` in `resultiterator.cpp` unconditionally inserted one space between every pair of words (`numSpaces = (words_appended > 0)`), regardless of whether the surrounding scripts use spaces as word delimiters.

## Fix

Add a static helper `IsWordSpaceDelimited()` that returns `false` when a word's first character:

- Belongs to a non-space-delimited script (Han, Hangul, Hiragana, Katakana, Thai) as reported by `unicharset::IsSpaceDelimited()`, **or**
- Falls in a Unicode block where some characters have Script=`Common` but contextually belong to a non-space-delimited writing system:
  - `U+3000–U+303F` CJK Symbols and Punctuation
  - `U+3040–U+309F` Hiragana block (covers `U+3099`/`U+309A` Inherited, `U+309B`/`U+309C` Common)
  - `U+30A0–U+30FF` Katakana block (covers `U+30FC` PROLONGED SOUND MARK, Script=Common)
  - `U+FE30–U+FE4F` CJK Compatibility Forms
  - `U+FF00–U+FF60` Halfwidth and Fullwidth Forms

In `IterateAndAppendUTF8TextlineText()`, a space is suppressed only when **both** the previous and the current word are non-space-delimited. Spaces at script boundaries (CJK↔Latin, CJK↔digits) are intentionally preserved.

The `preserve_interword_spaces` code path is unaffected.

## Performance

`IsWordSpaceDelimited()` is called once per word in the **post-processing / output formatting** phase (`GetUTF8Text`), which runs after recognition is complete. It has no effect on the recognition pipeline.

The function is designed with two fast exits:

1. **Script check** (`unicharset::IsSpaceDelimited`): O(1) array lookup — returns immediately for Han/Hiragana/Katakana/Thai/Hangul without further work.
2. **ASCII fast-path**: if the UTF-8 first byte is `< 0x80`, the character is ASCII (U+0000–U+007F), which is below all checked ranges (≥ U+3000). The `UNICHAR` decode is skipped entirely, keeping Latin/English text at near-zero overhead.

Only characters that pass both of the above checks (i.e., multi-byte UTF-8, Script=Common) reach the full Unicode range comparison.

## Scope

This fix targets `GetUTF8Text()` plain-text output only. hOCR, TSV, and PDF output are handled by separate code paths and are left for follow-up.

## Testing

Both the original and patched binaries were built from the same source tree (v5.5.2) and run against identical input images.

| Script | Input | Before (original) | After (patched) | Result |
|---|---|---|---|---|
| Chinese | `床前明月光` (Li Bai, 静夜思) | `床 前 明 月 光` | `床前明月光` | ✓ spaces removed |
| Japanese hiragana | `はるはあけぼの` (Sei Shōnagon, 枕草子) | `は る は あ け ぼ の` | `はるはあけぼの` | ✓ spaces removed |
| Japanese katakana | `アイスクリーム` (two `ー` U+30FC, Script=Common) | `ア イ ス ク リ ー ム` | `アイスクリーム` | ✓ spaces removed |
| Thai | `สวัสดีครับ` (common greeting) | `ส ว ั ส ด ี ค ร ั บ` | `สวัสดีครับ` | ✓ spaces removed |
| Chinese + Latin (script boundary) | `开源OCR引擎` | `开 源 OCR 引 擎` | `开源 OCR 引擎` | ✓ boundary space preserved |
| English phrase | `optical character recognition` | `optical character recognition` | `optical character recognition` | ✓ unchanged |
| English sentence | `The quick brown fox jumps over the lazy dog` | `The quick brown fox jumps over the lazy dog` | `The quick brown fox jumps over the lazy dog` | ✓ unchanged |