### PR TITLE
fix: prevent out-of-bounds access on truncated UTF-8 strings and crafted index maps

### DIFF
--- a/src/ccutil/indexmapbidi.cpp
+++ b/src/ccutil/indexmapbidi.cpp
@@ -31,6 +31,9 @@ IndexMap::~IndexMap() = default;
 // Uses a binary search to find the result. For faster speed use
 // IndexMapBiDi, but that takes more memory.
 int IndexMap::SparseToCompact(int sparse_index) const {
+  if (compact_map_.empty()) {
+    return -1;
+  }
   auto pos = std::upper_bound(compact_map_.begin(), compact_map_.end(), sparse_index);
   if (pos > compact_map_.begin()) {
     --pos;
@@ -142,6 +145,16 @@ void IndexMapBiDi::CopyFrom(const IndexMapBiDi &src) {
 // the merges must be concluded by a call to CompleteMerges.
 // Returns true if a merge was actually performed.
 bool IndexMapBiDi::Merge(int compact_index1, int compact_index2) {
+  // A compact index may be -1 (meaning "merge away") or in [0, compact size).
+  const bool index1_ok =
+      compact_index1 == -1 ||
+      (compact_index1 >= 0 && static_cast<size_t>(compact_index1) < compact_map_.size());
+  const bool index2_ok =
+      compact_index2 == -1 ||
+      (compact_index2 >= 0 && static_cast<size_t>(compact_index2) < compact_map_.size());
+  if (!index1_ok || !index2_ok) {
+    return false;
+  }
   // Find the current master index for index1 and index2.
   compact_index1 = MasterCompactIndex(compact_index1);
   compact_index2 = MasterCompactIndex(compact_index2);
@@ -241,14 +254,42 @@ bool IndexMapBiDi::DeSerialize(bool swap, FILE *fp) {
   if (!tesseract::DeSerialize(swap, fp, remaining_pairs)) {
     return false;
   }
+  // The indices in the file are untrusted. Validate them before using them
+  // as subscripts, so that corrupt or crafted data is rejected instead of
+  // writing outside sparse_map_ (or leaving invalid compact indices behind).
+  // Each sparse slot may be claimed by at most one compact representative
+  // or one remaining pair, as in any map produced by Setup/CompleteMerges;
+  // duplicate claims would let a crafted file encode a master cycle that
+  // makes MasterCompactIndex loop forever.
+  const size_t sparse_size = static_cast<size_t>(sparse_size_);
+  std::vector<uint8_t> claimed(sparse_size, 0);
+  for (int32_t sparse_index : compact_map_) {
+    if (sparse_index < 0 || static_cast<size_t>(sparse_index) >= sparse_size ||
+        claimed[sparse_index]) {
+      return false;
+    }
+    claimed[sparse_index] = 1;
+  }
+  if (remaining_pairs.size() % 2 != 0) {
+    return false;
+  }
+  for (size_t i = 0; i < remaining_pairs.size(); i += 2) {
+    const int32_t sparse_index = remaining_pairs[i];
+    const int32_t compact_index = remaining_pairs[i + 1];
+    if (sparse_index < 0 || static_cast<size_t>(sparse_index) >= sparse_size ||
+        compact_index < 0 || static_cast<size_t>(compact_index) >= compact_map_.size() ||
+        claimed[sparse_index]) {
+      return false;
+    }
+    claimed[sparse_index] = 1;
+  }
   sparse_map_.clear();
-  sparse_map_.resize(sparse_size_, -1);
+  sparse_map_.resize(sparse_size, -1);
   for (unsigned i = 0; i < compact_map_.size(); ++i) {
     sparse_map_[compact_map_[i]] = i;
   }
-  for (size_t i = 0; i < remaining_pairs.size(); ++i) {
-    int sparse_index = remaining_pairs[i++];
-    sparse_map_[sparse_index] = remaining_pairs[i];
+  for (size_t i = 0; i < remaining_pairs.size(); i += 2) {
+    sparse_map_[remaining_pairs[i]] = remaining_pairs[i + 1];
   }
   return true;
 }
@@ -264,7 +305,13 @@ int IndexMapBiDi::MapFeatures(const std::vector<int> &sparse, std::vector<int> *
   int missed_features = 0;
   int prev_good_feature = -1;
   for (int f = 0; f < num_features; ++f) {
-    int feature = sparse_map_[sparse[f]];
+    const int sparse_index = sparse[f];
+    if (sparse_index < 0 || static_cast<size_t>(sparse_index) >= sparse_map_.size()) {
+      // A feature outside the sparse space cannot map to the compact space.
+      ++missed_features;
+      continue;
+    }
+    int feature = sparse_map_[sparse_index];
     if (feature >= 0) {
       if (feature != prev_good_feature) {
         compact->push_back(feature);

--- a/src/ccutil/indexmapbidi.h
+++ b/src/ccutil/indexmapbidi.h
@@ -53,6 +53,9 @@ public:
   // CompactToSparse takes a compact index to the corresponding index in the
   // sparse space.
   int CompactToSparse(int compact_index) const {
+    if (compact_index < 0 || static_cast<size_t>(compact_index) >= compact_map_.size()) {
+      return -1;
+    }
     return compact_map_[compact_index];
   }
   // The size of the sparse space.
@@ -130,6 +133,10 @@ public:
   bool Merge(int compact_index1, int compact_index2);
   // Returns true if the given compact index has been deleted.
   bool IsCompactDeleted(int index) const {
+    // An index outside the compact space is not a live compact index.
+    if (index < 0 || static_cast<size_t>(index) >= compact_map_.size()) {
+      return true;
+    }
     return MasterCompactIndex(index) < 0;
   }
   // Completes one or more Merge operations by further compacting the
@@ -138,6 +145,9 @@ public:
 
   // SparseToCompact takes a sparse index to an index in the compact space.
   int SparseToCompact(int sparse_index) const override {
+    if (sparse_index < 0 || static_cast<size_t>(sparse_index) >= sparse_map_.size()) {
+      return -1;
+    }
     return sparse_map_[sparse_index];
   }
   // The size of the sparse space.

--- a/src/training/pango/pango_font_info.cpp
+++ b/src/training/pango/pango_font_info.cpp
@@ -222,23 +222,31 @@ bool PangoFontInfo::CoversUTF8Text(const char *utf8_text, int byte_length) const
     return false;
   }
   PangoCoverage *coverage = pango_font_get_coverage(font, nullptr);
-  for (UNICHAR::const_iterator it = UNICHAR::begin(utf8_text, byte_length);
-       it != UNICHAR::end(utf8_text, byte_length); ++it) {
-    if (IsWhitespace(*it) || pango_is_zero_width(*it)) {
-      continue;
-    }
-    if (pango_coverage_get(coverage, *it) != PANGO_COVERAGE_EXACT) {
-      char tmp[5];
-      int len = it.get_utf8(tmp);
-      tmp[len] = '\0';
-      tlog(2, "'%s' (U+%x) not covered by font\n", tmp, *it);
+  const char *const text_end = utf8_text + byte_length;
+  for (const char *p = utf8_text; p < text_end;) {
+    const int step = UNICHAR::utf8_step(p);
+    if (step > 0 && step <= text_end - p) {
+      const int unicode = UNICHAR(p, step).first_uni();
+      if (!IsWhitespace(unicode) && !pango_is_zero_width(unicode) &&
+          pango_coverage_get(coverage, unicode) != PANGO_COVERAGE_EXACT) {
+        char tmp[5];
+        memcpy(tmp, p, step);
+        tmp[step] = '\0';
+        tlog(2, "'%s' (U+%x) not covered by font\n", tmp, unicode);
 #if PANGO_VERSION_CHECK(1, 50, 4)
-      g_object_unref(coverage);
+        g_object_unref(coverage);
 #else
-      pango_coverage_unref(coverage);
+        pango_coverage_unref(coverage);
 #endif
-      g_object_unref(font);
-      return false;
+        g_object_unref(font);
+        return false;
+      }
+      p += step;
+    } else {
+      // An illegal byte or a multibyte sequence truncated at the end of the
+      // string is not a character to check coverage for. Skipping it one
+      // byte at a time also avoids reading past the end of the string.
+      ++p;
     }
   }
 #if PANGO_VERSION_CHECK(1, 50, 4)
@@ -286,19 +294,22 @@ int PangoFontInfo::DropUncoveredChars(std::string *utf8_text) const {
   // will repeatedly copy one covered UTF8 character from one to the other, and
   // at the end resize the string to the right length.
   char *out = const_cast<char *>(utf8_text->c_str());
-  const UNICHAR::const_iterator it_begin = UNICHAR::begin(utf8_text->c_str(), utf8_text->length());
-  const UNICHAR::const_iterator it_end = UNICHAR::end(utf8_text->c_str(), utf8_text->length());
-  for (UNICHAR::const_iterator it = it_begin; it != it_end;) {
-    // Skip bad utf-8.
-    if (!it.is_legal()) {
-      ++it; // One suitable error message will still be issued.
+  const char *const in_end = utf8_text->c_str() + utf8_text->length();
+  for (const char *p = utf8_text->c_str(); p < in_end;) {
+    const int step = UNICHAR::utf8_step(p);
+    if (step <= 0) {
+      // Skip bad utf-8.
+      ++p;
       continue;
     }
-    int unicode = *it;
-    int utf8_len = it.utf8_len();
-    const char *utf8_char = it.utf8_data();
-    // Move it forward before the data gets modified.
-    ++it;
+    if (step > in_end - p) {
+      // A multibyte sequence truncated at the end of the string: drop the
+      // stray bytes instead of reading past the NUL terminator.
+      ++num_dropped_chars;
+      ++p;
+      continue;
+    }
+    const int unicode = UNICHAR(p, step).first_uni();
     if (!IsWhitespace(unicode) && !pango_is_zero_width(unicode) &&
         pango_coverage_get(coverage, unicode) != PANGO_COVERAGE_EXACT) {
       if (TLOG_IS_ON(2)) {
@@ -308,10 +319,11 @@ int PangoFontInfo::DropUncoveredChars(std::string *utf8_text) const {
         delete[] str;
       }
       ++num_dropped_chars;
-      continue;
+    } else {
+      my_strnmove(out, p, step);
+      out += step;
     }
-    my_strnmove(out, utf8_char, utf8_len);
-    out += utf8_len;
+    p += step;
   }
 #if PANGO_VERSION_CHECK(1, 50, 4)
   g_object_unref(coverage);
@@ -336,10 +348,26 @@ bool PangoFontInfo::GetSpacingProperties(const std::string &utf8_char, int *x_be
   // Handle multi-unicode strings by reporting the left-most position of the
   // x-bearing, and right-most position of the x-advance if the string were to
   // be rendered.
-  const UNICHAR::const_iterator it_begin = UNICHAR::begin(utf8_char.c_str(), utf8_char.length());
-  const UNICHAR::const_iterator it_end = UNICHAR::end(utf8_char.c_str(), utf8_char.length());
-  for (UNICHAR::const_iterator it = it_begin; it != it_end; ++it) {
-    PangoGlyph glyph_index = get_glyph(font, *it);
+  bool first_char = true;
+  const char *p = utf8_char.c_str();
+  const char *const p_end = p + utf8_char.length();
+  for (; p < p_end;) {
+    const int step = UNICHAR::utf8_step(p);
+    int unicode;
+    if (step <= 0) {
+      // The iterator maps an illegal leading byte to a space.
+      unicode = ' ';
+      ++p;
+    } else if (step > p_end - p) {
+      // A multibyte sequence truncated at the end of the string: skip the
+      // stray bytes instead of reading past the NUL terminator.
+      ++p;
+      continue;
+    } else {
+      unicode = UNICHAR(p, step).first_uni();
+      p += step;
+    }
+    PangoGlyph glyph_index = get_glyph(font, unicode);
     if (!glyph_index) {
       // Glyph for given unicode character doesn't exist in font.
       g_object_unref(font);
@@ -352,9 +380,10 @@ bool PangoFontInfo::GetSpacingProperties(const std::string &utf8_char, int *x_be
     pango_extents_to_pixels(&logical_rect, nullptr);
 
     int bearing = total_advance + PANGO_LBEARING(ink_rect);
-    if (it == it_begin || bearing < min_bearing) {
+    if (first_char || bearing < min_bearing) {
       min_bearing = bearing;
     }
+    first_char = false;
     total_advance += PANGO_RBEARING(logical_rect);
   }
   *x_bearing = min_bearing;

--- a/src/training/unicharset/normstrngs.cpp
+++ b/src/training/unicharset/normstrngs.cpp
@@ -243,24 +243,54 @@ bool IsUTF8Whitespace(const char *text) {
 
 unsigned int SpanUTF8Whitespace(const char *text) {
   int n_white = 0;
-  for (UNICHAR::const_iterator it = UNICHAR::begin(text, strlen(text));
-       it != UNICHAR::end(text, strlen(text)); ++it) {
-    if (!IsWhitespace(*it)) {
+  const char *p = text;
+  const char *const end = p + strlen(text);
+  while (p < end) {
+    const int step = UNICHAR::utf8_step(p);
+    if (step <= 0) {
+      // The iterator maps an illegal leading byte to a space (one byte).
+      ++n_white;
+      ++p;
+      continue;
+    }
+    if (step > end - p) {
+      // A multibyte sequence truncated at the end of the string is not a
+      // whitespace character. Stopping here also avoids reading past the NUL
+      // terminator.
       break;
     }
-    n_white += it.utf8_len();
+    if (!IsWhitespace(UNICHAR(p, step).first_uni())) {
+      break;
+    }
+    n_white += step;
+    p += step;
   }
   return n_white;
 }
 
 unsigned int SpanUTF8NotWhitespace(const char *text) {
   int n_notwhite = 0;
-  for (UNICHAR::const_iterator it = UNICHAR::begin(text, strlen(text));
-       it != UNICHAR::end(text, strlen(text)); ++it) {
-    if (IsWhitespace(*it)) {
+  const char *p = text;
+  const char *const end = p + strlen(text);
+  while (p < end) {
+    const int step = UNICHAR::utf8_step(p);
+    if (step <= 0) {
+      // The iterator maps an illegal leading byte to a space, which ends the
+      // span of non-whitespace.
       break;
     }
-    n_notwhite += it.utf8_len();
+    if (step > end - p) {
+      // A multibyte sequence truncated at the end of the string is not
+      // whitespace. Count the remaining bytes without reading past the NUL
+      // terminator.
+      n_notwhite += static_cast<int>(end - p);
+      break;
+    }
+    if (IsWhitespace(UNICHAR(p, step).first_uni())) {
+      break;
+    }
+    n_notwhite += step;
+    p += step;
   }
   return n_notwhite;
 }

--- a/unittest/indexmapbidi_test.cc
+++ b/unittest/indexmapbidi_test.cc
@@ -13,7 +13,9 @@
 #include <cstdio>
 #include <string>
 
+#include "helpers.h"
 #include "indexmapbidi.h"
+#include "serialis.h"
 
 #include "include_gunit.h"
 
@@ -116,6 +118,156 @@ TEST_F(IndexMapBiDiTest, ManyToOne) {
   EXPECT_EQ(1, map.SparseToCompact(4));
   EXPECT_EQ(4, map.CompactToSparse(1));
   EXPECT_EQ(1, map.SparseToCompact(11));
+}
+
+// Writes a raw IndexMapBiDi serialization (sparse size, compact map,
+// remaining pairs) so crafted/invalid data can be fed to DeSerialize.
+static void WriteIndexMapBiDiBlob(const std::string &path, int32_t sparse_size,
+                                  const std::vector<int32_t> &compact_map,
+                                  const std::vector<int32_t> &remaining_pairs) {
+  FILE *fp = fopen(path.c_str(), "wb");
+  ASSERT_TRUE(fp != nullptr);
+  ASSERT_TRUE(tesseract::Serialize(fp, &sparse_size));
+  ASSERT_TRUE(tesseract::Serialize(fp, compact_map));
+  ASSERT_TRUE(tesseract::Serialize(fp, remaining_pairs));
+  fclose(fp);
+}
+
+// Indices read from a serialized map are untrusted. Out-of-range values must
+// be rejected instead of writing outside sparse_map_.
+TEST_F(IndexMapBiDiTest, DeSerializeRejectsBadIndices) {
+  // Positive control: a valid many-to-one map round-trips.
+  IndexMapBiDi valid;
+  valid.Init(13, false);
+  valid.SetMap(2, true);
+  valid.SetMap(4, true);
+  valid.SetMap(7, true);
+  valid.SetMap(9, true);
+  valid.SetMap(11, true);
+  valid.Setup();
+  valid.Merge(valid.SparseToCompact(2), valid.SparseToCompact(9));
+  valid.Merge(valid.SparseToCompact(4), valid.SparseToCompact(11));
+  valid.CompleteMerges();
+  const std::string good = OutputNameToPath("good.indexmap");
+  {
+    FILE *fp = fopen(good.c_str(), "wb");
+    ASSERT_TRUE(fp != nullptr);
+    ASSERT_TRUE(valid.Serialize(fp));
+    fclose(fp);
+  }
+  {
+    FILE *fp = fopen(good.c_str(), "rb");
+    ASSERT_TRUE(fp != nullptr);
+    IndexMapBiDi m;
+    ASSERT_TRUE(m.DeSerialize(false, fp));
+    fclose(fp);
+    EXPECT_EQ(13, m.SparseSize());
+    EXPECT_EQ(3, m.CompactSize());
+    EXPECT_EQ(0, m.SparseToCompact(2));
+    EXPECT_EQ(0, m.SparseToCompact(9));
+  }
+
+  auto reject = [this](const std::string &name, int32_t sparse_size,
+                       const std::vector<int32_t> &compact_map,
+                       const std::vector<int32_t> &remaining_pairs) {
+    const std::string path = OutputNameToPath(name);
+    WriteIndexMapBiDiBlob(path, sparse_size, compact_map, remaining_pairs);
+    FILE *fp = fopen(path.c_str(), "rb");
+    ASSERT_TRUE(fp != nullptr);
+    IndexMapBiDi m;
+    EXPECT_FALSE(m.DeSerialize(false, fp));
+    fclose(fp);
+  };
+
+  // compact_map_ entry outside the sparse space.
+  reject("bad1.indexmap", 2, {5}, {});
+  // Negative compact_map_ entry.
+  reject("bad2.indexmap", 2, {-1}, {});
+  // Remaining pair with a sparse index outside the sparse space.
+  reject("bad3.indexmap", 2, {0}, {5, 0});
+  // Remaining pair with a negative sparse index.
+  reject("bad4.indexmap", 2, {0}, {-1, 0});
+  // Remaining pair with a compact index outside the compact space.
+  reject("bad5.indexmap", 2, {0}, {0, 5});
+  // Remaining pair with a negative compact index.
+  reject("bad6.indexmap", 2, {0}, {0, -1});
+  // Odd number of remaining pairs.
+  reject("bad7.indexmap", 2, {0}, {0});
+  // Cyclic master mapping (0 <-> 1) that would make MasterCompactIndex
+  // loop forever.
+  reject("bad8.indexmap", 2, {0, 1}, {0, 1, 1, 0});
+  // Two compact representatives claiming the same sparse slot.
+  reject("bad9.indexmap", 2, {0, 0}, {});
+}
+
+// Public accessors must not read outside their maps when given bad indices.
+TEST_F(IndexMapBiDiTest, AccessorsRejectBadIndices) {
+  IndexMapBiDi map;
+  map.Init(4, false);
+  map.SetMap(1, true);
+  map.SetMap(3, true);
+  map.Setup();
+  // Sparse space is [0,4); compact space is [0,2) with sparse 1->0, 3->1.
+  EXPECT_EQ(4, map.SparseSize());
+  EXPECT_EQ(2, map.CompactSize());
+
+  // Out-of-range sparse index reports unmapped instead of reading OOB.
+  EXPECT_EQ(-1, map.SparseToCompact(-1));
+  EXPECT_EQ(-1, map.SparseToCompact(4));
+  EXPECT_EQ(-1, map.SparseToCompact(1324324));
+  // In-range behavior is unchanged.
+  EXPECT_EQ(0, map.SparseToCompact(1));
+  EXPECT_EQ(-1, map.SparseToCompact(0)); // unmapped.
+  EXPECT_EQ(1, map.SparseToCompact(3));
+
+  // Out-of-range compact index reports unmapped instead of reading OOB.
+  EXPECT_EQ(-1, map.CompactToSparse(-1));
+  EXPECT_EQ(-1, map.CompactToSparse(2));
+  EXPECT_EQ(1, map.CompactToSparse(0));
+  EXPECT_EQ(3, map.CompactToSparse(1));
+
+  // Out-of-range compact indices are not merged.
+  EXPECT_FALSE(map.Merge(2, 0));
+  EXPECT_FALSE(map.Merge(0, 2));
+  EXPECT_FALSE(map.Merge(0, 1324324));
+  EXPECT_FALSE(map.Merge(-5, 0));
+  // The map is unchanged by the rejected merges.
+  EXPECT_EQ(2, map.CompactSize());
+  EXPECT_EQ(0, map.SparseToCompact(1));
+  EXPECT_EQ(1, map.SparseToCompact(3));
+
+  // Out-of-range compact index is reported as deleted.
+  EXPECT_TRUE(map.IsCompactDeleted(-1));
+  EXPECT_TRUE(map.IsCompactDeleted(2));
+  EXPECT_TRUE(map.IsCompactDeleted(1324324));
+  EXPECT_FALSE(map.IsCompactDeleted(0));
+
+  // Out-of-range features count as missed; valid ones still map.
+  std::vector<int> compact;
+  const int missed = map.MapFeatures({-1, 0, 1, 3, 4}, &compact);
+  EXPECT_EQ(3, missed); // -1 (OOB), 0 (unmapped), 4 (OOB).
+  ASSERT_EQ(2, compact.size());
+  EXPECT_EQ(0, compact[0]);
+  EXPECT_EQ(1, compact[1]);
+
+  // The -1 sentinel (delete a compact index) is still permitted.
+  EXPECT_TRUE(map.Merge(-1, 1));
+  EXPECT_TRUE(map.IsCompactDeleted(1));
+
+  // Empty maps built via the public API must report unmapped for any
+  // index instead of reading past the end of their vectors. The plain
+  // IndexMap is the only way to reach the base-class binary-search
+  // implementation, since the IndexMapBiDi override handles its own
+  // empty check.
+  IndexMapBiDi empty_bidi;
+  empty_bidi.Init(0, false);
+  empty_bidi.Setup();
+  EXPECT_EQ(-1, empty_bidi.SparseToCompact(0));
+  EXPECT_EQ(-1, empty_bidi.CompactToSparse(0));
+  IndexMap empty_base;
+  empty_base.CopyFrom(empty_bidi);
+  EXPECT_EQ(-1, empty_base.SparseToCompact(0));
+  EXPECT_EQ(-1, empty_base.CompactToSparse(0));
 }
 
 } // namespace tesseract

--- a/unittest/normstrngs_test.cc
+++ b/unittest/normstrngs_test.cc
@@ -348,6 +348,27 @@ TEST(NormstrngsTest, SpanUTF8NotWhitespace) {
   EXPECT_EQ(12, SpanUTF8NotWhitespace(kMixedText));
 }
 
+TEST(NormstrngsTest, SpanUTF8TruncatedPrefix) {
+  // A multibyte sequence truncated at the end of the string must not be
+  // read past the NUL terminator (issue #4495).
+  // 2-, 3- and 4-byte prefixes truncated at the terminator.
+  EXPECT_EQ(0, SpanUTF8Whitespace("\xC2"));
+  EXPECT_EQ(0, SpanUTF8Whitespace("\xE8"));
+  EXPECT_EQ(0, SpanUTF8Whitespace("\xF0"));
+  // A truncated prefix is not whitespace, even after leading spaces.
+  EXPECT_EQ(2, SpanUTF8Whitespace("  \xE8"));
+  EXPECT_FALSE(IsUTF8Whitespace(" \xE8"));
+  // A truncated prefix is counted as non-whitespace.
+  EXPECT_EQ(3, SpanUTF8NotWhitespace("ab\xE8"));
+  EXPECT_EQ(1, SpanUTF8NotWhitespace("\xC2"));
+  // An illegal leading byte keeps the previous semantics: one whitespace
+  // byte for the whitespace span, and a boundary for the other.
+  EXPECT_EQ(1, SpanUTF8Whitespace("\x80"));
+  EXPECT_EQ(2, SpanUTF8Whitespace("\x80 "));
+  EXPECT_EQ(0, SpanUTF8NotWhitespace("\x80" "abc"));
+  EXPECT_EQ(3, SpanUTF8NotWhitespace("abc\x80"));
+}
+
 // Test that the method clones the util/utf8/unilib definition of
 // interchange validity.
 TEST(NormstrngsTest, IsInterchangeValid) {

--- a/unittest/pango_font_info_test.cc
+++ b/unittest/pango_font_info_test.cc
@@ -171,6 +171,20 @@ TEST_F(PangoFontInfoTest, CanDropUncoveredChars) {
   }
 }
 
+TEST_F(PangoFontInfoTest, HandlesTruncatedUtf8) {
+  font_info_.ParseFontDescriptionName("Verdana 12");
+  // A multibyte sequence truncated at the end of the string must not be
+  // read past the end of the string (or loop forever).
+  std::string word = std::string("ab") + "\xE8";
+  EXPECT_EQ(1, font_info_.DropUncoveredChars(&word));
+  EXPECT_STREQ("ab", word.c_str());
+  const std::string covers = std::string("ab") + "\xF0";
+  EXPECT_TRUE(font_info_.CoversUTF8Text(covers.c_str(), covers.length()));
+  int x_bearing, x_advance;
+  EXPECT_TRUE(font_info_.GetSpacingProperties(covers, &x_bearing, &x_advance));
+  EXPECT_GT(x_advance, 0);
+}
+
 // ------------------------ FontUtils ------------------------------------
 
 class FontUtilsTest : public ::testing::Test {


### PR DESCRIPTION
I created this PR and the included commits with OpenCode / qwen3.8-27b.

## Background

Follow-up to #4609 (`fix: prevent out-of-bounds read in UNICHAR::UTF8ToUTF32`)
and #4614 (`fix(ccutil): guard IndexMapBiDi sparse indices`). While reviewing
those PRs I found the same bug classes in a few more places; this PR fixes
the remaining instances:

### 1. `IndexMapBiDi::DeSerialize` (src/ccutil/indexmapbidi.cpp)

The compact and sparse indices read from the file were used directly as
subscripts of `sparse_map_`. A crafted or corrupt `.traineddata` with
out-of-range values performs a heap out-of-bounds **write** during
deserialization — same class as #3584, but on the load path, reachable from
untrusted file input. `DeSerialize` now validates every index before use and
rejects such data, including `remaining_pairs` with an odd element count,
which previously read one element past the end of the vector.

### 2. Unchecked `IndexMapBiDi` accessors (src/ccutil/indexmapbidi.{h,cpp})

`IndexMapBiDi::SparseToCompact`, `IndexMap::CompactToSparse`, `Merge`,
`MapFeatures` and `IsCompactDeleted` subscripted their vectors without bounds
checks (OOB reads, reachable from training data via `TrainingSampleSet` and
`IntFeatureMap`). They now return the not-mapped / not-merged /
missed-feature result for out-of-range input. The `Merge(-1, x)` merge-away
sentinel used by `IntFeatureMap::DeleteMapFeature` is still accepted, and
`IndexMap::SparseToCompact` no longer reads `compact_map_` when the map is
empty.

### 3. UTF-8 span scans (src/training/unicharset/normstrngs.cpp)

`SpanUTF8Whitespace` / `SpanUTF8NotWhitespace` iterated with
`UNICHAR::const_iterator`, which derives the character width from the leading
byte alone. A multibyte sequence truncated at the end of the string (e.g.
`"ab\xE8"`) made `*it` read past the NUL terminator and `++it` run past the
end of the string — an OOB read (issue #4495's class) that only stopped at a
crash. Both scans now step the bytes manually with explicit width checks.

### 4. `PangoFontInfo` character loops (src/training/pango/pango_font_info.cpp)

`CoversUTF8Text`, `DropUncoveredChars` and `GetSpacingProperties` had the
same iterator pattern and the same OOB read / infinite loop on a truncated
trailing prefix. They now step the bytes manually.

For all of these, behavior on valid input is unchanged (including the
iterator's space fallback for illegal bytes); only previously-undefined
cases get defined behavior.

## Test plan

ASan build (Debug, `-fsanitize=address`, legacy + training + pango tests).
The new regression tests crash on unpatched code and pass on the patched
code:

| New test | Unpatched (ASan) | Patched |
|---|---|---|
| `IndexMapBiDiTest.DeSerializeRejectsBadIndices` | heap-buffer-overflow **WRITE** in `IndexMapBiDi::DeSerialize` | PASS |
| `IndexMapBiDiTest.AccessorsRejectBadIndices` | heap-buffer-overflow **READ** in `IndexMapBiDi::SparseToCompact` | PASS |
| `NormstrngsTest.SpanUTF8TruncatedPrefix` | global-buffer-overflow **READ** in `UNICHAR::utf8_step` via `const_iterator::operator*` | PASS |
| `PangoFontInfoTest.HandlesTruncatedUtf8` | stack-buffer-overflow **READ** in `UNICHAR::utf8_step` via `is_legal()` in `DropUncoveredChars` | PASS |

`DeSerializeRejectsBadIndices` feeds crafted blobs (out-of-range, negative
and odd-count indices) and includes a many-to-one
serialize/deserialize round trip as a positive control.

Regression runs (all pass under ASan): `indexmapbidi_test`,
`normstrngs_test`, `pango_font_info_test`, `intfeaturemap_test`,
`stringrenderer_test`, `mastertrainer_test`, `ligature_table_test`,
`unicharset_test`, `dawg_test`.

## Out of scope

The same truncated-prefix pattern still appears in
`LigatureTable::RemoveLigatures` / `RemoveCustomLigatures`
(src/training/pango/ligature_table.cpp:115,135) and in several
`StringRenderer` loops (src/training/pango/stringrenderer.cpp:289,673,693,711,846);
happy to address those in a follow-up.