### PR TITLE
autotools: Simplify Makefile rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,10 +89,16 @@ endif
 
 AM_CXXFLAGS = $(OPENMP_CXXFLAGS)
 
-# Rules for src/api.
+libtesseract_la_LIBADD =
+libtesseract_la_SOURCES =
+
+# Common rules for libtesseract.
 
 libtesseract_la_CPPFLAGS = $(AM_CPPFLAGS)
 libtesseract_la_CPPFLAGS += -DTESS_COMMON_TRAINING_API=
+if !NO_TESSDATA_PREFIX
+libtesseract_la_CPPFLAGS += -DTESSDATA_PREFIX='"@datadir@"'
+endif
 libtesseract_la_CPPFLAGS += -I$(top_srcdir)/src/arch
 libtesseract_la_CPPFLAGS += -I$(top_srcdir)/src/ccmain
 libtesseract_la_CPPFLAGS += -I$(top_srcdir)/src/ccstruct
@@ -105,6 +111,7 @@ libtesseract_la_CPPFLAGS += -I$(top_srcdir)/src/textord
 libtesseract_la_CPPFLAGS += -I$(top_srcdir)/src/training/common
 libtesseract_la_CPPFLAGS += -I$(top_srcdir)/src/viewer
 libtesseract_la_CPPFLAGS += -I$(top_srcdir)/src/wordrec
+libtesseract_la_CPPFLAGS += $(libarchive_CFLAGS)
 libtesseract_la_CPPFLAGS += $(libcurl_CFLAGS)
 
 lib_LTLIBRARIES = libtesseract.la
@@ -118,7 +125,11 @@ libtesseract_la_LDFLAGS += $(NOUNDEFINED)
 endif
 libtesseract_la_LDFLAGS += -version-info $(GENERIC_LIBRARY_VERSION)
 
-libtesseract_la_SOURCES = src/api/baseapi.cpp
+# Rules for src/api.
+
+noinst_HEADERS += src/api/pdf_ttf.h
+
+libtesseract_la_SOURCES += src/api/baseapi.cpp
 libtesseract_la_SOURCES += src/api/altorenderer.cpp
 libtesseract_la_SOURCES += src/api/pagerenderer.cpp
 libtesseract_la_SOURCES += src/api/capi.cpp
@@ -128,8 +139,6 @@ libtesseract_la_SOURCES += src/api/pdfrenderer.cpp
 libtesseract_la_SOURCES += src/api/renderer.cpp
 libtesseract_la_SOURCES += src/api/wordstrboxrenderer.cpp
 
-libtesseract_la_LIBADD = libtesseract_ccutil.la
-libtesseract_la_LIBADD += libtesseract_lstm.la
 libtesseract_la_LIBADD += libtesseract_native.la
 
 # Rules for src/arch.
@@ -352,12 +361,6 @@ endif
 
 # Rules for src/ccutil
 
-libtesseract_ccutil_la_CPPFLAGS = $(AM_CPPFLAGS)
-libtesseract_ccutil_la_CPPFLAGS += $(libarchive_CFLAGS)
-if !NO_TESSDATA_PREFIX
-libtesseract_ccutil_la_CPPFLAGS += -DTESSDATA_PREFIX='"@datadir@"'
-endif
-
 noinst_HEADERS += src/ccutil/ccutil.h
 noinst_HEADERS += src/ccutil/clst.h
 noinst_HEADERS += src/ccutil/elst2.h
@@ -388,23 +391,21 @@ noinst_HEADERS += src/ccutil/indexmapbidi.h
 noinst_HEADERS += src/ccutil/universalambigs.h
 endif
 
-noinst_LTLIBRARIES += libtesseract_ccutil.la
-
-libtesseract_ccutil_la_SOURCES = src/ccutil/ccutil.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/errcode.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/serialis.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/scanutils.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/tessdatamanager.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/tprintf.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/unichar.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/unicharcompress.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/unicharmap.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/unicharset.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/params.cpp
+libtesseract_la_SOURCES += src/ccutil/ccutil.cpp
+libtesseract_la_SOURCES += src/ccutil/errcode.cpp
+libtesseract_la_SOURCES += src/ccutil/serialis.cpp
+libtesseract_la_SOURCES += src/ccutil/scanutils.cpp
+libtesseract_la_SOURCES += src/ccutil/tessdatamanager.cpp
+libtesseract_la_SOURCES += src/ccutil/tprintf.cpp
+libtesseract_la_SOURCES += src/ccutil/unichar.cpp
+libtesseract_la_SOURCES += src/ccutil/unicharcompress.cpp
+libtesseract_la_SOURCES += src/ccutil/unicharmap.cpp
+libtesseract_la_SOURCES += src/ccutil/unicharset.cpp
+libtesseract_la_SOURCES += src/ccutil/params.cpp
 if !DISABLED_LEGACY_ENGINE
