### PR TITLE
Fix XML_CATALOG_FILES cleared on Linux in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -450,8 +450,8 @@ AS_IF([test "$enable_doc" != "no"], [
   # XML_CATALOG_FILES for xsltproc.
   if $have_asciidoc && $have_xsltproc; then
     AM_CONDITIONAL([ASCIIDOC], true)
-    XML_CATALOG_FILES=
     if $have_brew; then
+      XML_CATALOG_FILES=
       catalog_file=$brew_prefix/etc/xml/catalog
       if test -f $catalog_file; then
         AM_CONDITIONAL([HAVE_XML_CATALOG_FILES], true)


### PR DESCRIPTION
## Summary

Moves the `XML_CATALOG_FILES=` assignment inside the `$have_brew` block in `configure.ac` so it only clears the variable on macOS with Homebrew.

## Problem

On Linux, `configure.ac` unconditionally clears `XML_CATALOG_FILES` at line 453, before checking `$have_brew`. This wipes the system XML catalog path (typically `/etc/xml/catalog`), causing `xsltproc` to fail resolving DocBook XSL stylesheets during man page generation. The `SyntaxWarning` and `BrokenPipeError` reported in #4454 stem from this.

The clearing was only needed for macOS/Homebrew, where the variable must be set to `file:$brew_prefix/etc/xml/catalog`. On Linux without Homebrew, the system-provided path should be preserved.

Workaround before this fix: `make XML_CATALOG_FILES=/etc/xml/catalog` (as noted by @denbrice in [#4454 comment](https://github.com/tesseract-ocr/tesseract/issues/4454#issuecomment-4020203255)).

## Changes

`configure.ac`: Moved `XML_CATALOG_FILES=` from before the `if $have_brew` check to inside it.

## Testing

Verified `if`/`fi` balance in the affected block (3/3). The change is a 1-line move with no logic change on the Homebrew path.

Fixes #4454

This contribution was developed with AI assistance (Claude Code).