### PR TITLE
Fix GitHub AI findings from 'Security and quality'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -949,7 +949,7 @@ text2image_SOURCES = src/training/text2image.cpp
 text2image_LDADD = libtesseract_training.la
 text2image_LDADD += $(ICU_I18N_LIBS) $(ICU_UC_LIBS)
 text2image_LDADD += $(extralib)
-text2image_LDADD += $(ICU_UC_LIBS) $(cairo_LIBS)
+text2image_LDADD += $(cairo_LIBS)
 text2image_LDADD += $(pango_LIBS) $(pangocairo_LIBS) $(pangoft2_LIBS)
 
 unicharset_extractor_CPPFLAGS = $(training_CPPFLAGS)
@@ -1588,7 +1588,7 @@ $(TESTING_DIR)/Arial_Bold_Italic.ttf:
 	mv Arialbi.TTF $@
 
 $(TESTING_DIR)/DejaVuSans-ExtraLight.ttf:
-	curl -sSL http://sourceforge.net/projects/dejavu/files/dejavu/2.37/dejavu-fonts-ttf-2.37.tar.bz2 | \
+	curl -sSL https://sourceforge.net/projects/dejavu/files/dejavu/2.37/dejavu-fonts-ttf-2.37.tar.bz2 | \
 	tar -xjO dejavu-fonts-ttf-2.37/ttf/DejaVuSans-ExtraLight.ttf >$@
 
 $(TESTING_DIR)/Lohit-Hindi.ttf:

--- a/doc/tesseract.1.asc
+++ b/doc/tesseract.1.asc
@@ -107,7 +107,7 @@ OPTIONS
   * *page* -- Output in PAGE format ('OUTPUTBASE'`.page.xml`).
               The output can be customized with the flags:
               page_xml_polygon -- Create polygons instead of bounding boxes (default: true)
-              page_xml_level -- Create the PAGE file on  0=linelevel or 1=wordlevel (default: 0)
+              page_xml_level -- Create the PAGE file on 0=linelevel or 1=wordlevel (default: 0)
   * *pdf* -- Output PDF ('OUTPUTBASE'`.pdf`).
   * *tsv* -- Output TSV ('OUTPUTBASE'`.tsv`).
   * *txt* -- Output plain text ('OUTPUTBASE'`.txt`).
@@ -410,7 +410,7 @@ on 'read_pattern_list()'.
 PARAMETERS
 ----------
 
-Tesseract parameters control the behaviour of the OCR engine and can be set
+Tesseract parameters control the behavior of the OCR engine and can be set
 using the *-c* option (e.g. `-c tessedit_char_whitelist=0123456789`) or by
 placing them in a <<CONFIGFILE,'CONFIGFILE'>>.
 The example above restricts recognized characters to digits only.
@@ -522,7 +522,7 @@ IMAGE PROCESSING PARAMETERS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *thresholding_method* (int, default: 0) [Both]::
-  Select the algorithm used to convert a greyscale image to binary before OCR:
+  Select the algorithm used to convert a grayscale image to binary before OCR:
   0 = Otsu global thresholding (default);
   1 = LeptonicaOtsu (tiled Otsu, better for uneven lighting);
   2 = Sauvola local adaptive thresholding (best for heavily degraded documents).
@@ -546,7 +546,7 @@ IMAGE PROCESSING PARAMETERS
 
 *thresholding_score_fraction* (double, default: 0.1) [Both]::
   Fraction of the maximum Otsu score used by LeptonicaOtsu
-  (*thresholding_method* = 1).  Use 0.0 for standard Otsu behaviour;
+  (*thresholding_method* = 1).  Use 0.0 for standard Otsu behavior;
   0.1 is recommended for better robustness.
 
 *tessedit_do_invert* (bool, default: 1) [Both]::
@@ -688,11 +688,11 @@ model such as those from https://github.com/tesseract-ocr/tessdata).
   of frequent words.
 
 *language_model_penalty_case* (double, default: 0.1) [Legacy]::
-  Penalty applied when the capitalisation of a recognised word is inconsistent
+  Penalty applied when the capitalization of a recognized word is inconsistent
   with the surrounding context.
 
 *language_model_penalty_script* (double, default: 0.5) [Legacy]::
-  Penalty applied when a recognised character belongs to a different script
+  Penalty applied when a recognized character belongs to a different script
   from the surrounding text.
 
 *language_model_penalty_punc* (double, default: 0.2) [Legacy]::

--- a/src/training/unicharset/lstmtrainer.cpp
+++ b/src/training/unicharset/lstmtrainer.cpp
@@ -182,7 +182,7 @@ bool LSTMTrainer::InitNetwork(const char *network_spec, int append_index,
   return true;
 }
 
-// Resets all the iteration counters for fine tuning or traininng a head,
+// Resets all the iteration counters for fine tuning or training a head,
 // where we want the error reporting to reset.
 void LSTMTrainer::InitIterations() {
   sample_iteration_ = 0;

--- a/src/viewer/svutil.cpp
+++ b/src/viewer/svutil.cpp
@@ -135,7 +135,7 @@ SVSemaphore::~SVSemaphore() {
 #  elif defined(__APPLE__)
   sem_close(semaphore_);
 #  else
-  sem_close(&semaphore_);
+  sem_destroy(&semaphore_);
 #  endif
 }
 
@@ -360,7 +360,9 @@ SVNetwork::SVNetwork(const char *hostname, int port) {
 #  ifdef _WIN32
   // WSACleanup();  // This cause ScrollView windows is not displayed
 #  endif // _WIN32
-  freeaddrinfo(addr_info);
+  if (addr_info != nullptr) {
+    freeaddrinfo(addr_info);
+  }
 }
 
 SVNetwork::~SVNetwork() {


### PR DESCRIPTION
Fix the AI-generated findings reported by the GitHub 'Security and quality' checks:

- doc/tesseract.1.asc: remove double space before '0=linelevel'; use American English spellings (behavior, capitalization, recognized, grayscale) consistently
- Makefile.am: remove the duplicated $(ICU_UC_LIBS) from text2image_LDADD; use https for the DejaVu font download URL
- src/training/unicharset/lstmtrainer.cpp: fix typo 'traininng'
- src/viewer/svutil.cpp: destroy the unnamed POSIX semaphore with sem_destroy() instead of sem_close(); only call freeaddrinfo() when addr_info is not null

Assisted-by: OpenCode / qwen3.8-27b-thinking (Alibaba Cloud)