### PR TITLE
fix: require TIFF version bytes before treating stdin as TIFF

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1158,6 +1158,7 @@ if !DISABLED_LEGACY_ENGINE
 check_PROGRAMS += equationdetect_test
 endif # !DISABLED_LEGACY_ENGINE
 check_PROGRAMS += fileio_test
+check_PROGRAMS += filelist_test
 check_PROGRAMS += fullyconnected_test
 check_PROGRAMS += genericvector_test
 check_PROGRAMS += heap_test
@@ -1296,6 +1297,10 @@ endif # !DISABLED_LEGACY_ENGINE
 fileio_test_SOURCES = unittest/fileio_test.cc
 fileio_test_CPPFLAGS = $(unittest_CPPFLAGS)
 fileio_test_LDADD = $(TRAINING_LIBS)
+
+filelist_test_SOURCES = unittest/filelist_test.cc
+filelist_test_CPPFLAGS = $(unittest_CPPFLAGS)
+filelist_test_LDADD = $(TRAINING_LIBS) $(LEPTONICA_LIBS)
 
 fullyconnected_test_SOURCES = unittest/fullyconnected_test.cc
 fullyconnected_test_CPPFLAGS = $(unittest_CPPFLAGS)

--- a/src/api/baseapi.cpp
+++ b/src/api/baseapi.cpp
@@ -1141,6 +1141,36 @@ bool TessBaseAPI::ProcessPagesInternal(const char *filename, const char *retry_c
   int r =
       (data != nullptr) ? findFileFormatBuffer(data, &format) : findFileFormat(filename, &format);
 
+  // Leptonica's format probe only checks the TIFF byte-order marker ("II"/"MM"),
+  // so a filelist whose first filename starts with those letters is misdetected
+  // as TIFF (issue #4619). Require the classic TIFF version field (42) before
+  // treating the input as an image; otherwise fall through to the filelist path.
+  if (r == 0 && L_FORMAT_IS_TIFF(format)) {
+    const l_uint8 *hdr = data;
+    l_uint8 file_hdr[4] = {0, 0, 0, 0};
+    size_t hdr_size = 0;
+    if (hdr != nullptr) {
+      hdr_size = buf.size();
+    } else if (filename != nullptr) {
+      if (FILE *fp = fopen(filename, "rb")) {
+        hdr_size = fread(file_hdr, 1, 4, fp);
+        fclose(fp);
+        hdr = file_hdr;
+      }
+    }
+    bool valid_tiff = false;
+    if (hdr != nullptr && hdr_size >= 4) {
+      if (hdr[0] == 'I' && hdr[1] == 'I') {
+        valid_tiff = (hdr[2] == 42 && hdr[3] == 0);
+      } else if (hdr[0] == 'M' && hdr[1] == 'M') {
+        valid_tiff = (hdr[2] == 0 && hdr[3] == 42);
+      }
+    }
+    if (!valid_tiff) {
+      format = IFF_UNKNOWN;
+    }
+  }
+
   // Maybe we have a filelist
   if (r != 0 || format == IFF_UNKNOWN) {
     std::string s;

--- a/unittest/filelist_test.cc
+++ b/unittest/filelist_test.cc
@@ -1,0 +1,100 @@
+// (C) Copyright 2017, Google Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <tesseract/baseapi.h>
+#include "include_gunit.h"
+
+namespace tesseract {
+
+namespace {
+
+class CinRedirect {
+public:
+  explicit CinRedirect(std::istream &in) : old_(std::cin.rdbuf(in.rdbuf())) {}
+  ~CinRedirect() {
+    std::cin.rdbuf(old_);
+  }
+
+private:
+  std::streambuf *old_;
+};
+
+class CwdGuard {
+public:
+  explicit CwdGuard(const std::filesystem::path &dir)
+      : old_(std::filesystem::current_path()) {
+    std::filesystem::current_path(dir);
+  }
+  ~CwdGuard() {
+    std::filesystem::current_path(old_);
+  }
+
+private:
+  std::filesystem::path old_;
+};
+
+bool ProcessStdin(TessBaseAPI *api, const std::string &input) {
+  std::istringstream in(input);
+  CinRedirect redirect(in);
+  return api->ProcessPages("-", nullptr, 0, nullptr);
+}
+
+} // namespace
+
+// Filelists whose first filename starts with the TIFF byte-order markers
+// "MM" or "II" must still be treated as filelists when streamed on stdin.
+// Leptonica's findFileFormatBuffer() only looks at those two bytes, so
+// without a version check Tesseract misdetects the list as a TIFF (issue 4619).
+
+TEST(FileListStdinTest, FilenamesStartingWithMMAreNotTreatedAsTiff) {
+  TessBaseAPI api;
+  api.InitForAnalysePage();
+  // Missing listed image: filelist path returns false; TIFF path returns true.
+  EXPECT_FALSE(ProcessStdin(&api, "MM11_missing_image.pnm\n"));
+}
+
+TEST(FileListStdinTest, FilenamesStartingWithIIAreNotTreatedAsTiff) {
+  TessBaseAPI api;
+  api.InitForAnalysePage();
+  EXPECT_FALSE(ProcessStdin(&api, "II11_missing_image.pnm\n"));
+}
+
+TEST(FileListStdinTest, FileListStartingWithMMReadsTheListedImage) {
+  TessBaseAPI api;
+  api.InitForAnalysePage();
+  api.SetPageSegMode(PSM_AUTO_ONLY);
+
+  const auto tmp = std::filesystem::temp_directory_path() / "tesseract_mm_filelist_test";
+  std::filesystem::create_directories(tmp);
+  {
+    // Binary PGM: leptonica rejects the minimal ASCII P1 we tried first.
+    std::ofstream out(tmp / "MMpage.pgm", std::ios::binary);
+    ASSERT_TRUE(out.good());
+    out << "P5\n1 1\n255\n" << char(128);
+  }
+
+  {
+    CwdGuard cwd(tmp);
+    // 1x1 image may fail layout analysis; we only need the filelist path to run.
+    ProcessStdin(&api, "MMpage.pgm\n");
+  }
+
+  // ProcessPage records the listed filename. The TIFF misdetect never does.
+  EXPECT_STREQ("MMpage.pgm", api.GetInputName());
+}
+
+} // namespace tesseract


### PR DESCRIPTION
## Summary

Leptonica's `findFileFormatBuffer` only checks the TIFF byte-order marker (`II`/`MM`). A stdin filelist whose first filename starts with those letters was misdetected as TIFF, so OCR never walked the list (issue #4619).

After the Leptonica probe reports TIFF, require the classic TIFF version field (`42`) before taking the multipage TIFF path. Otherwise fall through to the existing filelist handler.

## Test plan

- [x] `./build/bin/filelist_test` (3 cases: MM missing, II missing, MM listed image sets `GetInputName`)

Fixes #4619