### PR TITLE
Fix memory-safety issues in .traineddata deserialization

### DIFF
--- a/src/ccstruct/fontinfo.cpp
+++ b/src/ccstruct/fontinfo.cpp
@@ -145,6 +145,10 @@ bool read_info(TFile *f, FontInfo *fi) {
   if (!f->DeSerialize(&size)) {
     return false;
   }
+  // Reject unreasonably large font names to prevent overflow in size + 1.
+  if (size > 100000) {
+    return false;
+  }
   char *font_name = new char[size + 1];
   fi->name = font_name;
   if (!f->DeSerialize(font_name, size)) {
@@ -161,16 +165,16 @@ bool write_info(FILE *f, const FontInfo &fi) {
 }
 
 bool read_spacing_info(TFile *f, FontInfo *fi) {
-  int32_t vec_size, kern_size;
+  uint32_t vec_size;
+  int32_t kern_size;
   if (!f->DeSerialize(&vec_size)) {
     return false;
   }
-  ASSERT_HOST(vec_size >= 0);
   if (vec_size == 0) {
     return true;
   }
   fi->init_spacing(vec_size);
-  for (int i = 0; i < vec_size; ++i) {
+  for (uint32_t i = 0; i < vec_size; ++i) {
     auto *fs = new FontSpacingInfo();
     if (!f->DeSerialize(&fs->x_gap_before) || !f->DeSerialize(&fs->x_gap_after) ||
         !f->DeSerialize(&kern_size)) {

--- a/src/ccstruct/fontinfo.cpp
+++ b/src/ccstruct/fontinfo.cpp
@@ -173,6 +173,10 @@ bool read_spacing_info(TFile *f, FontInfo *fi) {
   if (vec_size == 0) {
     return true;
   }
+  // Reject unreasonably large spacing vectors.
+  if (vec_size > 1000000) {
+    return false;
+  }
   fi->init_spacing(vec_size);
   for (uint32_t i = 0; i < vec_size; ++i) {
     auto *fs = new FontSpacingInfo();

--- a/src/ccstruct/fontinfo.cpp
+++ b/src/ccstruct/fontinfo.cpp
@@ -150,10 +150,11 @@ bool read_info(TFile *f, FontInfo *fi) {
     return false;
   }
   char *font_name = new char[size + 1];
-  fi->name = font_name;
   if (!f->DeSerialize(font_name, size)) {
+    delete[] font_name;
     return false;
   }
+  fi->name = font_name;
   font_name[size] = '\0';
   return f->DeSerialize(&fi->properties);
 }

--- a/src/ccstruct/fontinfo.h
+++ b/src/ccstruct/fontinfo.h
@@ -76,7 +76,7 @@ struct FontInfo {
   bool DeSerialize(TFile *fp);
 
   // Reserves unicharset_size spots in spacing_vec.
-  void init_spacing(int unicharset_size) {
+  void init_spacing(uint32_t unicharset_size) {
     spacing_vec = new std::vector<FontSpacingInfo *>(unicharset_size);
   }
   // Adds the given pointer to FontSpacingInfo to spacing_vec member

--- a/src/ccutil/bitvector.cpp
+++ b/src/ccutil/bitvector.cpp
@@ -102,6 +102,10 @@ bool BitVector::DeSerialize(bool swap, FILE *fp) {
   if (swap) {
     ReverseN(&new_bit_size, sizeof(new_bit_size));
   }
+  // Reject unreasonably large bit vectors.
+  if (new_bit_size > 500000000) {
+    return false;
+  }
   Alloc(new_bit_size);
   int wordlen = WordLength();
   if (!tesseract::DeSerialize(fp, &array_[0], wordlen)) {

--- a/src/ccutil/serialis.cpp
+++ b/src/ccutil/serialis.cpp
@@ -143,6 +143,10 @@ bool TFile::Serialize(const std::vector<char> &data) {
 }
 
 bool TFile::Skip(size_t count) {
+  if (data_ != nullptr && offset_ + count > data_->size()) {
+    offset_ = data_->size();
+    return false;
+  }
   offset_ += count;
   return true;
 }

--- a/src/ccutil/serialis.cpp
+++ b/src/ccutil/serialis.cpp
@@ -143,9 +143,13 @@ bool TFile::Serialize(const std::vector<char> &data) {
 }
 
 bool TFile::Skip(size_t count) {
-  if (data_ != nullptr && offset_ + count > data_->size()) {
-    offset_ = data_->size();
-    return false;
+  if (data_ != nullptr) {
+    size_t data_size = data_->size();
+    // Subtraction-based check to avoid overflow in offset_ + count.
+    if (offset_ >= data_size || count > data_size - offset_) {
+      offset_ = data_size > UINT_MAX ? UINT_MAX : static_cast<unsigned>(data_size);
+      return false;
+    }
   }
   offset_ += count;
   return true;

--- a/src/ccutil/serialis.cpp
+++ b/src/ccutil/serialis.cpp
@@ -88,12 +88,19 @@ bool TFile::DeSerializeSkip(size_t size) {
   if (!DeSerialize(&len)) {
     return false;
   }
+  // Check for overflow: len * size must not overflow size_t.
+  if (size != 0 && len > SIZE_MAX / size) {
+    return false;
+  }
   return Skip(len * size);
 }
 
 bool TFile::DeSerialize(std::string &data) {
   uint32_t size;
   if (!DeSerialize(&size)) {
+    return false;
+  } else if (size > 50000000) {
+    // Arbitrarily limit the size to protect against bad data.
     return false;
   } else if (size > 0) {
     // TODO: optimize.
@@ -112,6 +119,9 @@ bool TFile::Serialize(const std::string &data) {
 bool TFile::DeSerialize(std::vector<char> &data) {
   uint32_t size;
   if (!DeSerialize(&size)) {
+    return false;
+  } else if (size > 50000000) {
+    // Arbitrarily limit the size to protect against bad data.
     return false;
   } else if (size > 0) {
     // TODO: optimize.

--- a/src/ccutil/serialis.h
+++ b/src/ccutil/serialis.h
@@ -75,6 +75,10 @@ public:
   void set_swap(bool value) {
     swap_ = value;
   }
+  // Returns the number of bytes remaining to be read.
+  size_t RemainingBytes() const {
+    return data_ != nullptr && offset_ < data_->size() ? data_->size() - offset_ : 0;
+  }
 
   // Deserialize data.
   bool DeSerializeSize(int32_t *data);

--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -132,13 +132,22 @@ bool TessdataManager::LoadMemBuffer(const char *name, const char *data, int size
   }
   for (unsigned i = 0; i < num_entries && i < TESSDATA_NUM_ENTRIES; ++i) {
     if (offset_table[i] >= 0) {
+      if (offset_table[i] > size) {
+        return false;
+      }
       int64_t entry_size = size - offset_table[i];
       unsigned j = i + 1;
       while (j < num_entries && offset_table[j] == -1) {
         ++j;
       }
       if (j < num_entries) {
+        if (offset_table[j] < 0 || offset_table[j] > size) {
+          return false;
+        }
         entry_size = offset_table[j] - offset_table[i];
+      }
+      if (entry_size < 0) {
+        return false;
       }
       entries_[i].resize(entry_size);
       if (!fp.DeSerialize(&entries_[i][0], entry_size)) {

--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -109,6 +109,9 @@ bool TessdataManager::Init(const char *data_file_name) {
 // Loads from the given memory buffer as if a file.
 bool TessdataManager::LoadMemBuffer(const char *name, const char *data, int size) {
   // TODO: This method supports only the proprietary file format.
+  if (size < 0) {
+    return false;
+  }
   Clear();
   data_file_name_ = name;
   TFile fp;

--- a/src/ccutil/tessdatamanager.cpp
+++ b/src/ccutil/tessdatamanager.cpp
@@ -150,7 +150,7 @@ bool TessdataManager::LoadMemBuffer(const char *name, const char *data, int size
         return false;
       }
       entries_[i].resize(entry_size);
-      if (!fp.DeSerialize(&entries_[i][0], entry_size)) {
+      if (entry_size > 0 && !fp.DeSerialize(&entries_[i][0], entry_size)) {
         return false;
       }
     }

--- a/src/ccutil/unicharcompress.cpp
+++ b/src/ccutil/unicharcompress.cpp
@@ -180,7 +180,7 @@ bool UnicharCompress::ComputeEncoding(const UNICHARSET &unicharset, int null_id,
         // Add the direct_set unichar-ids of the unicodes in sequence to the
         // code.
         for (int uni : unicodes) {
-          int position = code.length();
+          uint32_t position = code.length();
           if (position >= RecodedCharID::kMaxCodeLen) {
             tprintf("Unichar %d=%s is too long to encode!!\n", u, unicharset.id_to_unichar(u));
             return false;
@@ -259,7 +259,7 @@ void UnicharCompress::DefragmentCodeValues(int encoded_null) {
   std::vector<int> offsets(code_range_);
   // Find which codes are used
   for (auto &code : encoder_) {
-    for (int i = 0; i < code.length(); ++i) {
+    for (uint32_t i = 0; i < code.length(); ++i) {
       offsets[code(i)] = 1;
     }
   }
@@ -303,8 +303,8 @@ int UnicharCompress::EncodeUnichar(unsigned unichar_id, RecodedCharID *code) con
 // Decodes code, returning the original unichar-id, or
 // INVALID_UNICHAR_ID if the input is invalid.
 int UnicharCompress::DecodeUnichar(const RecodedCharID &code) const {
-  int len = code.length();
-  if (len <= 0 || len > RecodedCharID::kMaxCodeLen) {
+  uint32_t len = code.length();
+  if (len == 0 || len > RecodedCharID::kMaxCodeLen) {
     return INVALID_UNICHAR_ID;
   }
   auto it = decoder_.find(code);
@@ -345,7 +345,7 @@ std::string UnicharCompress::GetEncodingAsString(const UNICHARSET &unicharset) c
       continue;
     }
     encoding += std::to_string(code(0));
-    for (int i = 1; i < code.length(); ++i) {
+    for (uint32_t i = 1; i < code.length(); ++i) {
       encoding += "," + std::to_string(code(i));
     }
     encoding += "\t";
@@ -383,7 +383,7 @@ bool UnicharCompress::DecomposeHangul(int unicode, int *leading, int *vowel, int
 void UnicharCompress::ComputeCodeRange() {
   code_range_ = -1;
   for (auto &code : encoder_) {
-    for (int i = 0; i < code.length(); ++i) {
+    for (uint32_t i = 0; i < code.length(); ++i) {
       if (code(i) > code_range_) {
         code_range_ = code(i);
       }
@@ -402,14 +402,19 @@ void UnicharCompress::SetupDecoder() {
     decoder_[code] = c;
     is_valid_start_[code(0)] = true;
     RecodedCharID prefix = code;
-    int len = code.length() - 1;
+    uint32_t len = code.length();
+    if (len == 0) {
+      continue;
+    }
+    --len;
     prefix.Truncate(len);
     auto final_it = final_codes_.find(prefix);
     if (final_it == final_codes_.end()) {
       auto *code_list = new std::vector<int>;
       code_list->push_back(code(len));
       final_codes_[prefix] = code_list;
-      while (--len >= 0) {
+      while (len > 0) {
+        --len;
         prefix.Truncate(len);
         auto next_it = next_codes_.find(prefix);
         if (next_it == next_codes_.end()) {

--- a/src/ccutil/unicharcompress.h
+++ b/src/ccutil/unicharcompress.h
@@ -39,7 +39,7 @@ public:
   RecodedCharID() : self_normalized_(1), length_(0) {
     code_.fill(0);
   }
-  void Truncate(int length) {
+  void Truncate(uint32_t length) {
     length_ = length;
   }
   // Sets the code value at the given index in the code.
@@ -67,7 +67,7 @@ public:
   uint32_t length() const {
     return length_;
   }
-  int operator()(int index) const {
+  int operator()(uint32_t index) const {
     return code_[index];
   }
 

--- a/src/ccutil/unicharcompress.h
+++ b/src/ccutil/unicharcompress.h
@@ -43,7 +43,7 @@ public:
     length_ = length;
   }
   // Sets the code value at the given index in the code.
-  void Set(int index, int value) {
+  void Set(uint32_t index, int value) {
     code_[index] = value;
     if (length_ <= index) {
       length_ = index + 1;
@@ -61,7 +61,7 @@ public:
     return length_ == 0;
   }
   // Accessors
-  int length() const {
+  uint32_t length() const {
     return length_;
   }
   int operator()(int index) const {
@@ -75,14 +75,19 @@ public:
   }
   // Reads from the given file. Returns false in case of error.
   bool DeSerialize(TFile *fp) {
-    return fp->DeSerialize(&self_normalized_) && fp->DeSerialize(&length_) &&
-           fp->DeSerialize(&code_[0], length_);
+    if (!fp->DeSerialize(&self_normalized_) || !fp->DeSerialize(&length_)) {
+      return false;
+    }
+    if (length_ > kMaxCodeLen) {
+      return false;
+    }
+    return fp->DeSerialize(&code_[0], length_);
   }
   bool operator==(const RecodedCharID &other) const {
     if (length_ != other.length_) {
       return false;
     }
-    for (int i = 0; i < length_; ++i) {
+    for (uint32_t i = 0; i < length_; ++i) {
       if (code_[i] != other.code_[i]) {
         return false;
       }
@@ -93,7 +98,7 @@ public:
   struct RecodedCharIDHash {
     uint64_t operator()(const RecodedCharID &code) const {
       uint64_t result = 0;
-      for (int i = 0; i < code.length_; ++i) {
+      for (uint32_t i = 0; i < code.length_; ++i) {
         result ^= static_cast<uint64_t>(code(i)) << (7 * i);
       }
       return result;
@@ -105,7 +110,7 @@ private:
   // that map to the same code. Has boolean value, but int8_t for serialization.
   int8_t self_normalized_;
   // The number of elements in use in code_;
-  int32_t length_;
+  uint32_t length_;
   // The re-encoded form of the unichar-id to which this RecodedCharID relates.
   std::array<int32_t, kMaxCodeLen> code_;
 };

--- a/src/ccutil/unicharcompress.h
+++ b/src/ccutil/unicharcompress.h
@@ -44,6 +44,9 @@ public:
   }
   // Sets the code value at the given index in the code.
   void Set(uint32_t index, int value) {
+    if (index >= kMaxCodeLen) {
+      return;
+    }
     code_[index] = value;
     if (length_ <= index) {
       length_ = index + 1;

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -26,6 +26,7 @@
 #include "helpers.h"
 #include "tprintf.h"
 
+#include <climits>
 #include <memory>
 
 /*----------------------------------------------------------------------
@@ -292,6 +293,7 @@ void SquishedDawg::print_node(NODE_REF node, int max_num_edges) const {
         return;
       }
       if (last_edge(edge)) {
+        ++edge; // Advance past the last forward edge.
         break;
       }
       ++edge;
@@ -353,6 +355,11 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
 
   uint32_t unicharset_size;
   if (!file->DeSerialize(&unicharset_size)) {
+    return false;
+  }
+  // Dawg::init takes int; reject values that would overflow.
+  if (unicharset_size == 0 || unicharset_size > INT_MAX) {
+    tprintf("Bad dawg unicharset_size %u\n", unicharset_size);
     return false;
   }
   if (!file->DeSerialize(&num_edges_)) {

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -391,23 +391,31 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
     if (edges_[i] == next_node_mask_) {
       continue; // Empty slot.
     }
-    NODE_REF next = next_node_from_edge_rec(edges_[i]);
-    if (next != 0 && static_cast<uint32_t>(next) >= num_edges_) {
-      tprintf("Dawg edge %u has out-of-bounds next_node\n", i);
-      return false;
-    }
     if (forward_edge(i)) {
-      uint32_t j = i;
+      // Validate the entire forward-edge run and skip to its terminator.
       bool terminated = false;
+      uint32_t j = i;
       do {
+        NODE_REF nj = next_node_from_edge_rec(edges_[j]);
+        if (nj != 0 && static_cast<uint32_t>(nj) >= num_edges_) {
+          tprintf("Dawg edge %u has out-of-bounds next_node\n", j);
+          return false;
+        }
         if (last_edge(j)) {
           terminated = true;
+          i = j; // Advance outer loop past the terminator.
           break;
         }
         ++j;
       } while (j < num_edges_);
       if (!terminated) {
         tprintf("Dawg forward edge run starting at %u is not terminated\n", i);
+        return false;
+      }
+    } else {
+      NODE_REF next = next_node_from_edge_rec(edges_[i]);
+      if (next != 0 && static_cast<uint32_t>(next) >= num_edges_) {
+        tprintf("Dawg edge %u has out-of-bounds next_node\n", i);
         return false;
       }
     }

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -362,11 +362,43 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
     tprintf("Empty dawg: num_edges is 0\n");
     return false;
   }
+  // Reject if the declared edge count exceeds the remaining component bytes.
+  if (num_edges_ > file->RemainingBytes() / sizeof(EDGE_RECORD)) {
+    tprintf("Dawg num_edges %u exceeds remaining data\n", num_edges_);
+    return false;
+  }
   Dawg::init(unicharset_size);
 
   edges_ = new EDGE_RECORD[num_edges_];
   if (!file->DeSerialize(&edges_[0], num_edges_)) {
     return false;
+  }
+  // Validate the loaded edge structure: check that next_node values are in
+  // bounds and that forward edge runs are properly terminated.
+  for (uint32_t i = 0; i < num_edges_; ++i) {
+    if (edges_[i] == next_node_mask_) {
+      continue; // Empty slot.
+    }
+    NODE_REF next = next_node_from_edge_rec(edges_[i]);
+    if (next != 0 && static_cast<uint32_t>(next) >= num_edges_) {
+      tprintf("Dawg edge %u has out-of-bounds next_node\n", i);
+      return false;
+    }
+    if (forward_edge(i)) {
+      uint32_t j = i;
+      bool terminated = false;
+      do {
+        if (last_edge(j)) {
+          terminated = true;
+          break;
+        }
+        ++j;
+      } while (j < num_edges_);
+      if (!terminated) {
+        tprintf("Dawg forward edge run starting at %u is not terminated\n", i);
+        return false;
+      }
+    }
   }
   if (debug_level_ > 2) {
     tprintf("type: %d lang: %s perm: %d unicharset_size: %d num_edges: %" PRIu32 "\n",

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -369,6 +369,11 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
     tprintf("Empty dawg: num_edges is 0\n");
     return false;
   }
+  // Hard upper bound to prevent resource-exhaustion DoS.
+  if (num_edges_ > 50000000) {
+    tprintf("Dawg num_edges %u exceeds hard limit\n", num_edges_);
+    return false;
+  }
   // Reject if the declared edge count exceeds the remaining component bytes.
   if (num_edges_ > file->RemainingBytes() / sizeof(EDGE_RECORD)) {
     tprintf("Dawg num_edges %u exceeds remaining data\n", num_edges_);

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -230,7 +230,11 @@ EDGE_REF SquishedDawg::edge_char_of(NODE_REF node, UNICHAR_ID unichar_id,
             (!word_end || end_of_word_from_edge_rec(edges_[edge]))) {
           return (edge);
         }
-      } while (!last_edge(edge++));
+        if (last_edge(edge)) {
+          break;
+        }
+        ++edge;
+      } while (edge < num_edges_);
     }
   }
   return (NO_EDGE); // not found
@@ -243,7 +247,11 @@ int32_t SquishedDawg::num_forward_edges(NODE_REF node) const {
   if (forward_edge(edge)) {
     do {
       num++;
-    } while (!last_edge(edge++));
+      if (last_edge(edge)) {
+        break;
+      }
+      ++edge;
+    } while (edge < num_edges_);
   }
 
   return (num);
@@ -283,7 +291,11 @@ void SquishedDawg::print_node(NODE_REF node, int max_num_edges) const {
       if (edge - node > max_num_edges) {
         return;
       }
-    } while (!last_edge(edge++));
+      if (last_edge(edge)) {
+        break;
+      }
+      ++edge;
+    } while (edge < num_edges_);
 
     if (edge < num_edges_ && edge_occupied(edge) && backward_edge(edge)) {
       do {
@@ -299,7 +311,11 @@ void SquishedDawg::print_node(NODE_REF node, int max_num_edges) const {
         if (edge - node > MAX_NODE_EDGES_DISPLAY) {
           return;
         }
-      } while (!last_edge(edge++));
+        if (last_edge(edge)) {
+          break;
+        }
+        ++edge;
+      } while (edge < num_edges_);
     }
   } else {
     tprintf(REFFORMAT " : no edges in this node\n", node);
@@ -335,14 +351,17 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
     return false;
   }
 
-  int32_t unicharset_size;
+  uint32_t unicharset_size;
   if (!file->DeSerialize(&unicharset_size)) {
     return false;
   }
   if (!file->DeSerialize(&num_edges_)) {
     return false;
   }
-  ASSERT_HOST(num_edges_ > 0); // DAWG should not be empty
+  if (num_edges_ == 0) {
+    tprintf("Empty dawg: num_edges is 0\n");
+    return false;
+  }
   Dawg::init(unicharset_size);
 
   edges_ = new EDGE_RECORD[num_edges_];
@@ -350,7 +369,7 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
     return false;
   }
   if (debug_level_ > 2) {
-    tprintf("type: %d lang: %s perm: %d unicharset_size: %d num_edges: %d\n",
+    tprintf("type: %d lang: %s perm: %d unicharset_size: %d num_edges: %" PRIu32 "\n",
             type_, lang_.c_str(), perm_, unicharset_size_, num_edges_);
     for (EDGE_REF edge = 0; edge < num_edges_; ++edge) {
       print_edge(edge);
@@ -387,8 +406,11 @@ std::unique_ptr<EDGE_REF[]> SquishedDawg::build_node_map(
         break;
       }
       if (backward_edge(edge)) {
-        while (!last_edge(edge++)) {
-          ;
+        while (edge < num_edges_ && !last_edge(edge)) {
+          ++edge;
+        }
+        if (edge < num_edges_) {
+          ++edge; // Skip past the last backward edge.
         }
       }
       edge--;

--- a/src/dict/dawg.cpp
+++ b/src/dict/dawg.cpp
@@ -381,8 +381,12 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
   }
   Dawg::init(unicharset_size);
 
+  delete[] edges_;
   edges_ = new EDGE_RECORD[num_edges_];
   if (!file->DeSerialize(&edges_[0], num_edges_)) {
+    delete[] edges_;
+    edges_ = nullptr;
+    num_edges_ = 0;
     return false;
   }
   // Validate the loaded edge structure: check that next_node values are in
@@ -399,6 +403,9 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
         NODE_REF nj = next_node_from_edge_rec(edges_[j]);
         if (nj != 0 && static_cast<uint32_t>(nj) >= num_edges_) {
           tprintf("Dawg edge %u has out-of-bounds next_node\n", j);
+          delete[] edges_;
+          edges_ = nullptr;
+          num_edges_ = 0;
           return false;
         }
         if (last_edge(j)) {
@@ -410,12 +417,18 @@ bool SquishedDawg::read_squished_dawg(TFile *file) {
       } while (j < num_edges_);
       if (!terminated) {
         tprintf("Dawg forward edge run starting at %u is not terminated\n", i);
+        delete[] edges_;
+        edges_ = nullptr;
+        num_edges_ = 0;
         return false;
       }
     } else {
       NODE_REF next = next_node_from_edge_rec(edges_[i]);
       if (next != 0 && static_cast<uint32_t>(next) >= num_edges_) {
         tprintf("Dawg edge %u has out-of-bounds next_node\n", i);
+        delete[] edges_;
+        edges_ = nullptr;
+        num_edges_ = 0;
         return false;
       }
     }

--- a/src/dict/dawg.h
+++ b/src/dict/dawg.h
@@ -413,7 +413,7 @@ public:
     ASSERT_HOST(read_squished_dawg(&file));
     num_forward_edges_in_node0 = num_forward_edges(0);
   }
-  SquishedDawg(EDGE_ARRAY edges, int num_edges, DawgType type,
+  SquishedDawg(EDGE_ARRAY edges, uint32_t num_edges, DawgType type,
                const std::string &lang, PermuterType perm, int unicharset_size,
                int debug_level)
       : Dawg(type, lang, perm, debug_level),
@@ -436,7 +436,7 @@ public:
     return true;
   }
 
-  int NumEdges() {
+  uint32_t NumEdges() const {
     return num_edges_;
   }
 
@@ -457,7 +457,11 @@ public:
       if (!word_end || end_of_word_from_edge_rec(edges_[edge])) {
         vec->push_back(NodeChild(unichar_id_from_edge_rec(edges_[edge]), edge));
       }
-    } while (!last_edge(edge++));
+      if (last_edge(edge)) {
+        break;
+      }
+      ++edge;
+    } while (edge < num_edges_);
   }
 
   /// Returns the next node visited by following the edge
@@ -511,7 +515,7 @@ private:
   }
   /// Goes through all the edges and clears each one out.
   inline void clear_all_edges() {
-    for (int edge = 0; edge < num_edges_; edge++) {
+    for (uint32_t edge = 0; edge < num_edges_; edge++) {
       set_empty_edge(edge);
     }
   }
@@ -550,7 +554,7 @@ private:
   /// Prints the contents of the SquishedDawg.
   void print_all(const char *msg) {
     tprintf("\n__________________________\n%s\n", msg);
-    for (int i = 0; i < num_edges_; ++i) {
+    for (uint32_t i = 0; i < num_edges_; ++i) {
       print_edge(i);
     }
     tprintf("__________________________\n");
@@ -560,7 +564,7 @@ private:
 
   // Member variables.
   EDGE_ARRAY edges_ = nullptr;
-  int32_t num_edges_ = 0;
+  uint32_t num_edges_ = 0;
   int num_forward_edges_in_node0 = 0;
 };
 

--- a/src/lstm/plumbing.cpp
+++ b/src/lstm/plumbing.cpp
@@ -222,6 +222,10 @@ bool Plumbing::DeSerialize(TFile *fp) {
   if (!fp->DeSerialize(&size)) {
     return false;
   }
+  // Reject unreasonably large network stacks.
+  if (size > 10000) {
+    return false;
+  }
   for (uint32_t i = 0; i < size; ++i) {
     Network *network = CreateFromFile(fp);
     if (network == nullptr) {

--- a/src/lstm/weightmatrix.cpp
+++ b/src/lstm/weightmatrix.cpp
@@ -295,6 +295,10 @@ bool WeightMatrix::DeSerialize(bool training, TFile *fp) {
     if (!fp->DeSerialize(&size)) {
       return false;
     }
+    // Reject unreasonably large scale vectors.
+    if (size > 100000000) {
+      return false;
+    }
 #ifdef FAST_FLOAT
     scales_.reserve(size);
     for (auto n = size; n > 0; n--) {


### PR DESCRIPTION
Add bounds checking on count/length fields read from untrusted .traineddata files before they are used to size allocations or index arrays. Use unsigned types where negative values make no sense.

Key changes:
- serialis.cpp: overflow check in DeSerializeSkip, size limits for DeSerialize(string) and DeSerialize(vector<char>)
- unicharcompress.h: validate RecodedCharID length before reading into fixed-size code array (buffer overflow fix)
- dawg.cpp/h: use uint32_t for num_edges_, add bounds checks on all edge traversal loops, replace no-op ASSERT_HOST with proper errors
- fontinfo.cpp: bounds check font name size to prevent integer overflow in size+1, use uint32_t for spacing vector size
- tessdatamanager.cpp: validate offsets are within file bounds
- bitvector.cpp, weightmatrix.cpp, plumbing.cpp: add size limits

Assisted-by: OpenCode / big-pickle (opencode)