### PR TITLE
arch,viewer: add missing <cstdlib> and <string>

### DIFF
--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -18,6 +18,7 @@
 #ifdef HAVE_CONFIG_H
 #  include "config_auto.h" // for HAVE_AVX, ...
 #endif
+#include <cstdlib> // for getenv
 #include <numeric> // for std::inner_product
 #include "dotproduct.h"
 #include "intsimdmatrix.h" // for IntSimdMatrix

--- a/src/viewer/scrollview.h
+++ b/src/viewer/scrollview.h
@@ -38,6 +38,7 @@
 #include <cstdio>
 #include <memory>
 #include <mutex>
+#include <string>
 
 namespace tesseract {
 


### PR DESCRIPTION
Fixes these build errors when using `clang++ -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES`:

```
../src/arch/simddetect.cpp:287:32: error: use of undeclared identifier 'getenv'
  287 |   const char *dotproduct_env = getenv("DOTPRODUCT");
      |                                ^~~~~~


In file included from ../src/ccstruct/quspline.cpp:24:
In file included from ../src/ccstruct/quspline.h:23:
../src/viewer/scrollview.h:73:15: error: implicit instantiation of undefined template 'std::basic_string<char>'
   73 |   std::string parameter;           // Any string that might have been passed as argument.
      |               ^
/usr/include/c++/v1/__fwd/string.h:43:7: note: template is declared here
   43 | class basic_string;
      |       ^
```