### PR TITLE
Fix some compiler warnings (-Wunused-parameter)

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -822,7 +822,7 @@ int TessBaseAPI::Recognize(ETEXT_DESC *monitor) {
   } else if (tesseract_->tessedit_ambigs_training) {
     FILE *training_output_file = tesseract_->init_recog_training(input_file_.c_str());
     // OCR the page segmented into words by tesseract.
-    tesseract_->recog_training_segmented(input_file_.c_str(), page_res_, monitor,
+    tesseract_->recog_training_segmented(input_file_.c_str(), page_res_,
                                          training_output_file);
     fclose(training_output_file);
 #endif // ndef DISABLED_LEGACY_ENGINE
@@ -2139,7 +2139,7 @@ int TessBaseAPI::FindLines() {
 
   // If Devanagari is being recognized, we use different images for page seg
   // and for OCR.
-  tesseract_->PrepareForTessOCR(block_list_, osd_tess, &osr);
+  tesseract_->PrepareForTessOCR(block_list_);
   return 0;
 }
 

--- a/src/api/pagerenderer.cpp
+++ b/src/api/pagerenderer.cpp
@@ -705,7 +705,7 @@ char *TessBaseAPI::GetPAGEText(int page_number) {
 /// Make an XML-formatted string with PAGE markup from the internal
 /// data structures.
 ///
-char *TessBaseAPI::GetPAGEText(ETEXT_DESC *monitor, int page_number) {
+char *TessBaseAPI::GetPAGEText(ETEXT_DESC *monitor, int /*page_number*/) {
   if (tesseract_ == nullptr ||
       (page_res_ == nullptr && Recognize(monitor) < 0)) {
     return nullptr;

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -1417,7 +1417,7 @@ void Tesseract::classify_word_pass1(const WordData &word_data, WERD_RES **in_wor
 
 #ifndef DISABLED_LEGACY_ENGINE
   WERD_RES *word = *in_word;
-  match_word_pass_n(1, word, row, block);
+  match_word_pass_n(1, word, row);
   if (!word->tess_failed && !word->word->flag(W_REP_CHAR)) {
     word->tess_would_adapt = AdaptableWord(word);
     bool adapt_ok = word_adaptable(word, tessedit_tess_adaption_mode);
@@ -1506,7 +1506,7 @@ bool Tesseract::TestNewNormalization(int original_misfits, float baseline_shift,
   new_x_ht_word.SetupForRecognition(unicharset, this, BestPix(), tessedit_ocr_engine_mode, nullptr,
                                     classify_bln_numeric_mode, textord_use_cjk_fp_model,
                                     poly_allow_detailed_fx, row, block);
-  match_word_pass_n(2, &new_x_ht_word, row, block);
+  match_word_pass_n(2, &new_x_ht_word, row);
   if (!new_x_ht_word.tess_failed) {
     int new_misfits = CountMisfitTops(&new_x_ht_word);
     if (debug_x_ht_level >= 1) {
@@ -1558,7 +1558,7 @@ void Tesseract::classify_word_pass2(const WordData &word_data, WERD_RES **in_wor
     if (word->x_height == 0.0f) {
       word->x_height = row->x_height();
     }
-    match_word_pass_n(2, word, row, block);
+    match_word_pass_n(2, word, row);
     check_debug_pt(word, 40);
   }
 
@@ -1593,7 +1593,7 @@ void Tesseract::classify_word_pass2(const WordData &word_data, WERD_RES **in_wor
  *
  * Baseline normalize the word and pass it to Tess.
  */
-void Tesseract::match_word_pass_n(int pass_n, WERD_RES *word, ROW *row, BLOCK *block) {
+void Tesseract::match_word_pass_n(int pass_n, WERD_RES *word, ROW *row) {
   if (word->tess_failed) {
     return;
   }
@@ -1616,7 +1616,7 @@ void Tesseract::match_word_pass_n(int pass_n, WERD_RES *word, ROW *row, BLOCK *b
       word->tess_accepted = tess_acceptable_word(word);
 
       // Also sets word->done flag
-      make_reject_map(word, row, pass_n);
+      make_reject_map(word, pass_n);
     }
   }
   set_word_fonts(word);

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -1417,7 +1417,7 @@ void Tesseract::classify_word_pass1(const WordData &word_data, WERD_RES **in_wor
 
 #ifndef DISABLED_LEGACY_ENGINE
   WERD_RES *word = *in_word;
-  match_word_pass_n(1, word, row);
+  match_word_pass_n(1, word);
   if (!word->tess_failed && !word->word->flag(W_REP_CHAR)) {
     word->tess_would_adapt = AdaptableWord(word);
     bool adapt_ok = word_adaptable(word, tessedit_tess_adaption_mode);
@@ -1506,7 +1506,7 @@ bool Tesseract::TestNewNormalization(int original_misfits, float baseline_shift,
   new_x_ht_word.SetupForRecognition(unicharset, this, BestPix(), tessedit_ocr_engine_mode, nullptr,
                                     classify_bln_numeric_mode, textord_use_cjk_fp_model,
                                     poly_allow_detailed_fx, row, block);
-  match_word_pass_n(2, &new_x_ht_word, row);
+  match_word_pass_n(2, &new_x_ht_word);
   if (!new_x_ht_word.tess_failed) {
     int new_misfits = CountMisfitTops(&new_x_ht_word);
     if (debug_x_ht_level >= 1) {
@@ -1558,7 +1558,7 @@ void Tesseract::classify_word_pass2(const WordData &word_data, WERD_RES **in_wor
     if (word->x_height == 0.0f) {
       word->x_height = row->x_height();
     }
-    match_word_pass_n(2, word, row);
+    match_word_pass_n(2, word);
     check_debug_pt(word, 40);
   }
 
@@ -1593,7 +1593,7 @@ void Tesseract::classify_word_pass2(const WordData &word_data, WERD_RES **in_wor
  *
  * Baseline normalize the word and pass it to Tess.
  */
-void Tesseract::match_word_pass_n(int pass_n, WERD_RES *word, ROW *row) {
+void Tesseract::match_word_pass_n(int pass_n, WERD_RES *word) {
   if (word->tess_failed) {
     return;
   }

--- a/src/ccmain/control.cpp
+++ b/src/ccmain/control.cpp
@@ -1540,7 +1540,7 @@ bool Tesseract::TestNewNormalization(int original_misfits, float baseline_shift,
  */
 
 void Tesseract::classify_word_pass2(const WordData &word_data, WERD_RES **in_word,
-                                    PointerVector<WERD_RES> *out_words) {
+                                    PointerVector<WERD_RES> */*out_words*/) {
   // Return if we do not want to run Tesseract.
   if (tessedit_ocr_engine_mode == OEM_LSTM_ONLY) {
     return;

--- a/src/ccmain/osdetect.cpp
+++ b/src/ccmain/osdetect.cpp
@@ -187,7 +187,7 @@ int orientation_and_script_detection(const char *filename, OSResults *osr,
   int height = pixGetHeight(tess->pix_binary());
 
   BLOCK_LIST blocks;
-  if (!read_unlv_file(name, width, height, &blocks)) {
+  if (!read_unlv_file(name, height, &blocks)) {
     FullPageBlock(width, height, &blocks);
   }
 
@@ -312,7 +312,8 @@ int os_detect_blobs(const std::vector<int> *allowed_scripts, BLOBNBOX_CLIST *blo
 // Processes a single blob to estimate script and orientation.
 // Return true if estimate of orientation and script satisfies stopping
 // criteria.
-bool os_detect_blob(BLOBNBOX *bbox, OrientationDetector *o, ScriptDetector *s, OSResults *osr,
+bool os_detect_blob(BLOBNBOX *bbox, OrientationDetector *o,
+                    ScriptDetector *s, OSResults */*osr*/,
                     tesseract::Tesseract *tess) {
   tess->tess_cn_matching.set_value(true); // turn it on
   tess->tess_bn_matching.set_value(false);

--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -223,7 +223,7 @@ int Tesseract::AutoPageSeg(PageSegMode pageseg_mode, BLOCK_LIST *blocks, TO_BLOC
       finder->SetEquationDetect(equ_detect_);
     }
 #endif // ndef DISABLED_LEGACY_ENGINE
-    result = finder->FindBlocks(pageseg_mode, scaled_color_, scaled_factor_, to_block,
+    result = finder->FindBlocks(pageseg_mode, to_block,
                                 photomask_pix, pix_thresholds_, pix_grey_, &pixa_debug_,
                                 &found_blocks, diacritic_blobs, to_blocks);
     if (result >= 0) {

--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -112,7 +112,7 @@ int Tesseract::SegmentPage(const char *input_file, BLOCK_LIST *blocks, Tesseract
     if (lastdot != std::string::npos) {
       name.resize(lastdot);
     }
-    read_unlv_file(name, width, height, blocks);
+    read_unlv_file(name, height, blocks);
   }
   if (blocks->empty()) {
     // No UNLV file present. Work according to the PageSegMode.

--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -278,7 +278,6 @@ ColumnFinder *Tesseract::SetupPageSegAndDetectOrientation(PageSegMode pageseg_mo
   int vertical_y = 1;
   TabVector_LIST v_lines;
   TabVector_LIST h_lines;
-  ICOORD bleft(0, 0);
 
   ASSERT_HOST(pix_binary_ != nullptr);
   if (tessedit_dump_pageseg_images) {

--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -866,7 +866,7 @@ static void CalculateTabStops(std::vector<RowScratchRegisters> *rows, int row_st
 //     We mark a line as short (end of paragraph) if the offside indent
 //     is greater than eop_threshold.
 static void MarkRowsWithModel(std::vector<RowScratchRegisters> *rows, int row_start, int row_end,
-                              const ParagraphModel *model, bool ltr, int eop_threshold) {
+                              const ParagraphModel *model, int eop_threshold) {
   if (!AcceptableRowArgs(0, 0, __func__, rows, row_start, row_end)) {
     return;
   }
@@ -1099,7 +1099,7 @@ static void GeometricClassifyThreeTabStopTextBlock(int debug_level, GeometricCla
     }
   }
   const ParagraphModel *model = theory->AddModel(s.Model());
-  MarkRowsWithModel(s.rows, s.row_start, s.row_end, model, s.ltr, s.eop_threshold);
+  MarkRowsWithModel(s.rows, s.row_start, s.row_end, model, s.eop_threshold);
   return;
 }
 
@@ -1263,7 +1263,7 @@ static void GeometricClassify(int debug_level, std::vector<RowScratchRegisters> 
       }
     }
   }
-  MarkRowsWithModel(rows, row_start, row_end, model, s.ltr, s.eop_threshold);
+  MarkRowsWithModel(rows, row_start, row_end, model, s.eop_threshold);
 }
 
 // =============== Implementation of ParagraphTheory =====================
@@ -1541,7 +1541,7 @@ static void DiscardUnusedModels(const std::vector<RowScratchRegisters> &rows,
 //   Comb backwards through the row scratch registers, and turn any
 //   sequences of body lines of equivalent type abutted against the beginning
 //   or a body or start line of a different type into a crown paragraph.
-static void DowngradeWeakestToCrowns(int debug_level, ParagraphTheory *theory,
+static void DowngradeWeakestToCrowns(ParagraphTheory *theory,
                                      std::vector<RowScratchRegisters> *rows) {
   int start;
   for (int end = rows->size(); end > 0; end = start) {
@@ -2080,8 +2080,7 @@ static void SeparateSimpleLeaderLines(std::vector<RowScratchRegisters> *rows, in
 
 // Collect sequences of unique hypotheses in row registers and create proper
 // paragraphs for them, referencing the paragraphs in row_owners.
-static void ConvertHypothesizedModelRunsToParagraphs(int debug_level,
-                                                     std::vector<RowScratchRegisters> &rows,
+static void ConvertHypothesizedModelRunsToParagraphs(std::vector<RowScratchRegisters> &rows,
                                                      std::vector<PARA *> *row_owners,
                                                      ParagraphTheory *theory) {
   int end = rows.size();
@@ -2377,7 +2376,7 @@ void DetectParagraphs(int debug_level, std::vector<RowInfo> *row_infos,
   }
 
   // Undo any flush models for which there's little evidence.
-  DowngradeWeakestToCrowns(debug_level, &theory, &rows);
+  DowngradeWeakestToCrowns(&theory, &rows);
 
   DebugDump(debug_level > 1, "End of Pass 3", theory, rows);
 
@@ -2393,7 +2392,7 @@ void DetectParagraphs(int debug_level, std::vector<RowInfo> *row_infos,
   DebugDump(debug_level > 1, "End of Pass 4", theory, rows);
 
   // Convert all of the unique hypothesis runs to PARAs.
-  ConvertHypothesizedModelRunsToParagraphs(debug_level, rows, row_owners, &theory);
+  ConvertHypothesizedModelRunsToParagraphs(rows, row_owners, &theory);
 
   DebugDump(debug_level > 0, "Final Paragraph Segmentation", theory, rows);
 

--- a/src/ccmain/pgedit.cpp
+++ b/src/ccmain/pgedit.cpp
@@ -879,7 +879,7 @@ bool Tesseract::word_dumper(PAGE_RES_IT *pr_it) {
     pr_it->block()->block->print(nullptr, false);
   }
   tprintf("\nRow data...\n");
-  pr_it->row()->row->print(nullptr);
+  pr_it->row()->row->print();
   tprintf("\nWord data...\n");
   WERD_RES *word_res = pr_it->word();
   word_res->word->print();

--- a/src/ccmain/recogtraining.cpp
+++ b/src/ccmain/recogtraining.cpp
@@ -84,7 +84,7 @@ static bool read_t(PAGE_RES_IT *page_res_it, TBOX *tbox) {
 // single bounding box from the input box file) it outputs the ocred result,
 // the correct label, rating and certainty.
 void Tesseract::recog_training_segmented(const char *filename, PAGE_RES *page_res,
-                                         volatile ETEXT_DESC *monitor, FILE *output_file) {
+                                         FILE *output_file) {
   std::string box_fname = filename;
   const char *lastdot = strrchr(box_fname.c_str(), '.');
   if (lastdot != nullptr) {

--- a/src/ccmain/reject.cpp
+++ b/src/ccmain/reject.cpp
@@ -93,7 +93,7 @@ void Tesseract::set_done(WERD_RES *word, int16_t pass) {
  *
  * Sets a reject map for the word.
  *************************************************************************/
-void Tesseract::make_reject_map(WERD_RES *word, ROW *row, int16_t pass) {
+void Tesseract::make_reject_map(WERD_RES *word, int16_t pass) {
   flip_0O(word);
   check_debug_pt(word, -1); // For trap only
   set_done(word, pass);     // Set acceptance
@@ -560,7 +560,7 @@ void Tesseract::reject_mostly_rejects(WERD_RES *word) {
   }
 }
 
-bool Tesseract::repeated_nonalphanum_wd(WERD_RES *word, ROW *row) {
+bool Tesseract::repeated_nonalphanum_wd(WERD_RES *word) {
   if (word->best_choice->unichar_lengths().length() <= 1) {
     return false;
   }

--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -283,7 +283,11 @@ void Tesseract::ParseLanguageString(const std::string &lang_str, std::vector<std
 // Initialize for potentially a set of languages defined by the language
 // string and recursively any additional languages required by any language
 // traineddata file (via tessedit_load_sublangs in its config) that is loaded.
-// See init_tesseract_internal for args.
+// arg0 is the datapath for the tessdata directory, which could be the
+// path of the tessdata directory with no trailing /, or (if tessdata
+// lives in the same directory as the executable, the path of the executable,
+// hence the name arg0.
+// See init_tesseract_internal for remaining args.
 int Tesseract::init_tesseract(const std::string &arg0, const std::string &textbase,
                               const std::string &language, OcrEngineMode oem, char **configs,
                               int configs_size, const std::vector<std::string> *vars_vec,
@@ -319,7 +323,7 @@ int Tesseract::init_tesseract(const std::string &arg0, const std::string &textba
         tess_to_init->main_setup(arg0, textbase);
       }
 
-      int result = tess_to_init->init_tesseract_internal(arg0, textbase, lang_str, oem, configs,
+      int result = tess_to_init->init_tesseract_internal(textbase, lang_str, oem, configs,
                                                          configs_size, vars_vec, vars_values,
                                                          set_only_non_debug_params, mgr);
       // Forget that language, but keep any reader we were given.
@@ -376,10 +380,6 @@ int Tesseract::init_tesseract(const std::string &arg0, const std::string &textba
 }
 
 // Common initialization for a single language.
-// arg0 is the datapath for the tessdata directory, which could be the
-// path of the tessdata directory with no trailing /, or (if tessdata
-// lives in the same directory as the executable, the path of the executable,
-// hence the name arg0.
 // textbase is an optional output file basename (used only for training)
 // language is the language code to load.
 // oem controls which engine(s) will operate on the image
@@ -391,7 +391,7 @@ int Tesseract::init_tesseract(const std::string &arg0, const std::string &textba
 // in vars_vec.
 // If set_only_non_debug_params is true, only params that do not contain
 // "debug" in the name will be set.
-int Tesseract::init_tesseract_internal(const std::string &arg0, const std::string &textbase,
+int Tesseract::init_tesseract_internal(const std::string &textbase,
                                        const std::string &language, OcrEngineMode oem,
                                        char **configs, int configs_size,
                                        const std::vector<std::string> *vars_vec,

--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -73,8 +73,7 @@ void Tesseract::read_config_file(const char *filename, SetParamConstraint constr
 // from the language-specific config file (stored in [lang].traineddata), from
 // the config files specified on the command line or left as the default
 // OEM_TESSERACT_ONLY if none of the configs specify this variable.
-bool Tesseract::init_tesseract_lang_data(const std::string &arg0,
-                                         const std::string &language, OcrEngineMode oem,
+bool Tesseract::init_tesseract_lang_data(const std::string &language, OcrEngineMode oem,
                                          char **configs, int configs_size,
                                          const std::vector<std::string> *vars_vec,
                                          const std::vector<std::string> *vars_values,
@@ -398,7 +397,7 @@ int Tesseract::init_tesseract_internal(const std::string &arg0, const std::strin
                                        const std::vector<std::string> *vars_vec,
                                        const std::vector<std::string> *vars_values,
                                        bool set_only_non_debug_params, TessdataManager *mgr) {
-  if (!init_tesseract_lang_data(arg0, language, oem, configs, configs_size, vars_vec,
+  if (!init_tesseract_lang_data(language, oem, configs, configs_size, vars_vec,
                                 vars_values, set_only_non_debug_params, mgr)) {
     return -1;
   }

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -457,8 +457,6 @@ Tesseract::Tesseract()
     , source_resolution_(0)
     , textord_(this)
     , right_to_left_(false)
-    , scaled_color_(nullptr)
-    , scaled_factor_(-1)
     , deskew_(1.0f, 0.0f)
     , reskew_(1.0f, 0.0f)
     , gradient_(0.0f)
@@ -496,12 +494,10 @@ void Tesseract::Clear() {
   pix_binary_.destroy();
   pix_grey_.destroy();
   pix_thresholds_.destroy();
-  scaled_color_.destroy();
   deskew_ = FCOORD(1.0f, 0.0f);
   reskew_ = FCOORD(1.0f, 0.0f);
   gradient_ = 0.0f;
   splitter_.Clear();
-  scaled_factor_ = -1;
   for (auto &sub_lang : sub_langs_) {
     sub_lang->Clear();
   }

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -589,7 +589,7 @@ void Tesseract::PrepareForPageseg() {
 // Note that this method resets pix_binary_ to the original binarized image,
 // which may be different from the image actually used for OCR depending on the
 // value of devanagari_ocr_split_strategy.
-void Tesseract::PrepareForTessOCR(BLOCK_LIST *block_list, Tesseract *osd_tess, OSResults *osr) {
+void Tesseract::PrepareForTessOCR(BLOCK_LIST *block_list) {
   // Find the max splitter strategy over all langs.
   auto max_ocr_strategy = static_cast<ShiroRekhaSplitter::SplitStrategy>(
       static_cast<int32_t>(ocr_devanagari_split_strategy));

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -326,7 +326,7 @@ public:
   // Uses the strategy specified in the global variable
   // ocr_devanagari_split_strategy for performing splitting while preparing for
   // Tesseract ocr.
-  void PrepareForTessOCR(BLOCK_LIST *block_list, Tesseract *osd_tess, OSResults *osr);
+  void PrepareForTessOCR(BLOCK_LIST *block_list);
 
   int SegmentPage(const char *input_file, BLOCK_LIST *blocks, Tesseract *osd_tess, OSResults *osr);
   void SetupWordScripts(BLOCK_LIST *blocks);
@@ -445,8 +445,8 @@ public:
   ACCEPTABLE_WERD_TYPE acceptable_word_string(const UNICHARSET &char_set, const char *s,
                                               const char *lengths);
   ACCEPTABLE_WERD_TYPE check_abbreviation(const UNICHARSET &char_set, const char *s,
-                                           const char *lengths, ACCEPTABLE_WERD_TYPE word_type);
-  void match_word_pass_n(int pass_n, WERD_RES *word, ROW *row, BLOCK *block);
+                                          const char *lengths, ACCEPTABLE_WERD_TYPE word_type);
+  void match_word_pass_n(int pass_n, WERD_RES *word, ROW *row);
   void classify_word_pass2(const WordData &word_data, WERD_RES **in_word,
                            PointerVector<WERD_RES> *out_words);
   void ReportXhtFixResult(bool accept_new_word, float new_x_ht, WERD_RES *word, WERD_RES *new_word);
@@ -534,8 +534,7 @@ public:
   void recognize_page(std::string &image_name);
   void end_tesseract();
 
-  bool init_tesseract_lang_data(const std::string &arg0,
-                                const std::string &language, OcrEngineMode oem, char **configs,
+  bool init_tesseract_lang_data(const std::string &language, OcrEngineMode oem, char **configs,
                                 int configs_size, const std::vector<std::string> *vars_vec,
                                 const std::vector<std::string> *vars_values,
                                 bool set_only_non_debug_params, TessdataManager *mgr);
@@ -567,7 +566,7 @@ public:
   void blob_feature_display(PAGE_RES *page_res, const TBOX &selection_box);
   //// reject.h //////////////////////////////////////////////////////////
   // make rej map for word
-  void make_reject_map(WERD_RES *word, ROW *row, int16_t pass);
+  void make_reject_map(WERD_RES *word, int16_t pass);
   bool one_ell_conflict(WERD_RES *word_res, bool update_map);
   int16_t first_alphanum_index(const char *word, const char *word_lengths);
   int16_t first_alphanum_offset(const char *word, const char *word_lengths);
@@ -579,7 +578,7 @@ public:
   void flip_0O(WERD_RES *word);
   bool non_0_digit(const UNICHARSET &ch_set, UNICHAR_ID unichar_id);
   bool non_O_upper(const UNICHARSET &ch_set, UNICHAR_ID unichar_id);
-  bool repeated_nonalphanum_wd(WERD_RES *word, ROW *row);
+  bool repeated_nonalphanum_wd(WERD_RES *word);
   void nn_match_word( // Match a word
       WERD_RES *word, ROW *row);
   void nn_recover_rejects(WERD_RES *word, ROW *row);
@@ -973,7 +972,7 @@ public:
   //// ambigsrecog.cpp /////////////////////////////////////////////////////////
   FILE *init_recog_training(const char *filename);
   void recog_training_segmented(const char *filename, PAGE_RES *page_res,
-                                volatile ETEXT_DESC *monitor, FILE *output_file);
+                                FILE *output_file);
   void ambigs_classify_and_output(const char *label, PAGE_RES_IT *pr_it, FILE *output_file);
 
 private:

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -446,7 +446,7 @@ public:
                                               const char *lengths);
   ACCEPTABLE_WERD_TYPE check_abbreviation(const UNICHARSET &char_set, const char *s,
                                           const char *lengths, ACCEPTABLE_WERD_TYPE word_type);
-  void match_word_pass_n(int pass_n, WERD_RES *word, ROW *row);
+  void match_word_pass_n(int pass_n, WERD_RES *word);
   void classify_word_pass2(const WordData &word_data, WERD_RES **in_word,
                            PointerVector<WERD_RES> *out_words);
   void ReportXhtFixResult(bool accept_new_word, float new_x_ht, WERD_RES *word, WERD_RES *new_word);
@@ -495,7 +495,11 @@ public:
   // Initialize for potentially a set of languages defined by the language
   // string and recursively any additional languages required by any language
   // traineddata file (via tessedit_load_sublangs in its config) that is loaded.
-  // See init_tesseract_internal for args.
+  // arg0 is the datapath for the tessdata directory, which could be the
+  // path of the tessdata directory with no trailing /, or (if tessdata
+  // lives in the same directory as the executable, the path of the executable,
+  // hence the name arg0.
+  // See init_tesseract_internal for remaining args.
   int init_tesseract(const std::string &arg0, const std::string &textbase,
                      const std::string &language, OcrEngineMode oem, char **configs,
                      int configs_size, const std::vector<std::string> *vars_vec,
@@ -506,10 +510,6 @@ public:
     return init_tesseract(datapath, {}, language, oem, nullptr, 0, nullptr, nullptr, false, &mgr);
   }
   // Common initialization for a single language.
-  // arg0 is the datapath for the tessdata directory, which could be the
-  // path of the tessdata directory with no trailing /, or (if tessdata
-  // lives in the same directory as the executable, the path of the executable,
-  // hence the name arg0.
   // textbase is an optional output file basename (used only for training)
   // language is the language code to load.
   // oem controls which engine(s) will operate on the image
@@ -521,7 +521,7 @@ public:
   // in vars_vec.
   // If set_only_non_debug_params is true, only params that do not contain
   // "debug" in the name will be set.
-  int init_tesseract_internal(const std::string &arg0, const std::string &textbase,
+  int init_tesseract_internal(const std::string &textbase,
                               const std::string &language, OcrEngineMode oem, char **configs,
                               int configs_size, const std::vector<std::string> *vars_vec,
                               const std::vector<std::string> *vars_values,

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -262,16 +262,6 @@ public:
   int ImageHeight() const {
     return pixGetHeight(pix_binary_);
   }
-  Image scaled_color() const {
-    return scaled_color_;
-  }
-  int scaled_factor() const {
-    return scaled_factor_;
-  }
-  void SetScaledColor(int factor, Image color) {
-    scaled_factor_ = factor;
-    scaled_color_ = color;
-  }
   const Textord &textord() const {
     return textord_;
   }
@@ -1003,8 +993,6 @@ private:
   Textord textord_;
   // True if the primary language uses right_to_left reading order.
   bool right_to_left_;
-  Image scaled_color_;
-  int scaled_factor_;
   FCOORD deskew_;
   FCOORD reskew_;
   float gradient_;

--- a/src/ccmain/tfacepp.cpp
+++ b/src/ccmain/tfacepp.cpp
@@ -182,7 +182,6 @@ void Tesseract::split_word(WERD_RES *word, unsigned split_pt, WERD_RES **right_p
   delete word2->chopped_word;
   word2->chopped_word = nullptr;
 
-  const UNICHARSET &unicharset = *word->uch_set;
   word->ClearResults();
   word2->ClearResults();
   word->chopped_word = chopped;

--- a/src/ccmain/tfacepp.cpp
+++ b/src/ccmain/tfacepp.cpp
@@ -187,8 +187,8 @@ void Tesseract::split_word(WERD_RES *word, unsigned split_pt, WERD_RES **right_p
   word2->ClearResults();
   word->chopped_word = chopped;
   word2->chopped_word = chopped2;
-  word->SetupBasicsFromChoppedWord(unicharset);
-  word2->SetupBasicsFromChoppedWord(unicharset);
+  word->SetupBasicsFromChoppedWord();
+  word2->SetupBasicsFromChoppedWord();
 
   // Try to adjust the blamer bundle.
   if (orig_bb != nullptr) {

--- a/src/ccstruct/blamer.cpp
+++ b/src/ccstruct/blamer.cpp
@@ -466,7 +466,7 @@ bool BlamerBundle::GuidedSegsearchNeeded(const WERD_CHOICE *best_choice) const {
 #if !defined(DISABLED_LEGACY_ENGINE)
 // Setup ready to guide the segmentation search to the correct segmentation.
 void BlamerBundle::InitForSegSearch(const WERD_CHOICE *best_choice, MATRIX *ratings,
-                                    UNICHAR_ID wildcard_id, bool debug, std::string &debug_str,
+                                    bool debug, std::string &debug_str,
                                     tesseract::LMPainPoints *pain_points, double max_char_wh_ratio,
                                     WERD_RES *word_res) {
   segsearch_is_looking_for_blame_ = true;
@@ -480,8 +480,7 @@ void BlamerBundle::InitForSegSearch(const WERD_CHOICE *best_choice, MATRIX *rati
     debug_str += "col=" + std::to_string(correct_segmentation_cols_[idx]);
     debug_str += " row=" + std::to_string(correct_segmentation_rows_[idx]);
     debug_str += "\n";
-    if (!ratings->Classified(correct_segmentation_cols_[idx], correct_segmentation_rows_[idx],
-                             wildcard_id) &&
+    if (!ratings->Classified(correct_segmentation_cols_[idx], correct_segmentation_rows_[idx]) &&
         !pain_points->GeneratePainPoint(
             correct_segmentation_cols_[idx], correct_segmentation_rows_[idx],
             tesseract::LM_PPTYPE_BLAMER, 0.0, false, max_char_wh_ratio, word_res)) {

--- a/src/ccstruct/blamer.h
+++ b/src/ccstruct/blamer.h
@@ -273,7 +273,7 @@ struct BlamerBundle {
   // Returns true if a guided segmentation search is needed.
   bool GuidedSegsearchNeeded(const WERD_CHOICE *best_choice) const;
   // Setup ready to guide the segmentation search to the correct segmentation.
-  void InitForSegSearch(const WERD_CHOICE *best_choice, MATRIX *ratings, UNICHAR_ID wildcard_id,
+  void InitForSegSearch(const WERD_CHOICE *best_choice, MATRIX *ratings,
                         bool debug, std::string &debug_str, tesseract::LMPainPoints *pain_points,
                         double max_char_wh_ratio, WERD_RES *word_res);
   // Returns true if the guided segsearch is in progress.

--- a/src/ccstruct/blobbox.cpp
+++ b/src/ccstruct/blobbox.cpp
@@ -117,7 +117,6 @@ void BLOBNBOX::really_merge(BLOBNBOX *other) {
 void BLOBNBOX::chop(       // chop blobs
     BLOBNBOX_IT *start_it, // location of this
     BLOBNBOX_IT *end_it,   // iterator
-    FCOORD rotation,       // for landscape
     float xheight          // of line
 ) {
   int16_t blobcount;          // no of blobs

--- a/src/ccstruct/blobbox.h
+++ b/src/ccstruct/blobbox.h
@@ -198,7 +198,6 @@ public:
   void chop(                 // fake chop blob
       BLOBNBOX_IT *start_it, // location of this
       BLOBNBOX_IT *blob_it,  // iterator
-      FCOORD rotation,       // for landscape
       float xheight);        // line height
 
   void NeighbourGaps(int gaps[BND_COUNT]) const;

--- a/src/ccstruct/blobs.cpp
+++ b/src/ccstruct/blobs.cpp
@@ -1341,7 +1341,7 @@ TWERD *TWERD::PolygonalCopy(bool allow_detailed_fx, WERD *src) {
 // Baseline normalizes the blobs in-place, recording the normalization in the
 // DENORMs in the blobs.
 void TWERD::BLNormalize(const BLOCK *block, const ROW *row, Image pix, bool inverse, float x_height,
-                        float baseline_shift, bool numeric_mode, tesseract::OcrEngineMode hint,
+                        float baseline_shift, bool numeric_mode,
                         const TBOX *norm_box, DENORM *word_denorm) {
   TBOX word_box = bounding_box();
   if (norm_box != nullptr) {

--- a/src/ccstruct/blobs.h
+++ b/src/ccstruct/blobs.h
@@ -436,7 +436,7 @@ struct TWERD {
   // Baseline normalizes the blobs in-place, recording the normalization in the
   // DENORMs in the blobs.
   void BLNormalize(const BLOCK *block, const ROW *row, Image pix, bool inverse, float x_height,
-                   float baseline_shift, bool numeric_mode, tesseract::OcrEngineMode hint,
+                   float baseline_shift, bool numeric_mode,
                    const TBOX *norm_box, DENORM *word_denorm);
   // Copies the data and the blobs, but leaves next untouched.
   void CopyFrom(const TWERD &src);

--- a/src/ccstruct/blread.cpp
+++ b/src/ccstruct/blread.cpp
@@ -35,7 +35,6 @@ namespace tesseract {
 
 bool read_unlv_file(   // print list of sides
     std::string &name, // basename of file
-    int32_t xsize,     // image size
     int32_t ysize,     // image size
     BLOCK_LIST *blocks // output list
 ) {

--- a/src/ccstruct/blread.h
+++ b/src/ccstruct/blread.h
@@ -28,7 +28,6 @@ class BLOCK_LIST;
 
 bool read_unlv_file(   // print list of sides
     std::string &name, // basename of file
-    int32_t xsize,     // image size
     int32_t ysize,     // image size
     BLOCK_LIST *blocks // output list
 );

--- a/src/ccstruct/matrix.cpp
+++ b/src/ccstruct/matrix.cpp
@@ -33,7 +33,7 @@ namespace tesseract {
 MATRIX::~MATRIX() = default;
 
 // Returns true if there are any real classification results.
-bool MATRIX::Classified(int col, int row, int wildcard_id) const {
+bool MATRIX::Classified(int col, int row) const {
   if (get(col, row) == NOT_CLASSIFIED) {
     return false;
   }

--- a/src/ccstruct/matrix.h
+++ b/src/ccstruct/matrix.h
@@ -662,7 +662,7 @@ public:
   ~MATRIX() override;
 
   // Returns true if there are any real classification results.
-  bool Classified(int col, int row, int wildcard_id) const;
+  bool Classified(int col, int row) const;
 
   // Expands the existing matrix in-place to make the band wider, without
   // losing any existing data.

--- a/src/ccstruct/ocrrow.cpp
+++ b/src/ccstruct/ocrrow.cpp
@@ -164,9 +164,7 @@ void ROW::move(      // reposition row
  * Display members
  **********************************************************************/
 
-void ROW::print( // print
-    FILE *fp     // file to print on
-) const {
+void ROW::print() const {
   tprintf("Kerning= %d\n", kerning);
   tprintf("Spacing= %d\n", spacing);
   bound_box.print();

--- a/src/ccstruct/ocrrow.h
+++ b/src/ccstruct/ocrrow.h
@@ -126,8 +126,7 @@ public:
   void move(             // reposition row
       const ICOORD vec); // by vector
 
-  void print(    // print
-      FILE *fp) const; // file to print on
+  void print() const; // print
 
 #ifndef GRAPHICS_DISABLED
   void plot(                     // draw one

--- a/src/ccstruct/pageres.cpp
+++ b/src/ccstruct/pageres.cpp
@@ -329,9 +329,9 @@ bool WERD_RES::SetupForRecognition(const UNICHARSET &unicharset_in,
           : x_height;
   chopped_word->BLNormalize(block, row, pix, word->flag(W_INVERSE),
                             word_xheight, baseline_shift, numeric_mode,
-                            norm_mode_hint, norm_box, &denorm);
+                            norm_box, &denorm);
   blob_row = row;
-  SetupBasicsFromChoppedWord(unicharset_in);
+  SetupBasicsFromChoppedWord();
   SetupBlamerBundle();
   int num_blobs = chopped_word->NumBlobs();
   ratings = new MATRIX(num_blobs, kWordrecMaxNumJoinChunks);
@@ -342,7 +342,7 @@ bool WERD_RES::SetupForRecognition(const UNICHARSET &unicharset_in,
 // Set up the seam array, bln_boxes, best_choice, and raw_choice to empty
 // accumulators from a made chopped word.  We presume the fields are already
 // empty.
-void WERD_RES::SetupBasicsFromChoppedWord(const UNICHARSET &unicharset_in) {
+void WERD_RES::SetupBasicsFromChoppedWord() {
   bln_boxes = tesseract::BoxWord::CopyFromNormalized(chopped_word);
   start_seam_list(chopped_word, &seam_array);
   SetupBlobWidthsAndGaps();

--- a/src/ccstruct/pageres.h
+++ b/src/ccstruct/pageres.h
@@ -478,7 +478,7 @@ public:
   // Set up the seam array, bln_boxes, best_choice, and raw_choice to empty
   // accumulators from a made chopped word.  We presume the fields are already
   // empty.
-  void SetupBasicsFromChoppedWord(const UNICHARSET &unicharset_in);
+  void SetupBasicsFromChoppedWord();
 
   // Sets up the members used in recognition for an empty recognition result:
   // bln_boxes, chopped_word, seam_array, denorm, best_choice, raw_choice.

--- a/src/ccutil/unichar.cpp
+++ b/src/ccutil/unichar.cpp
@@ -206,7 +206,7 @@ bool UNICHAR::const_iterator::is_legal() const {
   return utf8_step(it_) > 0;
 }
 
-UNICHAR::const_iterator UNICHAR::begin(const char *utf8_str, int len) {
+UNICHAR::const_iterator UNICHAR::begin(const char *utf8_str, int /*len*/) {
   return UNICHAR::const_iterator(utf8_str);
 }
 

--- a/src/classify/adaptive.cpp
+++ b/src/classify/adaptive.cpp
@@ -45,7 +45,7 @@ void AddAdaptedClass(ADAPT_TEMPLATES_STRUCT *Templates, ADAPT_CLASS_STRUCT *Clas
   assert(UnusedClassIdIn(Templates->Templates, ClassId));
   assert(Class->NumPermConfigs == 0);
 
-  auto IntClass = new INT_CLASS_STRUCT(1, 1);
+  auto IntClass = new INT_CLASS_STRUCT(1);
   AddIntClass(Templates->Templates, ClassId, IntClass);
 
   assert(Templates->Class[ClassId] == nullptr);

--- a/src/classify/adaptmatch.cpp
+++ b/src/classify/adaptmatch.cpp
@@ -1036,7 +1036,7 @@ void Classify::AddNewResult(const UnicharRating &new_result, ADAPT_RESULTS *resu
  */
 void Classify::AmbigClassifier(const std::vector<INT_FEATURE_STRUCT> &int_features,
                                const INT_FX_RESULT_STRUCT &fx_info, const TBLOB *blob,
-                               INT_TEMPLATES_STRUCT *templates, ADAPT_CLASS_STRUCT **classes,
+                               INT_TEMPLATES_STRUCT *templates,
                                UNICHAR_ID *ambiguities, ADAPT_RESULTS *results) {
   if (int_features.empty()) {
     return;
@@ -1499,7 +1499,7 @@ void Classify::DoAdaptiveMatch(TBLOB *Blob, ADAPT_RESULTS *Results) {
         Results->match.empty()) {
       CharNormClassifier(Blob, *sample, Results);
     } else if (Ambiguities && *Ambiguities >= 0 && !tess_bn_matching) {
-      AmbigClassifier(bl_features, fx_info, Blob, PreTrainedTemplates, AdaptedTemplates->Class,
+      AmbigClassifier(bl_features, fx_info, Blob, PreTrainedTemplates,
                       Ambiguities, Results);
     }
   }

--- a/src/classify/blobclass.cpp
+++ b/src/classify/blobclass.cpp
@@ -83,7 +83,7 @@ void Classify::LearnBlob(const std::string &fontname, TBLOB *blob, const DENORM 
   CharDesc->FeatureSets[2] = ExtractIntCNFeatures(*blob, fx_info);
   CharDesc->FeatureSets[3] = ExtractIntGeoFeatures(*blob, fx_info);
 
-  if (ValidCharDescription(feature_defs_, CharDesc.get())) {
+  if (ValidCharDescription(CharDesc.get())) {
     // Label the features with a class name and font name.
     tr_file_data_ += "\n";
     tr_file_data_ += fontname;

--- a/src/classify/classify.h
+++ b/src/classify/classify.h
@@ -169,7 +169,7 @@ public:
                         ADAPT_TEMPLATES_STRUCT *Templates);
   void AmbigClassifier(const std::vector<INT_FEATURE_STRUCT> &int_features,
                        const INT_FX_RESULT_STRUCT &fx_info, const TBLOB *blob,
-                       INT_TEMPLATES_STRUCT *templates, ADAPT_CLASS_STRUCT **classes, UNICHAR_ID *ambiguities,
+                       INT_TEMPLATES_STRUCT *templates, UNICHAR_ID *ambiguities,
                        ADAPT_RESULTS *results);
   void MasterMatcher(INT_TEMPLATES_STRUCT *templates, int16_t num_features,
                      const INT_FEATURE_STRUCT *features, const uint8_t *norm_factors,

--- a/src/classify/cluster.cpp
+++ b/src/classify/cluster.cpp
@@ -1392,7 +1392,7 @@ static PROTOTYPE *NewEllipticalProto(int16_t N, CLUSTER *Cluster, STATISTICS *St
 
 static PROTOTYPE *NewMixedProto(int16_t N, CLUSTER *Cluster, STATISTICS *Statistics);
 
-static PROTOTYPE *NewSimpleProto(int16_t N, CLUSTER *Cluster);
+static PROTOTYPE *NewSimpleProto(CLUSTER *Cluster);
 
 static bool Independent(PARAM_DESC *ParamDesc, int16_t N, float *CoVariance, float Independence);
 
@@ -1814,7 +1814,7 @@ static CLUSTER *FindNearestNeighbor(KDTREE *Tree, CLUSTER *Cluster, float *Dista
   CLUSTER *BestNeighbor;
 
   // find the 2 nearest neighbors of the cluster
-  KDNearestNeighborSearch(Tree, &Cluster->Mean[0], MAXNEIGHBORS, MAXDISTANCE, &NumberOfNeighbors,
+  KDNearestNeighborSearch(Tree, &Cluster->Mean[0], MAXNEIGHBORS, &NumberOfNeighbors,
                           reinterpret_cast<void **>(Neighbor), Dist);
 
   // search for the nearest neighbor that is not the cluster itself
@@ -2449,7 +2449,7 @@ static STATISTICS *ComputeStatistics(int16_t N, PARAM_DESC ParamDesc[], CLUSTER 
 static PROTOTYPE *NewSphericalProto(uint16_t N, CLUSTER *Cluster, STATISTICS *Statistics) {
   PROTOTYPE *Proto;
 
-  Proto = NewSimpleProto(N, Cluster);
+  Proto = NewSimpleProto(Cluster);
 
   Proto->Variance.Spherical = Statistics->AvgVariance;
   if (Proto->Variance.Spherical < MINVARIANCE) {
@@ -2479,7 +2479,7 @@ static PROTOTYPE *NewEllipticalProto(int16_t N, CLUSTER *Cluster, STATISTICS *St
   PROTOTYPE *Proto;
   int i;
 
-  Proto = NewSimpleProto(N, Cluster);
+  Proto = NewSimpleProto(Cluster);
   Proto->Variance.Elliptical = new float[N];
   Proto->Magnitude.Elliptical = new float[N];
   Proto->Weight.Elliptical = new float[N];
@@ -2526,11 +2526,10 @@ static PROTOTYPE *NewMixedProto(int16_t N, CLUSTER *Cluster, STATISTICS *Statist
  * This routine allocates memory to hold a simple prototype
  * data structure, i.e. one without independent distributions
  * and variances for each dimension.
- * @param N number of dimensions
  * @param Cluster cluster to be made into a prototype
  * @return  Pointer to new simple prototype
  */
-static PROTOTYPE *NewSimpleProto(int16_t N, CLUSTER *Cluster) {
+static PROTOTYPE *NewSimpleProto(CLUSTER *Cluster) {
   auto Proto = new PROTOTYPE;
   Proto->Mean = Cluster->Mean;
   Proto->Distrib.clear();

--- a/src/classify/featdefs.cpp
+++ b/src/classify/featdefs.cpp
@@ -128,7 +128,7 @@ void WriteCharDescription(const FEATURE_DEFS_STRUCT &FeatureDefs, CHAR_DESC_STRU
 
 // Return whether all of the fields of the given feature set
 // are well defined (not inf or nan).
-bool ValidCharDescription(const FEATURE_DEFS_STRUCT &FeatureDefs, CHAR_DESC_STRUCT *CharDesc) {
+bool ValidCharDescription(CHAR_DESC_STRUCT *CharDesc) {
   bool anything_written = false;
   bool well_formed = true;
   for (size_t Type = 0; Type < CharDesc->NumFeatureSets; Type++) {

--- a/src/classify/featdefs.h
+++ b/src/classify/featdefs.h
@@ -69,7 +69,7 @@ struct CHAR_DESC_STRUCT {
 TESS_API
 void InitFeatureDefs(FEATURE_DEFS_STRUCT *featuredefs);
 
-bool ValidCharDescription(const FEATURE_DEFS_STRUCT &FeatureDefs, CHAR_DESC_STRUCT *CharDesc);
+bool ValidCharDescription(CHAR_DESC_STRUCT *CharDesc);
 
 void WriteCharDescription(const FEATURE_DEFS_STRUCT &FeatureDefs, CHAR_DESC_STRUCT *CharDesc, std::string &str);
 

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -506,7 +506,7 @@ INT_TEMPLATES_STRUCT *Classify::CreateIntTemplates(CLASSES FloatProtos,
               target_unicharset.id_to_unichar(ClassId));
     }
     assert(UnusedClassIdIn(IntTemplates, ClassId));
-    IClass = new INT_CLASS_STRUCT(FClass->NumProtos, FClass->NumConfigs);
+    IClass = new INT_CLASS_STRUCT(FClass->NumProtos);
     unsigned fs_size = FClass->font_set.size();
     FontSet fs;
     fs.reserve(fs_size);
@@ -574,13 +574,12 @@ void DisplayIntProto(INT_CLASS_STRUCT *Class, PROTO_ID ProtoId, float Evidence) 
 /// to handle the specified number of protos and configs.
 /// @param MaxNumProtos  number of protos to allocate space for
 /// @param MaxNumConfigs number of configs to allocate space for
-INT_CLASS_STRUCT::INT_CLASS_STRUCT(int MaxNumProtos, int MaxNumConfigs) :
+INT_CLASS_STRUCT::INT_CLASS_STRUCT(int MaxNumProtos) :
   NumProtos(0),
   NumProtoSets((MaxNumProtos + PROTOS_PER_PROTO_SET - 1) / PROTOS_PER_PROTO_SET),
   NumConfigs(0),
   ProtoLengths(MaxNumIntProtosIn(this))
 {
-  assert(MaxNumConfigs <= MAX_NUM_CONFIGS);
   assert(NumProtoSets <= MAX_NUM_PROTO_SETS);
 
   for (int i = 0; i < NumProtoSets; i++) {
@@ -827,7 +826,7 @@ INT_TEMPLATES_STRUCT *Classify::ReadIntTemplates(TFile *fp) {
   if (version_id < 2) {
     /* add an empty nullptr class with class id 0 */
     assert(UnusedClassIdIn(Templates, 0));
-    ClassForClassId(Templates, 0) = new INT_CLASS_STRUCT(1, 1);
+    ClassForClassId(Templates, 0) = new INT_CLASS_STRUCT(1);
     ClassForClassId(Templates, 0)->font_set_id = -1;
     Templates->NumClasses++;
     /* make sure the classes are contiguous */

--- a/src/classify/intproto.h
+++ b/src/classify/intproto.h
@@ -94,7 +94,7 @@ typedef uint32_t CONFIG_PRUNER[NUM_PP_PARAMS][NUM_PP_BUCKETS][4];
 
 struct INT_CLASS_STRUCT {
   INT_CLASS_STRUCT() = default;
-  INT_CLASS_STRUCT(int MaxNumProtos, int MaxNumConfigs);
+  INT_CLASS_STRUCT(int MaxNumProtos);
   ~INT_CLASS_STRUCT();
   uint16_t NumProtos = 0;
   uint8_t NumProtoSets = 0;

--- a/src/classify/kdtree.cpp
+++ b/src/classify/kdtree.cpp
@@ -296,13 +296,12 @@ void KDDelete(KDTREE *Tree, float Key[], void *Data) {
  * @param Tree    ptr to K-D tree to be searched
  * @param Query    ptr to query key (point in D-space)
  * @param QuerySize  number of nearest neighbors to be found
- * @param MaxDistance  all neighbors must be within this distance
  * @param NBuffer ptr to QuerySize buffer to hold nearest neighbors
  * @param DBuffer ptr to QuerySize buffer to hold distances
  *          from nearest neighbor to query point
  * @param NumberOfResults [out] Number of nearest neighbors actually found
  */
-void KDNearestNeighborSearch(KDTREE *Tree, float Query[], int QuerySize, float MaxDistance,
+void KDNearestNeighborSearch(KDTREE *Tree, float Query[], int QuerySize,
                              int *NumberOfResults, void **NBuffer, float DBuffer[]) {
   KDTreeSearch search(Tree, Query, QuerySize);
   search.Search(NumberOfResults, DBuffer, NBuffer);

--- a/src/classify/kdtree.h
+++ b/src/classify/kdtree.h
@@ -106,7 +106,7 @@ void KDStore(KDTREE *Tree, float *Key, CLUSTER *Data);
 
 void KDDelete(KDTREE *Tree, float Key[], void *Data);
 
-void KDNearestNeighborSearch(KDTREE *Tree, float Query[], int QuerySize, float MaxDistance,
+void KDNearestNeighborSearch(KDTREE *Tree, float Query[], int QuerySize,
                              int *NumberOfResults, void **NBuffer, float DBuffer[]);
 
 void KDWalk(KDTREE *Tree, kdwalk_proc Action, ClusteringContext *context);

--- a/src/classify/mfoutline.cpp
+++ b/src/classify/mfoutline.cpp
@@ -29,11 +29,31 @@
 namespace tesseract {
 
 /*---------------------------------------------------------------------------*/
+/**
+ * Convert a tree of outlines to a list of MFOUTLINEs (lists of MFEDGEPTs).
+ *
+ * @param outline      first outline to be converted
+ * @param mf_outlines  list to add converted outlines to
+ */
+static LIST ConvertOutlines(TESSLINE *outline, LIST mf_outlines) {
+  MFOUTLINE mf_outline;
+
+  while (outline != nullptr) {
+    mf_outline = ConvertOutline(outline);
+    if (mf_outline != nullptr) {
+      mf_outlines = push(mf_outlines, mf_outline);
+    }
+    outline = outline->next;
+  }
+  return mf_outlines;
+}
+
+/*---------------------------------------------------------------------------*/
 /** Convert a blob into a list of MFOUTLINEs (float-based microfeature format).
  */
 LIST ConvertBlob(TBLOB *blob) {
   LIST outlines = NIL_LIST;
-  return (blob == nullptr) ? NIL_LIST : ConvertOutlines(blob->outlines, outlines, OUTLINETYPE::outer);
+  return (blob == nullptr) ? NIL_LIST : ConvertOutlines(blob->outlines, outlines);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -66,27 +86,6 @@ MFOUTLINE ConvertOutline(TESSLINE *outline) {
     MakeOutlineCircular(MFOutline);
   }
   return MFOutline;
-}
-
-/*---------------------------------------------------------------------------*/
-/**
- * Convert a tree of outlines to a list of MFOUTLINEs (lists of MFEDGEPTs).
- *
- * @param outline      first outline to be converted
- * @param mf_outlines  list to add converted outlines to
- * @param outline_type  are the outlines outer or holes?
- */
-LIST ConvertOutlines(TESSLINE *outline, LIST mf_outlines, OUTLINETYPE outline_type) {
-  MFOUTLINE mf_outline;
-
-  while (outline != nullptr) {
-    mf_outline = ConvertOutline(outline);
-    if (mf_outline != nullptr) {
-      mf_outlines = push(mf_outlines, mf_outline);
-    }
-    outline = outline->next;
-  }
-  return mf_outlines;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/classify/mfoutline.h
+++ b/src/classify/mfoutline.h
@@ -48,8 +48,6 @@ struct MFEDGEPT {
   DIRECTION PreviousDirection;
 };
 
-enum class OUTLINETYPE { outer, hole };
-
 enum NORM_METHOD { baseline, character };
 
 /**----------------------------------------------------------------------------
@@ -89,8 +87,6 @@ void ComputeBlobCenter(TBLOB *Blob, TPOINT *BlobCenter);
 LIST ConvertBlob(TBLOB *Blob);
 
 MFOUTLINE ConvertOutline(TESSLINE *Outline);
-
-LIST ConvertOutlines(TESSLINE *Outline, LIST ConvertedOutlines, OUTLINETYPE OutlineType);
 
 void FilterEdgeNoise(MFOUTLINE Outline, float NoiseSegmentLength);
 

--- a/src/classify/shapeclassifier.cpp
+++ b/src/classify/shapeclassifier.cpp
@@ -55,8 +55,10 @@ int ShapeClassifier::UnicharClassifySample(const TrainingSample &sample, Image p
 // Classifies the given [training] sample, writing to results.
 // See shapeclassifier.h for a full description.
 // Default implementation aborts.
-int ShapeClassifier::ClassifySample(const TrainingSample &sample, Image page_pix, int debug,
-                                    int keep_this, std::vector<ShapeRating> *results) {
+int ShapeClassifier::ClassifySample(const TrainingSample &/*sample*/,
+                                    Image /*page_pix*/, int /*debug*/,
+                                    int /*keep_this*/,
+                                    std::vector<ShapeRating> */*results*/) {
   ASSERT_HOST("Must implement ClassifySample!" == nullptr);
   return 0;
 }
@@ -121,7 +123,7 @@ void ShapeClassifier::DebugDisplay(const TrainingSample &sample, Image page_pix,
     if (unichar_id >= 0) {
       tprintf("Debugging class %d = %s\n", unichar_id, unicharset.id_to_unichar(unichar_id));
       UnicharClassifySample(sample, page_pix, 1, unichar_id, &results);
-      DisplayClassifyAs(sample, page_pix, unichar_id, 1, windows);
+      DisplayClassifyAs(sample, page_pix, unichar_id, 1);
     } else {
       tprintf("Invalid unichar_id: %d\n", unichar_id);
       UnicharClassifySample(sample, page_pix, 1, -1, &results);
@@ -158,9 +160,9 @@ void ShapeClassifier::DebugDisplay(const TrainingSample &sample, Image page_pix,
 // windows to the windows output and returns a new index that may be used
 // by any subsequent classifiers. Caller waits for the user to view and
 // then destroys the windows by clearing the vector.
-int ShapeClassifier::DisplayClassifyAs(const TrainingSample &sample, Image page_pix,
-                                       UNICHAR_ID unichar_id, int index,
-                                       std::vector<ScrollView *> &windows) {
+int ShapeClassifier::DisplayClassifyAs(const TrainingSample &/*sample*/,
+                                       Image /*page_pix*/,
+                                       UNICHAR_ID /*unichar_id*/, int index) {
   // Does nothing in the default implementation.
   return index;
 }

--- a/src/classify/shapeclassifier.h
+++ b/src/classify/shapeclassifier.h
@@ -99,7 +99,7 @@ public:
   // by any subsequent classifiers. Caller waits for the user to view and
   // then destroys the windows by clearing the vector.
   virtual int DisplayClassifyAs(const TrainingSample &sample, Image page_pix, UNICHAR_ID unichar_id,
-                                int index, std::vector<ScrollView *> &windows);
+                                int index);
 
   // Prints debug information on the results. context is some introductory/title
   // message.

--- a/src/classify/tessclassifier.cpp
+++ b/src/classify/tessclassifier.cpp
@@ -25,7 +25,7 @@ namespace tesseract {
 
 // Classifies the given [training] sample, writing to results.
 // See ShapeClassifier for a full description.
-int TessClassifier::UnicharClassifySample(const TrainingSample &sample, Image page_pix, int debug,
+int TessClassifier::UnicharClassifySample(const TrainingSample &sample, Image /*page_pix*/, int debug,
                                           UNICHAR_ID keep_this,
                                           std::vector<UnicharRating> *results) {
   const int old_matcher_level = classify_->matcher_debug_level;
@@ -62,8 +62,8 @@ const UNICHARSET &TessClassifier::GetUnicharset() const {
 // windows to the windows output and returns a new index that may be used
 // by any subsequent classifiers. Caller waits for the user to view and
 // then destroys the windows by clearing the vector.
-int TessClassifier::DisplayClassifyAs(const TrainingSample &sample, Image page_pix, int unichar_id,
-                                      int index, std::vector<ScrollView *> &windows) {
+int TessClassifier::DisplayClassifyAs(const TrainingSample &sample, Image /*page_pix*/,
+                                      int unichar_id, int index) {
   int shape_id = unichar_id;
   // TODO(rays) Fix this so it works with both flat and real shapetables.
   //  if (GetShapeTable() != nullptr)

--- a/src/classify/tessclassifier.h
+++ b/src/classify/tessclassifier.h
@@ -53,8 +53,8 @@ public:
   // windows to the windows output and returns a new index that may be used
   // by any subsequent classifiers. Caller waits for the user to view and
   // then destroys the windows by clearing the vector.
-  int DisplayClassifyAs(const TrainingSample &sample, Image page_pix, int unichar_id, int index,
-                        std::vector<ScrollView *> &windows) override;
+  int DisplayClassifyAs(const TrainingSample &sample, Image page_pix,
+                        int unichar_id, int index) override;
 
 private:
   // Indicates that this classifier is to use just the ClassPruner, or the

--- a/src/lstm/convolve.cpp
+++ b/src/lstm/convolve.cpp
@@ -52,8 +52,9 @@ bool Convolve::DeSerialize(TFile *fp) {
 
 // Runs forward propagation of activations on the input line.
 // See NetworkCpp for a detailed discussion of the arguments.
-void Convolve::Forward(bool debug, const NetworkIO &input, const TransposedArray *input_transpose,
-                       NetworkScratch *scratch, NetworkIO *output) {
+void Convolve::Forward(bool debug, const NetworkIO &input,
+                       const TransposedArray * /*input_transpose*/,
+                       NetworkScratch * /*scratch*/, NetworkIO *output) {
   output->Resize(input, no_);
   int y_scale = 2 * half_y_ + 1;
   StrideMap::Index dest_index(output->stride_map());
@@ -89,7 +90,7 @@ void Convolve::Forward(bool debug, const NetworkIO &input, const TransposedArray
 
 // Runs backward propagation of errors on the deltas line.
 // See NetworkCpp for a detailed discussion of the arguments.
-bool Convolve::Backward(bool debug, const NetworkIO &fwd_deltas, NetworkScratch *scratch,
+bool Convolve::Backward(bool /*debug*/, const NetworkIO &fwd_deltas, NetworkScratch *scratch,
                         NetworkIO *back_deltas) {
   back_deltas->Resize(fwd_deltas, ni_);
   NetworkScratch::IO delta_sum;

--- a/src/lstm/fullyconnected.cpp
+++ b/src/lstm/fullyconnected.cpp
@@ -200,7 +200,7 @@ void FullyConnected::SetupForward(const NetworkIO &input, const TransposedArray 
   }
 }
 
-void FullyConnected::ForwardTimeStep(int t, TFloat *output_line) {
+void FullyConnected::ForwardTimeStep(TFloat *output_line) {
   if (type_ == NT_TANH) {
     FuncInplace<GFunc>(no_, output_line);
   } else if (type_ == NT_LOGISTIC) {
@@ -224,13 +224,13 @@ void FullyConnected::ForwardTimeStep(const TFloat *d_input, int t, TFloat *outpu
     source_t_.WriteStrided(t, d_input);
   }
   weights_.MatrixDotVector(d_input, output_line);
-  ForwardTimeStep(t, output_line);
+  ForwardTimeStep(output_line);
 }
 
 void FullyConnected::ForwardTimeStep(const int8_t *i_input, int t, TFloat *output_line) {
   // input is copied to source_ line-by-line for cache coherency.
   weights_.MatrixDotVector(i_input, output_line);
-  ForwardTimeStep(t, output_line);
+  ForwardTimeStep(output_line);
 }
 
 // Runs backward propagation of errors on the deltas line.

--- a/src/lstm/fullyconnected.cpp
+++ b/src/lstm/fullyconnected.cpp
@@ -158,7 +158,7 @@ void FullyConnected::Forward(bool debug, const NetworkIO &input,
 #endif
     TFloat *temp_line = temp_lines[thread_id];
     if (input.int_mode()) {
-      ForwardTimeStep(input.i(t), t, temp_line);
+      ForwardTimeStep(input.i(t), temp_line);
     } else {
       input.ReadTimeStep(t, curr_input[thread_id]);
       ForwardTimeStep(curr_input[thread_id], t, temp_line);
@@ -227,7 +227,7 @@ void FullyConnected::ForwardTimeStep(const TFloat *d_input, int t, TFloat *outpu
   ForwardTimeStep(output_line);
 }
 
-void FullyConnected::ForwardTimeStep(const int8_t *i_input, int t, TFloat *output_line) {
+void FullyConnected::ForwardTimeStep(const int8_t *i_input, TFloat *output_line) {
   // input is copied to source_ line-by-line for cache coherency.
   weights_.MatrixDotVector(i_input, output_line);
   ForwardTimeStep(output_line);

--- a/src/lstm/fullyconnected.h
+++ b/src/lstm/fullyconnected.h
@@ -93,7 +93,7 @@ public:
   void SetupForward(const NetworkIO &input, const TransposedArray *input_transpose);
   void ForwardTimeStep(TFloat *output_line);
   void ForwardTimeStep(const TFloat *d_input, int t, TFloat *output_line);
-  void ForwardTimeStep(const int8_t *i_input, int t, TFloat *output_line);
+  void ForwardTimeStep(const int8_t *i_input, TFloat *output_line);
 
   // Runs backward propagation of errors on the deltas line.
   // See Network for a detailed discussion of the arguments.

--- a/src/lstm/fullyconnected.h
+++ b/src/lstm/fullyconnected.h
@@ -91,7 +91,7 @@ public:
                NetworkScratch *scratch, NetworkIO *output) override;
   // Components of Forward so FullyConnected can be reused inside LSTM.
   void SetupForward(const NetworkIO &input, const TransposedArray *input_transpose);
-  void ForwardTimeStep(int t, TFloat *output_line);
+  void ForwardTimeStep(TFloat *output_line);
   void ForwardTimeStep(const TFloat *d_input, int t, TFloat *output_line);
   void ForwardTimeStep(const int8_t *i_input, int t, TFloat *output_line);
 

--- a/src/lstm/input.cpp
+++ b/src/lstm/input.cpp
@@ -61,15 +61,16 @@ void Input::CacheXScaleFactor(int factor) {
 
 // Runs forward propagation of activations on the input line.
 // See Network for a detailed discussion of the arguments.
-void Input::Forward(bool debug, const NetworkIO &input, const TransposedArray *input_transpose,
-                    NetworkScratch *scratch, NetworkIO *output) {
+void Input::Forward(bool /*debug*/, const NetworkIO &input,
+                    const TransposedArray * /*input_transpose*/,
+                    NetworkScratch * /*scratch*/, NetworkIO *output) {
   *output = input;
 }
 
 // Runs backward propagation of errors on the deltas line.
 // See NetworkCpp for a detailed discussion of the arguments.
-bool Input::Backward(bool debug, const NetworkIO &fwd_deltas, NetworkScratch *scratch,
-                     NetworkIO *back_deltas) {
+bool Input::Backward(bool /*debug*/, const NetworkIO & /*fwd_deltas*/,
+                     NetworkScratch * /*scratch*/, NetworkIO * /*back_deltas*/) {
   tprintf("Input::Backward should not be called!!\n");
   return false;
 }

--- a/src/lstm/input.cpp
+++ b/src/lstm/input.cpp
@@ -79,7 +79,7 @@ bool Input::Backward(bool debug, const NetworkIO &fwd_deltas, NetworkScratch *sc
 // Returns nullptr on error.
 /* static */
 Image Input::PrepareLSTMInputs(const ImageData &image_data, const Network *network, int min_width,
-                              TRand *randomizer, float *image_scale) {
+                               float *image_scale) {
   // Note that NumInputs() is defined as input image height.
   int target_height = network->NumInputs();
   int width, height;

--- a/src/lstm/input.h
+++ b/src/lstm/input.h
@@ -83,7 +83,7 @@ public:
   /* static */
   static Image PrepareLSTMInputs(const ImageData &image_data,
                                  const Network *network, int min_width,
-                                 TRand *randomizer, float *image_scale);
+                                 float *image_scale);
   // Converts the given pix to a NetworkIO of height and depth appropriate to
   // the given StaticShape:
   // If depth == 3, convert to 24 bit color, otherwise normalized grey.

--- a/src/lstm/lstm.cpp
+++ b/src/lstm/lstm.cpp
@@ -288,7 +288,8 @@ bool LSTM::DeSerialize(TFile *fp) {
 
 // Runs forward propagation of activations on the input line.
 // See NetworkCpp for a detailed discussion of the arguments.
-void LSTM::Forward(bool debug, const NetworkIO &input, const TransposedArray *input_transpose,
+void LSTM::Forward(bool debug, const NetworkIO &input,
+                   const TransposedArray * /*input_transpose*/,
                    NetworkScratch *scratch, NetworkIO *output) {
   input_map_ = input.stride_map();
   input_width_ = input.Width();
@@ -458,7 +459,7 @@ void LSTM::Forward(bool debug, const NetworkIO &input, const TransposedArray *in
     if (softmax_ != nullptr) {
       if (input.int_mode()) {
         int_output->WriteTimeStepPart(0, 0, ns_, curr_output);
-        softmax_->ForwardTimeStep(int_output->i(0), t, softmax_output);
+        softmax_->ForwardTimeStep(int_output->i(0), softmax_output);
       } else {
         softmax_->ForwardTimeStep(curr_output, t, softmax_output);
       }

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -261,13 +261,12 @@ void LSTMRecognizer::RecognizeLine(const ImageData &image_data,
   search_->excludedUnichars.clear();
   search_->Decode(outputs, kDictRatio, kCertOffset, worst_dict_cert, &GetUnicharset(),
                   lstm_choice_mode);
-  search_->ExtractBestPathAsWords(line_box, scale_factor, debug, &GetUnicharset(), words,
-                                  lstm_choice_mode);
+  search_->ExtractBestPathAsWords(line_box, scale_factor, debug, &GetUnicharset(), words);
   if (lstm_choice_mode) {
     search_->extractSymbolChoices(&GetUnicharset());
     for (int i = 0; i < lstm_choice_amount; ++i) {
       search_->DecodeSecondaryBeams(outputs, kDictRatio, kCertOffset, worst_dict_cert,
-                                    &GetUnicharset(), lstm_choice_mode);
+                                    &GetUnicharset());
       search_->extractSymbolChoices(&GetUnicharset());
     }
     search_->segmentTimestepsByCharacters();
@@ -325,7 +324,7 @@ bool LSTMRecognizer::RecognizeLine(const ImageData &image_data,
   // This ensures consistent recognition results.
   SetRandomSeed();
   int min_width = network_->XScaleFactor();
-  Image pix = Input::PrepareLSTMInputs(image_data, network_, min_width, &randomizer_, scale_factor);
+  Image pix = Input::PrepareLSTMInputs(image_data, network_, min_width, scale_factor);
   if (pix == nullptr) {
     tprintf("Line cannot be recognized!!\n");
     return false;

--- a/src/lstm/maxpool.cpp
+++ b/src/lstm/maxpool.cpp
@@ -34,8 +34,9 @@ bool Maxpool::DeSerialize(TFile *fp) {
 
 // Runs forward propagation of activations on the input line.
 // See NetworkCpp for a detailed discussion of the arguments.
-void Maxpool::Forward(bool debug, const NetworkIO &input, const TransposedArray *input_transpose,
-                      NetworkScratch *scratch, NetworkIO *output) {
+void Maxpool::Forward(bool /*debug*/, const NetworkIO &input,
+                      const TransposedArray * /*input_transpose*/,
+                      NetworkScratch * /*scratch*/, NetworkIO *output) {
   output->ResizeScaled(input, x_scale_, y_scale_, no_);
   maxes_.ResizeNoInit(output->Width(), ni_);
   back_map_ = input.stride_map();
@@ -67,7 +68,7 @@ void Maxpool::Forward(bool debug, const NetworkIO &input, const TransposedArray 
 
 // Runs backward propagation of errors on the deltas line.
 // See NetworkCpp for a detailed discussion of the arguments.
-bool Maxpool::Backward(bool debug, const NetworkIO &fwd_deltas, NetworkScratch *scratch,
+bool Maxpool::Backward(bool /*debug*/, const NetworkIO &fwd_deltas, NetworkScratch * /*scratch*/,
                        NetworkIO *back_deltas) {
   back_deltas->ResizeToMap(fwd_deltas.int_mode(), back_map_, ni_);
   back_deltas->MaxpoolBackward(fwd_deltas, maxes_);

--- a/src/lstm/parallel.cpp
+++ b/src/lstm/parallel.cpp
@@ -49,7 +49,8 @@ StaticShape Parallel::OutputShape(const StaticShape &input_shape) const {
 
 // Runs forward propagation of activations on the input line.
 // See NetworkCpp for a detailed discussion of the arguments.
-void Parallel::Forward(bool debug, const NetworkIO &input, const TransposedArray *input_transpose,
+void Parallel::Forward(bool debug, const NetworkIO &input,
+                       const TransposedArray * /*input_transpose*/,
                        NetworkScratch *scratch, NetworkIO *output) {
   bool parallel_debug = false;
   // If this parallel is a replicator of convolvers, or holds a 1-d LSTM pair,

--- a/src/lstm/recodebeam.cpp
+++ b/src/lstm/recodebeam.cpp
@@ -93,7 +93,7 @@ void RecodeBeamSearch::Decode(const NetworkIO &output, double dict_ratio,
     DecodeStep(output.f(t), t, dict_ratio, cert_offset, worst_dict_cert,
                charset);
     if (lstm_choice_mode) {
-      SaveMostCertainChoices(output.f(t), output.NumFeatures(), charset, t);
+      SaveMostCertainChoices(output.f(t), output.NumFeatures(), charset);
     }
   }
 }
@@ -111,7 +111,7 @@ void RecodeBeamSearch::Decode(const GENERIC_2D_ARRAY<float> &output,
 
 void RecodeBeamSearch::DecodeSecondaryBeams(
     const NetworkIO &output, double dict_ratio, double cert_offset,
-    double worst_dict_cert, const UNICHARSET *charset, int lstm_choice_mode) {
+    double worst_dict_cert, const UNICHARSET *charset) {
   for (auto data : secondary_beam_) {
     delete data;
   }
@@ -135,8 +135,7 @@ void RecodeBeamSearch::DecodeSecondaryBeams(
 
 void RecodeBeamSearch::SaveMostCertainChoices(const float *outputs,
                                               int num_outputs,
-                                              const UNICHARSET *charset,
-                                              int xCoord) {
+                                              const UNICHARSET *charset) {
   std::vector<std::pair<const char *, float>> choices;
   for (int i = 0; i < num_outputs; ++i) {
     if (outputs[i] >= 0.01f) {
@@ -239,8 +238,7 @@ void RecodeBeamSearch::ExtractBestPathAsUnicharIds(
 void RecodeBeamSearch::ExtractBestPathAsWords(const TBOX &line_box,
                                               float scale_factor, bool debug,
                                               const UNICHARSET *unicharset,
-                                              PointerVector<WERD_RES> *words,
-                                              int lstm_choice_mode) {
+                                              PointerVector<WERD_RES> *words) {
   words->truncate(0);
   std::vector<int> unichar_ids;
   std::vector<float> certs;
@@ -299,7 +297,7 @@ void RecodeBeamSearch::ExtractBestPathAsWords(const TBOX &line_box,
     WERD_RES *word_res =
         InitializeWord(leading_space, line_box, word_start, word_end,
                        std::min(space_cert, prev_space_cert), unicharset,
-                       xcoords, scale_factor);
+                       scale_factor);
     for (int i = word_start; i < word_end; ++i) {
       auto *choices = new BLOB_CHOICE_LIST;
       BLOB_CHOICE_IT bc_it(choices);
@@ -327,7 +325,7 @@ struct greater_than {
   }
 };
 
-void RecodeBeamSearch::PrintBeam2(bool uids, int num_outputs,
+void RecodeBeamSearch::PrintBeam2(bool uids,
                                   const UNICHARSET *charset,
                                   bool secondary) const {
   std::vector<std::vector<const RecodeNode *>> topology;
@@ -637,7 +635,6 @@ WERD_RES *RecodeBeamSearch::InitializeWord(bool leading_space,
                                            const TBOX &line_box, int word_start,
                                            int word_end, float space_certainty,
                                            const UNICHARSET *unicharset,
-                                           const std::vector<int> &xcoords,
                                            float scale_factor) {
   // Make a fake blob for each non-zero label.
   C_BLOB_LIST blobs;

--- a/src/lstm/recodebeam.h
+++ b/src/lstm/recodebeam.h
@@ -205,8 +205,7 @@ public:
               double worst_dict_cert, const UNICHARSET *charset);
 
   void DecodeSecondaryBeams(const NetworkIO &output, double dict_ratio, double cert_offset,
-                            double worst_dict_cert, const UNICHARSET *charset,
-                            int lstm_choice_mode = 0);
+                            double worst_dict_cert, const UNICHARSET *charset);
 
   // Returns the best path as labels/scores/xcoords similar to simple CTC.
   void ExtractBestPathAsLabels(std::vector<int> *labels, std::vector<int> *xcoords) const;
@@ -218,8 +217,7 @@ public:
 
   // Returns the best path as a set of WERD_RES.
   void ExtractBestPathAsWords(const TBOX &line_box, float scale_factor, bool debug,
-                              const UNICHARSET *unicharset, PointerVector<WERD_RES> *words,
-                              int lstm_choice_mode = 0);
+                              const UNICHARSET *unicharset, PointerVector<WERD_RES> *words);
 
   // Generates debug output of the content of the beams after a Decode.
   void DebugBeams(const UNICHARSET &unicharset) const;
@@ -232,7 +230,7 @@ public:
   void extractSymbolChoices(const UNICHARSET *unicharset);
 
   // Generates debug output of the content of the beams after a Decode.
-  void PrintBeam2(bool uids, int num_outputs, const UNICHARSET *charset, bool secondary) const;
+  void PrintBeam2(bool uids, const UNICHARSET *charset, bool secondary) const;
   // Segments the timestep bundle by the character_boundaries.
   void segmentTimestepsByCharacters();
   std::vector<std::vector<std::pair<const char *, float>>>
@@ -323,7 +321,7 @@ private:
   // right places.
   WERD_RES *InitializeWord(bool leading_space, const TBOX &line_box, int word_start, int word_end,
                            float space_certainty, const UNICHARSET *unicharset,
-                           const std::vector<int> &xcoords, float scale_factor);
+                           float scale_factor);
 
   // Fills top_n_flags_ with bools that are true iff the corresponding output
   // is one of the top_n.
@@ -342,8 +340,7 @@ private:
                            double worst_dict_cert, const UNICHARSET *charset, bool debug = false);
 
   // Saves the most certain choices for the current time-step.
-  void SaveMostCertainChoices(const float *outputs, int num_outputs, const UNICHARSET *charset,
-                              int xCoord);
+  void SaveMostCertainChoices(const float *outputs, int num_outputs, const UNICHARSET *charset);
 
   // Calculates more accurate character boundaries which can be used to
   // provide more accurate alternative symbol choices.

--- a/src/lstm/reconfig.cpp
+++ b/src/lstm/reconfig.cpp
@@ -66,8 +66,9 @@ bool Reconfig::DeSerialize(TFile *fp) {
 
 // Runs forward propagation of activations on the input line.
 // See NetworkCpp for a detailed discussion of the arguments.
-void Reconfig::Forward(bool debug, const NetworkIO &input, const TransposedArray *input_transpose,
-                       NetworkScratch *scratch, NetworkIO *output) {
+void Reconfig::Forward(bool /*debug*/, const NetworkIO &input,
+                       const TransposedArray * /*input_transpose*/,
+                       NetworkScratch * /*scratch*/, NetworkIO *output) {
   output->ResizeScaled(input, x_scale_, y_scale_, no_);
   back_map_ = input.stride_map();
   StrideMap::Index dest_index(output->stride_map());
@@ -90,7 +91,7 @@ void Reconfig::Forward(bool debug, const NetworkIO &input, const TransposedArray
 
 // Runs backward propagation of errors on the deltas line.
 // See NetworkCpp for a detailed discussion of the arguments.
-bool Reconfig::Backward(bool debug, const NetworkIO &fwd_deltas, NetworkScratch *scratch,
+bool Reconfig::Backward(bool /*debug*/, const NetworkIO &fwd_deltas, NetworkScratch * /*scratch*/,
                         NetworkIO *back_deltas) {
   back_deltas->ResizeToMap(fwd_deltas.int_mode(), back_map_, ni_);
   StrideMap::Index src_index(fwd_deltas.stride_map());

--- a/src/lstm/reversed.cpp
+++ b/src/lstm/reversed.cpp
@@ -49,7 +49,8 @@ void Reversed::SetNetwork(Network *network) {
 
 // Runs forward propagation of activations on the input line.
 // See NetworkCpp for a detailed discussion of the arguments.
-void Reversed::Forward(bool debug, const NetworkIO &input, const TransposedArray *input_transpose,
+void Reversed::Forward(bool debug, const NetworkIO &input,
+                       const TransposedArray * /*input_transpose*/,
                        NetworkScratch *scratch, NetworkIO *output) {
   NetworkScratch::IO rev_input(input, scratch);
   ReverseData(input, rev_input);
@@ -60,7 +61,8 @@ void Reversed::Forward(bool debug, const NetworkIO &input, const TransposedArray
 
 // Runs backward propagation of errors on the deltas line.
 // See NetworkCpp for a detailed discussion of the arguments.
-bool Reversed::Backward(bool debug, const NetworkIO &fwd_deltas, NetworkScratch *scratch,
+bool Reversed::Backward(bool debug, const NetworkIO &fwd_deltas,
+                        NetworkScratch *scratch,
                         NetworkIO *back_deltas) {
   NetworkScratch::IO rev_input(fwd_deltas, scratch);
   ReverseData(fwd_deltas, rev_input);

--- a/src/lstm/weightmatrix.cpp
+++ b/src/lstm/weightmatrix.cpp
@@ -339,7 +339,8 @@ bool WeightMatrix::DeSerialize(bool training, TFile *fp) {
 
 // As DeSerialize, but reads an old (float) format WeightMatrix for
 // backward compatibility.
-bool WeightMatrix::DeSerializeOld(bool training, TFile *fp) {
+bool WeightMatrix::DeSerializeOld([[maybe_unused]] bool training,
+                                  [[maybe_unused]] TFile *fp) {
 #ifdef FAST_FLOAT
   // Not implemented.
   ASSERT_HOST(!"not implemented");
@@ -427,7 +428,7 @@ void WeightMatrix::VectorDotMatrix(const TFloat *u, TFloat *v) const {
 // Note that (matching MatrixDotVector) v[last][] is missing, presumed 1.0.
 // Runs parallel if requested. Note that u and v must be transposed.
 void WeightMatrix::SumOuterTransposed(const TransposedArray &u, const TransposedArray &v,
-                                      bool in_parallel) {
+                                      [[maybe_unused]] bool in_parallel) {
   assert(!int_mode_);
   int num_outputs = dw_.dim1();
   assert(u.dim1() == num_outputs);

--- a/src/lstm/weightmatrix.h
+++ b/src/lstm/weightmatrix.h
@@ -126,7 +126,7 @@ public:
   bool DeSerialize(bool training, TFile *fp);
   // As DeSerialize, but reads an old (float) format WeightMatrix for
   // backward compatibility.
-  bool DeSerializeOld(bool training, TFile *fp);
+  bool DeSerializeOld(bool /*training*/, TFile * /*fp*/);
 
   // Computes matrix.vector v = Wu.
   // u is of size W.dim2() - 1 and the output v is of size W.dim1().

--- a/src/textord/cjkpitch.cpp
+++ b/src/textord/cjkpitch.cpp
@@ -1040,7 +1040,7 @@ FPAnalyzer::FPAnalyzer(ICOORD page_tr, TO_BLOCK_LIST *port_blocks)
     TO_BLOCK *block = block_it.data();
     if (!block->get_rows()->empty()) {
       ASSERT_HOST(block->xheight > 0);
-      find_repeated_chars(block, false);
+      find_repeated_chars(block);
     }
   }
 

--- a/src/textord/colfind.cpp
+++ b/src/textord/colfind.cpp
@@ -240,7 +240,7 @@ void ColumnFinder::CorrectOrientation(TO_BLOCK *block, bool vertical_text_lines,
     RotateBlobList(rotation_, &block->blobs);
     RotateBlobList(rotation_, &block->small_blobs);
     RotateBlobList(rotation_, &block->noise_blobs);
-    TabFind::ResetForVerticalText(rotation_, rerotate_, &horizontal_lines_, &min_gutter_width_);
+    TabFind::ResetForVerticalText(rotation_, &horizontal_lines_, &min_gutter_width_);
     part_grid_.Init(gridsize(), bleft(), tright());
     // Reset all blobs to initial state and filter by size.
     // Since they have rotated, the list they belong on could have changed.
@@ -294,10 +294,10 @@ int ColumnFinder::FindBlocks(PageSegMode pageseg_mode,
                                           denorm_, cjk_script_, &projection_, diacritic_blobs,
                                           &part_grid_, &big_parts_);
   if (!PSM_SPARSE(pageseg_mode)) {
-    ImageFind::FindImagePartitions(photo_mask_pix, rotation_, rerotate_, input_block, this,
+    ImageFind::FindImagePartitions(photo_mask_pix, rotation_, rerotate_,
                                    pixa_debug, &part_grid_, &big_parts_);
     ImageFind::TransferImagePartsToImageMask(rerotate_, &part_grid_, photo_mask_pix);
-    ImageFind::FindImagePartitions(photo_mask_pix, rotation_, rerotate_, input_block, this,
+    ImageFind::FindImagePartitions(photo_mask_pix, rotation_, rerotate_,
                                    pixa_debug, &part_grid_, &big_parts_);
   }
   part_grid_.ReTypeBlobs(&image_bblobs_);
@@ -415,9 +415,9 @@ int ColumnFinder::FindBlocks(PageSegMode pageseg_mode,
       table_finder.set_left_to_right_language(!input_block->block->right_to_left());
       // Copy cleaned partitions from part_grid_ to clean_part_grid_ and
       // insert dot-like noise into period_grid_
-      table_finder.InsertCleanPartitions(&part_grid_, input_block);
+      table_finder.InsertCleanPartitions(&part_grid_);
       // Get Table Regions
-      table_finder.LocateTables(&part_grid_, best_columns_, WidthCB(), reskew_);
+      table_finder.LocateTables(&part_grid_, best_columns_, WidthCB());
     }
     GridRemoveUnderlinePartitions();
     part_grid_.DeleteUnknownParts(input_block);
@@ -529,7 +529,7 @@ void ColumnFinder::DisplayBlocks(BLOCK_LIST *blocks) {
 
 // Displays the column edges at each grid y coordinate defined by
 // best_columns_.
-void ColumnFinder::DisplayColumnBounds(PartSetVector *sets) {
+void ColumnFinder::DisplayColumnBounds() {
   ScrollView *col_win = MakeWindow(50, 300, "Columns");
   DisplayBoxes(col_win);
   col_win->Pen(textord_debug_printable ? ScrollView::BLUE : ScrollView::GREEN);
@@ -595,7 +595,7 @@ bool ColumnFinder::MakeColumns(bool single_column) {
     bool any_multi_column = AssignColumns(part_sets);
 #ifndef GRAPHICS_DISABLED
     if (textord_tabfind_show_columns) {
-      DisplayColumnBounds(&part_sets);
+      DisplayColumnBounds();
     }
 #endif
     ComputeMeanColumnGap(any_multi_column);

--- a/src/textord/colfind.cpp
+++ b/src/textord/colfind.cpp
@@ -270,8 +270,6 @@ void ColumnFinder::CorrectOrientation(TO_BLOCK *block, bool vertical_text_lines,
 // removed and placed in the output blocks, while unused ones will be deleted.
 // If single_column is true, the input is treated as single column, but
 // it is still divided into blocks of equal line spacing/text size.
-// scaled_color is scaled down by scaled_factor from the input color image,
-// and may be nullptr if the input was not color.
 // grey_pix is optional, but if present must match the photo_mask_pix in size,
 // and must be a *real* grey image instead of binary_pix * 255.
 // thresholds_pix is expected to be present iff grey_pix is present and
@@ -283,7 +281,7 @@ void ColumnFinder::CorrectOrientation(TO_BLOCK *block, bool vertical_text_lines,
 // noise/diacriticness determined via classification.
 // Returns -1 if the user hits the 'd' key in the blocks window while running
 // in debug mode, which requests a retry with more debug info.
-int ColumnFinder::FindBlocks(PageSegMode pageseg_mode, Image scaled_color, int scaled_factor,
+int ColumnFinder::FindBlocks(PageSegMode pageseg_mode,
                              TO_BLOCK *input_block, Image photo_mask_pix, Image thresholds_pix,
                              Image grey_pix, DebugPixa *pixa_debug, BLOCK_LIST *blocks,
                              BLOBNBOX_LIST *diacritic_blobs, TO_BLOCK_LIST *to_blocks) {

--- a/src/textord/colfind.h
+++ b/src/textord/colfind.h
@@ -169,7 +169,7 @@ private:
   void DisplayBlocks(BLOCK_LIST *blocks);
   // Displays the column edges at each grid y coordinate defined by
   // best_columns_.
-  void DisplayColumnBounds(PartSetVector *sets);
+  void DisplayColumnBounds();
 
   ////// Functions involved in determining the columns used on the page. /////
 

--- a/src/textord/colfind.h
+++ b/src/textord/colfind.h
@@ -144,8 +144,6 @@ public:
   // removed and placed in the output blocks, while unused ones will be deleted.
   // If single_column is true, the input is treated as single column, but
   // it is still divided into blocks of equal line spacing/text size.
-  // scaled_color is scaled down by scaled_factor from the input color image,
-  // and may be nullptr if the input was not color.
   // grey_pix is optional, but if present must match the photo_mask_pix in size,
   // and must be a *real* grey image instead of binary_pix * 255.
   // thresholds_pix is expected to be present iff grey_pix is present and
@@ -156,7 +154,7 @@ public:
   // appropriate word after the rest of layout analysis.
   // Returns -1 if the user hits the 'd' key in the blocks window while running
   // in debug mode, which requests a retry with more debug info.
-  int FindBlocks(PageSegMode pageseg_mode, Image scaled_color, int scaled_factor, TO_BLOCK *block,
+  int FindBlocks(PageSegMode pageseg_mode, TO_BLOCK *block,
                  Image photo_mask_pix, Image thresholds_pix, Image grey_pix, DebugPixa *pixa_debug,
                  BLOCK_LIST *blocks, BLOBNBOX_LIST *diacritic_blobs, TO_BLOCK_LIST *to_blocks);
 

--- a/src/textord/colpartition.cpp
+++ b/src/textord/colpartition.cpp
@@ -1708,7 +1708,7 @@ TO_BLOCK *ColPartition::MakeBlock(const ICOORD &bleft, const ICOORD &tright,
   ColPartition *part = it.data();
   PolyBlockType type = part->type();
   if (type == PT_VERTICAL_TEXT) {
-    return MakeVerticalTextBlock(bleft, tright, block_parts, used_parts);
+    return MakeVerticalTextBlock(block_parts, used_parts);
   }
   // LineSpacingBlocks has handed us a collection of evenly spaced lines and
   // put the average spacing in each partition, so we can just take the
@@ -1754,9 +1754,7 @@ TO_BLOCK *ColPartition::MakeBlock(const ICOORD &bleft, const ICOORD &tright,
 
 // Constructs a block from the given list of vertical text partitions.
 // Currently only creates rectangular blocks.
-TO_BLOCK *ColPartition::MakeVerticalTextBlock(const ICOORD &bleft,
-                                              const ICOORD &tright,
-                                              ColPartition_LIST *block_parts,
+TO_BLOCK *ColPartition::MakeVerticalTextBlock(ColPartition_LIST *block_parts,
                                               ColPartition_LIST *used_parts) {
   if (block_parts->empty()) {
     return nullptr; // Nothing to do.

--- a/src/textord/colpartition.h
+++ b/src/textord/colpartition.h
@@ -665,9 +665,7 @@ public:
 
   // Constructs a block from the given list of vertical text partitions.
   // Currently only creates rectangular blocks.
-  static TO_BLOCK *MakeVerticalTextBlock(const ICOORD &bleft,
-                                         const ICOORD &tright,
-                                         ColPartition_LIST *block_parts,
+  static TO_BLOCK *MakeVerticalTextBlock(ColPartition_LIST *block_parts,
                                          ColPartition_LIST *used_parts);
 
   // Makes a TO_ROW matching this and moves all the blobs to it, transferring

--- a/src/textord/edgblob.cpp
+++ b/src/textord/edgblob.cpp
@@ -383,7 +383,6 @@ static void fill_buckets(C_OUTLINE_LIST *outlines, // outlines in block
  */
 
 static bool capture_children(OL_BUCKETS *buckets,  // bucket sort class
-                             C_BLOB_IT *reject_it, // dead grandchildren
                              C_OUTLINE_IT *blob_it // output outlines
 ) {
   // master outline
@@ -440,7 +439,7 @@ static void empty_buckets(BLOCK *block,       // block to scan
     // move to new list
     out_it.add_after_then_move(parent_it.extract());
     // healthy blob
-    bool good_blob = capture_children(buckets, &junk_blobs, &out_it);
+    bool good_blob = capture_children(buckets, &out_it);
     C_BLOB::ConstructBlobsFromOutlines(good_blob, &outlines, &good_blobs,
                                        &junk_blobs);
 

--- a/src/textord/fpchop.cpp
+++ b/src/textord/fpchop.cpp
@@ -63,8 +63,7 @@ static void join_segments(C_OUTLINE_FRAG *bottom, C_OUTLINE_FRAG *top);
  * Make a ROW from a fixed pitch TO_ROW.
  **********************************************************************/
 ROW *fixed_pitch_words( // find lines
-    TO_ROW *row,        // row to do
-    FCOORD rotation     // for drawing
+    TO_ROW *row         // row to do
 ) {
   bool bol;                // start of line
   uint8_t blanks;          // in front of word

--- a/src/textord/fpchop.h
+++ b/src/textord/fpchop.h
@@ -61,8 +61,7 @@ ELISTIZEH(C_OUTLINE_FRAG)
 extern INT_VAR_H(textord_fp_chop_error);
 
 ROW *fixed_pitch_words( // find lines
-    TO_ROW *row,        // row to do
-    FCOORD rotation     // for drawing
+    TO_ROW *row         // row to do
 );
 
 void split_to_blob(                 // split the blob

--- a/src/textord/imagefind.cpp
+++ b/src/textord/imagefind.cpp
@@ -1134,7 +1134,7 @@ static void DeleteSmallImages(ColPartitionGrid *part_grid) {
 // ColPartitionGrid::ReTypeBlobs must be called afterwards to fix this
 // situation and collect the image blobs.
 void ImageFind::FindImagePartitions(Image image_pix, const FCOORD &rotation,
-                                    const FCOORD &rerotation, TO_BLOCK *block, TabFind *tab_grid,
+                                    const FCOORD &rerotation,
                                     DebugPixa *pixa_debug, ColPartitionGrid *part_grid,
                                     ColPartition_LIST *big_parts) {
   int imageheight = pixGetHeight(image_pix);

--- a/src/textord/imagefind.h
+++ b/src/textord/imagefind.h
@@ -98,7 +98,7 @@ public:
   // ColPartitionGrid::ReTypeBlobs must be called afterwards to fix this
   // situation and collect the image blobs.
   static void FindImagePartitions(Image image_pix, const FCOORD &rotation, const FCOORD &rerotation,
-                                  TO_BLOCK *block, TabFind *tab_grid, DebugPixa *pixa_debug,
+                                  DebugPixa *pixa_debug,
                                   ColPartitionGrid *part_grid, ColPartition_LIST *big_parts);
 };
 

--- a/src/textord/makerow.cpp
+++ b/src/textord/makerow.cpp
@@ -182,7 +182,7 @@ static float MakeRowFromSubBlobs(TO_BLOCK *block, C_BLOB *blob, TO_ROW_IT *row_i
  * only a single blob, it makes 2 rows, in case the top-level blob
  * is a container of the real blobs to recognize.
  */
-float make_single_row(ICOORD page_tr, bool allow_sub_blobs, TO_BLOCK *block,
+float make_single_row(bool allow_sub_blobs, TO_BLOCK *block,
                       TO_BLOCK_LIST *blocks) {
   BLOBNBOX_IT blob_it = &block->blobs;
   TO_ROW_IT row_it = block->get_rows();
@@ -2022,7 +2022,7 @@ void Textord::make_spline_rows(TO_BLOCK *block, // block to do
       }
     }
 #endif
-    make_old_baselines(block, testing_on, gradient);
+    make_old_baselines(block, gradient);
   }
 #ifndef GRAPHICS_DISABLED
   if (testing_on) {
@@ -2054,7 +2054,7 @@ void make_baseline_spline(TO_ROW *row, // row to fit
   auto *xstarts = new int32_t[row->blob_list()->length() + 1];
   if (segment_baseline(row, block, segments, xstarts) && !textord_straight_baselines &&
       !textord_parallel_baselines) {
-    coeffs = linear_spline_baseline(row, block, segments, xstarts);
+    coeffs = linear_spline_baseline(row, segments, xstarts);
   } else {
     xstarts[1] = xstarts[segments];
     segments = 1;
@@ -2174,7 +2174,6 @@ bool segment_baseline( // split baseline
  */
 double *linear_spline_baseline( // split baseline
     TO_ROW *row,                // row to fit
-    TO_BLOCK *block,            // block it came from
     int32_t &segments,          // no of segments
     int32_t xstarts[]           // coords of segments
 ) {

--- a/src/textord/makerow.cpp
+++ b/src/textord/makerow.cpp
@@ -2454,7 +2454,6 @@ OVERLAP_STATE most_overlapping_row( // find best row
   float overlap;                 // of blob & row
   float bestover;                // nearest row
   float merge_top, merge_bottom; // size of merged row
-  ICOORD testpt;                 // testing only
   TO_ROW *row;                   // current row
   TO_ROW *test_row;              // for multiple overlaps
   BLOBNBOX_IT blob_it;           // for merging rows

--- a/src/textord/makerow.cpp
+++ b/src/textord/makerow.cpp
@@ -1888,7 +1888,7 @@ void pre_associate_blobs( // make rough chars
           }
         }
       } while (overlap);
-      blob->chop(&start_it, &blob_it, blob_rotation,
+      blob->chop(&start_it, &blob_it,
                  block->line_size * tesseract::CCStruct::kXHeightFraction * textord_chop_width);
       // attempt chop
     }

--- a/src/textord/makerow.h
+++ b/src/textord/makerow.h
@@ -106,7 +106,7 @@ inline bool within_error_margin(float test, float num, float margin) {
 void fill_heights(TO_ROW *row, float gradient, int min_height, int max_height, STATS *heights,
                   STATS *floating_heights);
 
-float make_single_row(ICOORD page_tr, bool allow_sub_blobs, TO_BLOCK *block, TO_BLOCK_LIST *blocks);
+float make_single_row(bool allow_sub_blobs, TO_BLOCK *block, TO_BLOCK_LIST *blocks);
 float make_rows(ICOORD page_tr, // top right
                 TO_BLOCK_LIST *port_blocks);
 void make_initial_textrows(ICOORD page_tr,
@@ -222,7 +222,6 @@ bool segment_baseline(                      // split baseline
 );
 double *linear_spline_baseline( // split baseline
     TO_ROW *row,                // row to fit
-    TO_BLOCK *block,            // block it came from
     int32_t &segments,          // no of segments
     int32_t xstarts[]           // coords of segments
 );

--- a/src/textord/oldbasel.cpp
+++ b/src/textord/oldbasel.cpp
@@ -77,7 +77,6 @@ static double_VAR(textord_oldbl_jumplimit, 0.15, "X fraction for new partition")
  **********************************************************************/
 
 void Textord::make_old_baselines(TO_BLOCK *block, // block to do
-                                 bool testing_on, // correct orientation
                                  float gradient) {
   QSPLINE *prev_baseline; // baseline of previous row
   TO_ROW *row;            // current row
@@ -378,7 +377,7 @@ void Textord::find_textlines(TO_BLOCK *block,   // block row is in
                               &row->baseline, jumplimit, &ydiffs[0]);
     pointcount = partition_coords(&blobcoords[0], blobcount, &partids[0], bestpart, &xcoords[0],
                                   &ycoords[0]);
-    segments = segment_spline(&blobcoords[0], blobcount, &xcoords[0], &ycoords[0], degree,
+    segments = segment_spline(&xcoords[0], &ycoords[0], degree,
                               pointcount, xstarts);
     if (!holed_line) {
       do {
@@ -400,7 +399,7 @@ void Textord::find_textlines(TO_BLOCK *block,   // block row is in
     old_first_xheight(row, &blobcoords[0], lineheight, blobcount, &row->baseline, jumplimit);
   } else if (textord_old_xheight) {
     make_first_xheight(row, &blobcoords[0], lineheight, static_cast<int>(block->line_size),
-                       blobcount, &row->baseline, jumplimit);
+                       blobcount, &row->baseline);
   } else {
     compute_row_xheight(row, block->block->classify_rotation(), row->line_m(), block->line_size);
   }
@@ -1004,8 +1003,6 @@ int partition_coords(  // find relevant coords
  **********************************************************************/
 
 int segment_spline(             // make xstarts
-    TBOX blobcoords[],          // boundign boxes
-    int blobcount,              /*no of blobs in row */
     int xcoords[],              /*points to work on */
     int ycoords[],              /*points to work on */
     int degree, int pointcount, /*no of points */
@@ -1424,8 +1421,7 @@ void make_first_xheight( // find xheight
     int lineheight,      // initial guess
     int init_lineheight, // block level guess
     int blobcount,       /*blobs in blobcoords */
-    QSPLINE *baseline,   /*established */
-    float jumplimit      /*min ascender height */
+    QSPLINE *baseline    // established
 ) {
   STATS heightstat(0, HEIGHTBUCKETS - 1);
   int lefts[HEIGHTBUCKETS];

--- a/src/textord/oldbasel.h
+++ b/src/textord/oldbasel.h
@@ -89,8 +89,6 @@ int partition_coords(  // find relevant coords
     int ycoords[]      /*points to work on */
 );
 int segment_spline(             // make xstarts
-    TBOX blobcoords[],          // boundign boxes
-    int blobcount,              /*no of blobs in row */
     int xcoords[],              /*points to work on */
     int ycoords[],              /*points to work on */
     int degree, int pointcount, /*no of points */
@@ -134,8 +132,7 @@ void make_first_xheight( // find xheight
     int lineheight,      // initial guess
     int init_lineheight, // block level guess
     int blobcount,       /*blobs in blobcoords */
-    QSPLINE *baseline,   /*established */
-    float jumplimit      /*min ascender height */
+    QSPLINE *baseline    // established
 );
 
 int *make_height_array( // get array of heights

--- a/src/textord/pithsync.cpp
+++ b/src/textord/pithsync.cpp
@@ -206,8 +206,7 @@ void FPCUTPT::assign_cheap( // constructor
     STATS *projection,      // vertical occupation
     float projection_scale, // scaling
     int16_t zero_count,     // official zero
-    int16_t pitch,          // proposed pitch
-    int16_t pitch_error     // allowed tolerance
+    int16_t pitch           // proposed pitch
 ) {
   int index;             // test index
   int16_t balance_count; // ding factor
@@ -610,8 +609,7 @@ double check_pitch_sync3(    // find segmentation
                                       projection, projection_scale, zero_count, pitch, pitch_error);
     } else {
       cutpts[x - array_origin].assign_cheap(&cutpts[0], array_origin, x, faking, mid_cut, offset,
-                                            projection, projection_scale, zero_count, pitch,
-                                            pitch_error);
+                                            projection, projection_scale, zero_count, pitch);
     }
     x++;
     if (next_zero < x || next_zero == x + zero_offset) {

--- a/src/textord/pithsync.h
+++ b/src/textord/pithsync.h
@@ -62,8 +62,7 @@ public:
       STATS *projection,      // occupation
       float projection_scale, // scaling
       int16_t zero_count,     // official zero
-      int16_t pitch,          // proposed pitch
-      int16_t pitch_error);   // allowed tolerance
+      int16_t pitch);         // proposed pitch
 
   int32_t position() { // access func
     return xpos;

--- a/src/textord/strokewidth.cpp
+++ b/src/textord/strokewidth.cpp
@@ -373,10 +373,9 @@ void StrokeWidth::GradeBlobsIntoPartitions(PageSegMode pageseg_mode, const FCOOR
   // Clear and re Insert to take advantage of the removed diacritics.
   Clear();
   InsertBlobs(block);
-  FCOORD skew;
   FindTextlineFlowDirection(pageseg_mode, true);
   PartitionFindResult r = FindInitialPartitions(pageseg_mode, rerotation, true, block,
-                                                diacritic_blobs, part_grid, big_parts, &skew);
+                                                diacritic_blobs, part_grid, big_parts);
   if (r == PFR_NOISE) {
     tprintf("Detected %d diacritics\n", diacritic_blobs->length());
     // Noise was found, and removed.
@@ -384,7 +383,7 @@ void StrokeWidth::GradeBlobsIntoPartitions(PageSegMode pageseg_mode, const FCOOR
     InsertBlobs(block);
     FindTextlineFlowDirection(pageseg_mode, true);
     r = FindInitialPartitions(pageseg_mode, rerotation, false, block, diacritic_blobs, part_grid,
-                              big_parts, &skew);
+                              big_parts);
   }
   nontext_map_ = nullptr;
   projection_ = nullptr;
@@ -1273,8 +1272,8 @@ void StrokeWidth::SmoothNeighbourTypes(PageSegMode pageseg_mode, bool reset_all,
 // called again after cleaning up the partly done work.
 PartitionFindResult StrokeWidth::FindInitialPartitions(
     PageSegMode pageseg_mode, const FCOORD &rerotation, bool find_problems, TO_BLOCK *block,
-    BLOBNBOX_LIST *diacritic_blobs, ColPartitionGrid *part_grid, ColPartition_LIST *big_parts,
-    FCOORD *skew_angle) {
+    BLOBNBOX_LIST *diacritic_blobs, ColPartitionGrid *part_grid,
+    ColPartition_LIST *big_parts) {
   if (!FindingHorizontalOnly(pageseg_mode)) {
     FindVerticalTextChains(part_grid);
   }
@@ -1288,10 +1287,6 @@ PartitionFindResult StrokeWidth::FindInitialPartitions(
     projection_->DisplayProjection();
   }
 #endif
-  if (find_problems) {
-    // TODO(rays) Do something to find skew, set skew_angle and return if there
-    // is some.
-  }
   part_grid->SplitOverlappingPartitions(big_parts);
   EasyMerges(part_grid);
   RemoveLargeUnusedBlobs(block, big_parts);

--- a/src/textord/strokewidth.cpp
+++ b/src/textord/strokewidth.cpp
@@ -1294,7 +1294,7 @@ PartitionFindResult StrokeWidth::FindInitialPartitions(
   }
   part_grid->SplitOverlappingPartitions(big_parts);
   EasyMerges(part_grid);
-  RemoveLargeUnusedBlobs(block, part_grid, big_parts);
+  RemoveLargeUnusedBlobs(block, big_parts);
   TBOX grid_box(bleft(), tright());
   while (part_grid->GridSmoothNeighbours(BTFT_CHAIN, nontext_map_, grid_box, rerotation)) {
     ;
@@ -1794,7 +1794,7 @@ void StrokeWidth::MergeDiacritics(TO_BLOCK *block, ColPartitionGrid *part_grid) 
 // Any blobs on the large_blobs list of block that are still unowned by a
 // ColPartition, are probably drop-cap or vertically touching so the blobs
 // are removed to the big_parts list and treated separately.
-void StrokeWidth::RemoveLargeUnusedBlobs(TO_BLOCK *block, ColPartitionGrid *part_grid,
+void StrokeWidth::RemoveLargeUnusedBlobs(TO_BLOCK *block,
                                          ColPartition_LIST *big_parts) {
   BLOBNBOX_IT large_it(&block->large_blobs);
   for (large_it.mark_cycle_pt(); !large_it.cycled_list(); large_it.forward()) {

--- a/src/textord/strokewidth.h
+++ b/src/textord/strokewidth.h
@@ -250,7 +250,7 @@ private:
   // Any blobs on the large_blobs list of block that are still unowned by a
   // ColPartition, are probably drop-cap or vertically touching so the blobs
   // are removed to the big_parts list and treated separately.
-  void RemoveLargeUnusedBlobs(TO_BLOCK *block, ColPartitionGrid *part_grid,
+  void RemoveLargeUnusedBlobs(TO_BLOCK *block,
                               ColPartition_LIST *big_parts);
 
   // All remaining unused blobs are put in individual ColPartitions.

--- a/src/textord/strokewidth.h
+++ b/src/textord/strokewidth.h
@@ -211,7 +211,7 @@ private:
                                             bool find_problems, TO_BLOCK *block,
                                             BLOBNBOX_LIST *diacritic_blobs,
                                             ColPartitionGrid *part_grid,
-                                            ColPartition_LIST *big_parts, FCOORD *skew_angle);
+                                            ColPartition_LIST *big_parts);
   // Detects noise by a significant increase in partition overlap from
   // pre_overlap to now, and removes noise from the union of all the overlapping
   // partitions, placing the blobs in diacritic_blobs. Returns true if any noise

--- a/src/textord/tabfind.cpp
+++ b/src/textord/tabfind.cpp
@@ -203,7 +203,7 @@ int TabFind::GutterWidth(int bottom_y, int top_y, const TabVector &v, bool ignor
 }
 
 // Find the gutter width and distance to inner neighbour for the given blob.
-void TabFind::GutterWidthAndNeighbourGap(int tab_x, int mean_height, int max_gutter, bool left,
+void TabFind::GutterWidthAndNeighbourGap(int tab_x, int max_gutter, bool left,
                                          BLOBNBOX *bbox, int *gutter_width, int *neighbour_gap) {
   const TBOX &box = bbox->bounding_box();
   // The gutter and internal sides of the box.
@@ -1320,7 +1320,7 @@ bool TabFind::Deskew(TabVector_LIST *hlines, BLOBNBOX_LIST *image_blobs, TO_BLOC
 // Flip the vertical and horizontal lines and rotate the grid ready
 // for working on the rotated image.
 // This also makes parameter adjustments for FindInitialTabVectors().
-void TabFind::ResetForVerticalText(const FCOORD &rotate, const FCOORD &rerotate,
+void TabFind::ResetForVerticalText(const FCOORD &rotate,
                                    TabVector_LIST *horizontal_lines, int *min_gutter_width) {
   // Rotate the horizontal and vertical vectors and swap them over.
   // Only the separators are kept and rotated; other tabs are used

--- a/src/textord/tabfind.h
+++ b/src/textord/tabfind.h
@@ -93,7 +93,7 @@ public:
   /**
    * Find the gutter width and distance to inner neighbour for the given blob.
    */
-  void GutterWidthAndNeighbourGap(int tab_x, int mean_height, int max_gutter, bool left,
+  void GutterWidthAndNeighbourGap(int tab_x, int max_gutter, bool left,
                                   BLOBNBOX *bbox, int *gutter_width, int *neighbour_gap);
 
   /**
@@ -217,7 +217,7 @@ protected:
   // for working on the rotated image.
   // The min_gutter_width will be adjusted to the median gutter width between
   // vertical tabs to set a better threshold for tabboxes in the 2nd pass.
-  void ResetForVerticalText(const FCOORD &rotate, const FCOORD &rerotate,
+  void ResetForVerticalText(const FCOORD &rotate,
                             TabVector_LIST *horizontal_lines, int *min_gutter_width);
 
   // Clear the grid and get rid of the tab vectors, but not separators,

--- a/src/textord/tablefind.cpp
+++ b/src/textord/tablefind.cpp
@@ -188,8 +188,7 @@ void TableFinder::Init(int grid_size, const ICOORD &bottom_left,
 
 // Copy cleaned partitions from part_grid_ to clean_part_grid_ and
 // insert leaders and rulers into the leader_and_ruling_grid_
-void TableFinder::InsertCleanPartitions(ColPartitionGrid *grid,
-                                        TO_BLOCK *block) {
+void TableFinder::InsertCleanPartitions(ColPartitionGrid *grid) {
   // Calculate stats. This lets us filter partitions in AllowTextPartition()
   // and filter blobs in AllowBlob().
   SetGlobalSpacings(grid);
@@ -258,7 +257,7 @@ void TableFinder::InsertCleanPartitions(ColPartitionGrid *grid,
 // High level function to perform table detection
 void TableFinder::LocateTables(ColPartitionGrid *grid,
                                ColPartitionSet **all_columns,
-                               WidthCallback width_cb, const FCOORD &reskew) {
+                               WidthCallback width_cb) {
   // initialize spacing, neighbors, and columns
   InitializePartitions(all_columns);
 

--- a/src/textord/tablefind.h
+++ b/src/textord/tablefind.h
@@ -137,7 +137,7 @@ public:
   // Copy cleaned partitions from ColumnFinder's part_grid_ to this
   // clean_part_grid_ and insert dot-like noise into period_grid_.
   // It resizes the grids in this object to the dimensions of grid.
-  void InsertCleanPartitions(ColPartitionGrid *grid, TO_BLOCK *block);
+  void InsertCleanPartitions(ColPartitionGrid *grid);
 
   // High level function to perform table detection
   // Finds tables and updates the grid object with new partitions for the
@@ -145,7 +145,7 @@ public:
   // The reskew argument is only used to write the tables to the out.png
   // if that feature is enabled.
   void LocateTables(ColPartitionGrid *grid, ColPartitionSet **columns,
-                    WidthCallback width_cb, const FCOORD &reskew);
+                    WidthCallback width_cb);
 
 protected:
   // Access for the grid dimensions.

--- a/src/textord/tabvector.cpp
+++ b/src/textord/tabvector.cpp
@@ -634,7 +634,7 @@ void TabVector::Evaluate(const ICOORD &vertical, TabFind *finder) {
     int tab_x = XAtY(mid_y);
     int gutter_width;
     int neighbour_gap;
-    finder->GutterWidthAndNeighbourGap(tab_x, mean_height, max_gutter, left, bbox, &gutter_width,
+    finder->GutterWidthAndNeighbourGap(tab_x, max_gutter, left, bbox, &gutter_width,
                                        &neighbour_gap);
     if (debug) {
       tprintf("Box (%d,%d)->(%d,%d) has gutter %d, ndist %d\n", box.left(), box.bottom(),
@@ -704,7 +704,7 @@ void TabVector::Evaluate(const ICOORD &vertical, TabFind *finder) {
       }
       int gutter_width;
       int neighbour_gap;
-      finder->GutterWidthAndNeighbourGap(tab_x, mean_height, max_gutter, left, bbox, &gutter_width,
+      finder->GutterWidthAndNeighbourGap(tab_x, max_gutter, left, bbox, &gutter_width,
                                          &neighbour_gap);
       // Now we can make the test.
       if (gutter_width >= median_gutter * kMinGutterFraction) {

--- a/src/textord/textord.cpp
+++ b/src/textord/textord.cpp
@@ -224,7 +224,7 @@ void Textord::TextordPage(PageSegMode pageseg_mode, const FCOORD &reskew, int wi
     *gradient = make_rows(page_tr_, to_blocks);
   } else if (!PSM_SPARSE(pageseg_mode)) {
     // RAW_LINE, SINGLE_LINE, SINGLE_WORD and SINGLE_CHAR all need a single row.
-    *gradient = make_single_row(page_tr_, pageseg_mode != PSM_RAW_LINE, to_block, to_blocks);
+    *gradient = make_single_row(pageseg_mode != PSM_RAW_LINE, to_block, to_blocks);
   } else {
     *gradient = 0.0f;
   }
@@ -235,7 +235,7 @@ void Textord::TextordPage(PageSegMode pageseg_mode, const FCOORD &reskew, int wi
   // Now make the words in the lines.
   if (PSM_WORD_FIND_ENABLED(pageseg_mode)) {
     // SINGLE_LINE uses the old word maker on the single line.
-    make_words(this, page_tr_, *gradient, blocks, to_blocks);
+    make_words(this, page_tr_, *gradient, to_blocks);
   } else {
     // SINGLE_WORD and SINGLE_CHAR cram all the blobs into a
     // single word, and in SINGLE_CHAR mode, all the outlines

--- a/src/textord/textord.h
+++ b/src/textord/textord.h
@@ -104,15 +104,9 @@ public:
   }
 
   // tospace.cpp ///////////////////////////////////////////
-  void to_spacing(ICOORD page_tr,       // topright of page
-                  TO_BLOCK_LIST *blocks // blocks on page
-  );
-  ROW *make_prop_words(TO_ROW *row,    // row to make
-                       FCOORD rotation // for drawing
-  );
-  ROW *make_blob_words(TO_ROW *row,    // row to make
-                       FCOORD rotation // for drawing
-  );
+  void to_spacing(TO_BLOCK_LIST *blocks);
+  ROW *make_prop_words(TO_ROW *row);
+  ROW *make_blob_words(TO_ROW *row);
   // tordmain.cpp ///////////////////////////////////////////
   void find_components(Image pix, BLOCK_LIST *blocks, TO_BLOCK_LIST *to_blocks);
   void filter_blobs(ICOORD page_tr, TO_BLOCK_LIST *blocks, bool testing_on);
@@ -147,7 +141,6 @@ public:
 private:
   //// oldbasel.cpp ////////////////////////////////////////
   void make_old_baselines(TO_BLOCK *block, // block to do
-                          bool testing_on, // correct orientation
                           float gradient);
   void correlate_lines(TO_BLOCK *block, float gradient);
   void correlate_neighbours(TO_BLOCK *block, // block rows are in.

--- a/src/textord/topitch.cpp
+++ b/src/textord/topitch.cpp
@@ -75,7 +75,6 @@ static int sort_floats(const void *arg1, const void *arg2) {
 void compute_fixed_pitch(ICOORD page_tr,             // top right
                          TO_BLOCK_LIST *port_blocks, // input list
                          float gradient,             // page skew
-                         FCOORD rotation,            // for drawing
                          bool testing_on) {          // correct orientation
   TO_BLOCK_IT block_it;                              // iterator
   TO_BLOCK *block;                                   // current block;
@@ -103,9 +102,7 @@ void compute_fixed_pitch(ICOORD page_tr,             // top right
     block_index = 1;
     for (block_it.mark_cycle_pt(); !block_it.cycled_list(); block_it.forward()) {
       block = block_it.data();
-      if (!try_block_fixed(block)) {
-        try_rows_fixed(block, block_index, testing_on);
-      }
+      try_rows_fixed(block, block_index, testing_on);
       block_index++;
     }
   }
@@ -484,16 +481,6 @@ bool try_doc_fixed(             // determine pitch
   }
 #endif
   row->char_cells.clear();
-  return false;
-}
-
-/**********************************************************************
- * try_block_fixed
- *
- * Try to call the entire block fixed.
- **********************************************************************/
-
-bool try_block_fixed(TO_BLOCK *block) {
   return false;
 }
 

--- a/src/textord/topitch.cpp
+++ b/src/textord/topitch.cpp
@@ -95,15 +95,15 @@ void compute_fixed_pitch(ICOORD page_tr,             // top right
   block_index = 1;
   for (block_it.mark_cycle_pt(); !block_it.cycled_list(); block_it.forward()) {
     block = block_it.data();
-    compute_block_pitch(block, rotation, block_index, testing_on);
+    compute_block_pitch(block, block_index, testing_on);
     block_index++;
   }
 
-  if (!try_doc_fixed(page_tr, port_blocks, gradient)) {
+  if (!try_doc_fixed(port_blocks, gradient)) {
     block_index = 1;
     for (block_it.mark_cycle_pt(); !block_it.cycled_list(); block_it.forward()) {
       block = block_it.data();
-      if (!try_block_fixed(block, block_index)) {
+      if (!try_block_fixed(block)) {
         try_rows_fixed(block, block_index, testing_on);
       }
       block_index++;
@@ -122,7 +122,7 @@ void compute_fixed_pitch(ICOORD page_tr,             // top right
     row_index = 1;
     for (row_it.mark_cycle_pt(); !row_it.cycled_list(); row_it.forward()) {
       row = row_it.data();
-      fix_row_pitch(row, block, port_blocks, row_index, block_index);
+      fix_row_pitch(row, port_blocks, row_index, block_index);
       row_index++;
     }
     block_index++;
@@ -142,7 +142,6 @@ void compute_fixed_pitch(ICOORD page_tr,             // top right
  **********************************************************************/
 
 void fix_row_pitch(TO_ROW *bad_row,        // row to fix
-                   TO_BLOCK *bad_block,    // block of bad_row
                    TO_BLOCK_LIST *blocks,  // blocks to scan
                    int32_t row_target,     // number of row
                    int32_t block_target) { // number of block
@@ -288,7 +287,6 @@ void fix_row_pitch(TO_ROW *bad_row,        // row to fix
  **********************************************************************/
 
 void compute_block_pitch(TO_BLOCK *block,     // input list
-                         FCOORD rotation,     // for drawing
                          int32_t block_index, // block number
                          bool testing_on) {   // correct orientation
   TBOX block_box;                             // bounding box
@@ -307,7 +305,7 @@ void compute_block_pitch(TO_BLOCK *block,     // input list
   block->pr_space = block->pr_nonsp * textord_spacesize_ratioprop;
   if (!block->get_rows()->empty()) {
     ASSERT_HOST(block->xheight > 0);
-    find_repeated_chars(block, textord_show_initial_words && testing_on);
+    find_repeated_chars(block);
 #ifndef GRAPHICS_DISABLED
     if (textord_show_initial_words && testing_on) {
       // overlap_picture_ops(true);
@@ -366,7 +364,6 @@ bool compute_rows_pitch( // find line stats
  **********************************************************************/
 
 bool try_doc_fixed(             // determine pitch
-    ICOORD page_tr,             // top right
     TO_BLOCK_LIST *port_blocks, // input list
     float gradient              // page skew
 ) {
@@ -496,10 +493,7 @@ bool try_doc_fixed(             // determine pitch
  * Try to call the entire block fixed.
  **********************************************************************/
 
-bool try_block_fixed(   // find line stats
-    TO_BLOCK *block,    // block to do
-    int32_t block_index // block number
-) {
+bool try_block_fixed(TO_BLOCK *block) {
   return false;
 }
 
@@ -1651,8 +1645,7 @@ void print_pitch_sd(         // find fp cells
  * Extract marked leader blobs and put them
  * into words in advance of fixed pitch checking and word generation.
  **********************************************************************/
-void find_repeated_chars(TO_BLOCK *block,   // Block to search.
-                         bool testing_on) { // Debug mode.
+void find_repeated_chars(TO_BLOCK *block) { // Block to search.
   POLY_BLOCK *pb = block->block->pdblk.poly_block();
   if (pb != nullptr && !pb->IsText()) {
     return; // Don't find repeated chars in non-text blocks.

--- a/src/textord/topitch.h
+++ b/src/textord/topitch.h
@@ -37,7 +37,6 @@ extern double_VAR_H(textord_balance_factor);
 void compute_fixed_pitch(ICOORD page_tr,             // top right
                          TO_BLOCK_LIST *port_blocks, // input list
                          float gradient,             // page skew
-                         FCOORD rotation,            // for drawing
                          bool testing_on);           // correct orientation
 void fix_row_pitch(TO_ROW *bad_row,        // row to fix
                    TO_BLOCK_LIST *blocks,  // blocks to scan
@@ -53,8 +52,6 @@ bool compute_rows_pitch(                      // find line stats
 );
 // determine pitch
 bool try_doc_fixed(TO_BLOCK_LIST *port_blocks, float gradient);
-// find line stats
-bool try_block_fixed(TO_BLOCK *block);
 bool try_rows_fixed(     // find line stats
     TO_BLOCK *block,     // block to do
     int32_t block_index, // block number

--- a/src/textord/topitch.h
+++ b/src/textord/topitch.h
@@ -39,15 +39,11 @@ void compute_fixed_pitch(ICOORD page_tr,             // top right
                          float gradient,             // page skew
                          FCOORD rotation,            // for drawing
                          bool testing_on);           // correct orientation
-void fix_row_pitch(                                  // get some value
-    TO_ROW *bad_row,                                 // row to fix
-    TO_BLOCK *bad_block,                             // block of bad_row
-    TO_BLOCK_LIST *blocks,                           // blocks to scan
-    int32_t row_target,                              // number of row
-    int32_t block_target                             // number of block
-);
+void fix_row_pitch(TO_ROW *bad_row,        // row to fix
+                   TO_BLOCK_LIST *blocks,  // blocks to scan
+                   int32_t row_target,     // number of row
+                   int32_t block_target);  // number of block
 void compute_block_pitch(TO_BLOCK *block,     // input list
-                         FCOORD rotation,     // for drawing
                          int32_t block_index, // block number
                          bool testing_on);    // correct orientation
 bool compute_rows_pitch(                      // find line stats
@@ -55,15 +51,10 @@ bool compute_rows_pitch(                      // find line stats
     int32_t block_index,                      // block number
     bool testing_on                           // correct orientation
 );
-bool try_doc_fixed(             // determine pitch
-    ICOORD page_tr,             // top right
-    TO_BLOCK_LIST *port_blocks, // input list
-    float gradient              // page skew
-);
-bool try_block_fixed(   // find line stats
-    TO_BLOCK *block,    // block to do
-    int32_t block_index // block number
-);
+// determine pitch
+bool try_doc_fixed(TO_BLOCK_LIST *port_blocks, float gradient);
+// find line stats
+bool try_block_fixed(TO_BLOCK *block);
 bool try_rows_fixed(     // find line stats
     TO_BLOCK *block,     // block to do
     int32_t block_index, // block number
@@ -165,8 +156,7 @@ void print_pitch_sd(         // find fp cells
     int16_t projection_right, float space_size,
     float initial_pitch // guess at pitch
 );
-void find_repeated_chars(TO_BLOCK *block,  // Block to search.
-                         bool testing_on); // Debug mode.
+void find_repeated_chars(TO_BLOCK *block); // Block to search.
 void plot_fp_word(                         // draw block of words
     TO_BLOCK *block,                       // block to draw
     float pitch,                           // pitch to draw with

--- a/src/textord/tospace.cpp
+++ b/src/textord/tospace.cpp
@@ -42,9 +42,7 @@
 #define MAXSPACING 128 /*max expected spacing in pix */
 
 namespace tesseract {
-void Textord::to_spacing(ICOORD page_tr,       // topright of page
-                         TO_BLOCK_LIST *blocks // blocks on page
-) {
+void Textord::to_spacing(TO_BLOCK_LIST *blocks) {
   TO_BLOCK_IT block_it; // iterator
   TO_BLOCK *block;      // current block;
   TO_ROW *row;          // current row
@@ -840,9 +838,7 @@ threshold is not within it, move the threshold so that is just inside it.
  *
  * Convert a TO_ROW to a ROW.
  **********************************************************************/
-ROW *Textord::make_prop_words(TO_ROW *row,    // row to make
-                              FCOORD rotation // for drawing
-) {
+ROW *Textord::make_prop_words(TO_ROW *row) {
   bool bol; // start of line
   /* prev_ values are for start of word being built. non prev_ values are for
 the gap between the word being built and the next one. */
@@ -1114,9 +1110,7 @@ the gap between the word being built and the next one. */
  * Converts words into blobs so that each blob is a single character.
  *  Used for chopper test.
  **********************************************************************/
-ROW *Textord::make_blob_words(TO_ROW *row,    // row to make
-                              FCOORD rotation // for drawing
-) {
+ROW *Textord::make_blob_words(TO_ROW *row) {
   bool bol;      // start of line
   ROW *real_row; // output row
   C_OUTLINE_IT cout_it;

--- a/src/textord/wordseg.cpp
+++ b/src/textord/wordseg.cpp
@@ -107,14 +107,14 @@ void make_words(tesseract::Textord *textord,
   if (textord->use_cjk_fp_model()) {
     compute_fixed_pitch_cjk(page_tr, port_blocks);
   } else {
-    compute_fixed_pitch(page_tr, port_blocks, gradient, FCOORD(0.0f, -1.0f),
+    compute_fixed_pitch(page_tr, port_blocks, gradient,
                         !bool(textord_test_landscape));
   }
   textord->to_spacing(port_blocks);
   block_it.set_to_list(port_blocks);
   for (block_it.mark_cycle_pt(); !block_it.cycled_list(); block_it.forward()) {
     block = block_it.data();
-    make_real_words(textord, block, FCOORD(1.0f, 0.0f));
+    make_real_words(textord, block);
   }
 }
 
@@ -468,8 +468,7 @@ int32_t row_words2(   // compute space size
  */
 
 void make_real_words(tesseract::Textord *textord,
-                     TO_BLOCK *block, // block to do
-                     FCOORD rotation  // for drawing
+                     TO_BLOCK *block // block to do
 ) {
   TO_ROW *row; // current row
   TO_ROW_IT row_it = block->get_rows();

--- a/src/textord/wordseg.cpp
+++ b/src/textord/wordseg.cpp
@@ -100,7 +100,6 @@ void make_single_word(bool one_blob, TO_ROW_LIST *rows, ROW_LIST *real_rows) {
 void make_words(tesseract::Textord *textord,
                 ICOORD page_tr,               // top right
                 float gradient,               // page skew
-                BLOCK_LIST *blocks,           // block list
                 TO_BLOCK_LIST *port_blocks) { // output list
   TO_BLOCK_IT block_it;                       // iterator
   TO_BLOCK *block;                            // current block
@@ -111,7 +110,7 @@ void make_words(tesseract::Textord *textord,
     compute_fixed_pitch(page_tr, port_blocks, gradient, FCOORD(0.0f, -1.0f),
                         !bool(textord_test_landscape));
   }
-  textord->to_spacing(page_tr, port_blocks);
+  textord->to_spacing(port_blocks);
   block_it.set_to_list(port_blocks);
   for (block_it.mark_cycle_pt(); !block_it.cycled_list(); block_it.forward()) {
     block = block_it.data();
@@ -128,7 +127,6 @@ void make_words(tesseract::Textord *textord,
 
 void set_row_spaces( // find space sizes
     TO_BLOCK *block, // block to do
-    FCOORD rotation, // for drawing
     bool testing_on  // correct orientation
 ) {
   TO_ROW *row; // current row
@@ -170,7 +168,6 @@ int32_t row_words(    // compute space size
     TO_BLOCK *block,  // block it came from
     TO_ROW *row,      // row to operate on
     int32_t maxwidth, // max expected space size
-    FCOORD rotation,  // for drawing
     bool testing_on   // for debug
 ) {
   bool testing_row;      // contains testpt
@@ -323,7 +320,6 @@ int32_t row_words2(   // compute space size
     TO_BLOCK *block,  // block it came from
     TO_ROW *row,      // row to operate on
     int32_t maxwidth, // max expected space size
-    FCOORD rotation,  // for drawing
     bool testing_on   // for debug
 ) {
   bool prev_valid;       // if decent size
@@ -495,13 +491,13 @@ void make_real_words(tesseract::Textord *textord,
       // with force_make_prop_words flag.
       POLY_BLOCK *pb = block->block->pdblk.poly_block();
       if (textord_chopper_test) {
-        real_row = textord->make_blob_words(row, rotation);
+        real_row = textord->make_blob_words(row);
       } else if (textord_force_make_prop_words || (pb != nullptr && !pb->IsText()) ||
                  row->pitch_decision == PITCH_DEF_PROP || row->pitch_decision == PITCH_CORR_PROP) {
-        real_row = textord->make_prop_words(row, rotation);
+        real_row = textord->make_prop_words(row);
       } else if (row->pitch_decision == PITCH_DEF_FIXED ||
                  row->pitch_decision == PITCH_CORR_FIXED) {
-        real_row = fixed_pitch_words(row, rotation);
+        real_row = fixed_pitch_words(row);
       } else {
         ASSERT_HOST(false);
       }

--- a/src/textord/wordseg.h
+++ b/src/textord/wordseg.h
@@ -51,8 +51,7 @@ int32_t row_words2(   // compute space size
     bool testing_on   // for debug
 );
 void make_real_words(tesseract::Textord *textord,
-                     TO_BLOCK *block, // block to do
-                     FCOORD rotation  // for drawing
+                     TO_BLOCK *block // block to do
 );
 ROW *make_rep_words( // make a row
     TO_ROW *row,     // row to convert

--- a/src/textord/wordseg.h
+++ b/src/textord/wordseg.h
@@ -33,25 +33,21 @@ void make_single_word(bool one_blob, TO_ROW_LIST *rows, ROW_LIST *real_rows);
 void make_words(tesseract::Textord *textord,
                 ICOORD page_tr,              // top right
                 float gradient,              // page skew
-                BLOCK_LIST *blocks,          // block list
                 TO_BLOCK_LIST *port_blocks); // output list
 void set_row_spaces(                         // find space sizes
     TO_BLOCK *block,                         // block to do
-    FCOORD rotation,                         // for drawing
     bool testing_on                          // correct orientation
 );
 int32_t row_words(    // compute space size
     TO_BLOCK *block,  // block it came from
     TO_ROW *row,      // row to operate on
     int32_t maxwidth, // max expected space size
-    FCOORD rotation,  // for drawing
     bool testing_on   // for debug
 );
 int32_t row_words2(   // compute space size
     TO_BLOCK *block,  // block it came from
     TO_ROW *row,      // row to operate on
     int32_t maxwidth, // max expected space size
-    FCOORD rotation,  // for drawing
     bool testing_on   // for debug
 );
 void make_real_words(tesseract::Textord *textord,

--- a/src/training/classifier_tester.cpp
+++ b/src/training/classifier_tester.cpp
@@ -36,8 +36,7 @@ enum ClassifierName { CN_PRUNER, CN_FULL, CN_COUNT };
 static const char *names[] = {"pruner", "full"};
 
 static tesseract::ShapeClassifier *InitializeClassifier(const char *classifier_name,
-                                                        const UNICHARSET &unicharset, int argc,
-                                                        char **argv, tesseract::TessBaseAPI **api) {
+                                                        tesseract::TessBaseAPI **api) {
   // Decode the classifier string.
   ClassifierName classifier = CN_COUNT;
   for (int c = 0; c < CN_COUNT; ++c) {
@@ -106,7 +105,7 @@ int main(int argc, char **argv) {
   tesseract::TessBaseAPI *api;
   // Decode the classifier string.
   tesseract::ShapeClassifier *shape_classifier =
-      InitializeClassifier(FLAGS_classifier.c_str(), trainer->unicharset(), argc, argv, &api);
+      InitializeClassifier(FLAGS_classifier.c_str(), &api);
   if (shape_classifier == nullptr) {
     fprintf(stderr, "Classifier init failed!:%s\n", FLAGS_classifier.c_str());
     return EXIT_FAILURE;

--- a/src/training/common/errorcounter.cpp
+++ b/src/training/common/errorcounter.cpp
@@ -90,7 +90,7 @@ double ErrorCounter::ComputeErrorRate(ShapeClassifier *classifier, int report_le
     ++total_samples;
   }
   // Create the appropriate error report.
-  unscaled_error = counter.ReportErrors(report_level, boosting_mode, fontinfo_table, *it,
+  unscaled_error = counter.ReportErrors(report_level, boosting_mode, fontinfo_table,
                                         unichar_error, fonts_report);
   if (scaled_error != nullptr) {
     *scaled_error = counter.scaled_error_;
@@ -356,7 +356,7 @@ bool ErrorCounter::AccumulateJunk(bool debug, const std::vector<UnicharRating> &
 // If not nullptr, the report string is saved in fonts_report.
 // (Ignoring report_level).
 double ErrorCounter::ReportErrors(int report_level, CountTypes boosting_mode,
-                                  const FontInfoTable &fontinfo_table, const SampleIterator &it,
+                                  const FontInfoTable &fontinfo_table,
                                   double *unichar_error, std::string *fonts_report) {
   // Compute totals over all the fonts and report individual font results
   // when required.

--- a/src/training/common/errorcounter.h
+++ b/src/training/common/errorcounter.h
@@ -176,7 +176,7 @@ private:
   // unichar_error. If not nullptr, the report string is saved in fonts_report.
   // (Ignoring report_level).
   double ReportErrors(int report_level, CountTypes boosting_mode,
-                      const FontInfoTable &fontinfo_table, const SampleIterator &it,
+                      const FontInfoTable &fontinfo_table,
                       double *unichar_error, std::string *fonts_report);
 
   // Sets the report string to a combined human and machine-readable report

--- a/src/training/common/intfeaturemap.cpp
+++ b/src/training/common/intfeaturemap.cpp
@@ -144,7 +144,7 @@ int IntFeatureMap::FindNZFeatureMapping(SampleIterator *it) {
   feature_map_.Setup();
   compact_size_ = feature_map_.CompactSize();
   mapping_changed_ = true;
-  FinalizeMapping(it);
+  FinalizeMapping();
   tprintf("%d non-zero features found in %d samples\n", compact_size_, total_samples);
   return compact_size_;
 }
@@ -152,7 +152,7 @@ int IntFeatureMap::FindNZFeatureMapping(SampleIterator *it) {
 
 // After deleting some features, finish setting up the mapping, and map
 // all the samples. Returns the size of the compacted feature space.
-int IntFeatureMap::FinalizeMapping(SampleIterator *it) {
+int IntFeatureMap::FinalizeMapping() {
   if (mapping_changed_) {
     feature_map_.CompleteMerges();
     compact_size_ = feature_map_.CompactSize();

--- a/src/training/common/intfeaturemap.h
+++ b/src/training/common/intfeaturemap.h
@@ -98,7 +98,7 @@ public:
 
   // After deleting some features, finish setting up the mapping, and map
   // all the samples. Returns the size of the compacted feature space.
-  int FinalizeMapping(SampleIterator *it);
+  int FinalizeMapping();
 
   // Indexes the given array of features to a vector of sorted indices.
   void IndexAndSortFeatures(const INT_FEATURE_STRUCT *features, int num_features,

--- a/src/training/common/trainingsampleset.cpp
+++ b/src/training/common/trainingsampleset.cpp
@@ -405,8 +405,8 @@ float TrainingSampleSet::ClusterDistance(int font_id1, int class_id1, int font_i
 float TrainingSampleSet::ComputeClusterDistance(int font_id1, int class_id1, int font_id2,
                                                 int class_id2,
                                                 const IntFeatureMap &feature_map) const {
-  int dist = ReliablySeparable(font_id1, class_id1, font_id2, class_id2, feature_map, false);
-  dist += ReliablySeparable(font_id2, class_id2, font_id1, class_id1, feature_map, false);
+  int dist = ReliablySeparable(font_id1, class_id1, font_id2, class_id2, feature_map);
+  dist += ReliablySeparable(font_id2, class_id2, font_id1, class_id1, feature_map);
   int denominator = GetCanonicalFeatures(font_id1, class_id1).size();
   denominator += GetCanonicalFeatures(font_id2, class_id2).size();
   return static_cast<float>(dist) / denominator;
@@ -449,7 +449,7 @@ static void AddNearFeatures(const IntFeatureMap &feature_map, int f, int levels,
 // ComputeCanonicalFeatures and ComputeCloudFeatures must have been called
 // first, or the results will be nonsense.
 int TrainingSampleSet::ReliablySeparable(int font_id1, int class_id1, int font_id2, int class_id2,
-                                         const IntFeatureMap &feature_map, bool thorough) const {
+                                         const IntFeatureMap &feature_map) const {
   int result = 0;
   const TrainingSample *sample2 = GetCanonicalSample(font_id2, class_id2);
   if (sample2 == nullptr) {

--- a/src/training/common/trainingsampleset.h
+++ b/src/training/common/trainingsampleset.h
@@ -136,7 +136,7 @@ public:
   // ComputeCanonicalFeatures and ComputeCloudFeatures must have been called
   // first, or the results will be nonsense.
   int ReliablySeparable(int font_id1, int class_id1, int font_id2, int class_id2,
-                        const IntFeatureMap &feature_map, bool thorough) const;
+                        const IntFeatureMap &feature_map) const;
 
   // Returns the total index of the requested sample.
   // OrganizeByFontAndClass must have been already called.

--- a/src/training/dawg2wordlist.cpp
+++ b/src/training/dawg2wordlist.cpp
@@ -25,7 +25,7 @@
 
 using namespace tesseract;
 
-static std::unique_ptr<tesseract::Dawg> LoadSquishedDawg(const UNICHARSET &unicharset, const char *filename) {
+static std::unique_ptr<tesseract::Dawg> LoadSquishedDawg(const char *filename) {
   const int kDictDebugLevel = 1;
   tesseract::TFile dawg_file;
   if (!dawg_file.Open(filename, nullptr)) {
@@ -90,7 +90,7 @@ int main(int argc, char *argv[]) {
     tprintf("Error loading unicharset from %s.\n", unicharset_file);
     return EXIT_FAILURE;
   }
-  auto dict = LoadSquishedDawg(unicharset, dawg_file);
+  auto dict = LoadSquishedDawg(dawg_file);
   if (dict == nullptr) {
     tprintf("Error loading dictionary from %s.\n", dawg_file);
     return EXIT_FAILURE;

--- a/src/training/lstmeval.cpp
+++ b/src/training/lstmeval.cpp
@@ -63,8 +63,7 @@ int main(int argc, char **argv) {
     tprintf("Failed to load eval data from: %s\n", FLAGS_eval_listfile.c_str());
     return EXIT_FAILURE;
   }
-  double errs = 0.0;
-  std::string result = tester.RunEvalSync(0, &errs, mgr,
+  std::string result = tester.RunEvalSync(0, mgr,
                                           /*training_stage (irrelevant)*/ 0, FLAGS_verbosity);
   tprintf("%s\n", result.c_str());
   return EXIT_SUCCESS;

--- a/src/training/mftraining.cpp
+++ b/src/training/mftraining.cpp
@@ -53,7 +53,7 @@ using namespace tesseract;
             Public Code
 -----------------------------------------------------------------------------*/
 #ifndef GRAPHICS_DISABLED
-static void DisplayProtoList(const char *ch, LIST protolist) {
+static void DisplayProtoList(LIST protolist) {
   auto window = std::make_unique<ScrollView>("Char samples", 50, 200, 520, 520, 260, 260, true);
   LIST proto = protolist;
   iterate(proto) {
@@ -101,7 +101,7 @@ static LIST ClusterOneConfig(int shape_id, const char *class_label, LIST mf_clas
   MergeInsignificantProtos(proto_list, class_label, clusterer, &Config);
 #ifndef GRAPHICS_DISABLED
   if (strcmp(FLAGS_test_ch.c_str(), class_label) == 0) {
-    DisplayProtoList(FLAGS_test_ch.c_str(), proto_list);
+    DisplayProtoList(proto_list);
   }
 #endif // !GRAPHICS_DISABLED
   // Delete the protos that will not be used in the inttemp output file.

--- a/src/training/unicharset/lstmtester.cpp
+++ b/src/training/unicharset/lstmtester.cpp
@@ -77,7 +77,7 @@ std::string LSTMTester::RunEvalAsync(int iteration, const double *training_error
 
 // Runs an evaluation synchronously on the stored data and returns a string
 // describing the results.
-std::string LSTMTester::RunEvalSync(int iteration, const double *training_errors,
+std::string LSTMTester::RunEvalSync(int iteration,
                                     const TessdataManager &model_mgr, int training_stage,
                                     int verbosity) {
   LSTMTrainer trainer;
@@ -132,7 +132,7 @@ std::string LSTMTester::RunEvalSync(int iteration, const double *training_errors
 // it will call UnlockRunning to release the lock after RunEvalSync completes.
 void LSTMTester::ThreadFunc() {
   test_result_ =
-      RunEvalSync(test_iteration_, test_training_errors_, test_model_mgr_, test_training_stage_,
+      RunEvalSync(test_iteration_, test_model_mgr_, test_training_stage_,
                   /*verbosity*/ 0);
   UnlockRunning();
 }

--- a/src/training/unicharset/lstmtester.h
+++ b/src/training/unicharset/lstmtester.h
@@ -59,7 +59,7 @@ public:
   // Runs an evaluation synchronously on the stored eval data and returns a
   // string describing the results. Args as RunEvalAsync, except verbosity,
   // which outputs errors, if 1, or all results if 2.
-  std::string RunEvalSync(int iteration, const double *training_errors, const TessdataManager &model_mgr,
+  std::string RunEvalSync(int iteration, const TessdataManager &model_mgr,
                           int training_stage, int verbosity);
 
 private:

--- a/src/training/unicharset/lstmtrainer.cpp
+++ b/src/training/unicharset/lstmtrainer.cpp
@@ -933,7 +933,7 @@ Trainability LSTMTrainer::PrepareForBackward(const ImageData *trainingdata,
   targets->Resize(*fwd_outputs, network_->NumOutputs());
   LossType loss_type = OutputLossType();
   if (loss_type == LT_SOFTMAX) {
-    if (!ComputeTextTargets(*fwd_outputs, truth_labels, targets)) {
+    if (!ComputeTextTargets(truth_labels, targets)) {
       tprintf("Compute simple targets failed for %s!\n",
               trainingdata->imagefilename().c_str());
       return UNENCODABLE;
@@ -955,8 +955,7 @@ Trainability LSTMTrainer::PrepareForBackward(const ImageData *trainingdata,
   if (loss_type != LT_CTC) {
     LabelsFromOutputs(*targets, &truth_labels, &xcoords);
   }
-  if (!DebugLSTMTraining(inputs, *trainingdata, *fwd_outputs, truth_labels,
-                         *targets)) {
+  if (!DebugLSTMTraining(inputs, *fwd_outputs, truth_labels, *targets)) {
     tprintf("Input width was %d\n", inputs.Width());
     return UNENCODABLE;
   }
@@ -1131,7 +1130,6 @@ void LSTMTrainer::EmptyConstructor() {
 // corresponding x_starts.
 // Returns false if the truth string is empty.
 bool LSTMTrainer::DebugLSTMTraining(const NetworkIO &inputs,
-                                    const ImageData &trainingdata,
                                     const NetworkIO &fwd_outputs,
                                     const std::vector<int> &truth_labels,
                                     const NetworkIO &outputs) {
@@ -1208,8 +1206,7 @@ void LSTMTrainer::DisplayTargets(const NetworkIO &targets,
 
 // Builds a no-compromises target where the first positions should be the
 // truth labels and the rest is padded with the null_char_.
-bool LSTMTrainer::ComputeTextTargets(const NetworkIO &outputs,
-                                     const std::vector<int> &truth_labels,
+bool LSTMTrainer::ComputeTextTargets(const std::vector<int> &truth_labels,
                                      NetworkIO *targets) {
   if (truth_labels.size() > targets->Width()) {
     tprintf("Error: transcription %s too long to fit into target of width %d\n",

--- a/src/training/unicharset/lstmtrainer.h
+++ b/src/training/unicharset/lstmtrainer.h
@@ -343,7 +343,7 @@ protected:
   // as an image in the given window, and the corresponding labels at the
   // corresponding x_starts.
   // Returns false if the truth string is empty.
-  bool DebugLSTMTraining(const NetworkIO &inputs, const ImageData &trainingdata,
+  bool DebugLSTMTraining(const NetworkIO &inputs,
                          const NetworkIO &fwd_outputs,
                          const std::vector<int> &truth_labels,
                          const NetworkIO &outputs);
@@ -353,8 +353,7 @@ protected:
 
   // Builds a no-compromises target where the first positions should be the
   // truth labels and the rest is padded with the null_char_.
-  bool ComputeTextTargets(const NetworkIO &outputs,
-                          const std::vector<int> &truth_labels,
+  bool ComputeTextTargets(const std::vector<int> &truth_labels,
                           NetworkIO *targets);
 
   // Builds a target using standard CTC. truth_labels should be pre-padded with

--- a/src/wordrec/language_model.cpp
+++ b/src/wordrec/language_model.cpp
@@ -248,7 +248,7 @@ static bool HasBetterCaseVariant(const UNICHARSET &unicharset, const BLOB_CHOICE
  */
 bool LanguageModel::UpdateState(bool just_classified, int curr_col, int curr_row,
                                 BLOB_CHOICE_LIST *curr_list, LanguageModelState *parent_node,
-                                LMPainPoints *pain_points, WERD_RES *word_res,
+                                WERD_RES *word_res,
                                 BestChoiceBundle *best_choice_bundle, BlamerBundle *blamer_bundle) {
   if (language_model_debug_level > 0) {
     tprintf("\nUpdateState: col=%d row=%d %s", curr_col, curr_row,
@@ -337,7 +337,7 @@ bool LanguageModel::UpdateState(bool just_classified, int curr_col, int curr_row
         blob_choice_flags |= kLowerCaseFlag;
       }
       new_changed |= AddViterbiStateEntry(blob_choice_flags, denom, word_end, curr_col, curr_row,
-                                          choice, curr_state, nullptr, pain_points, word_res,
+                                          choice, curr_state, nullptr, word_res,
                                           best_choice_bundle, blamer_bundle);
     } else {
       // Get viterbi entries from each parent ViterbiStateEntry.
@@ -367,7 +367,7 @@ bool LanguageModel::UpdateState(bool just_classified, int curr_col, int curr_row
         // Create a new ViterbiStateEntry if BLOB_CHOICE in c_it.data()
         // looks good according to the Dawgs or character ngram model.
         new_changed |= AddViterbiStateEntry(top_choice_flags, denom, word_end, curr_col, curr_row,
-                                            c_it.data(), curr_state, parent_vse, pain_points,
+                                            c_it.data(), curr_state, parent_vse,
                                             word_res, best_choice_bundle, blamer_bundle);
       }
     }
@@ -577,7 +577,7 @@ ViterbiStateEntry *LanguageModel::GetNextParentVSE(bool just_classified, bool mi
 bool LanguageModel::AddViterbiStateEntry(LanguageModelFlagsType top_choice_flags, float denom,
                                          bool word_end, int curr_col, int curr_row, BLOB_CHOICE *b,
                                          LanguageModelState *curr_state,
-                                         ViterbiStateEntry *parent_vse, LMPainPoints *pain_points,
+                                         ViterbiStateEntry *parent_vse,
                                          WERD_RES *word_res, BestChoiceBundle *best_choice_bundle,
                                          BlamerBundle *blamer_bundle) {
   ViterbiStateEntry_IT vit;
@@ -603,7 +603,7 @@ bool LanguageModel::AddViterbiStateEntry(LanguageModelFlagsType top_choice_flags
   }
 
   // Invoke Dawg language model component.
-  LanguageModelDawgInfo *dawg_info = GenerateDawgInfo(word_end, curr_col, curr_row, *b, parent_vse);
+  LanguageModelDawgInfo *dawg_info =   GenerateDawgInfo(word_end, curr_col, *b, parent_vse);
 
   float outline_length = AssociateUtils::ComputeOutlineLength(rating_cert_scale_, *b);
   // Invoke Ngram language model component.
@@ -611,7 +611,7 @@ bool LanguageModel::AddViterbiStateEntry(LanguageModelFlagsType top_choice_flags
   if (language_model_ngram_on) {
     ngram_info =
         GenerateNgramInfo(dict_->getUnicharset().id_to_unichar(b->unichar_id()), b->certainty(),
-                          denom, curr_col, curr_row, outline_length, parent_vse);
+                          denom, outline_length, parent_vse);
     ASSERT_HOST(ngram_info != nullptr);
   }
   bool liked_by_language_model =
@@ -679,7 +679,7 @@ bool LanguageModel::AddViterbiStateEntry(LanguageModelFlagsType top_choice_flags
   // Invoke Top Choice language model component to make the final adjustments
   // to new_vse->top_choice_flags.
   if (!curr_state->viterbi_state_entries.empty() && new_vse->top_choice_flags) {
-    GenerateTopChoiceInfo(new_vse, parent_vse, curr_state);
+    GenerateTopChoiceInfo(new_vse, curr_state);
   }
 
   // If language model components did not like this unichar - return.
@@ -713,7 +713,7 @@ bool LanguageModel::AddViterbiStateEntry(LanguageModelFlagsType top_choice_flags
 
   // Update best choice if needed.
   if (word_end) {
-    UpdateBestChoice(new_vse, pain_points, word_res, best_choice_bundle, blamer_bundle);
+    UpdateBestChoice(new_vse, word_res, best_choice_bundle, blamer_bundle);
     // Discard the entry if UpdateBestChoice() found flaws in it.
     if (new_vse->cost >= WERD_CHOICE::kBadRating && new_vse != best_choice_bundle->best_vse) {
       if (language_model_debug_level > 1) {
@@ -774,7 +774,6 @@ bool LanguageModel::AddViterbiStateEntry(LanguageModelFlagsType top_choice_flags
 }
 
 void LanguageModel::GenerateTopChoiceInfo(ViterbiStateEntry *new_vse,
-                                          const ViterbiStateEntry *parent_vse,
                                           LanguageModelState *lms) {
   ViterbiStateEntry_IT vit(&(lms->viterbi_state_entries));
   for (vit.mark_cycle_pt();
@@ -789,7 +788,7 @@ void LanguageModel::GenerateTopChoiceInfo(ViterbiStateEntry *new_vse,
   }
 }
 
-LanguageModelDawgInfo *LanguageModel::GenerateDawgInfo(bool word_end, int curr_col, int curr_row,
+LanguageModelDawgInfo *LanguageModel::GenerateDawgInfo(bool word_end, int curr_col,
                                                        const BLOB_CHOICE &b,
                                                        const ViterbiStateEntry *parent_vse) {
   // Initialize active_dawgs from parent_vse if it is not nullptr.
@@ -886,7 +885,7 @@ LanguageModelDawgInfo *LanguageModel::GenerateDawgInfo(bool word_end, int curr_c
 }
 
 LanguageModelNgramInfo *LanguageModel::GenerateNgramInfo(const char *unichar, float certainty,
-                                                         float denom, int curr_col, int curr_row,
+                                                         float denom,
                                                          float outline_length,
                                                          const ViterbiStateEntry *parent_vse) {
   // Initialize parent context.
@@ -1233,7 +1232,7 @@ float LanguageModel::ComputeAdjustedPathCost(ViterbiStateEntry *vse) {
   }
 }
 
-void LanguageModel::UpdateBestChoice(ViterbiStateEntry *vse, LMPainPoints *pain_points,
+void LanguageModel::UpdateBestChoice(ViterbiStateEntry *vse,
                                      WERD_RES *word_res, BestChoiceBundle *best_choice_bundle,
                                      BlamerBundle *blamer_bundle) {
   bool truth_path;

--- a/src/wordrec/language_model.h
+++ b/src/wordrec/language_model.h
@@ -77,8 +77,7 @@ public:
                    float rating_cert_scale);
 
   // Updates language model state of the given BLOB_CHOICE_LIST (from
-  // the ratings matrix) and its parent. Updates pain_points if new
-  // problematic points are found in the segmentation graph.
+  // the ratings matrix) and its parent.
   //
   // At most language_model_viterbi_list_size are kept in each
   // LanguageModelState.viterbi_state_entries list.
@@ -89,7 +88,7 @@ public:
   // The list ordered by cost that is computed collectively by several
   // language model components (currently dawg and ngram components).
   bool UpdateState(bool just_classified, int curr_col, int curr_row, BLOB_CHOICE_LIST *curr_list,
-                   LanguageModelState *parent_node, LMPainPoints *pain_points, WERD_RES *word_res,
+                   LanguageModelState *parent_node, WERD_RES *word_res,
                    BestChoiceBundle *best_choice_bundle, BlamerBundle *blamer_bundle);
 
   // Returns true if an acceptable best choice was discovered.
@@ -182,7 +181,7 @@ protected:
   bool AddViterbiStateEntry(LanguageModelFlagsType top_choice_flags, float denom, bool word_end,
                             int curr_col, int curr_row, BLOB_CHOICE *b,
                             LanguageModelState *curr_state, ViterbiStateEntry *parent_vse,
-                            LMPainPoints *pain_points, WERD_RES *word_res,
+                            WERD_RES *word_res,
                             BestChoiceBundle *best_choice_bundle, BlamerBundle *blamer_bundle);
 
   // Determines whether a potential entry is a true top choice and
@@ -190,7 +189,7 @@ protected:
   //
   // Note: The function assumes that b, top_choice_flags and changed
   // are not nullptr.
-  void GenerateTopChoiceInfo(ViterbiStateEntry *new_vse, const ViterbiStateEntry *parent_vse,
+  void GenerateTopChoiceInfo(ViterbiStateEntry *new_vse,
                              LanguageModelState *lms);
 
   // Calls dict_->LetterIsOk() with DawgArgs initialized from parent_vse and
@@ -198,8 +197,7 @@ protected:
   // with updated active dawgs, constraints and permuter.
   //
   // Note: the caller is responsible for deleting the returned pointer.
-  LanguageModelDawgInfo *GenerateDawgInfo(bool word_end, int curr_col, int curr_row,
-                                          const BLOB_CHOICE &b,
+  LanguageModelDawgInfo *GenerateDawgInfo(bool word_end, int curr_col, const BLOB_CHOICE &b,
                                           const ViterbiStateEntry *parent_vse);
 
   // Computes p(unichar | parent context) and records it in ngram_cost.
@@ -210,7 +208,7 @@ protected:
   //
   // Note: the caller is responsible for deleting the returned pointer.
   LanguageModelNgramInfo *GenerateNgramInfo(const char *unichar, float certainty, float denom,
-                                            int curr_col, int curr_row, float outline_length,
+                                            float outline_length,
                                             const ViterbiStateEntry *parent_vse);
 
   // Computes -(log(prob(classifier)) + log(prob(ngram model)))
@@ -240,8 +238,8 @@ protected:
   // constructed WERD_CHOICE is better than the best/raw choice recorded
   // in the best_choice_bundle, this function updates the corresponding
   // fields and sets best_choice_bunldle->updated to true.
-  void UpdateBestChoice(ViterbiStateEntry *vse, LMPainPoints *pain_points, WERD_RES *word_res,
-                        BestChoiceBundle *best_choice_bundle, BlamerBundle *blamer_bundle);
+  void UpdateBestChoice(ViterbiStateEntry *vse, WERD_RES *word_res, BestChoiceBundle *best_choice_bundle,
+                        BlamerBundle *blamer_bundle);
 
   // Constructs a WERD_CHOICE by tracing parent pointers starting with
   // the given LanguageModelStateEntry. Returns the constructed word.

--- a/src/wordrec/lm_pain_points.cpp
+++ b/src/wordrec/lm_pain_points.cpp
@@ -60,9 +60,9 @@ void LMPainPoints::GenerateInitial(WERD_RES *word_res) {
         continue;
       }
       // Add an initial pain point if needed.
-      if (ratings->Classified(col, row - 1, dict_->WildcardID()) ||
+      if (ratings->Classified(col, row - 1) ||
           (col + 1 < ratings->dimension() &&
-           ratings->Classified(col + 1, row, dict_->WildcardID()))) {
+           ratings->Classified(col + 1, row))) {
         GeneratePainPoint(col, row, LM_PPTYPE_SHAPE, 0.0, true, max_char_wh_ratio_, word_res);
       }
     }
@@ -95,7 +95,7 @@ void LMPainPoints::GenerateFromPath(float rating_cert_scale, ViterbiStateEntry *
     const MATRIX_COORD &parent_cell = parent_vse->curr_b->matrix_cell();
     MATRIX_COORD pain_coord(parent_cell.col, curr_cell.row);
     if (!pain_coord.Valid(*word_res->ratings) ||
-        !word_res->ratings->Classified(parent_cell.col, curr_cell.row, dict_->WildcardID())) {
+        !word_res->ratings->Classified(parent_cell.col, curr_cell.row)) {
       // rat_subtr contains ratings sum of the two adjacent blobs to be merged.
       // rat_subtr will be subtracted from the ratings sum of the path, since
       // the blobs will be joined into a new blob, whose rating is yet unknown.
@@ -144,7 +144,7 @@ bool LMPainPoints::GeneratePainPoint(int col, int row, LMPainPointsType pp_type,
                                      float max_char_wh_ratio, WERD_RES *word_res) {
   MATRIX_COORD coord(col, row);
   if (coord.Valid(*word_res->ratings) &&
-      word_res->ratings->Classified(col, row, dict_->WildcardID())) {
+      word_res->ratings->Classified(col, row)) {
     return false;
   }
   if (debug_level_ > 3) {

--- a/src/wordrec/lm_pain_points.h
+++ b/src/wordrec/lm_pain_points.h
@@ -64,11 +64,10 @@ public:
     return LMPainPointsTypeName[type];
   }
 
-  LMPainPoints(int max, float rat, bool fp, const Dict *d, int deb)
+  LMPainPoints(int max, float rat, bool fp, int deb)
       : max_heap_size_(max)
       , max_char_wh_ratio_(rat)
       , fixed_pitch_(fp)
-      , dict_(d)
       , debug_level_(deb) {}
   ~LMPainPoints() = default;
 
@@ -122,8 +121,6 @@ private:
   float max_char_wh_ratio_;
   // Set to true if fixed pitch should be assumed.
   bool fixed_pitch_;
-  // Cached pointer to dictionary.
-  const Dict *dict_;
   // Debug level for print statements.
   int debug_level_;
 };

--- a/src/wordrec/segsearch.cpp
+++ b/src/wordrec/segsearch.cpp
@@ -70,7 +70,7 @@ void Wordrec::SegSearch(WERD_RES *word_res, BestChoiceBundle *best_choice_bundle
         word_res->ratings->IncreaseBandSize(pain_point.row - pain_point.col + 1);
       }
       if (pain_point.Valid(*word_res->ratings) &&
-          !word_res->ratings->Classified(pain_point.col, pain_point.row, getDict().WildcardID())) {
+          !word_res->ratings->Classified(pain_point.col, pain_point.row)) {
         found_nothing = false;
         break;
       }
@@ -296,7 +296,7 @@ void Wordrec::ResetNGramSearch(WERD_RES *word_res, BestChoiceBundle *best_choice
 void Wordrec::InitBlamerForSegSearch(WERD_RES *word_res, LMPainPoints *pain_points,
                                      BlamerBundle *blamer_bundle, std::string &blamer_debug) {
   pain_points->Clear(); // Clear pain points heap.
-  blamer_bundle->InitForSegSearch(word_res->best_choice, word_res->ratings, getDict().WildcardID(),
+  blamer_bundle->InitForSegSearch(word_res->best_choice, word_res->ratings,
                                   wordrec_debug_blamer, blamer_debug, pain_points,
                                   segsearch_max_char_wh_ratio, word_res);
 }

--- a/src/wordrec/segsearch.cpp
+++ b/src/wordrec/segsearch.cpp
@@ -33,7 +33,7 @@ namespace tesseract {
 void Wordrec::SegSearch(WERD_RES *word_res, BestChoiceBundle *best_choice_bundle,
                         BlamerBundle *blamer_bundle) {
   LMPainPoints pain_points(segsearch_max_pain_points, segsearch_max_char_wh_ratio,
-                           assume_fixed_pitch_char_segment, &getDict(), segsearch_debug_level);
+                           assume_fixed_pitch_char_segment, segsearch_debug_level);
   // Compute scaling factor that will help us recover blob outline length
   // from classifier rating and certainty for the blob.
   float rating_cert_scale = -1.0 * getDict().certainty_scale / rating_scale;
@@ -186,7 +186,7 @@ void Wordrec::UpdateSegSearchNodes(float rating_cert_scale, int starting_col,
       LanguageModelState *parent_node = col == 0 ? nullptr : best_choice_bundle->beam[col - 1];
       if (current_node != nullptr &&
           language_model_->UpdateState((*pending)[col].IsRowJustClassified(row), col, row,
-                                       current_node, parent_node, pain_points, word_res,
+                                       current_node, parent_node, word_res,
                                        best_choice_bundle, blamer_bundle) &&
           row + 1 < ratings->dimension()) {
         // Since the language model state of this entry changed, process all

--- a/src/wordrec/tface.cpp
+++ b/src/wordrec/tface.cpp
@@ -59,7 +59,7 @@ void Wordrec::program_editup(const std::string &textbase, TessdataManager *init_
  * Cleanup and exit the recog program.
  */
 int Wordrec::end_recog() {
-  program_editdown(0);
+  program_editdown();
 
   return (0);
 }
@@ -70,7 +70,7 @@ int Wordrec::end_recog() {
  * This function holds any necessary post processing for the Wise Owl
  * program.
  */
-void Wordrec::program_editdown(int32_t elapsed_time) {
+void Wordrec::program_editdown() {
 #ifndef DISABLED_LEGACY_ENGINE
   EndAdaptiveClassifier();
 #endif // ndef DISABLED_LEGACY_ENGINE

--- a/src/wordrec/wordrec.h
+++ b/src/wordrec/wordrec.h
@@ -52,7 +52,7 @@ public:
   // tface.cpp
   void program_editup(const std::string &textbase, TessdataManager *init_classifier,
                       TessdataManager *init_dict);
-  void program_editdown(int32_t elapsed_time);
+  void program_editdown();
   int end_recog();
   int dict_word(const WERD_CHOICE &word);
 
@@ -246,7 +246,7 @@ public:
   void program_editup(const std::string &textbase, TessdataManager *init_classifier,
                       TessdataManager *init_dict);
   void cc_recog(WERD_RES *word);
-  void program_editdown(int32_t elapsed_time);
+  void program_editdown();
   void set_pass1();
   void set_pass2();
   int end_recog();

--- a/unittest/intfeaturemap_test.cc
+++ b/unittest/intfeaturemap_test.cc
@@ -106,7 +106,7 @@ TEST_F(IntFeatureMapTest, Exhaustive) {
   // test again.
   map.DeleteMapFeature(0);
   map.DeleteMapFeature(total_buckets - 1);
-  map.FinalizeMapping(nullptr);
+  map.FinalizeMapping();
   map.IndexAndSortFeatures(features.get(), total_size, &index_features);
   // Has no effect on index features.
   EXPECT_EQ(total_size, index_features.size());

--- a/unittest/textlineprojection_test.cc
+++ b/unittest/textlineprojection_test.cc
@@ -100,7 +100,7 @@ protected:
     denorm_ = finder_->denorm();
     TO_BLOCK_LIST to_blocks;
     BLOBNBOX_LIST diacritic_blobs;
-    EXPECT_GE(finder_->FindBlocks(tesseract::PSM_AUTO, nullptr, 1, to_block, photomask_pix, nullptr,
+    EXPECT_GE(finder_->FindBlocks(tesseract::PSM_AUTO, to_block, photomask_pix, nullptr,
                                   nullptr, nullptr, &found_blocks, &diacritic_blobs, &to_blocks),
               0);
     projection_ = finder_->projection();


### PR DESCRIPTION
This patch set removes numerous unused function parameters and fixes compiler warnings for unused parameters
which cannot be removed.

After cleaning the function parameters, some functions and class member variables were no longer used
and could be removed, too.

Assisted-by: qwen3.6-36b (Alibaba)