### PR TITLE
ci: Improve installer for windows

### DIFF
--- a/.github/workflows/installer-for-windows.yml
+++ b/.github/workflows/installer-for-windows.yml
@@ -24,4 +24,5 @@ jobs:
     - uses: actions/upload-artifact@v7
       with:
         name: Tesseract Installer for Windows (64 bit)
-        path: dist
+        path: bin/ndebug/x86_64-w64-mingw32/nsis/tesseract-ocr-w*-setup-*.exe
+        archive: false

--- a/nsis/build.sh
+++ b/nsis/build.sh
@@ -94,7 +94,9 @@ export PKG_CONFIG_PATH
   CXXFLAGS="-fno-math-errno -Wall -Wextra -Wpedantic -g -O2 -isystem $MINGW/include" \
   LDFLAGS="-L$MINGW/lib"
 
-make all training
+make all -j$(nproc)
+make training -j$(nproc)
+
 MINGW_INSTALL=${PWD}${MINGW}
 make install-jars install training-install html prefix="$MINGW_INSTALL" INSTALL_STRIP_FLAG=-s
 test -d venv || python3 -m venv venv

--- a/nsis/build.sh
+++ b/nsis/build.sh
@@ -2,7 +2,7 @@
 
 # GitHub actions - Create Tesseract installer for Windows
 
-# Author: Stefan Weil (2010-2024)
+# Author: Stefan Weil (2010-2026)
 
 set -e
 set -x
@@ -19,10 +19,9 @@ else
 fi
 
 ROOTDIR=$PWD
-DISTDIR=$ROOTDIR/dist
 HOST=$ARCH-w64-mingw32
 TAG=$(cat VERSION).$(date +%Y%m%d)
-BUILDDIR=bin/ndebug/$HOST-$TAG
+BUILDDIR=bin/ndebug/$HOST
 PKG_ARCH=mingw-w64-${ARCH/_/-}
 
 # Install packages.
@@ -106,6 +105,3 @@ ln -sv $("$ROOTDIR/nsis/find_deps.py" "$MINGW_INSTALL"/bin/*.exe "$MINGW_INSTALL
 ln -svf /usr/lib/gcc/x86_64-w64-mingw32/*-win32/libstdc++-6.dll dll/
 ln -svf /usr/lib/gcc/x86_64-w64-mingw32/*-win32/libgcc_s_seh-1.dll dll/
 make winsetup prefix="$MINGW_INSTALL"
-
-# Copy result for upload.
-mkdir -p "$DISTDIR" && cp nsis/tesseract-ocr-w*-setup-*.exe "$DISTDIR"


### PR DESCRIPTION
The CI build time was reduced from more than 17 minutes to less than 9 minutes by running several make jobs simultaneously.

In addition, the installer executable is now no longer provided in a zip archive but can be downloaded directly as build artifact.