### PR TITLE
fix build of training tool on windows with VS2022:

### DIFF
--- a/src/ccstruct/image.h
+++ b/src/ccstruct/image.h
@@ -21,7 +21,6 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <allheaders.h> // Pix, from leptonica
-#include <arrayaccess.h> // GET_DATA_* and SET_DATA_* macros, from leptonica
 #pragma GCC diagnostic pop
 #include <tesseract/export.h>
 
@@ -57,19 +56,19 @@ public:
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-  static void clearDataBit(const std::uint32_t *data, int n) {
+  static void clearDataBit(const uint32_t *data, int n) {
     CLEAR_DATA_BIT(data, n);
   }
-  static int getDataBit(const std::uint32_t *data, int n) {
+  static int getDataBit(const uint32_t *data, int n) {
     return GET_DATA_BIT(data, n);
   }
-  static int getDataByte(const std::uint32_t *data, int n) {
+  static int getDataByte(const uint32_t *data, int n) {
     return GET_DATA_BYTE(data, n);
   }
-  static void setDataBit(std::uint32_t *data, int n) {
+  static void setDataBit(uint32_t *data, int n) {
     SET_DATA_BIT(data, n);
   }
-  static void setDataByte(std::uint32_t *data, int n, int b) {
+  static void setDataByte(uint32_t *data, int n, int b) {
     SET_DATA_BYTE(data, n, b);
   }
 #pragma GCC diagnostic pop

--- a/src/ccstruct/image.h
+++ b/src/ccstruct/image.h
@@ -16,9 +16,12 @@
 #ifndef TESSERACT_CCSTRUCT_IMAGE_H_
 #define TESSERACT_CCSTRUCT_IMAGE_H_
 
+#include <cstdint>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <allheaders.h> // Pix, from leptonica
+#include <arrayaccess.h> // GET_DATA_* and SET_DATA_* macros, from leptonica
 #pragma GCC diagnostic pop
 #include <tesseract/export.h>
 
@@ -54,19 +57,19 @@ public:
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-  static void clearDataBit(const uint32_t *data, int n) {
+  static void clearDataBit(const std::uint32_t *data, int n) {
     CLEAR_DATA_BIT(data, n);
   }
-  static int getDataBit(const uint32_t *data, int n) {
+  static int getDataBit(const std::uint32_t *data, int n) {
     return GET_DATA_BIT(data, n);
   }
-  static int getDataByte(const uint32_t *data, int n) {
+  static int getDataByte(const std::uint32_t *data, int n) {
     return GET_DATA_BYTE(data, n);
   }
-  static void setDataBit(uint32_t *data, int n) {
+  static void setDataBit(std::uint32_t *data, int n) {
     SET_DATA_BIT(data, n);
   }
-  static void setDataByte(uint32_t *data, int n, int b) {
+  static void setDataByte(std::uint32_t *data, int n, int b) {
     SET_DATA_BYTE(data, n, b);
   }
 #pragma GCC diagnostic pop


### PR DESCRIPTION
src\ccstruct\image.h(57,28): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int [build.msvc.Release\src\training\unicharset_training.vcxproj](compiling source file '../../../src/training/unicharset/lstmtester.cpp')

src\ccstruct\image.h(57,43): error C2143: syntax error: missing ',' before '*' [build.msvc.Release\src\training\unicharset_training.vcxproj] (compiling source file '../../../src/training/unicharset/lstmtester.cpp')