### PR TITLE
 Fix compiler warnings (-Wold-style-cast) 

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -35,6 +35,7 @@
 #include "errcode.h" // for ASSERT_HOST
 #include "helpers.h" // for IntCastRounded, chomp_string, copy_string
 #include "host.h"    // for MAX_PATH
+#include "image.h"   // for Image, Leptonica (pixDestroy, boxCreate, ...)
 #include "imageio.h" // for IFF_TIFF_G4, IFF_TIFF, IFF_TIFF_G3, ...
 #ifndef DISABLED_LEGACY_ENGINE
 #  include "intfx.h" // for INT_FX_RESULT_STRUCT
@@ -74,7 +75,6 @@
 #include <string_view>
 #include <vector>   // for std::vector
 
-#include <allheaders.h> // for pixDestroy, boxCreate, boxaAddBox, box...
 #ifdef HAVE_LIBCURL
 #  include <curl/curl.h>
 #endif

--- a/src/api/pagerenderer.cpp
+++ b/src/api/pagerenderer.cpp
@@ -15,6 +15,7 @@
 
 #include "errcode.h" // for ASSERT_HOST
 #include "helpers.h" // for copy_string
+#include "image.h"   // for Leptonica (ptaGetCount, ...)
 #include "tprintf.h" // for tprintf
 
 #include <tesseract/baseapi.h>
@@ -27,7 +28,6 @@
 #include <sstream> // for std::stringstream
 #include <unordered_set>
 
-#include <allheaders.h>
 #if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || \
     LIBLEPT_MAJOR_VERSION > 1
 #  include <array_internal.h>

--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -23,8 +23,8 @@
 #include "pdf_ttf.h"
 #include "tprintf.h"
 #include "helpers.h" // for Swap, copy_string
+#include "image.h"   // for Leptonica (lept_free, ...)
 
-#include <allheaders.h>
 #include <tesseract/baseapi.h>
 #include <tesseract/publictypes.h> // for PTIsTextType()
 #include <tesseract/renderer.h>

--- a/src/ccmain/applybox.cpp
+++ b/src/ccmain/applybox.cpp
@@ -17,7 +17,6 @@
  **********************************************************************/
 
 #ifndef DISABLED_LEGACY_ENGINE
-#  include <allheaders.h>
 #  include <cctype>
 #  include <cerrno>
 #  include <cstring>

--- a/src/ccmain/linerec.cpp
+++ b/src/ccmain/linerec.cpp
@@ -17,7 +17,6 @@
 
 #include "tesseractclass.h"
 
-#include <allheaders.h>
 #include "boxread.h"
 #include "imagedata.h" // for ImageData
 #include "lstmrecognizer.h"

--- a/src/ccmain/ltrresultiterator.cpp
+++ b/src/ccmain/ltrresultiterator.cpp
@@ -23,8 +23,6 @@
 #include "pageres.h"
 #include "tesseractclass.h"
 