-libtesseract_ccutil_la_SOURCES += src/ccutil/ambigs.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/bitvector.cpp
-libtesseract_ccutil_la_SOURCES += src/ccutil/indexmapbidi.cpp
+libtesseract_la_SOURCES += src/ccutil/ambigs.cpp
+libtesseract_la_SOURCES += src/ccutil/bitvector.cpp
+libtesseract_la_SOURCES += src/ccutil/indexmapbidi.cpp
 endif
 
 # Rules for src/classify.
@@ -500,19 +501,6 @@ endif
 
 # Rules for src/lstm.
 
-libtesseract_lstm_la_CPPFLAGS = $(AM_CPPFLAGS)
-libtesseract_lstm_la_CPPFLAGS += -I$(top_srcdir)/src/arch
-libtesseract_lstm_la_CPPFLAGS += -I$(top_srcdir)/src/ccstruct
-libtesseract_lstm_la_CPPFLAGS += -I$(top_srcdir)/src/ccutil
-libtesseract_lstm_la_CPPFLAGS += -I$(top_srcdir)/src/classify
-libtesseract_lstm_la_CPPFLAGS += -I$(top_srcdir)/src/cutil
-libtesseract_lstm_la_CPPFLAGS += -I$(top_srcdir)/src/dict
-libtesseract_lstm_la_CPPFLAGS += -I$(top_srcdir)/src/lstm
-libtesseract_lstm_la_CPPFLAGS += -I$(top_srcdir)/src/viewer
-if !NO_TESSDATA_PREFIX
-libtesseract_lstm_la_CPPFLAGS += -DTESSDATA_PREFIX='"@datadir@"'
-endif
-
 noinst_HEADERS += src/lstm/convolve.h
 noinst_HEADERS += src/lstm/fullyconnected.h
 noinst_HEADERS += src/lstm/functions.h
@@ -533,25 +521,23 @@ noinst_HEADERS += src/lstm/static_shape.h
 noinst_HEADERS += src/lstm/stridemap.h
 noinst_HEADERS += src/lstm/weightmatrix.h
 
-noinst_LTLIBRARIES += libtesseract_lstm.la
-
-libtesseract_lstm_la_SOURCES = src/lstm/convolve.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/fullyconnected.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/functions.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/input.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/lstm.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/lstmrecognizer.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/maxpool.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/network.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/networkio.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/parallel.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/plumbing.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/recodebeam.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/reconfig.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/reversed.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/series.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/stridemap.cpp
-libtesseract_lstm_la_SOURCES += src/lstm/weightmatrix.cpp
+libtesseract_la_SOURCES += src/lstm/convolve.cpp
+libtesseract_la_SOURCES += src/lstm/fullyconnected.cpp
+libtesseract_la_SOURCES += src/lstm/functions.cpp
+libtesseract_la_SOURCES += src/lstm/input.cpp
+libtesseract_la_SOURCES += src/lstm/lstm.cpp
+libtesseract_la_SOURCES += src/lstm/lstmrecognizer.cpp
+libtesseract_la_SOURCES += src/lstm/maxpool.cpp
+libtesseract_la_SOURCES += src/lstm/network.cpp
+libtesseract_la_SOURCES += src/lstm/networkio.cpp
+libtesseract_la_SOURCES += src/lstm/parallel.cpp
+libtesseract_la_SOURCES += src/lstm/plumbing.cpp
+libtesseract_la_SOURCES += src/lstm/recodebeam.cpp
+libtesseract_la_SOURCES += src/lstm/reconfig.cpp
+libtesseract_la_SOURCES += src/lstm/reversed.cpp
+libtesseract_la_SOURCES += src/lstm/series.cpp
+libtesseract_la_SOURCES += src/lstm/stridemap.cpp
+libtesseract_la_SOURCES += src/lstm/weightmatrix.cpp
 
 # Rules for src/textord.
 


### PR DESCRIPTION
Don't build the intermediate files libtesseract_ccutil.la and libtesseract_lstm.la.

This reduces the build time and needs less disk storage.

Remove also pdf_ttf.h from the list of installed header files.