### PR TITLE
Fix malformed ALTO WC for single-digit and 100 confidences

### DIFF
--- a/src/api/altorenderer.cpp
+++ b/src/api/altorenderer.cpp
@@ -45,7 +45,8 @@ static void AddBoxToAlto(const ResultIterator *it, PageIteratorLevel level,
 
   if (level == RIL_WORD) {
     int wc = it->Confidence(RIL_WORD);
-    alto_str << " WC=\"0." << wc << "\"";
+    alto_str << " WC=\"" << wc / 100 << "." << (wc % 100 < 10 ? "0" : "")
+             << wc % 100 << "\"";
   } else {
     alto_str << ">";
   }

--- a/src/api/altorenderer.cpp
+++ b/src/api/altorenderer.cpp
@@ -45,8 +45,11 @@ static void AddBoxToAlto(const ResultIterator *it, PageIteratorLevel level,
 
   if (level == RIL_WORD) {
     int wc = it->Confidence(RIL_WORD);
-    alto_str << " WC=\"" << wc / 100 << "." << (wc % 100 < 10 ? "0" : "")
-             << wc % 100 << "\"";
+    // Note: std::fixed and std::setprecision persist on alto_str, but this
+    // is the only floating-point value ever written to that stream, so the
+    // formatting state cannot affect any other output.
+    alto_str << " WC=\"" << std::fixed << std::setprecision(2)
+             << wc / 100.0f << "\"";
   } else {
     alto_str << ">";
   }


### PR DESCRIPTION
This commit corrects word confidence translation from Tesseract to ALTO. Tesseract uses integer confidence, ALTO uses floats from 0.0 to 1.0. The current code converts Tesseract to ALTO by concatenating onto the string "0.", but this is incorrect for confidences under 10 percent or exactly 100 percent.

For example, if Tesseract reports 9 percent confident, the current implementation converts this to 0.9, or 90 percent confident in ALTO.

We update the conversion.

This closes #4615 