-#include <allheaders.h>
-
 namespace tesseract {
 
 LTRResultIterator::LTRResultIterator(PAGE_RES *page_res, Tesseract *tesseract, int scale,

--- a/src/ccmain/pageiterator.cpp
+++ b/src/ccmain/pageiterator.cpp
@@ -17,9 +17,9 @@
 //
 ///////////////////////////////////////////////////////////////////////
 
-#include <allheaders.h>
 #include <tesseract/pageiterator.h>
 #include "helpers.h"
+#include "image.h"          // for Image
 #include "pageres.h"
 #include "tesseractclass.h"
 

--- a/src/ccmain/pagesegmain.cpp
+++ b/src/ccmain/pagesegmain.cpp
@@ -29,7 +29,6 @@
 #  include "config_auto.h"
 #endif
 
-#include <allheaders.h>
 #include "blobbox.h"
 #include "blread.h"
 #include "colfind.h"
@@ -38,6 +37,7 @@
 #  include "equationdetect.h"
 #endif
 #include <tesseract/osdetect.h>
+#include "image.h"          // for Image
 #include "imagefind.h"
 #include "linefind.h"
 #include "makerow.h"

--- a/src/ccmain/resultiterator.cpp
+++ b/src/ccmain/resultiterator.cpp
@@ -25,8 +25,6 @@
 #include "tesseractclass.h"
 #include "unicharset.h"
 
-#include <allheaders.h>
-
 #include <set>
 #include <vector>
 

--- a/src/ccmain/tesseractclass.cpp
+++ b/src/ccmain/tesseractclass.cpp
@@ -40,11 +40,11 @@
 
 #include "tesseractclass.h"
 
-#include <allheaders.h>
 #include "edgblob.h"
 #ifndef DISABLED_LEGACY_ENGINE
 #  include "equationdetect.h"
 #endif
+#include "image.h"       // for Image
 #include "lstmrecognizer.h"
 #include "thresholder.h" // for ThresholdMethod
 

--- a/src/ccmain/tesseractclass.h
+++ b/src/ccmain/tesseractclass.h
@@ -36,6 +36,7 @@
 #  include "docqual.h" // for GARBAGE_LEVEL
 #endif
 #include "genericvector.h"   // for PointerVector
+#include "image.h"           // for Image
 #include "pageres.h"         // for WERD_RES (ptr only), PAGE_RES (pt...
 #include "params.h"          // for BOOL_VAR_H, BoolParam, DoubleParam
 #include "points.h"          // for FCOORD
@@ -46,8 +47,6 @@
 
 #include <tesseract/publictypes.h> // for OcrEngineMode, PageSegMode, OEM_L...
 #include <tesseract/unichar.h>     // for UNICHAR_ID
-
-#include <allheaders.h> // for pixDestroy, pixGetWidth, pixGetHe...
 
 #include <cstdint> // for int16_t, int32_t, uint16_t
 #include <cstdio>  // for FILE

--- a/src/ccmain/thresholder.cpp
+++ b/src/ccmain/thresholder.cpp
@@ -21,11 +21,11 @@
 #  include "config_auto.h"
 #endif
 
+#include "image.h"   // for Image
 #include "otsuthr.h"
 #include "thresholder.h"
 #include "tprintf.h" // for tprintf
 
-#include <allheaders.h>
 #include <tesseract/baseapi.h> // for api->GetIntVariable()
 
 #include <algorithm> // for std::max, std::min
@@ -83,9 +83,9 @@ void ImageThresholder::SetImage(const unsigned char *imagedata, int width, int h
       for (int y = 0; y < height; ++y, data += wpl, imagedata += bytes_per_line) {
         for (int x = 0; x < width; ++x) {
           if (imagedata[x / 8] & (0x80 >> (x % 8))) {
-            CLEAR_DATA_BIT(data, x);
+            Image::clearDataBit(data, x);
           } else {
-            SET_DATA_BIT(data, x);
+            Image::setDataBit(data, x);
           }
         }
       }
@@ -95,7 +95,7 @@ void ImageThresholder::SetImage(const unsigned char *imagedata, int width, int h
       // Greyscale just copies the bytes in the right order.
       for (int y = 0; y < height; ++y, data += wpl, imagedata += bytes_per_line) {
         for (int x = 0; x < width; ++x) {
-          SET_DATA_BYTE(data, x, imagedata[x]);
+          Image::setDataByte(data, x, imagedata[x]);
         }
       }
       break;
@@ -104,9 +104,9 @@ void ImageThresholder::SetImage(const unsigned char *imagedata, int width, int h
       // Put the colors in the correct places in the line buffer.
       for (int y = 0; y < height; ++y, imagedata += bytes_per_line) {
         for (int x = 0; x < width; ++x, ++data) {
-          SET_DATA_BYTE(data, COLOR_RED, imagedata[3 * x]);
-          SET_DATA_BYTE(data, COLOR_GREEN, imagedata[3 * x + 1]);
-          SET_DATA_BYTE(data, COLOR_BLUE, imagedata[3 * x + 2]);
+          Image::setDataByte(data, COLOR_RED, imagedata[3 * x]);
+          Image::setDataByte(data, COLOR_GREEN, imagedata[3 * x + 1]);
+          Image::setDataByte(data, COLOR_BLUE, imagedata[3 * x + 2]);
         }
       }
       break;
@@ -403,16 +403,16 @@ void ImageThresholder::ThresholdRectToPix(Image src_pix, int num_channels, const
     for (int x = 0; x < rect_width_; ++x) {
       bool white_result = true;
       for (int ch = 0; ch < num_channels; ++ch) {
-        int pixel = GET_DATA_BYTE(linedata, (x + rect_left_) * num_channels + ch);
+        int pixel = Image::getDataByte(linedata, (x + rect_left_) * num_channels + ch);
         if (hi_values[ch] >= 0 && (pixel > thresholds[ch]) == (hi_values[ch] == 0)) {
           white_result = false;
           break;
         }
       }
       if (white_result) {
-        CLEAR_DATA_BIT(pixline, x);
+        Image::clearDataBit(pixline, x);
       } else {
-        SET_DATA_BIT(pixline, x);
+        Image::setDataBit(pixline, x);
       }
     }
   }

--- a/src/ccstruct/blobbox.cpp
+++ b/src/ccstruct/blobbox.cpp
@@ -26,11 +26,10 @@
 #include "coutln.h"  // for C_OUTLINE_IT, C_OUTLINE, C_OUTLINE_LIST
 #include "environ.h" // for l_uint32
 #include "host.h"    // for NearlyEqual
+#include "image.h"   // for Image
 #include "points.h"  // for operator+=, ICOORD::rotate
 
 #include "helpers.h" // for UpdateRange, IntCastRounded
-
-#include <allheaders.h> // for pixGetHeight, pixGetPixel
 
 #include <algorithm> // for max, min
 #include <cmath>

--- a/src/ccstruct/coutln.cpp
+++ b/src/ccstruct/coutln.cpp
@@ -23,16 +23,14 @@
 
 #include "coutln.h"
 
-#include "arrayaccess.h" // for GET_DATA_BYTE
 #include "blobs.h"       // for TPOINT
 #include "crakedge.h"    // for CRACKEDGE
 #include "environ.h"     // for l_uint32
 #include "errcode.h"     // for ASSERT_HOST
+#include "helpers.h"     // for ClipToRange, IntCastRounded, Modulo
+#include "image.h"       // for Image, Leptonica (pixSetPixel, pixGetData, ...)
 #include "normalis.h"    // for DENORM
 
-#include "helpers.h" // for ClipToRange, IntCastRounded, Modulo
-
-#include <allheaders.h> // for pixSetPixel, pixGetData, pixRasterop, pixGe...
 #include "pix.h"        // for Pix (ptr only), PIX_DST, PIX_NOT
 
 #include <algorithm> // for max, min
@@ -669,10 +667,10 @@ void C_OUTLINE::RemoveSmallRecursive(int min_size, C_OUTLINE_IT *it) {
 static void ComputeGradient(const l_uint32 *data, int wpl, int x, int y, int width, int height,
                             ICOORD *gradient) {
   const l_uint32 *line = data + y * wpl;
-  int pix_x_y = x < width && y < height ? GET_DATA_BYTE(line, x) : 255;
-  int pix_x_prevy = x < width && y > 0 ? GET_DATA_BYTE(line - wpl, x) : 255;
-  int pix_prevx_prevy = x > 0 && y > 0 ? GET_DATA_BYTE(line - wpl, x - 1) : 255;
-  int pix_prevx_y = x > 0 && y < height ? GET_DATA_BYTE(line, x - 1) : 255;
+  int pix_x_y = x < width && y < height ? Image::getDataByte(line, x) : 255;
+  int pix_x_prevy = x < width && y > 0 ? Image::getDataByte(line - wpl, x) : 255;
+  int pix_prevx_prevy = x > 0 && y > 0 ? Image::getDataByte(line - wpl, x - 1) : 255;
+  int pix_prevx_y = x > 0 && y < height ? Image::getDataByte(line, x - 1) : 255;
   gradient->set_x(pix_x_y + pix_x_prevy - (pix_prevx_y + pix_prevx_prevy));
   gradient->set_y(pix_x_prevy + pix_prevx_prevy - (pix_x_y + pix_prevx_y));
 }
@@ -688,8 +686,8 @@ static bool EvaluateVerticalDiff(const l_uint32 *data, int wpl, int diff_sign, i
     return false;
   }
   const l_uint32 *line = data + y * wpl;
-  int pixel1 = GET_DATA_BYTE(line - wpl, x);
-  int pixel2 = GET_DATA_BYTE(line, x);
+  int pixel1 = Image::getDataByte(line - wpl, x);
+  int pixel2 = Image::getDataByte(line, x);
   int diff = (pixel2 - pixel1) * diff_sign;
   if (diff > *best_diff) {
     *best_diff = diff;
@@ -709,8 +707,8 @@ static bool EvaluateHorizontalDiff(const l_uint32 *line, int diff_sign, int x, i
   if (x <= 0 || x >= width) {
     return false;
   }
-  int pixel1 = GET_DATA_BYTE(line, x - 1);
-  int pixel2 = GET_DATA_BYTE(line, x);
+  int pixel1 = Image::getDataByte(line, x - 1);
+  int pixel2 = Image::getDataByte(line, x);
   int diff = (pixel2 - pixel1) * diff_sign;
   if (diff > *best_diff) {
     *best_diff = diff;

--- a/src/ccstruct/debugpixa.h
+++ b/src/ccstruct/debugpixa.h
@@ -3,8 +3,6 @@
 
 #include "image.h"
 
-#include <allheaders.h>
-
 namespace tesseract {
 
 // Class to hold a Pixa collection of debug images with captions and save them

--- a/src/ccstruct/image.cpp
+++ b/src/ccstruct/image.cpp
@@ -17,8 +17,6 @@
 
 #include "image.h"
 
-#include <allheaders.h>
-
 namespace tesseract {
 
 Image Image::clone() const {

--- a/src/ccstruct/image.h
+++ b/src/ccstruct/image.h
@@ -16,9 +16,11 @@
 #ifndef TESSERACT_CCSTRUCT_IMAGE_H_
 #define TESSERACT_CCSTRUCT_IMAGE_H_
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#include <allheaders.h> // Pix, from leptonica
+#pragma GCC diagnostic pop
 #include <tesseract/export.h>
-
-struct Pix;
 
 namespace tesseract {
 
@@ -49,6 +51,25 @@ public:
   Image &operator|=(Image);
   Image operator&(Image) const;
   Image &operator&=(Image);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  static void clearDataBit(const uint32_t *data, int n) {
+    CLEAR_DATA_BIT(data, n);
+  }
+  static int getDataBit(const uint32_t *data, int n) {
+    return GET_DATA_BIT(data, n);
+  }
+  static int getDataByte(const uint32_t *data, int n) {
+    return GET_DATA_BYTE(data, n);
+  }
+  static void setDataBit(uint32_t *data, int n) {
+    SET_DATA_BIT(data, n);
+  }
+  static void setDataByte(uint32_t *data, int n, int b) {
+    SET_DATA_BYTE(data, n, b);
+  }
+#pragma GCC diagnostic pop
 };
 
 } // namespace tesseract

--- a/src/ccstruct/imagedata.cpp
+++ b/src/ccstruct/imagedata.cpp
@@ -24,6 +24,7 @@
 #include "imagedata.h"
 
 #include "boxread.h"    // for ReadMemBoxes
+#include "image.h"      // for Image
 #include "rect.h"       // for TBOX
 #include "scrollview.h" // for ScrollView, ScrollView::CYAN, ScrollView::NONE
 #include "tprintf.h"    // for tprintf
@@ -31,8 +32,6 @@
 
 #include "helpers.h"  // for IntCastRounded, TRand, ClipToRange, Modulo
 #include "serialis.h" // for TFile
-
-#include <allheaders.h> // for pixDestroy, pixGetHeight, pixGetWidth, lept_...
 
 #include <cinttypes>    // for PRId64
 #include <fstream>      // for std::ifstream

--- a/src/ccstruct/normalis.cpp
+++ b/src/ccstruct/normalis.cpp
@@ -18,7 +18,6 @@
 
 #include "normalis.h"
 
-#include <allheaders.h>
 #include "blobs.h"
 #include "helpers.h"
 #include "matrix.h"

--- a/src/ccstruct/otsuthr.cpp
+++ b/src/ccstruct/otsuthr.cpp
@@ -18,9 +18,9 @@
 
 #include "otsuthr.h"
 
-#include <allheaders.h>
 #include <cstring>
 #include "helpers.h"
+#include "image.h"
 
 namespace tesseract {
 
@@ -101,7 +101,7 @@ void HistogramRect(Image src_pix, int channel, int left, int top, int width, int
   for (int y = top; y < bottom; ++y) {
     const l_uint32 *linedata = srcdata + y * src_wpl;
     for (int x = 0; x < width; ++x) {
-      int pixel = GET_DATA_BYTE(linedata, (x + left) * num_channels + channel);
+      int pixel = Image::getDataByte(linedata, (x + left) * num_channels + channel);
       ++histogram[pixel];
     }
   }

--- a/src/ccstruct/pdblock.cpp
+++ b/src/ccstruct/pdblock.cpp
@@ -23,7 +23,7 @@
 
 #include "pdblock.h"
 
-#include <allheaders.h>
+#include "image.h"   // for Image
 
 #include <cinttypes> // for PRId32
 #include <cstdlib>

--- a/src/ccstruct/quspline.cpp
+++ b/src/ccstruct/quspline.cpp
@@ -23,11 +23,11 @@
 
 #include "quspline.h"
 
+#include "image.h"    // for Image
 #include "points.h"   // for ICOORD
 #include "quadlsq.h"  // for QLSQ
 #include "quadratc.h" // for QUAD_COEFFS
 
-#include <allheaders.h> // for pixRenderPolyline, pixGetDepth, pixGetHeight
 #include "pix.h"        // for L_CLEAR_PIXELS, L_SET_PIXELS, Pix (ptr only)
 
 namespace tesseract {

--- a/src/ccstruct/stepblob.cpp
+++ b/src/ccstruct/stepblob.cpp
@@ -23,9 +23,9 @@
 
 #include "stepblob.h"
 
+#include "image.h"  // for Image
 #include "points.h" // for operator+=, FCOORD, ICOORD
 
-#include <allheaders.h> // for pixCreate, pixGetDepth
 #include <vector>       // for std::vector
 
 namespace tesseract {

--- a/src/ccutil/kdpair.h
+++ b/src/ccutil/kdpair.h
@@ -104,7 +104,7 @@ public:
   // Copy constructor steals the pointer from src and nulls it in src, thereby
   // moving the (single) ownership of the data.
   KDPtrPair(const KDPtrPair &src) : data_(src.data_), key_(src.key_) {
-    ((KDPtrPair &)src).data_ = nullptr;
+    const_cast<KDPtrPair &>(src).data_ = nullptr;
   }
   // Destructor deletes data, assuming it is the sole owner.
   ~KDPtrPair() {
@@ -116,7 +116,7 @@ public:
   void operator=(const KDPtrPair &src) {
     delete this->data_;
     this->data_ = src.data_;
-    ((KDPtrPair &)src).data_ = nullptr;
+    const_cast<KDPtrPair &>(src).data_ = nullptr;
     this->key_ = src.key_;
   }
 

--- a/src/classify/intfx.cpp
+++ b/src/classify/intfx.cpp
@@ -31,8 +31,6 @@
 
 #include "helpers.h"
 
-#include <allheaders.h>
-
 #include <cmath> // for M_PI
 #include <mutex> // for std::mutex
 

--- a/src/classify/trainingsample.cpp
+++ b/src/classify/trainingsample.cpp
@@ -22,11 +22,10 @@
 #include "trainingsample.h"
 
 #include "helpers.h"
+#include "image.h"           // for Image
 #include "intfeaturespace.h"
 #include "normfeat.h"
 #include "shapetable.h"
-
-#include <allheaders.h>
 
 #include <cmath> // for M_PI
 

--- a/src/lstm/input.cpp
+++ b/src/lstm/input.cpp
@@ -17,7 +17,7 @@
 
 #include "input.h"
 
-#include <allheaders.h>
+#include "image.h"     // for Image
 #include "imagedata.h"
 #include "pageres.h"
 #include "scrollview.h"

--- a/src/lstm/lstmrecognizer.cpp
+++ b/src/lstm/lstmrecognizer.cpp
@@ -22,10 +22,10 @@
 
 #include "lstmrecognizer.h"
 
-#include <allheaders.h>
 #include "dict.h"
 #include "genericheap.h"
 #include "helpers.h"
+#include "image.h"       // for Image
 #include "imagedata.h"
 #include "input.h"
 #include "lstm.h"

--- a/src/lstm/network.cpp
+++ b/src/lstm/network.cpp
@@ -26,9 +26,9 @@
 
 // This base class needs to know about all its sub-classes because of the
 // factory deserializing method: CreateFromFile.
-#include <allheaders.h>
 #include "convolve.h"
 #include "fullyconnected.h"
+#include "image.h"          // for Image
 #include "input.h"
 #include "lstm.h"
 #include "maxpool.h"

--- a/src/lstm/networkio.cpp
+++ b/src/lstm/networkio.cpp
@@ -19,8 +19,8 @@
 #include <cfloat> // for FLT_MAX
 #include <cmath>
 
-#include <allheaders.h>
 #include "functions.h"
+#include "image.h"     // for Image
 #include "statistc.h"
 #include "tprintf.h"
 
@@ -131,10 +131,10 @@ static void ComputeBlackWhite(Image pix, float *black, float *white) {
   if (width >= 3) {
     int y = height / 2;
     l_uint32 *line = pixGetData(pix) + pixGetWpl(pix) * y;
-    int prev = GET_DATA_BYTE(line, 0);
-    int curr = GET_DATA_BYTE(line, 1);
+    int prev = Image::getDataByte(line, 0);
+    int curr = Image::getDataByte(line, 1);
     for (int x = 1; x + 1 < width; ++x) {
-      int next = GET_DATA_BYTE(line, x + 1);
+      int next = Image::getDataByte(line, x + 1);
       if ((curr < prev && curr <= next) || (curr <= prev && curr < next)) {
         // Local minimum.
         mins.add(curr, 1);
@@ -235,11 +235,11 @@ void NetworkIO::Copy2DImage(int batch, Image pix, float black, float contrast, T
         if (color) {
           int f = 0;
           for (int c = COLOR_RED; c <= COLOR_BLUE; ++c) {
-            int pixel = GET_DATA_BYTE(line + x, c);
+            int pixel = Image::getDataByte(line + x, c);
             SetPixel(t, f++, pixel, black, contrast);
           }
         } else {
-          int pixel = GET_DATA_BYTE(line, x);
+          int pixel = Image::getDataByte(line, x);
           SetPixel(t, 0, pixel, black, contrast);
         }
       }
@@ -271,7 +271,7 @@ void NetworkIO::Copy1DGreyImage(int batch, Image pix, float black, float contras
   for (x = 0; x < width; ++x, ++t) {
     for (int y = 0; y < height; ++y) {
       uint32_t *line = pixGetData(pix) + wpl * y;
-      int pixel = GET_DATA_BYTE(line, x);
+      int pixel = Image::getDataByte(line, x);
       SetPixel(t, y, pixel, black, contrast);
     }
   }

--- a/src/tesseract.cpp
+++ b/src/tesseract.cpp
@@ -31,7 +31,6 @@
 #include <map>    // for std::map
 #include <memory> // std::unique_ptr
 
-#include <allheaders.h>
 #include <tesseract/baseapi.h>
 #include "dict.h"
 #include <tesseract/renderer.h>

--- a/src/textord/baselinedetect.cpp
+++ b/src/textord/baselinedetect.cpp
@@ -24,7 +24,6 @@
 
 #include "baselinedetect.h"
 
-#include <allheaders.h>
 #include <algorithm>
 #include <cfloat> // for FLT_MAX
 #include <cmath>  // for M_PI
@@ -32,6 +31,7 @@
 #include "detlinefit.h"
 #include "drawtord.h"
 #include "helpers.h"
+#include "image.h"          // for Image
 #include "linlsq.h"
 #include "makerow.h"
 #include "tesserrstream.h"  // for tesserr

--- a/src/textord/bbgrid.cpp
+++ b/src/textord/bbgrid.cpp
@@ -19,6 +19,7 @@
 
 #include "bbgrid.h"
 #include "helpers.h"
+#include "image.h"    // for Image
 #include "ocrblock.h"
 
 namespace tesseract {
@@ -232,7 +233,7 @@ Image TraceOutlineOnReducedPix(C_OUTLINE *outline, int gridsize, ICOORD bleft, i
   for (int i = 0; i < length; ++i) {
     int grid_x = (pos.x() - bleft.x()) / gridsize - *left;
     int grid_y = (pos.y() - bleft.y()) / gridsize - *bottom;
-    SET_DATA_BIT(data + grid_y * wpl, grid_x);
+    Image::setDataBit(data + grid_y * wpl, grid_x);
     pos += outline->step(i);
   }
   return pix;
@@ -265,7 +266,7 @@ Image TraceBlockOnReducedPix(BLOCK *block, int gridsize, ICOORD bleft, int *left
     while (pos != next_pos) {
       int grid_x = (pos.x() - bleft.x()) / gridsize - *left;
       int grid_y = (pos.y() - bleft.y()) / gridsize - *bottom;
-      SET_DATA_BIT(data + grid_y * wpl, grid_x);
+      Image::setDataBit(data + grid_y * wpl, grid_x);
       pos += major_step;
       accumulator += minor;
       if (accumulator >= major) {

--- a/src/textord/bbgrid.h
+++ b/src/textord/bbgrid.h
@@ -24,10 +24,9 @@
 
 #include "clst.h"
 #include "coutln.h"
+#include "image.h"      // for Image
 #include "rect.h"
 #include "scrollview.h"
-
-#include <allheaders.h>
 
 class BLOCK;
 
@@ -546,7 +545,7 @@ void BBGrid<BBC, BBC_CLIST, BBC_C_IT>::InsertPixPtBBox(int left, int bottom, Ima
   for (int y = 0; y < height; ++y) {
     l_uint32 *data = pixGetData(pix) + y * pixGetWpl(pix);
     for (int x = 0; x < width; ++x) {
-      if (GET_DATA_BIT(data, x)) {
+      if (Image::getDataBit(data, x)) {
         grid_[(bottom + y) * gridwidth_ + x + left].add_sorted(SortByBoxLeft<BBC>, true, bbox);
       }
     }

--- a/src/textord/devanagari_processing.cpp
+++ b/src/textord/devanagari_processing.cpp
@@ -24,10 +24,9 @@
 #include "devanagari_processing.h"
 
 #include "debugpixa.h"
+#include "image.h"     // for Image
 #include "statistc.h"
 #include "tordmain.h"
-
-#include <allheaders.h>
 
 namespace tesseract {
 
@@ -471,7 +470,7 @@ void PixelHistogram::ConstructVerticalCountHist(Image pix) {
   for (int i = 0; i < height; ++i) {
     l_uint32 *line = data + i * wpl;
     for (int j = 0; j < width; ++j) {
-      if (GET_DATA_BIT(line, j)) {
+      if (Image::getDataBit(line, j)) {
         ++(hist_[j]);
       }
     }

--- a/src/textord/devanagari_processing.h
+++ b/src/textord/devanagari_processing.h
@@ -13,13 +13,9 @@
 #ifndef TESSERACT_TEXTORD_DEVNAGARI_PROCESSING_H_
 #define TESSERACT_TEXTORD_DEVNAGARI_PROCESSING_H_
 
-#include <allheaders.h>
+#include "image.h"    // for Image
 #include "ocrblock.h"
 #include "params.h"
-
-struct Pix;
-struct Box;
-struct Boxa;
 
 namespace tesseract {
 

--- a/src/textord/equationdetectbase.cpp
+++ b/src/textord/equationdetectbase.cpp
@@ -2,7 +2,6 @@
 // File:        equationdetectbase.cpp
 // Description: The base class equation detection class.
 // Author:      Zongyi (Joe) Liu (joeliu@google.com)
-// Created:     Fri Aug 31 11:13:01 PST 2011
 //
 // (C) Copyright 2011, Google Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,8 +23,7 @@
 #include "equationdetectbase.h"
 
 #include "blobbox.h"
-
-#include <allheaders.h>
+#include "image.h"   // for Image
 
 namespace tesseract {
 

--- a/src/textord/imagefind.cpp
+++ b/src/textord/imagefind.cpp
@@ -24,11 +24,10 @@
 #include "imagefind.h"
 
 #include "colpartitiongrid.h"
+#include "image.h"            // for Image
 #include "linlsq.h"
 #include "params.h"
 #include "statistc.h"
-
-#include <allheaders.h>
 
 #include <algorithm>
 
@@ -63,7 +62,7 @@ static bool HScanForEdge(uint32_t *data, int wpl, int x_start, int x_end, int mi
     int pix_count = 0;
     uint32_t *line = data + wpl * y;
     for (int x = x_start; x < x_end; ++x) {
-      if (GET_DATA_BIT(line, x)) {
+      if (Image::getDataBit(line, x)) {
         ++pix_count;
       }
     }
@@ -98,7 +97,7 @@ static bool VScanForEdge(uint32_t *data, int wpl, int y_start, int y_end, int mi
     int pix_count = 0;
     uint32_t *line = data + y_start * wpl;
     for (int y = y_start; y < y_end; ++y, line += wpl) {
-      if (GET_DATA_BIT(line, x)) {
+      if (Image::getDataBit(line, x)) {
         ++pix_count;
       }
     }

--- a/src/textord/linefind.cpp
+++ b/src/textord/linefind.cpp
@@ -25,6 +25,7 @@
 #include "blobbox.h"
 #include "crakedge.h" // for CRACKEDGE
 #include "edgblob.h"
+#include "image.h"    // for Image
 #include "linefind.h"
 #include "tabvector.h"
 
@@ -117,7 +118,7 @@ static int MaxStrokeWidth(Image pix) {
   int max_dist = 0;
   for (int y = 0; y < height; ++y) {
     for (int x = 0; x < width; ++x) {
-      int pixel = GET_DATA_BYTE(data, x);
+      int pixel = Image::getDataByte(data, x);
       if (pixel > max_dist) {
         max_dist = pixel;
       }
@@ -275,7 +276,7 @@ static void GetLineBoxes(bool horizontal_lines, Image pix_lines, Image pix_inter
   if (horizontal_lines) {
     for (int y = 0; y < height; ++y, data += wpl) {
       for (int x = kCrackSpacing; x < width; x += kCrackSpacing) {
-        CLEAR_DATA_BIT(data, x);
+        Image::clearDataBit(data, x);
       }
     }
   } else {

--- a/src/textord/scanedg.cpp
+++ b/src/textord/scanedg.cpp
@@ -20,9 +20,8 @@
 
 #include "crakedge.h"
 #include "edgloop.h"
+#include "image.h"    // for Image
 #include "pdblock.h"
-
-#include <allheaders.h>
 
 #include <memory> // std::unique_ptr
 
@@ -90,7 +89,7 @@ void block_edges(Image t_pix,   // thresholded image
       // Get the binary pixels from the image.
       l_uint32 *line = pixGetData(t_pix) + wpl * (height - 1 - y);
       for (int x = 0; x < block_width; ++x) {
-        bwline[x] = GET_DATA_BIT(line, x + bleft.x()) ^ 1;
+        bwline[x] = Image::getDataBit(line, x + bleft.x()) ^ 1;
       }
       make_margins(block, &line_it, bwline.get(), margin, bleft.x(), tright.x(), y);
     } else {

--- a/src/textord/tablefind.cpp
+++ b/src/textord/tablefind.cpp
@@ -25,8 +25,6 @@
 #include <utility>
 #include "tablefind.h"
 
-#include <allheaders.h>
-
 #include "colpartitionset.h"
 #include "tablerecog.h"
 

--- a/src/textord/textlineprojection.cpp
+++ b/src/textord/textlineprojection.cpp
@@ -15,12 +15,12 @@
 #  include "config_auto.h"
 #endif
 
-#include <allheaders.h>
 #include "bbgrid.h"  // Base class.
 #include "blobbox.h" // BlobNeighbourDir.
 #include "blobs.h"
 #include "colpartition.h"
 #include "helpers.h" // for IntCastRounded
+#include "image.h"   // for Image
 #include "normalis.h"
 #include "textlineprojection.h"
 
@@ -134,7 +134,7 @@ void TextlineProjection::DisplayProjection() const {
   uint32_t *col_data = pixGetData(pixc);
   for (int y = 0; y < height; ++y, src_data += src_wpl, col_data += col_wpl) {
     for (int x = 0; x < width; ++x) {
-      int pixel = GET_DATA_BYTE(src_data, x);
+      int pixel = Image::getDataByte(src_data, x);
       l_uint32 result;
       if (pixel <= 17) {
         composeRGBPixel(0, 0, pixel * 15, &result);
@@ -281,12 +281,12 @@ int TextlineProjection::VerticalDistance(bool debug, int x, int y1, int y2) cons
   int step = y1 < y2 ? 1 : -1;
   uint32_t *data = pixGetData(pix_) + y1 * wpl;
   wpl *= step;
-  int prev_pixel = GET_DATA_BYTE(data, x);
+  int prev_pixel = Image::getDataByte(data, x);
   int distance = 0;
   int right_way_steps = 0;
   for (int y = y1; y != y2; y += step) {
     data += wpl;
-    int pixel = GET_DATA_BYTE(data, x);
+    int pixel = Image::getDataByte(data, x);
     if (debug) {
       tprintf("At (%d,%d), pix = %d, prev=%d\n", x, y + step, pixel, prev_pixel);
     }
@@ -314,11 +314,11 @@ int TextlineProjection::HorizontalDistance(bool debug, int x1, int x2, int y) co
   int wpl = pixGetWpl(pix_);
   int step = x1 < x2 ? 1 : -1;
   uint32_t *data = pixGetData(pix_) + y * wpl;
-  int prev_pixel = GET_DATA_BYTE(data, x1);
+  int prev_pixel = Image::getDataByte(data, x1);
   int distance = 0;
   int right_way_steps = 0;
   for (int x = x1; x != x2; x += step) {
-    int pixel = GET_DATA_BYTE(data, x + step);
+    int pixel = Image::getDataByte(data, x + step);
     if (debug) {
       tprintf("At (%d,%d), pix = %d, prev=%d\n", x + step, y, pixel, prev_pixel);
     }
@@ -542,7 +542,7 @@ int TextlineProjection::MeanPixelsInLineSegment(const DENORM *denorm, int offset
     count = x_delta * x_step + 1;
     for (int x = start_pt.x; x != end_pt.x; x += x_step) {
       int y = start_pt.y + DivRounded(y_delta * (x - start_pt.x), x_delta);
-      total += GET_DATA_BYTE(data + wpl * y, x);
+      total += Image::getDataByte(data + wpl * y, x);
     }
   } else {
     // Vertical line. Add the offset horizontally.
@@ -559,7 +559,7 @@ int TextlineProjection::MeanPixelsInLineSegment(const DENORM *denorm, int offset
     count = y_delta * y_step + 1;
     for (int y = start_pt.y; y != end_pt.y; y += y_step) {
       int x = start_pt.x + DivRounded(x_delta * (y - start_pt.y), y_delta);
-      total += GET_DATA_BYTE(data + wpl * y, x);
+      total += Image::getDataByte(data + wpl * y, x);
     }
   }
   return DivRounded(total, count);
@@ -636,9 +636,9 @@ void TextlineProjection::IncrementRectangle8Bit(const TBOX &box) {
   uint32_t *data = pixGetData(pix_) + scaled_top * wpl;
   for (int y = scaled_top; y <= scaled_bottom; ++y) {
     for (int x = scaled_left; x <= scaled_right; ++x) {
-      int pixel = GET_DATA_BYTE(data, x);
+      int pixel = Image::getDataByte(data, x);
       if (pixel < 255) {
-        SET_DATA_BYTE(data, x, pixel + 1);
+        Image::setDataByte(data, x, pixel + 1);
       }
     }
     data += wpl;

--- a/src/textord/tordmain.cpp
+++ b/src/textord/tordmain.cpp
@@ -24,7 +24,6 @@
 
 #include "tordmain.h"
 
-#include "arrayaccess.h" // for GET_DATA_BYTE
 #include "blobbox.h"     // for BLOBNBOX_IT, BLOBNBOX, TO_BLOCK, TO_B...
 #include "ccstruct.h"    // for CCStruct, CCStruct::kXHeightFraction
 #include "clst.h"        // for CLISTIZE
@@ -32,6 +31,7 @@
 #include "drawtord.h"    // for plot_box_list, to_win, create_to_win
 #include "edgblob.h"     // for extract_edges
 #include "errcode.h"     // for ASSERT_HOST, ...
+#include "image.h"       // for Image, Leptonica (pixDestroy, pixGetHeight, ...)
 #include "makerow.h"     // for textord_test_x, textord_test_y, texto...
 #include "ocrblock.h"    // for BLOCK_IT, BLOCK, BLOCK_LIST (ptr only)
 #include "ocrrow.h"      // for ROW, ROW_IT, ROW_LIST, tweak_row_base...
@@ -48,8 +48,6 @@
 #include "textord.h"     // for Textord, WordWithBox, WordGrid, WordS...
 #include "tprintf.h"     // for tprintf
 #include "werd.h"        // for WERD_IT, WERD, WERD_LIST, W_DONT_CHOP
-
-#include <allheaders.h> // for pixDestroy, pixGetHeight, boxCreate
 
 #include <cfloat>  // for FLT_MAX
 #include <cmath>   // for ceil, floor, M_PI
@@ -84,17 +82,17 @@ void SetBlobStrokeWidth(Image pix, BLOBNBOX *blob) {
   for (int y = 0; y < height; ++y) {
     uint32_t *pixels = data + y * wpl;
     int prev_pixel = 0;
-    int pixel = GET_DATA_BYTE(pixels, 0);
+    int pixel = Image::getDataByte(pixels, 0);
     for (int x = 1; x < width; ++x) {
-      int next_pixel = GET_DATA_BYTE(pixels, x);
+      int next_pixel = Image::getDataByte(pixels, x);
       // We are looking for a pixel that is equal to its vertical neighbours,
       // yet greater than its left neighbour.
-      if (prev_pixel < pixel && (y == 0 || pixel == GET_DATA_BYTE(pixels - wpl, x - 1)) &&
-          (y == height - 1 || pixel == GET_DATA_BYTE(pixels + wpl, x - 1))) {
+      if (prev_pixel < pixel && (y == 0 || pixel == Image::getDataByte(pixels - wpl, x - 1)) &&
+          (y == height - 1 || pixel == Image::getDataByte(pixels + wpl, x - 1))) {
         if (pixel > next_pixel) {
           // Single local max, so an odd width.
           h_stats.add(pixel * 2 - 1, 1);
-        } else if (pixel == next_pixel && x + 1 < width && pixel > GET_DATA_BYTE(pixels, x + 1)) {
+        } else if (pixel == next_pixel && x + 1 < width && pixel > Image::getDataByte(pixels, x + 1)) {
           // Double local max, so an even width.
           h_stats.add(pixel * 2, 1);
         }
@@ -107,19 +105,19 @@ void SetBlobStrokeWidth(Image pix, BLOBNBOX *blob) {
   STATS v_stats(0, height);
   for (int x = 0; x < width; ++x) {
     int prev_pixel = 0;
-    int pixel = GET_DATA_BYTE(data, x);
+    int pixel = Image::getDataByte(data, x);
     for (int y = 1; y < height; ++y) {
       uint32_t *pixels = data + y * wpl;
-      int next_pixel = GET_DATA_BYTE(pixels, x);
+      int next_pixel = Image::getDataByte(pixels, x);
       // We are looking for a pixel that is equal to its horizontal neighbours,
       // yet greater than its upper neighbour.
-      if (prev_pixel < pixel && (x == 0 || pixel == GET_DATA_BYTE(pixels - wpl, x - 1)) &&
-          (x == width - 1 || pixel == GET_DATA_BYTE(pixels - wpl, x + 1))) {
+      if (prev_pixel < pixel && (x == 0 || pixel == Image::getDataByte(pixels - wpl, x - 1)) &&
+          (x == width - 1 || pixel == Image::getDataByte(pixels - wpl, x + 1))) {
         if (pixel > next_pixel) {
           // Single local max, so an odd width.
           v_stats.add(pixel * 2 - 1, 1);
         } else if (pixel == next_pixel && y + 1 < height &&
-                   pixel > GET_DATA_BYTE(pixels + wpl, x)) {
+                   pixel > Image::getDataByte(pixels + wpl, x)) {
           // Double local max, so an even width.
           v_stats.add(pixel * 2, 1);
         }

--- a/src/training/common/commontraining.cpp
+++ b/src/training/common/commontraining.cpp
@@ -63,7 +63,6 @@ void ParseArguments(int *argc, char ***argv) {
 
 #else
 
-#  include <allheaders.h>
 #  include "ccutil.h"
 #  include "classify.h"
 #  include "cluster.h"

--- a/src/training/common/mastertrainer.cpp
+++ b/src/training/common/mastertrainer.cpp
@@ -21,13 +21,13 @@
 #  include "config_auto.h"
 #endif
 
-#include <allheaders.h>
 #include <cmath>
 #include <ctime>
 #include "boxread.h"
 #include "classify.h"
 #include "errorcounter.h"
 #include "featdefs.h"
+#include "image.h"           // for Image
 #include "mastertrainer.h"
 #include "sampleiterator.h"
 #include "shapeclassifier.h"

--- a/src/training/common/trainingsampleset.cpp
+++ b/src/training/common/trainingsampleset.cpp
@@ -19,7 +19,6 @@
 
 #include <algorithm>
 
-#include <allheaders.h>
 #include "boxread.h"
 #include "fontinfo.h"
 //#include "helpers.h"

--- a/src/training/degradeimage.cpp
+++ b/src/training/degradeimage.cpp
@@ -18,8 +18,8 @@
  **********************************************************************/
 
 #include "degradeimage.h"
+#include "image.h"        // for Image
 
-#include <allheaders.h> // from leptonica
 #include <cstdlib>
 #include "helpers.h" // For TRand.
 #include "rect.h"
@@ -150,7 +150,7 @@ Image DegradeImage(Image input, int exposure, TRand *randomizer, float *rotation
   l_uint32 *data = pixGetData(input);
   for (int y = 0; y < height; ++y) {
     for (int x = 0; x < width; ++x) {
-      int pixel = GET_DATA_BYTE(data, x);
+      int pixel = Image::getDataByte(data, x);
       if (randomizer != nullptr) {
         pixel += randomizer->IntRand() % (kSaltnPepper * 2 + 1) - kSaltnPepper;
       }
@@ -164,7 +164,7 @@ Image DegradeImage(Image input, int exposure, TRand *randomizer, float *rotation
       if (pixel > 255) {
         pixel = 255;
       }
-      SET_DATA_BYTE(data, x, pixel);
+      Image::setDataByte(data, x, pixel);
     }
     data += pixGetWpl(input);
   }

--- a/src/training/degradeimage.h
+++ b/src/training/degradeimage.h
@@ -19,8 +19,8 @@
 #ifndef TESSERACT_TRAINING_DEGRADEIMAGE_H_
 #define TESSERACT_TRAINING_DEGRADEIMAGE_H_
 
-#include <allheaders.h>
 #include "helpers.h" // For TRand.
+#include "image.h"   // for Image
 #include "rect.h"
 
 namespace tesseract {

--- a/src/training/pango/boxchar.h
+++ b/src/training/pango/boxchar.h
@@ -22,10 +22,10 @@
 #ifndef TESSERACT_TRAINING_BOXCHAR_H_
 #define TESSERACT_TRAINING_BOXCHAR_H_
 
+#include "image.h"        // for Leptonica (Box, ...)
 #include <string>
 #include <vector>
 
-#include <allheaders.h>   // for Leptonica API
 #if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || LIBLEPT_MAJOR_VERSION > 1
 #include <pix_internal.h> // for fast access to Box geometry
 #endif

--- a/src/training/pango/stringrenderer.cpp
+++ b/src/training/pango/stringrenderer.cpp
@@ -19,9 +19,9 @@
 
 #include "stringrenderer.h"
 
-#include <allheaders.h> // from leptonica
 #include "boxchar.h"
-#include "helpers.h" // for TRand
+#include "helpers.h"        // for TRand
+#include "image.h"          // for Image
 #include "ligature_table.h"
 #include "normstrngs.h"
 #include "tlog.h"

--- a/src/training/text2image.cpp
+++ b/src/training/text2image.cpp
@@ -33,12 +33,11 @@
 #include "errcode.h"
 #include "fileio.h"
 #include "helpers.h"
+#include "image.h"          // for Image
 #include "normstrngs.h"
 #include "stringrenderer.h"
 #include "tlog.h"
 #include "unicharset.h"
-
-#include <allheaders.h> // from leptonica
 
 #include <algorithm>
 #include <cstdlib>

--- a/src/training/unicharset/lstmtrainer.cpp
+++ b/src/training/unicharset/lstmtrainer.cpp
@@ -28,7 +28,6 @@
 #include <string>
 #include "lstmtrainer.h"
 
-#include <allheaders.h>
 #include "boxread.h"
 #include "ctc.h"
 #include "imagedata.h"

--- a/src/viewer/scrollview.cpp
+++ b/src/viewer/scrollview.cpp
@@ -26,17 +26,16 @@
 
 #include "svutil.h" // for SVNetwork
 
-#include <allheaders.h>
-
 #include <algorithm>
 #include <climits>
 #include <cstdarg>
 #include <cstring>
+#include "image.h"  // for Image
 #include <map>
-#include <memory> // for std::unique_ptr
-#include <mutex> // for std::mutex
+#include <memory>   // for std::unique_ptr
+#include <mutex>    // for std::mutex
 #include <string>
-#include <thread> // for std::thread
+#include <thread>   // for std::thread
 #include <utility>
 #include <vector>
 

--- a/unittest/apiexample_test.cc
+++ b/unittest/apiexample_test.cc
@@ -22,7 +22,6 @@
 // expects clone of tessdata_fast repo in ../../tessdata_fast
 
 //#include "log.h"
-#include <allheaders.h>
 #include <tesseract/baseapi.h>
 #include <time.h>
 #include <fstream>

--- a/unittest/applybox_test.cc
+++ b/unittest/applybox_test.cc
@@ -9,11 +9,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <allheaders.h>
 #include <tesseract/baseapi.h>
 #include <tesseract/resultiterator.h>
 #include <string>
 #include "boxread.h"
+#include "image.h"   // for Image
 #include "rect.h"
 
 #include "include_gunit.h"

--- a/unittest/baseapi_test.cc
+++ b/unittest/baseapi_test.cc
@@ -12,13 +12,13 @@
 #include "include_gunit.h"
 
 #include "cycletimer.h" // for CycleTimer
+#include "image.h"      // for Image
 #include "log.h"        // for LOG
 #include "ocrblock.h"   // for class BLOCK
 #include "pageres.h"
 
 #include <tesseract/baseapi.h>
 
-#include <allheaders.h>
 #include "gmock/gmock-matchers.h"
 
 #include <memory>

--- a/unittest/baseapi_thread_test.cc
+++ b/unittest/baseapi_thread_test.cc
@@ -26,7 +26,6 @@
 #ifdef INCLUDE_TENSORFLOW
 #  include <tensorflow/core/lib/core/threadpool.h>
 #endif
-#include <allheaders.h>
 #include <tesseract/baseapi.h>
 #include "commandlineflags.h"
 #include "include_gunit.h"

--- a/unittest/equationdetect_test.cc
+++ b/unittest/equationdetect_test.cc
@@ -13,9 +13,8 @@
 
 #include "colpartitiongrid.h"
 #include "equationdetect.h"
+#include "image.h"            // for Image
 #include "tesseractclass.h"
-
-#include <allheaders.h>
 
 #include <memory>
 #include <string>

--- a/unittest/layout_test.cc
+++ b/unittest/layout_test.cc
@@ -14,13 +14,13 @@
 
 #include "include_gunit.h"
 
-#include <allheaders.h>
 #include <tesseract/baseapi.h>
 #include <tesseract/resultiterator.h>
 #include "coutln.h"
-#include "log.h" // for LOG
+#include "image.h"           // for Image
+#include "log.h"             // for LOG
 #include "mutableiterator.h"
-#include "ocrblock.h" // for class BLOCK
+#include "ocrblock.h"        // for class BLOCK
 #include "pageres.h"
 #include "polyblk.h"
 #include "stepblob.h"

--- a/unittest/lstmtrainer_test.cc
+++ b/unittest/lstmtrainer_test.cc
@@ -9,8 +9,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <allheaders.h>
 #include <tesseract/baseapi.h>
+#include "image.h"     // for Image
 #include "lstm_test.h"
 
 namespace tesseract {

--- a/unittest/osd_test.cc
+++ b/unittest/osd_test.cc
@@ -19,7 +19,6 @@
 // expects clones of tessdata, tessdata_fast and tessdata_best repos
 
 //#include "log.h"
-#include <allheaders.h>
 #include <tesseract/baseapi.h>
 #include <iostream>
 #include <memory> // std::unique_ptr

--- a/unittest/pagesegmode_test.cc
+++ b/unittest/pagesegmode_test.cc
@@ -9,7 +9,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <allheaders.h>
 #include <tesseract/baseapi.h>
 #include <filesystem>
 #include <string>

--- a/unittest/progress_test.cc
+++ b/unittest/progress_test.cc
@@ -22,7 +22,6 @@
 #include <tesseract/ocrclass.h>
 #include "image.h"
 
-#include <allheaders.h>
 #include "gmock/gmock.h"
 
 #include <fstream>

--- a/unittest/resultiterator_test.cc
+++ b/unittest/resultiterator_test.cc
@@ -1,8 +1,8 @@
 
-#include <allheaders.h>
 #include <tesseract/baseapi.h>
 #include <tesseract/resultiterator.h>
 #include <string>
+#include "image.h"      // for Image
 #include "scrollview.h"
 
 #include "include_gunit.h"

--- a/unittest/stringrenderer_test.cc
+++ b/unittest/stringrenderer_test.cc
@@ -14,9 +14,8 @@
 #include "boxchar.h"
 #include "boxread.h"
 #include "commandlineflags.h"
+#include "image.h"            // for Image
 #include "stringrenderer.h"
-
-#include <allheaders.h>
 
 #include <memory>
 #include <string>

--- a/unittest/textlineprojection_test.cc
+++ b/unittest/textlineprojection_test.cc
@@ -9,7 +9,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <allheaders.h>
 #include <string> // for std::string
 
 #include "include_gunit.h"
@@ -17,6 +16,7 @@
 #include <tesseract/baseapi.h>
 #include <tesseract/osdetect.h>
 #include "colfind.h"
+#include "image.h"            // for Image
 #include "log.h" // for LOG
 #include "mutableiterator.h"
 #include "pageres.h"

--- a/unittest/unicharcompress_test.cc
+++ b/unittest/unicharcompress_test.cc
@@ -11,8 +11,6 @@
 
 #include <string>
 
-#include <allheaders.h>
-
 #include "include_gunit.h"
 #include "log.h" // for LOG
 #include "serialis.h"


### PR DESCRIPTION
Most compiler warnings were caused by C code in Leptonica (arrayaccess.h).
These warnings are now suppressed by using new C++ wrapper functions.