### PR TITLE
Exit child process when execvp fails

### DIFF
--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -168,8 +168,23 @@ void SVNetwork::Send(const char *msg) {
 void SVNetwork::Flush() {
   std::lock_guard<std::mutex> guard(mutex_send_);
   while (!msg_buffer_out_.empty()) {
-    int i = send(stream_, msg_buffer_out_.c_str(), msg_buffer_out_.length(), 0);
-    msg_buffer_out_.erase(0, i);
+    int i =
+        send(stream_, msg_buffer_out_.c_str(), msg_buffer_out_.length(), 0);
+
+    if (i < 0) {
+#ifndef _WIN32
+      if (errno == EINTR) {
+        continue;
+      }
+#endif
+      break;
+    }
+
+    if (i == 0) {
+      break;
+    }
+
+    msg_buffer_out_.erase(0, static_cast<std::string::size_type>(i));
   }
 }
 

--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -109,6 +109,9 @@ void SVSync::StartProcess(const char *executable, const char *args) {
     }
     argv[argc] = nullptr;
     execvp(executable, argv.get());
+    // execvp returns only if execution failed.
+    perror(executable);
+_exit(EXIT_FAILURE);
   }
 #  endif
 }

--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -111,7 +111,7 @@ void SVSync::StartProcess(const char *executable, const char *args) {
     execvp(executable, argv.get());
     // execvp returns only if execution failed.
     perror(executable);
-_exit(EXIT_FAILURE);
+    _exit(EXIT_FAILURE);
   }
 #  endif
 }

--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -26,6 +26,7 @@
 
 #include "svutil.h"
 
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -171,15 +172,15 @@ void SVNetwork::Send(const char *msg) {
 void SVNetwork::Flush() {
   std::lock_guard<std::mutex> guard(mutex_send_);
   while (!msg_buffer_out_.empty()) {
-    int i =
+    auto i =
         send(stream_, msg_buffer_out_.c_str(), msg_buffer_out_.length(), 0);
 
     if (i < 0) {
-#ifndef _WIN32
+#  ifndef _WIN32
       if (errno == EINTR) {
         continue;
       }
-#endif
+#  endif
       break;
     }
 


### PR DESCRIPTION
### Summary

Handle the failure case of `execvp()` in `SVSync::StartProcess()`.

If `execvp()` fails, the child process now reports the error and exits immediately instead of continuing along the parent's execution path.
