### PR TITLE
Build unit tests without training tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -882,7 +882,8 @@ if(BUILD_TESTS
   add_subdirectory(unittest)
 endif()
 
-if(BUILD_TRAINING_TOOLS)
+if(BUILD_TRAINING_TOOLS OR BUILD_TESTS)
+  # The training libraries are also required by the unit tests.
   add_subdirectory(src/training)
 endif()
 

--- a/src/training/CMakeLists.txt
+++ b/src/training/CMakeLists.txt
@@ -130,7 +130,7 @@ project_group(common_training "Training Tools")
 # EXECUTABLE ambiguous_words
 # ##############################################################################
 
-if(NOT DISABLED_LEGACY_ENGINE)
+if(BUILD_TRAINING_TOOLS AND NOT DISABLED_LEGACY_ENGINE)
   add_executable(ambiguous_words ambiguous_words.cpp)
   target_link_libraries(ambiguous_words common_training)
   project_group(ambiguous_words "Training Tools")
@@ -148,7 +148,7 @@ endif()
 # EXECUTABLE classifier_tester
 # ##############################################################################
 
-if(NOT DISABLED_LEGACY_ENGINE)
+if(BUILD_TRAINING_TOOLS AND NOT DISABLED_LEGACY_ENGINE)
   add_executable(classifier_tester classifier_tester.cpp)
   target_link_libraries(classifier_tester common_training)
   project_group(classifier_tester "Training Tools")
@@ -166,23 +166,25 @@ endif()
 # EXECUTABLE combine_tessdata
 # ##############################################################################
 
-add_executable(combine_tessdata combine_tessdata.cpp)
-target_link_libraries(combine_tessdata common_training)
-project_group(combine_tessdata "Training Tools")
-install(
-  TARGETS combine_tessdata
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
-if (MSVC)
-  install(FILES $<TARGET_PDB_FILE:combine_tessdata> DESTINATION bin OPTIONAL)
+if(BUILD_TRAINING_TOOLS)
+  add_executable(combine_tessdata combine_tessdata.cpp)
+  target_link_libraries(combine_tessdata common_training)
+  project_group(combine_tessdata "Training Tools")
+  install(
+    TARGETS combine_tessdata
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+  if (MSVC)
+    install(FILES $<TARGET_PDB_FILE:combine_tessdata> DESTINATION bin OPTIONAL)
+  endif()
 endif()
 
 # ##############################################################################
 # EXECUTABLE cntraining
 # ##############################################################################
 
-if(NOT DISABLED_LEGACY_ENGINE)
+if(BUILD_TRAINING_TOOLS AND NOT DISABLED_LEGACY_ENGINE)
   add_executable(cntraining cntraining.cpp)
   target_link_libraries(cntraining common_training)
   project_group(cntraining "Training Tools")
@@ -200,23 +202,25 @@ endif()
 # EXECUTABLE dawg2wordlist
 # ##############################################################################
 
-add_executable(dawg2wordlist dawg2wordlist.cpp)
-target_link_libraries(dawg2wordlist common_training)
-project_group(dawg2wordlist "Training Tools")
-install(
-  TARGETS dawg2wordlist
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
-if (MSVC)
-  install(FILES $<TARGET_PDB_FILE:dawg2wordlist> DESTINATION bin OPTIONAL)
+if(BUILD_TRAINING_TOOLS)
+  add_executable(dawg2wordlist dawg2wordlist.cpp)
+  target_link_libraries(dawg2wordlist common_training)
+  project_group(dawg2wordlist "Training Tools")
+  install(
+    TARGETS dawg2wordlist
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+  if (MSVC)
+    install(FILES $<TARGET_PDB_FILE:dawg2wordlist> DESTINATION bin OPTIONAL)
+  endif()
 endif()
 
 # ##############################################################################
 # EXECUTABLE mftraining
 # ##############################################################################
 
-if(NOT DISABLED_LEGACY_ENGINE)
+if(BUILD_TRAINING_TOOLS AND NOT DISABLED_LEGACY_ENGINE)
   add_executable(mftraining mftraining.cpp mergenf.cpp mergenf.h)
   target_link_libraries(mftraining common_training)
   project_group(mftraining "Training Tools")
@@ -234,7 +238,7 @@ endif()
 # EXECUTABLE shapeclustering
 # ##############################################################################
 
-if(NOT DISABLED_LEGACY_ENGINE)
+if(BUILD_TRAINING_TOOLS AND NOT DISABLED_LEGACY_ENGINE)
   add_executable(shapeclustering shapeclustering.cpp)
   target_link_libraries(shapeclustering common_training)
   project_group(shapeclustering "Training Tools")
@@ -252,16 +256,18 @@ endif()
 # EXECUTABLE wordlist2dawg
 # ##############################################################################
 
-add_executable(wordlist2dawg wordlist2dawg.cpp)
-target_link_libraries(wordlist2dawg common_training)
-project_group(wordlist2dawg "Training Tools")
-install(
-  TARGETS wordlist2dawg
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
-if (MSVC)
-  install(FILES $<TARGET_PDB_FILE:wordlist2dawg> DESTINATION bin OPTIONAL)
+if(BUILD_TRAINING_TOOLS)
+  add_executable(wordlist2dawg wordlist2dawg.cpp)
+  target_link_libraries(wordlist2dawg common_training)
+  project_group(wordlist2dawg "Training Tools")
+  install(
+    TARGETS wordlist2dawg
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+  if (MSVC)
+    install(FILES $<TARGET_PDB_FILE:wordlist2dawg> DESTINATION bin OPTIONAL)
+  endif()
 endif()
 
 if(ICU_FOUND)
@@ -297,102 +303,114 @@ if(ICU_FOUND)
   # EXECUTABLE combine_lang_model
   # ############################################################################
 
-  add_executable(combine_lang_model combine_lang_model.cpp)
-  target_link_libraries(combine_lang_model unicharset_training)
-  project_group(combine_lang_model "Training Tools")
-  install(
-    TARGETS combine_lang_model
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
-  if (MSVC)
-    install(FILES $<TARGET_PDB_FILE:combine_lang_model> DESTINATION bin OPTIONAL)
+  if(BUILD_TRAINING_TOOLS)
+    add_executable(combine_lang_model combine_lang_model.cpp)
+    target_link_libraries(combine_lang_model unicharset_training)
+    project_group(combine_lang_model "Training Tools")
+    install(
+      TARGETS combine_lang_model
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib)
+    if (MSVC)
+      install(FILES $<TARGET_PDB_FILE:combine_lang_model> DESTINATION bin OPTIONAL)
+    endif()
   endif()
 
   # ############################################################################
   # EXECUTABLE lstmeval
   # ############################################################################
 
-  add_executable(lstmeval lstmeval.cpp)
-  target_link_libraries(lstmeval unicharset_training)
-  project_group(lstmeval "Training Tools")
-  install(
-    TARGETS lstmeval
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
-  if (MSVC)
-    install(FILES $<TARGET_PDB_FILE:lstmeval> DESTINATION bin OPTIONAL)
+  if(BUILD_TRAINING_TOOLS)
+    add_executable(lstmeval lstmeval.cpp)
+    target_link_libraries(lstmeval unicharset_training)
+    project_group(lstmeval "Training Tools")
+    install(
+      TARGETS lstmeval
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib)
+    if (MSVC)
+      install(FILES $<TARGET_PDB_FILE:lstmeval> DESTINATION bin OPTIONAL)
+    endif()
   endif()
 
   # ############################################################################
   # EXECUTABLE lstmtraining
   # ############################################################################
 
-  add_executable(lstmtraining lstmtraining.cpp)
-  target_link_libraries(lstmtraining unicharset_training)
-  project_group(lstmtraining "Training Tools")
-  install(
-    TARGETS lstmtraining
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
-  if (MSVC)
-    install(FILES $<TARGET_PDB_FILE:lstmtraining> DESTINATION bin OPTIONAL)
+  if(BUILD_TRAINING_TOOLS)
+    add_executable(lstmtraining lstmtraining.cpp)
+    target_link_libraries(lstmtraining unicharset_training)
+    project_group(lstmtraining "Training Tools")
+    install(
+      TARGETS lstmtraining
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib)
+    if (MSVC)
+      install(FILES $<TARGET_PDB_FILE:lstmtraining> DESTINATION bin OPTIONAL)
+    endif()
   endif()
 
   # ############################################################################
   # EXECUTABLE merge_unicharsets
   # ############################################################################
 
-  add_executable(merge_unicharsets merge_unicharsets.cpp)
-  target_link_libraries(merge_unicharsets common_training)
-  project_group(merge_unicharsets "Training Tools")
-  install(
-    TARGETS merge_unicharsets
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
-  if (MSVC)
-    install(FILES $<TARGET_PDB_FILE:merge_unicharsets> DESTINATION bin OPTIONAL)
+  if(BUILD_TRAINING_TOOLS)
+    add_executable(merge_unicharsets merge_unicharsets.cpp)
+    target_link_libraries(merge_unicharsets common_training)
+    project_group(merge_unicharsets "Training Tools")
+    install(
+      TARGETS merge_unicharsets
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib)
+    if (MSVC)
+      install(FILES $<TARGET_PDB_FILE:merge_unicharsets> DESTINATION bin OPTIONAL)
+    endif()
   endif()
 
   # ############################################################################
   # EXECUTABLE set_unicharset_properties
   # ############################################################################
 
-  add_executable(set_unicharset_properties set_unicharset_properties.cpp)
-  target_link_libraries(set_unicharset_properties unicharset_training)
-  project_group(set_unicharset_properties "Training Tools")
-  install(
-    TARGETS set_unicharset_properties
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
-  if (MSVC)
-    install(FILES $<TARGET_PDB_FILE:set_unicharset_properties> DESTINATION bin OPTIONAL)
+  if(BUILD_TRAINING_TOOLS)
+    add_executable(set_unicharset_properties set_unicharset_properties.cpp)
+    target_link_libraries(set_unicharset_properties unicharset_training)
+    project_group(set_unicharset_properties "Training Tools")
+    install(
+      TARGETS set_unicharset_properties
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib)
+    if (MSVC)
+      install(FILES $<TARGET_PDB_FILE:set_unicharset_properties> DESTINATION bin OPTIONAL)
+    endif()
   endif()
 
   # ############################################################################
   # EXECUTABLE unicharset_extractor
   # ############################################################################
 
-  add_executable(unicharset_extractor unicharset_extractor.cpp)
-  target_compile_features(unicharset_extractor PRIVATE cxx_std_17)
-  target_link_libraries(unicharset_extractor unicharset_training)
-  project_group(unicharset_extractor "Training Tools")
-  install(
-    TARGETS unicharset_extractor
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
-  if (MSVC)
-    install(FILES $<TARGET_PDB_FILE:unicharset_extractor> DESTINATION bin OPTIONAL)
+  if(BUILD_TRAINING_TOOLS)
+    add_executable(unicharset_extractor unicharset_extractor.cpp)
+    target_compile_features(unicharset_extractor PRIVATE cxx_std_17)
+    target_link_libraries(unicharset_extractor unicharset_training)
+    project_group(unicharset_extractor "Training Tools")
+    install(
+      TARGETS unicharset_extractor
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib)
+    if (MSVC)
+      install(FILES $<TARGET_PDB_FILE:unicharset_extractor> DESTINATION bin OPTIONAL)
+    endif()
   endif()
 
   # ############################################################################
 
-  if(PKG_CONFIG_FOUND)
+  if(BUILD_TRAINING_TOOLS AND PKG_CONFIG_FOUND)
     pkg_check_modules(
       PANGO
       REQUIRED


### PR DESCRIPTION
The unit tests link the training libraries common_training and unicharset_training, but add_subdirectory(src/training) was only enabled for BUILD_TRAINING_TOOLS. A build with BUILD_TRAINING_TOOLS disabled and BUILD_TESTS enabled therefore failed with missing libraries.

Now the training libraries are also built when BUILD_TESTS is enabled, while the training executables and the pango dependency are still only built for BUILD_TRAINING_TOOLS.

Assisted-by: OpenCode / big-pickle (opencode)