### PR TITLE
fix: pin 7 unpinned action(s)

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
     - name: Build Fuzzers
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@51fea8a581a325b79f2af174b9f7c04333c283c0 # master
       with:
         oss-fuzz-project-name: 'tesseract-ocr'
         language: c++
         dry-run: false
     - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@51fea8a581a325b79f2af174b9f7c04333c283c0 # master
       with:
         oss-fuzz-project-name: 'tesseract-ocr'
         fuzz-seconds: 600

--- a/.github/workflows/cmake-win64.yml
+++ b/.github/workflows/cmake-win64.yml
@@ -24,8 +24,8 @@ jobs:
     name: cmake-win64
     runs-on: windows-latest
     steps:
-      - uses: ilammy/setup-nasm@v1
-      - uses: microsoft/setup-msbuild@v3
+      - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1
+      - uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: recursive
-    - uses: msys2/setup-msys2@v2
+    - uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2
       with:
         msystem: ${{ matrix.msystem }}
         install: autoconf automake automake-wrapper git libtool make

--- a/.github/workflows/sw.yml
+++ b/.github/workflows/sw.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: recursive
-    - uses: egorpugin/sw-action@master
+    - uses: egorpugin/sw-action@7b42fb19616b8ae0cc327db80ce0c5fb4417eac8 # master
 
     - name: build
       if: github.event_name != 'pull_request' && (matrix.os == 'windows-2022')
@@ -81,7 +81,7 @@ jobs:
 
     - name: Publish Test Report
       if: always() && matrix.os != 'windows-2022'
-      uses: mikepenz/action-junit-report@v6
+      uses: mikepenz/action-junit-report@49b2ca06f62aa7ef83ae6769a2179271e160d8e4 # v6
       with:
         check_name: test (${{ matrix.os }})
         report_paths: .sw/test/results.xml


### PR DESCRIPTION
> This is a re-submission of #4535, which was closed due to a branch issue on my end. Same fixes, apologies for the noise.

## Security: Harden GitHub Actions workflows

Hey, I found some CI/CD security issues in this repo's GitHub Actions workflows. These are the same vulnerability classes that were exploited in the tj-actions/changed-files supply chain attack. I've been reviewing repos that are affected and submitting fixes where I can.

This PR applies mechanical fixes and flags anything else that needs a manual look. Happy to answer any questions.

### Fixes applied

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/cifuzz.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/cmake-win64.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/msys2.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/sw.yml` | Pinned 2 third-party action(s) to commit SHA |


### Additional findings (manual review recommended)

No additional findings beyond the fixes applied above.

### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks or reference unpinned third-party actions are vulnerable to code injection and supply chain attacks. These are the same vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-attack-and-its-impact) which compromised CI secrets across thousands of repositories.

### How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: Pins third-party actions to immutable commit SHAs (original version tag preserved as comment)


---

If this PR is not welcome, just close it and I won't send another.