### PR TITLE
ci: Remove unused ilammy/setup-nasm

### DIFF
--- a/.github/workflows/cmake-win64.yml
+++ b/.github/workflows/cmake-win64.yml
@@ -24,7 +24,6 @@ jobs:
     name: cmake-win64
     runs-on: windows-latest
     steps:
-      - uses: ilammy/setup-nasm@v1
       - uses: microsoft/setup-msbuild@v3
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v7


### PR DESCRIPTION
A positive side effect of this removal is that it not only simplifies the CI rules, but also fixes this CI warning:

    Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: ilammy/setup-nasm@v1.