### PR TITLE
Avoid redundant result iterator restarts

### DIFF
--- a/src/ccmain/resultiterator.cpp
+++ b/src/ccmain/resultiterator.cpp
@@ -61,7 +61,9 @@ bool ResultIterator::CurrentParagraphIsLtr() const {
     return true; // doesn't matter.
   }
   LTRResultIterator it(*this);
-  it.RestartParagraph();
+  if (!it.PageIterator::IsAtBeginningOf(RIL_PARA)) {
+    it.RestartParagraph();
+  }
   // Try to figure out the ltr-ness of the paragraph.  The rules below
   // make more sense in the context of a difficult paragraph example.
   // Here we denote {ltr characters, RTL CHARACTERS}:
@@ -269,7 +271,9 @@ void ResultIterator::CalculateTextlineOrder(bool paragraph_is_ltr, const LTRResu
 
   // A LTRResultIterator goes strictly left-to-right word order.
   LTRResultIterator ltr_it(resit);
-  ltr_it.RestartRow();
+  if (!ltr_it.PageIterator::IsAtBeginningOf(RIL_TEXTLINE)) {
+    ltr_it.RestartRow();
+  }
   if (ltr_it.Empty(RIL_WORD)) {
     return;
   }
@@ -446,7 +450,9 @@ void ResultIterator::AppendSuffixMarks(std::string *text) const {
 
 void ResultIterator::MoveToLogicalStartOfTextline() {
   std::vector<int> word_indices;
-  RestartRow();
+  if (!PageIterator::IsAtBeginningOf(RIL_TEXTLINE)) {
+    RestartRow();
+  }
   CalculateTextlineOrder(current_paragraph_is_ltr_, dynamic_cast<const LTRResultIterator &>(*this),
                          &word_indices);
   unsigned i = 0;
@@ -489,7 +495,7 @@ bool ResultIterator::Next(PageIteratorLevel level) {
       if (!PageIterator::Next(level)) {
         return false;
       }
-      if (IsWithinFirstTextlineOfParagraph()) {
+      if (PageIterator::IsAtBeginningOf(RIL_PARA)) {
         // if we've advanced to a new paragraph,
         // recalculate current_paragraph_is_ltr_
         current_paragraph_is_ltr_ = CurrentParagraphIsLtr();

--- a/unittest/resultiterator_test.cc
+++ b/unittest/resultiterator_test.cc
@@ -32,9 +32,10 @@ protected:
   }
   ~ResultIteratorTest() override = default;
 
-  void SetImage(const char *filename) {
+  void SetImage(const char *filename, const char *language = "eng",
+                OcrEngineMode oem = tesseract::OEM_TESSERACT_ONLY) {
     src_pix_ = pixRead(TestDataNameToPath(filename).c_str());
-    api_.Init(TessdataPath().c_str(), "eng", tesseract::OEM_TESSERACT_ONLY);
+    api_.Init(TessdataPath().c_str(), language, oem);
     //    if (!FLAGS_tess_config.empty())
     //      api_.ReadConfigFile(FLAGS_tess_config.c_str());
     api_.SetPageSegMode(tesseract::PSM_AUTO);
@@ -363,6 +364,71 @@ TEST_F(ResultIteratorTest, GreyTest) {
   EXPECT_FALSE(it == nullptr);
   // The images should rebuild almost perfectly.
   VerifyRebuilds(600, 600, 600, 600, 600, it);
+  delete it;
+}
+
+// Tests that higher-level iteration lands at both the logical and physical
+// start of each LTR object, including when constructed from an interior word.
+TEST_F(ResultIteratorTest, IteratorLevelStartsTest) {
+  SetImage("8087_054.3B.tif");
+  char *text = api_.GetUTF8Text();
+  delete[] text;
+
+  const PageIteratorLevel levels[] = {RIL_BLOCK, RIL_PARA, RIL_TEXTLINE};
+  for (const auto level : levels) {
+    ResultIterator *it = api_.GetIterator();
+    ASSERT_NE(nullptr, it);
+    int count = 0;
+    do {
+      EXPECT_TRUE(it->IsAtBeginningOf(level));
+      EXPECT_TRUE(it->PageIterator::IsAtBeginningOf(level));
+      ++count;
+    } while (it->Next(level));
+    EXPECT_GT(count, 1);
+    delete it;
+  }
+
+  ResultIterator *it = api_.GetIterator();
+  ASSERT_NE(nullptr, it);
+  while (it->PageIterator::IsAtBeginningOf(RIL_TEXTLINE)) {
+    ASSERT_TRUE(it->Next(RIL_WORD));
+  }
+  EXPECT_FALSE(it->IsAtBeginningOf(RIL_TEXTLINE));
+  EXPECT_FALSE(it->PageIterator::IsAtBeginningOf(RIL_TEXTLINE));
+
+  ResultIterator *paragraph_start = ResultIterator::StartOfParagraph(*it);
+  ASSERT_NE(nullptr, paragraph_start);
+  EXPECT_TRUE(paragraph_start->IsAtBeginningOf(RIL_PARA));
+  EXPECT_TRUE(paragraph_start->PageIterator::IsAtBeginningOf(RIL_PARA));
+  delete paragraph_start;
+  delete it;
+}
+
+// Tests that RTL iteration remains at logical starts even when those differ
+// from the physical left-to-right starts used by PageIterator.
+TEST_F(ResultIteratorTest, RightToLeftIteratorStartsTest) {
+  SetImage("hebrew.png", "heb", tesseract::OEM_DEFAULT);
+  char *text = api_.GetUTF8Text();
+  ASSERT_NE(nullptr, text);
+  std::string truth(text);
+  delete[] text;
+
+  ResultIterator *it = api_.GetIterator();
+  ASSERT_NE(nullptr, it);
+  ASSERT_FALSE(it->ParagraphIsLtr());
+  int line_count = 0;
+  int logical_only_starts = 0;
+  do {
+    EXPECT_TRUE(it->IsAtBeginningOf(RIL_TEXTLINE));
+    if (!it->PageIterator::IsAtBeginningOf(RIL_TEXTLINE)) {
+      ++logical_only_starts;
+    }
+    ++line_count;
+  } while (it->Next(RIL_TEXTLINE));
+  EXPECT_GT(line_count, 1);
+  EXPECT_GT(logical_only_starts, 0);
+
+  VerifyAllText(truth, it);
   delete it;
 }
 


### PR DESCRIPTION
## Summary

Avoid redundant paragraph and text-line restarts when a `ResultIterator` is already at the required physical start position.

The reading-order setup repeatedly copied iterators and restarted them even when `PageIterator::Next()` had just placed them at a paragraph or text-line start. On sparse layouts with many blocks, those no-op restarts become costly repeated scans.

## Change

- guards paragraph and row restarts with the physical `PageIterator::IsAtBeginningOf()` predicate
- uses the same physical predicate to detect paragraph transitions after `PageIterator::Next()`
- adds focused LTR and RTL coverage for block, paragraph, and text-line iteration, including logical versus physical starts and an interior word

## Performance

GCC 15.2 RelWithDebInfo build, with OEM 3, PSM 11 and `OMP_THREAD_LIMIT=1`:

| Input | Before | After |
| --- | ---: | ---: |
| `input-4267x3200.png` | 52.90 s | 8.41 s |
| #4430 `page.png` | >300 s | 95.62 s |

The minimal reproducer's OCR output is identical to the baseline from `main`.
The reproducer, `input-4267x3200.png`, is generated by repeating a 16x16 texture-only image across a 4267x3200 canvas.

<details>

<summary>input-4267x3200.png</summary>

<img width="4267" height="3200" alt="input-4267x3200" src="https://github.com/user-attachments/assets/35082f57-8986-4d7b-941d-f3759a805106" />

</details>

<details>

<summary>background-tile-16.png</summary>

<img width="16" height="16" alt="background-tile-16" src="https://github.com/user-attachments/assets/eca4dc26-6a97-467d-9720-680a83bab175" />

</details>
Related to #4430.

## Validation

- Full CTest suite: 62/62 passed.