### PR TITLE
Fix crash when LSTM is missing in disabled-legacy build (#4448)

### DIFF
--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -173,6 +173,9 @@ bool Tesseract::init_tesseract_lang_data(const std::string &arg0,
       ASSERT_HOST(lstm_recognizer_->Load(this->params(), lstm_use_matrix ? language : "", mgr));
     } else {
 #ifdef DISABLED_LEGACY_ENGINE
+      // The legacy engine is compiled out, so we cannot fall back to it.
+      // Returning false here propagates a load failure to init_tesseract,
+      // which logs "Failed loading language '%s'" and skips this language.
       tprintf(
           "Error: LSTM requested, but not present in %s; the legacy "
           "engine is disabled in this build, so there is no fallback.\n",

--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -172,8 +172,16 @@ bool Tesseract::init_tesseract_lang_data(const std::string &arg0,
       lstm_recognizer_ = new LSTMRecognizer(language_data_path_prefix.c_str());
       ASSERT_HOST(lstm_recognizer_->Load(this->params(), lstm_use_matrix ? language : "", mgr));
     } else {
+#ifdef DISABLED_LEGACY_ENGINE
+      tprintf(
+          "Error: LSTM requested, but not present in %s; the legacy "
+          "engine is disabled in this build, so there is no fallback.\n",
+          tessdata_path.c_str());
+      return false;
+#else
       tprintf("Error: LSTM requested, but not present!! Loading tesseract.\n");
       tessedit_ocr_engine_mode.set_value(OEM_TESSERACT_ONLY);
+#endif // DISABLED_LEGACY_ENGINE
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #4448. When tesseract is compiled with `--disable-legacy` and the
user supplies a `.traineddata` file that does not contain an LSTM
component (e.g. the `gsta.traineddata` attached to the issue), tesseract
crashes with a segmentation fault during pass-1 post-processing.

## Root cause

`Tesseract::init_tesseract_lang_data` (`src/ccmain/tessedit.cpp:171–178`)
checks whether an LSTM component is available. If not, it prints
`"Error: LSTM requested, but not present!! Loading tesseract."` and
downgrades `tessedit_ocr_engine_mode` to `OEM_TESSERACT_ONLY`. Under
`DISABLED_LEGACY_ENGINE` the legacy engine code is compiled out, so this
"fallback" never actually loads a recognizer — but the function still
returns `true`. Recognition runs with no engine, every word ends up with
`best_choice == nullptr`, and `recog_all_words` segfaults at
`control.cpp:356` when it dereferences `best_choice->permuter()`.

## Reproduction (from issue #4448)

```
CXXFLAGS='-g -O0 -fno-omit-frame-pointer' ./configure --prefix=$PWD/installed \
    --enable-debug --disable-legacy && make install
TESSDATA_PREFIX=$PWD ./installed/bin/tesseract -l gsta lorem-ipsum.png out.txt
# Segmentation fault
```

The valgrind trace pinpoints the NULL deref at
`tesseract::WERD_CHOICE::permuter() const (ratngs.h:332)` reached from
`recog_all_words (control.cpp:356)`.

## Fix

Inside the existing `else` branch (LSTM unavailable), split behavior by
build mode:

- Under `DISABLED_LEGACY_ENGINE`: emit a clearer error message that
  names the tessdata path, and `return false`. The caller
  (`init_tesseract`) already handles a per-language load failure with
  `"Failed loading language '%s'"`, and if no language loads at all the
  existing `"Tesseract couldn't load any languages!"` path triggers, so
  multi-language inputs (`-l eng+gsta`) degrade gracefully.
- Default build (legacy enabled): the existing fallback to
  `OEM_TESSERACT_ONLY` is unchanged.

The diff is 8 added lines, 0 removed, confined to one TU.

## Relationship to PR #4449

@sebras opened #4449 with a one-line NULL guard at the crash site in
`control.cpp`. This PR addresses the deeper fix that @amitdo described
in the #4448 thread: refuse to claim a successful init when no engine
can run. The two changes are orthogonal — #4449 is defense in depth at
the consumer side, this PR fixes the producer side. Either can land
first; landing both is fine.

## Test plan

- [x] `git diff` review — change is minimal and confined to one
      `#ifdef`-guarded branch.
- [ ] CI: `unittest` (default build) — behavior unchanged in the
      `#ifndef DISABLED_LEGACY_ENGINE` branch; existing tests pass.
- [ ] CI: `unittest-disablelegacy` (autotools, `--disable-legacy`) —
      exercises the new early-return path; existing tests use tessdata
      with LSTM, so they do not trip it.
- [ ] CI: `cmake`, `cifuzz`, `CodeQL`, `Codacy` — single conditional
      return; no new flagged patterns expected.
- [ ] Manual: with the reporter's `gsta.traineddata`, the segfault is
      replaced by a clean error message and a non-zero exit code.
