### PR TITLE
Fix Coverity warnings

### DIFF
--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -889,7 +889,7 @@ bool TessBaseAPI::ProcessPagesFileList(FILE *flist, std::string *buf, const char
     std::string line;
     for (const auto ch : *buf) {
       if (ch == '\n') {
-        lines.push_back(line);
+        lines.push_back(std::move(line));
         line.clear();
       } else {
         line.push_back(ch);
@@ -897,7 +897,7 @@ bool TessBaseAPI::ProcessPagesFileList(FILE *flist, std::string *buf, const char
     }
     if (!line.empty()) {
       // Add last line without terminating LF.
-      lines.push_back(line);
+      lines.push_back(std::move(line));
     }
     if (lines.empty()) {
       return false;

--- a/src/ccmain/paragraphs.cpp
+++ b/src/ccmain/paragraphs.cpp
@@ -547,7 +547,7 @@ void RowScratchRegisters::AppendDebugInfo(const ParagraphTheory &theory,
     model_string += "0";
   }
 
-  dbg.push_back(model_string);
+  dbg.push_back(std::move(model_string));
 }
 
 void RowScratchRegisters::Init(const RowInfo &row) {

--- a/src/ccmain/tessedit.cpp
+++ b/src/ccmain/tessedit.cpp
@@ -286,7 +286,7 @@ void Tesseract::ParseLanguageString(const std::string &lang_str, std::vector<std
     lang_code = prefix + lang_code;
     // Check whether lang_code is already in the target vector and add.
     if (!IsStrInList(lang_code, *target)) {
-      target->push_back(lang_code);
+      target->push_back(std::move(lang_code));
     }
   }
 }

--- a/src/ccstruct/blamer.cpp
+++ b/src/ccstruct/blamer.cpp
@@ -79,7 +79,7 @@ void BlamerBundle::SetWordTruth(const UNICHARSET &unicharset, const char *truth_
     if (id != INVALID_UNICHAR_ID) {
       uch = unicharset.get_normed_unichar(id);
     }
-    truth_text_.push_back(uch);
+    truth_text_.push_back(std::move(uch));
   }
 }
 
@@ -96,7 +96,7 @@ void BlamerBundle::SetSymbolTruth(const UNICHARSET &unicharset, const char *char
     }
   }
   int length = truth_word_.length();
-  truth_text_.push_back(symbol_str);
+  truth_text_.push_back(std::move(symbol_str));
   truth_word_.InsertBox(length, char_box);
   if (length == 0) {
     truth_has_char_boxes_ = true;

--- a/src/ccstruct/blamer.h
+++ b/src/ccstruct/blamer.h
@@ -232,6 +232,7 @@ struct BlamerBundle {
       lattice_size_ = other.lattice_size_;
     } else {
       lattice_data_ = nullptr;
+      lattice_size_ = 0;
     }
   }
   const char *IncorrectReason() const;

--- a/src/ccstruct/boxread.cpp
+++ b/src/ccstruct/boxread.cpp
@@ -31,6 +31,7 @@
 #include <locale>  // for std::locale::classic
 #include <sstream> // for std::stringstream
 #include <string>  // for std::string
+#include <utility> // for std::move
 
 namespace tesseract {
 
@@ -130,7 +131,7 @@ bool ReadMemBoxes(int target_page, bool skip_blanks, const char *box_data, bool 
     if (box_texts != nullptr) {
       std::string full_text;
       MakeBoxFileStr(utf8_str.c_str(), box, target_page, full_text);
-      box_texts->push_back(full_text);
+      box_texts->push_back(std::move(full_text));
     }
     if (pages != nullptr) {
       pages->push_back(page);

--- a/src/ccstruct/matrix.h
+++ b/src/ccstruct/matrix.h
@@ -75,6 +75,15 @@ public:
       : array_(nullptr), empty_(static_cast<T>(0)), dim1_(0), dim2_(0), size_allocated_(0) {
     *this = src;
   }
+  GENERIC_2D_ARRAY(GENERIC_2D_ARRAY<T> &&src) noexcept
+      : array_(src.array_), empty_(src.empty_), dim1_(src.dim1_), dim2_(src.dim2_),
+        size_allocated_(src.size_allocated_) {
+    src.array_ = nullptr;
+    src.empty_ = static_cast<T>(0);
+    src.dim1_ = 0;
+    src.dim2_ = 0;
+    src.size_allocated_ = 0;
+  }
   virtual ~GENERIC_2D_ARRAY() {
     delete[] array_;
   }
@@ -84,6 +93,21 @@ public:
     int size = num_elements();
     if (size > 0) {
       memcpy(array_, src.array_, size * sizeof(array_[0]));
+    }
+  }
+  void operator=(GENERIC_2D_ARRAY<T> &&src) noexcept {
+    if (this != &src) {
+      delete[] array_;
+      array_ = src.array_;
+      empty_ = src.empty_;
+      dim1_ = src.dim1_;
+      dim2_ = src.dim2_;
+      size_allocated_ = src.size_allocated_;
+      src.array_ = nullptr;
+      src.empty_ = static_cast<T>(0);
+      src.dim1_ = 0;
+      src.dim2_ = 0;
+      src.size_allocated_ = 0;
     }
   }
 

--- a/src/ccstruct/pageres.cpp
+++ b/src/ccstruct/pageres.cpp
@@ -1635,7 +1635,6 @@ WERD_RES *PAGE_RES_IT::internal_forward(bool new_block, bool empty_ok) {
 
   while (!block_res_it.cycled_list()) {
     if (new_block) {
-      new_block = false;
       row_res_it.set_to_list(&block_res_it.data()->row_res_list);
       row_res_it.mark_cycle_pt();
       if (row_res_it.empty() && empty_ok) {

--- a/src/ccstruct/quspline.cpp
+++ b/src/ccstruct/quspline.cpp
@@ -141,6 +141,16 @@ QSPLINE::QSPLINE( // constructor
   *this = src;
 }
 
+QSPLINE::QSPLINE( // move constructor
+    QSPLINE &&src) noexcept {
+  segments = src.segments;
+  xcoords = src.xcoords;
+  quadratics = src.quadratics;
+  src.segments = 0;
+  src.xcoords = nullptr;
+  src.quadratics = nullptr;
+}
+
 /**********************************************************************
  * QSPLINE::~QSPLINE
  *
@@ -168,6 +178,22 @@ QSPLINE &QSPLINE::operator=( // assignment
   quadratics = new QUAD_COEFFS[segments];
   memmove(xcoords, source.xcoords, (segments + 1) * sizeof(int32_t));
   memmove(quadratics, source.quadratics, segments * sizeof(QUAD_COEFFS));
+  return *this;
+}
+
+QSPLINE &QSPLINE::operator=( // move assignment
+    QSPLINE &&source) noexcept {
+  if (this != &source) {
+    delete[] xcoords;
+    delete[] quadratics;
+
+    segments = source.segments;
+    xcoords = source.xcoords;
+    quadratics = source.quadratics;
+    source.segments = 0;
+    source.xcoords = nullptr;
+    source.quadratics = nullptr;
+  }
   return *this;
 }
 

--- a/src/ccstruct/quspline.h
+++ b/src/ccstruct/quspline.h
@@ -46,6 +46,7 @@ public:
   }
   QSPLINE( // copy constructor
       const QSPLINE &src);
+  QSPLINE(QSPLINE &&src) noexcept;  // move constructor
   QSPLINE(                          // constructor
       int32_t count,                // number of segments
       int32_t *xstarts,             // segment starts
@@ -85,6 +86,7 @@ public:
   void plot(Image pix) const;
 
   QSPLINE &operator=(const QSPLINE &source); // from this
+  QSPLINE &operator=(QSPLINE &&source) noexcept;
 
 private:
   int32_t spline_index(    // binary search

--- a/src/ccstruct/ratngs.h
+++ b/src/ccstruct/ratngs.h
@@ -76,6 +76,7 @@ public:
               float yshift,              // the larger of y shift (top or bottom)
               BlobChoiceClassifier c);   // adapted match or other
   BLOB_CHOICE(const BLOB_CHOICE &other);
+  BLOB_CHOICE(BLOB_CHOICE &&other) noexcept = default;
   ~BLOB_CHOICE() = default;
 
   UNICHAR_ID unichar_id() const {
@@ -192,6 +193,8 @@ public:
 private:
   // Copy assignment operator.
   BLOB_CHOICE &operator=(const BLOB_CHOICE &other);
+  // Move assignment operator.
+  BLOB_CHOICE &operator=(BLOB_CHOICE &&other) noexcept = default;
 
   UNICHAR_ID unichar_id_; // unichar id
 #ifndef DISABLED_LEGACY_ENGINE
@@ -276,6 +279,7 @@ public:
     this->init(word.length());
     this->operator=(word);
   }
+  WERD_CHOICE(WERD_CHOICE &&word) noexcept = default;
   ~WERD_CHOICE();
 
   const UNICHARSET *unicharset() const {
@@ -573,6 +577,7 @@ public:
       const WERD_CHOICE &second); // second on first
 
   WERD_CHOICE &operator=(const WERD_CHOICE &source);
+  WERD_CHOICE &operator=(WERD_CHOICE &&source) noexcept = default;
 
 private:
   const UNICHARSET *unicharset_;

--- a/src/ccutil/clst.h
+++ b/src/ccutil/clst.h
@@ -146,6 +146,13 @@ public:
   public:
     Iterator() { // constructor
       list = nullptr;
+      prev = nullptr;
+      current = nullptr;
+      next = nullptr;
+      cycle_pt = nullptr; // await explicit set
+      started_cycling = false;
+      ex_current_was_last = false;
+      ex_current_was_cycle_pt = false;
     } // unassigned list
 
   /***********************************************************************

--- a/src/ccutil/elst.h
+++ b/src/ccutil/elst.h
@@ -209,6 +209,13 @@ public:
   public:
     Iterator() { // constructor
       list = nullptr;
+      prev = nullptr;
+      current = nullptr;
+      next = nullptr;
+      cycle_pt = nullptr; // await explicit set
+      started_cycling = false;
+      ex_current_was_last = false;
+      ex_current_was_cycle_pt = false;
     } // unassigned list
     /***********************************************************************
    *                          ELIST_ITERATOR::ELIST_ITERATOR

--- a/src/ccutil/helpers.h
+++ b/src/ccutil/helpers.h
@@ -26,6 +26,7 @@
 #include <cstdio>
 #include <algorithm>  // for std::find
 #include <string>
+#include <utility>    // for std::move
 #include <vector>
 
 #include "serialis.h"
@@ -55,12 +56,12 @@ inline const std::vector<std::string> split(const std::string &s, char c) {
     if (n != c) {
       buff += n;
     } else if (n == c && !buff.empty()) {
-      v.push_back(buff);
+      v.push_back(std::move(buff));
       buff.clear();
     }
   }
   if (!buff.empty()) {
-    v.push_back(buff);
+    v.push_back(std::move(buff));
   }
   return v;
 }

--- a/src/ccutil/kdpair.h
+++ b/src/ccutil/kdpair.h
@@ -99,7 +99,7 @@ struct KDPairDec : public KDPair<Key, Data> {
 template <typename Key, typename Data>
 class KDPtrPair {
 public:
-  KDPtrPair() : data_(nullptr) {}
+  KDPtrPair() : data_(nullptr), key_{} {}
   KDPtrPair(Key k, Data *d) : data_(d), key_(k) {}
   // Copy constructor steals the pointer from src and nulls it in src, thereby
   // moving the (single) ownership of the data.

--- a/src/classify/cluster.h
+++ b/src/classify/cluster.h
@@ -32,7 +32,7 @@ constexpr int MAXBUCKETS = 39;
           Types
 ----------------------------------------------------------------------*/
 struct CLUSTER {
-  CLUSTER(size_t n) : Mean(n) {
+  CLUSTER(size_t n) : Left(nullptr), Right(nullptr), Mean(n) {
   }
 
   ~CLUSTER() {

--- a/src/classify/featdefs.h
+++ b/src/classify/featdefs.h
@@ -47,9 +47,8 @@ using FEATURE_DEFS = FEATURE_DEFS_STRUCT *;
 struct CHAR_DESC_STRUCT {
   /// Allocate a new character description, initialize its
   /// feature sets to be empty, and return it.
-  CHAR_DESC_STRUCT(const FEATURE_DEFS_STRUCT &FeatureDefs) {
-    NumFeatureSets = FeatureDefs.NumFeatureTypes;
-  }
+  CHAR_DESC_STRUCT(const FEATURE_DEFS_STRUCT &FeatureDefs)
+      : NumFeatureSets(FeatureDefs.NumFeatureTypes), FeatureSets{} {}
 
   /// Release the memory consumed by the specified character
   /// description and all of the features in that description.

--- a/src/classify/intproto.cpp
+++ b/src/classify/intproto.cpp
@@ -608,6 +608,9 @@ INT_TEMPLATES_STRUCT::INT_TEMPLATES_STRUCT() {
   for (int i = 0; i < MAX_NUM_CLASSES; i++) {
     ClassForClassId(this, i) = nullptr;
   }
+  for (int i = 0; i < MAX_NUM_CLASS_PRUNERS; i++) {
+    ClassPruners[i] = nullptr;
+  }
 }
 
 INT_TEMPLATES_STRUCT::~INT_TEMPLATES_STRUCT() {

--- a/src/classify/shapetable.cpp
+++ b/src/classify/shapetable.cpp
@@ -28,6 +28,7 @@
 #include "unicity_table.h"
 
 #include <algorithm>
+#include <utility> // for std::move
 
 namespace tesseract {
 
@@ -743,7 +744,7 @@ int ShapeTable::AddUnicharToResults(int unichar_id, float rating, std::vector<in
   if (result_index < 0) {
     UnicharRating result(unichar_id, rating);
     result_index = results->size();
-    results->push_back(result);
+    results->push_back(std::move(result));
     (*unichar_map)[unichar_id] = result_index;
   }
   return result_index;

--- a/src/dict/trie.cpp
+++ b/src/dict/trie.cpp
@@ -27,6 +27,8 @@
 #include "helpers.h"
 #include "kdpair.h"
 
+#include <utility> // for std::move
+
 namespace tesseract {
 
 const char kDoNotReverse[] = "RRP_DO_NO_REVERSE";
@@ -298,7 +300,7 @@ bool Trie::read_word_list(const char *filename, std::vector<std::string> *words)
     if (debug_level_ && word_count % 10000 == 0) {
       tprintf("Read %d words so far\n", word_count);
     }
-    words->push_back(word_str);
+    words->push_back(std::move(word_str));
   }
   if (debug_level_) {
     tprintf("Read %d words total.\n", word_count);

--- a/src/lstm/plumbing.cpp
+++ b/src/lstm/plumbing.cpp
@@ -18,6 +18,8 @@
 
 #include "plumbing.h"
 
+#include <utility> // for std::move
+
 namespace tesseract {
 
 // ni_ and no_ will be set by AddToStack.
@@ -152,7 +154,7 @@ void Plumbing::EnumerateLayers(const std::string *prefix, std::vector<std::strin
       auto *plumbing = static_cast<Plumbing *>(stack_[i]);
       plumbing->EnumerateLayers(&layer_name, layers);
     } else {
-      layers.push_back(layer_name);
+      layers.push_back(std::move(layer_name));
     }
   }
 }

--- a/src/lstm/recodebeam.cpp
+++ b/src/lstm/recodebeam.cpp
@@ -24,6 +24,7 @@
 #include "unicharcompress.h"
 
 #include <algorithm> // for std::reverse
+#include <utility>   // for std::move
 
 namespace tesseract {
 
@@ -157,7 +158,7 @@ void RecodeBeamSearch::SaveMostCertainChoices(const float *outputs,
                      std::pair<const char *, float>(character, outputs[i]));
     }
   }
-  timesteps.push_back(choices);
+  timesteps.push_back(std::move(choices));
 }
 
 void RecodeBeamSearch::segmentTimestepsByCharacters() {
@@ -167,7 +168,7 @@ void RecodeBeamSearch::segmentTimestepsByCharacters() {
          ++j) {
       segment.push_back(timesteps[j]);
     }
-    segmentedTimesteps.push_back(segment);
+    segmentedTimesteps.push_back(std::move(segment));
   }
 }
 std::vector<std::vector<std::pair<const char *, float>>>
@@ -334,7 +335,7 @@ void RecodeBeamSearch::PrintBeam2(bool uids,
   // create the topology
   for (int step = beam.size() - 1; step >= 0; --step) {
     std::vector<const RecodeNode *> layer;
-    topology.push_back(layer);
+    topology.push_back(std::move(layer));
   }
   // fill the topology with depths first
   for (int step = beam.size() - 1; step >= 0; --step) {
@@ -475,7 +476,7 @@ void RecodeBeamSearch::extractSymbolChoices(const UNICHARSET *unicharset) {
           excludedUnichars[j - 1].insert(elem);
         }
       } else {
-        excludedUnichars.push_back(excludeCodeList);
+        excludedUnichars.push_back(std::move(excludeCodeList));
       }
       // Save the best choice for the choice iterator.
       if (j - 1 < ctc_choices.size()) {
@@ -490,17 +491,17 @@ void RecodeBeamSearch::extractSymbolChoices(const UNICHARSET *unicharset) {
         const char *result = unicharset->id_to_unichar_ext(id);
         float rating = ratings[bestPos];
         choice.emplace_back(result, rating);
-        ctc_choices.push_back(choice);
+        ctc_choices.push_back(std::move(choice));
       }
       // fill the blank spot with an empty array
     } else {
       if (j - 1 >= excludedUnichars.size()) {
         std::unordered_set<int> excludeCodeList;
-        excludedUnichars.push_back(excludeCodeList);
+        excludedUnichars.push_back(std::move(excludeCodeList));
       }
       if (j - 1 >= ctc_choices.size()) {
         std::vector<std::pair<const char *, float>> choice;
-        ctc_choices.push_back(choice);
+        ctc_choices.push_back(std::move(choice));
       }
     }
   }

--- a/src/training/pango/pango_font_info.cpp
+++ b/src/training/pango/pango_font_info.cpp
@@ -43,6 +43,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string_view>
+#include <utility> // for std::move
 
 #ifndef _MSC_VER
 #  include <sys/param.h>
@@ -647,7 +648,7 @@ std::string FontUtils::BestFonts(const std::unordered_map<char32, int64_t> &ch_m
     most_ok_chars = std::max(ok_chars, most_ok_chars);
     best_raw_score = std::max(raw_score, best_raw_score);
 
-    font_flags.push_back(ch_flags);
+    font_flags.push_back(std::move(ch_flags));
     font_scores.push_back(ok_chars);
     raw_scores.push_back(raw_score);
   }
@@ -669,7 +670,7 @@ std::string FontUtils::BestFonts(const std::unordered_map<char32, int64_t> &ch_m
     int score = font_scores[i];
     int raw_score = raw_scores[i];
     if ((score >= least_good_enough && raw_score >= least_raw_enough) || score >= override_enough) {
-      fonts->push_back(std::make_pair(font_names[i].c_str(), font_flags[i]));
+      fonts->push_back(std::make_pair(font_names[i].c_str(), std::move(font_flags[i])));
       tlog(1, "OK font %s = %.4f%%, raw = %d = %.2f%%\n", font_names[i].c_str(),
            100.0 * score / most_ok_chars, raw_score, 100.0 * raw_score / best_raw_score);
       font_list += font_names[i];

--- a/unittest/imagedata_test.cc
+++ b/unittest/imagedata_test.cc
@@ -10,6 +10,7 @@
 // limitations under the License.
 
 #include <string>
+#include <utility> // for std::move
 #include <vector>
 
 #include "imagedata.h"
@@ -97,7 +98,7 @@ TEST_F(ImagedataTest, CachesMultiDocs) {
   for (size_t d = 0; d < kNumPages.size(); ++d) {
     page_texts.emplace_back(std::vector<std::string>());
     std::string filename = MakeFakeDoc(kNumPages[d], d, &page_texts.back());
-    filenames.push_back(filename);
+    filenames.push_back(std::move(filename));
   }
   // Now try getting them back with different cache strategies and check that
   // the pages come out in the right order.

--- a/unittest/paragraphs_test.cc
+++ b/unittest/paragraphs_test.cc
@@ -9,7 +9,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string> // for std::string
+#include <string>  // for std::string
+#include <utility> // for std::move
 
 #include "include_gunit.h" // for TEST
 #include "log.h"           // for LOG
@@ -156,7 +157,7 @@ void EvaluateParagraphDetection(const TextAndModel *correct, int n,
                         correct[i].model.ToString() +
                         (correct[i].is_very_first_or_continuation ? " crown" : "") +
                         (correct[i].is_list_item ? " li" : "");
-        dbg_lines.push_back(s);
+        dbg_lines.push_back(std::move(s));
       } else {
         dbg_lines.emplace_back(correct[i].ascii);
       }
@@ -178,7 +179,7 @@ void EvaluateParagraphDetection(const TextAndModel *correct, int n,
         }
       }
       std::string s = correct[i].ascii + annotation;
-      dbg_lines.push_back(s);
+      dbg_lines.push_back(std::move(s));
     }
     std::string s;
     for (auto &dbg_line : dbg_lines) {


### PR DESCRIPTION
This PR fixes a number of warnings from the Coverity static code analysis, mostly in classes and code of the legacy classifier, the LSTM recognizer and shared utility code.