### PR TITLE
docs: update dead Tesseract training docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You should note that in many cases, in order to get better OCR results, you'll n
 This project **does not include a GUI application**. If you need one, please see the [3rdParty](https://tesseract-ocr.github.io/tessdoc/User-Projects-%E2%80%93-3rdParty.html) documentation.
 
 Tesseract **can be trained to recognize other languages**.
-See [Tesseract Training](https://tesseract-ocr.github.io/tessdoc/Training-Tesseract.html) for more information.
+See [Tesseract Training](https://tesseract-ocr.github.io/tessdoc/tess5/TrainingTesseract-5.html) for more information.
 
 ## Brief history
 


### PR DESCRIPTION
The README links to the retired tessdoc page `Training-Tesseract.html` (404 - the tessdoc site was restructured into versioned sections). Updated to the current Tesseract 5 training page, which is what this repository ships.