### PR TITLE
Fix inefficient empty string test in ScrollView menus

### DIFF
--- a/java/com/google/scrollview/ui/SVMenuBar.java
+++ b/java/com/google/scrollview/ui/SVMenuBar.java
@@ -74,7 +74,7 @@ public class SVMenuBar implements ActionListener {
     // A duplicate entry - we just throw it away, since its already in.
     if (items.get(name) != null) { return; }
     // A new submenu at the top-level
-    if (parent.equals("")) {
+    if (parent.isEmpty()) {
       JMenu jli = new JMenu(name);
       SVAbstractMenuItem mli = new SVSubMenuItem(name, jli);
       items.put(name, mli);

--- a/java/com/google/scrollview/ui/SVPopupMenu.java
+++ b/java/com/google/scrollview/ui/SVPopupMenu.java
@@ -65,7 +65,7 @@ public class SVPopupMenu implements ActionListener {
     // A duplicate entry - we just throw it away, since its already in.
     if (items.get(name) != null) { return; }
     // A new submenu at the top-level.
-    if (parent.equals("")) {
+    if (parent.isEmpty()) {
       JMenu jli = new JMenu(name);
       SVAbstractMenuItem mli = new SVSubMenuItem(name, jli);
       items.put(name, mli);


### PR DESCRIPTION
Replace parent.equals("") with parent.isEmpty() in SVMenuBar and SVPopupMenu, fixing CodeQL's inefficient-empty-string-test warning.

Assisted-by: OpenCode / qwen3.8-27b-thinking (Alibaba Cloud)