### PR TITLE
fix: prevent out-of-bounds read in UNICHAR::UTF8ToUTF32

### DIFF
--- a/src/ccutil/unichar.cpp
+++ b/src/ccutil/unichar.cpp
@@ -223,12 +223,17 @@ std::vector<char32> UNICHAR::UTF8ToUTF32(const char *utf8_str) {
   unicodes.reserve(utf8_length);
   const_iterator end_it(end(utf8_str, utf8_length));
   for (const_iterator it(begin(utf8_str, utf8_length)); it != end_it; ++it) {
-    if (it.is_legal()) {
-      unicodes.push_back(*it);
-    } else {
+    // Reject a truncated multibyte prefix (issue #4495): utf8_step() reports
+    // the full width from the leading byte alone, but the string may end
+    // mid-sequence. Clamp the step to the remaining bytes so the iterator
+    // never reads past the end of the string.
+    const int remaining = end_it.utf8_data() - it.utf8_data();
+    const int step = utf8_step(it.utf8_data());
+    if (step <= 0 || step > remaining) {
       unicodes.clear();
       return unicodes;
     }
+    unicodes.push_back(*it);
   }
   return unicodes;
 }

--- a/src/ccutil/unichar.cpp
+++ b/src/ccutil/unichar.cpp
@@ -223,10 +223,9 @@ std::vector<char32> UNICHAR::UTF8ToUTF32(const char *utf8_str) {
   unicodes.reserve(utf8_length);
   const_iterator end_it(end(utf8_str, utf8_length));
   for (const_iterator it(begin(utf8_str, utf8_length)); it != end_it; ++it) {
-    // Reject a truncated multibyte prefix (issue #4495): utf8_step() reports
-    // the full width from the leading byte alone, but the string may end
-    // mid-sequence. Clamp the step to the remaining bytes so the iterator
-    // never reads past the end of the string.
+    // utf8_step() reports the width from the leading byte alone; reject a
+    // truncated trailing sequence rather than let the iterator run past the
+    // end of the string (issue #4495).
     const int remaining = end_it.utf8_data() - it.utf8_data();
     const int step = utf8_step(it.utf8_data());
     if (step <= 0 || step > remaining) {

--- a/unittest/unichar_test.cc
+++ b/unittest/unichar_test.cc
@@ -45,6 +45,8 @@ TEST(UnicharTest, TruncatedUtf8) {
   // string that ends with a truncated multibyte prefix (issue #4495).
   // A truncated multibyte prefix is invalid UTF-8, so the conversion
   // must return an empty vector instead of reading past the NUL.
+  // Keep the explicit NULs to make the truncation boundary visible in each
+  // fixture; without them, the literal terminator is implicit.
   const char *kTruncated2 = "\xC2\0";
   const char *kTruncated3 = "\xE8\0";
   const char *kTruncated4 = "\xF0\0";

--- a/unittest/unichar_test.cc
+++ b/unittest/unichar_test.cc
@@ -40,4 +40,21 @@ TEST(UnicharTest, InvalidText) {
   EXPECT_TRUE(utf8.empty());
 }
 
+TEST(UnicharTest, TruncatedUtf8) {
+  // This test verifies that UTF8ToUTF32 does not read past the end of a
+  // string that ends with a truncated multibyte prefix (issue #4495).
+  // A truncated multibyte prefix is invalid UTF-8, so the conversion
+  // must return an empty vector instead of reading past the NUL.
+  const char *kTruncated2 = "\xC2\0";
+  const char *kTruncated3 = "\xE8\0";
+  const char *kTruncated4 = "\xF0\0";
+  const char *kTruncatedMid = "ab\xE8\0";
+  const char *kIllegalLeading = "\x80\0";
+  EXPECT_TRUE(UNICHAR::UTF8ToUTF32(kTruncated2).empty());
+  EXPECT_TRUE(UNICHAR::UTF8ToUTF32(kTruncated3).empty());
+  EXPECT_TRUE(UNICHAR::UTF8ToUTF32(kTruncated4).empty());
+  EXPECT_TRUE(UNICHAR::UTF8ToUTF32(kTruncatedMid).empty());
+  EXPECT_TRUE(UNICHAR::UTF8ToUTF32(kIllegalLeading).empty());
+}
+
 } // namespace tesseract


### PR DESCRIPTION
`UNICHAR::UTF8ToUTF32` no longer reads past the end of a string that ends with a truncated multibyte UTF-8 prefix. Previously, a string like `"\xE8\0"` made the iterator advance past the NUL terminator and read one byte out of bounds (a stack/global buffer overflow depending on where the input lives). Such input now returns an empty vector, matching the documented "empty on invalid UTF-8" contract.

The fix clamps the per-character step to the number of bytes remaining before the end of the string, rejecting a truncated trailing sequence before any dereference.

## Validation

- Added `UnicharTest.TruncatedUtf8` covering 2/3/4-byte truncated prefixes, a mid-string truncated prefix, and an illegal leading continuation byte.
- The new test triggers the out-of-bounds read on unfixed code under AddressSanitizer (global-buffer-overflow in `utf8_step`) and passes after the fix.
- `unichar_test` passes 3/3 in both ASan and non-ASan builds; related `normstrngs_test` (17 pass) and `unicharset_test` (4 pass) are unaffected under ASan.

Fixes #4495
