### PR TITLE
Fix two \param names that refer to the member, not the argument

### DIFF
--- a/src/classify/ocrfeatures.h
+++ b/src/classify/ocrfeatures.h
@@ -70,7 +70,7 @@ using FEATURE = FEATURE_STRUCT *;
 struct FEATURE_SET_STRUCT {
   /// Creator for a new feature set large enough to
   /// hold the specified number of features.
-  /// @param NumFeatures maximum # of features to be put in feature set
+  /// @param numFeatures maximum # of features to be put in feature set
   FEATURE_SET_STRUCT(int numFeatures) : NumFeatures(0), MaxNumFeatures(numFeatures), Features(numFeatures) {
   }
 

--- a/src/training/common/commontraining.h
+++ b/src/training/common/commontraining.h
@@ -78,7 +78,7 @@ extern CLUSTERCONFIG Config;
 struct LABELEDLISTNODE {
   /// This constructor allocates a new, empty labeled list and gives
   /// it the specified label.
-  /// @param Label label for new list
+  /// @param label label for new list
   LABELEDLISTNODE(const char *label) : Label(label) {
   }
   std::string Label;


### PR DESCRIPTION
Two `\param` tags name the member the argument is assigned to, rather than the argument:

```cpp
/// @param NumFeatures maximum # of features to be put in feature set
FEATURE_SET_STRUCT(int numFeatures) : NumFeatures(0), MaxNumFeatures(numFeatures), ...
```

```cpp
/// @param Label label for new list
LABELEDLISTNODE(const char *label) : Label(label) { }
std::string Label;
```

In both cases `NumFeatures` and `Label` are the struct fields; the constructor arguments are `numFeatures` and `label`. Doxygen matches `\param` by name, so it documents a parameter that does not exist and the real one is left undescribed.

Changed the two tags to the argument names. Comments only — no signature, initialiser, or behaviour is touched.

Found with a static checker comparing `\param` names against the declaration below them; both were read by hand against the constructor before changing.
