### PR TITLE
exports GetDetector() from the tesseract DLL, so linker can resolve it.

### DIFF
--- a/src/arch/simddetect.h
+++ b/src/arch/simddetect.h
@@ -74,7 +74,7 @@ public:
   // The detector is constructed on first use (a function local static
   // variable), which avoids an unspecified order of static initialization
   // with the static members of other classes (like IntSimdMatrix).
-  static const SIMDDetect &GetDetector();
+  static TESS_API const SIMDDetect &GetDetector();
 
 private:
   // Constructor, must set all static member variables.


### PR DESCRIPTION
This should fix failing [cmake-win64](https://github.com/tesseract-ocr/tesseract/actions/runs/31461603105) action