### PR TITLE
Handle send() failures in SVNetwork::Flush

### DIFF
--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -168,8 +168,23 @@ void SVNetwork::Send(const char *msg) {
 void SVNetwork::Flush() {
   std::lock_guard<std::mutex> guard(mutex_send_);
   while (!msg_buffer_out_.empty()) {
-    int i = send(stream_, msg_buffer_out_.c_str(), msg_buffer_out_.length(), 0);
-    msg_buffer_out_.erase(0, i);
+    int i =
+        send(stream_, msg_buffer_out_.c_str(), msg_buffer_out_.length(), 0);
+
+    if (i < 0) {
+#ifndef _WIN32
+      if (errno == EINTR) {
+        continue;
+      }
+#endif
+      break;
+    }
+
+    if (i == 0) {
+      break;
+    }
+
+    msg_buffer_out_.erase(0, static_cast<std::string::size_type>(i));
   }
 }
 


### PR DESCRIPTION
Handle `send()` failures in `SVNetwork::Flush()`.

This change avoids removing data from the outgoing buffer when `send()` fails and retries interrupted `send()` calls (`EINTR`) on POSIX systems.