### PR TITLE
Reject non-text sparse partitions

### DIFF
--- a/src/textord/colpartitiongrid.cpp
+++ b/src/textord/colpartitiongrid.cpp
@@ -701,7 +701,8 @@ void ColPartitionGrid::ExtractPartitionsAsBlocks(BLOCK_LIST *blocks,
     // The partition has to be at least vaguely like text.
     BlobRegionType blob_type = part->blob_type();
     if (BLOBNBOX::IsTextType(blob_type) ||
-        (blob_type == BRT_UNKNOWN && part->boxes_count() > 1)) {
+        (blob_type == BRT_UNKNOWN && part->flow() != BTFT_NONTEXT &&
+         part->boxes_count() > 1)) {
       PolyBlockType type =
           blob_type == BRT_VERT_TEXT ? PT_VERTICAL_TEXT : PT_FLOWING_TEXT;
       // Get metrics from the row that will be used for the block.

--- a/unittest/colpartition_test.cc
+++ b/unittest/colpartition_test.cc
@@ -9,11 +9,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "blobbox.h"
 #include "colpartition.h"
+#include "colpartitiongrid.h"
+#include "ocrblock.h"
 
 #include "include_gunit.h"
 
 namespace tesseract {
+
+namespace {
+
+int ExtractedBlockCount(BlobRegionType type, BlobTextFlowType flow, int box_count) {
+  ColPartitionGrid grid(10, ICOORD(0, 0), ICOORD(100, 100));
+  ColPartition *part =
+      ColPartition::FakePartition(TBOX(10, 10, 20, 20), PT_FLOWING_TEXT, type, flow);
+  for (int i = 1; i < box_count; ++i) {
+    const TBOX box(10 + i * 12, 10, 20 + i * 12, 20);
+    part->AddBox(new BLOBNBOX(C_BLOB::FakeBlob(box)));
+  }
+  // Make each BLOBNBOX own its C_BLOB so the fake blobs aren't leaked.
+  BLOBNBOX_C_IT owns_it(part->boxes());
+  for (owns_it.mark_cycle_pt(); !owns_it.cycled_list(); owns_it.forward()) {
+    owns_it.data()->set_owns_cblob(true);
+  }
+  part->ComputeLimits();
+  part->ClaimBoxes();
+  part->SetBlobTypes();
+  grid.InsertBBox(true, true, part);
+
+  BLOCK_LIST blocks;
+  TO_BLOCK_LIST to_blocks;
+  grid.ExtractPartitionsAsBlocks(&blocks, &to_blocks);
+  return blocks.length();
+}
+
+} // namespace
 
 class TestableColPartition : public ColPartition {
 public:
@@ -71,6 +102,22 @@ TEST_F(ColPartitionTest, IsInSameColumnAsPartialOverlap) {
 
   EXPECT_TRUE(a.IsInSameColumnAs(b));
   EXPECT_TRUE(b.IsInSameColumnAs(a));
+}
+
+TEST(ColPartitionGridTest, RejectsMultiBlobUnknownNonTextPartition) {
+  EXPECT_EQ(0, ExtractedBlockCount(BRT_UNKNOWN, BTFT_NONTEXT, 2));
+}
+
+TEST(ColPartitionGridTest, RetainsMultiBlobUnknownPartitionWithTextFlow) {
+  EXPECT_EQ(1, ExtractedBlockCount(BRT_UNKNOWN, BTFT_NEIGHBOURS, 2));
+}
+
+TEST(ColPartitionGridTest, RejectsSingleBlobUnknownPartition) {
+  EXPECT_EQ(0, ExtractedBlockCount(BRT_UNKNOWN, BTFT_NONTEXT, 1));
+}
+
+TEST(ColPartitionGridTest, RetainsTextPartitionWithNonTextFlow) {
+  EXPECT_EQ(1, ExtractedBlockCount(BRT_TEXT, BTFT_NONTEXT, 2));
 }
 
 } // namespace tesseract


### PR DESCRIPTION
## Summary

Refine sparse partition extraction so that a multi-blob `BRT_UNKNOWN` partition is accepted only when its text flow is not `BTFT_NONTEXT`.

Sparse segmentation can classify background texture as unknown partitions with an explicit non-text flow. The extractor previously accepted every multi-blob unknown partition, turning those regions into separate text blocks and making pathological inputs extremely expensive to process.

All text region types remain accepted regardless of flow. Multi-blob unknown partitions with other flow values also remain accepted.

Related to #4430.

## Performance

GCC 15.2 RelWithDebInfo build, with OEM 3, PSM 11 and `OMP_THREAD_LIMIT=1`:

| Input | Before | After |
| --- | ---: | ---: |
| `input-4267x3200.png` | 52.90 s | 0.85 s |
| #4430 `page.png` | >300 s | 5.02 s |

The minimal repro changes from 1,681 extracted blocks and words to 48, and from 6,723 bytes of OCR text to 191 bytes. The removed output came from unknown partitions whose flow was explicitly classified as non-text.
The `main` run ("before") for the #4430 image did not complete within 300 seconds, so it has no completed OCR output for comparison.

<details>

<summary>input-4267x3200.png</summary>

<img width="4267" height="3200" alt="input-4267x3200" src="https://github.com/user-attachments/assets/35082f57-8986-4d7b-941d-f3759a805106" />

</details>

<details>

<summary>background-tile-16.png</summary>

<img width="16" height="16" alt="background-tile-16" src="https://github.com/user-attachments/assets/eca4dc26-6a97-467d-9720-680a83bab175" />

</details>

## Validation

- Four focused extraction-policy cases pass, covering rejected and retained unknown partitions plus preservation of text region types.
- Full CTest suite: 62/62 passed.
- PSM 11 and PSM 12 output remained byte-identical to `main` across 14 runs covering seven English, Hebrew and Arabic test images.

`BTFT_NONTEXT` is a segmentation heuristic, so weak real text over photos or textures could be excluded if it is classified as both `BRT_UNKNOWN` and `BTFT_NONTEXT`. The focused tests and available smoke set showed no regression but broader scene-text corpus evaluation would provide additional confidence.