### PR TITLE
fix: add buffer-length check in winpath.cpp

### DIFF
--- a/nsis/winpath.cpp
+++ b/nsis/winpath.cpp
@@ -28,9 +28,7 @@ int main(int argc, char *argv[]) {
     if (last != nullptr) {
       *last = '\0';
     }
-    strcpy(path, dir);
-    strcat(path, ";");
-    strcat(path, getenv("PATH"));
+    snprintf(path, sizeof(path), "%s;%s", dir, getenv("PATH"));
     _putenv_s("PATH", path);
     _spawnvp(_P_WAIT, argv[1], argv + 1);
     //~ _spawnvp(_P_OVERLAY, argv[1], argv + 1);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `nsis/winpath.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `nsis/winpath.cpp:31` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-120 |

**Description**: The code uses unsafe C string functions (strcpy and strcat) to copy and concatenate strings into a fixed-size buffer without bounds checking. If the combined length of the 'dir' parameter and PATH environment variable exceeds the buffer size, a stack buffer overflow occurs.

## Evidence

**Exploitation scenario**: An attacker can set the PATH environment variable to a very long string before invoking the NSIS installer build process, causing buffer overflow when the function is called.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a local CLI tool - exploitation requires the attacker to control command-line arguments or input files.

## Changes
- `nsis/winpath.cpp`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
